### PR TITLE
Fix Render API build errors

### DIFF
--- a/build/apps/api/package.json
+++ b/build/apps/api/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
+    "prebuild": "pnpm prisma:generate",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",

--- a/build/apps/api/src/auth/clerk-auth.service.ts
+++ b/build/apps/api/src/auth/clerk-auth.service.ts
@@ -58,9 +58,13 @@ export class ClerkAuthService {
 
       return verifiedPayload;
     } catch (error) {
-      this.logger.error('Token verification failed', error);
+      const trace = error instanceof Error ? error.stack : undefined;
+      this.logger.error('Token verification failed', trace);
       if (error instanceof jwt.JsonWebTokenError) {
         throw new UnauthorizedException(`Token verification failed: ${error.message}`);
+      }
+      if (error instanceof Error) {
+        throw new UnauthorizedException(`Invalid token: ${error.message}`);
       }
       throw new UnauthorizedException('Invalid token');
     }
@@ -109,7 +113,8 @@ export class ClerkAuthService {
 
       return publicKey;
     } catch (error) {
-      this.logger.error('Failed to fetch Clerk public key', error);
+      const trace = error instanceof Error ? error.stack : undefined;
+      this.logger.error('Failed to fetch Clerk public key', trace);
       return null;
     }
   }

--- a/build/apps/api/src/auth/public.decorator.ts
+++ b/build/apps/api/src/auth/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/build/apps/api/src/common/decorators/throttle.decorator.ts
+++ b/build/apps/api/src/common/decorators/throttle.decorator.ts
@@ -1,0 +1,10 @@
+import { applyDecorators } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+
+const AUTH_REQUESTS_LIMIT = 5;
+const AUTH_TTL_SECONDS = 60;
+const UPLOAD_REQUESTS_LIMIT = 10;
+const UPLOAD_TTL_SECONDS = 60;
+
+export const AuthThrottle = () => applyDecorators(Throttle(AUTH_REQUESTS_LIMIT, AUTH_TTL_SECONDS));
+export const UploadThrottle = () => applyDecorators(Throttle(UPLOAD_REQUESTS_LIMIT, UPLOAD_TTL_SECONDS));

--- a/build/render.yaml
+++ b/build/render.yaml
@@ -4,7 +4,7 @@ services:
     name: pc-solutions-api
     env: node
     plan: starter
-    buildCommand: cd apps/api && pnpm install && pnpm build
+    buildCommand: cd apps/api && pnpm install --prod=false && pnpm build
     startCommand: cd apps/api && pnpm start:prod
     envVars:
       - key: NODE_ENV


### PR DESCRIPTION
## Summary
- ensure Prisma Client is generated before building by adding a prebuild script
- add the missing Public and throttle decorators referenced by the API controllers
- update Render's API service build command to install devDependencies needed for Prisma generation

## Testing
- pnpm build *(fails: missing optional dependencies in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8714adf608325be90b451c9378861