### PR TITLE
Check for catch-all route after express.static

### DIFF
--- a/Dockerfile.admin
+++ b/Dockerfile.admin
@@ -30,8 +30,8 @@ COPY --from=builder /app/admin/dist /usr/share/nginx/html
 # Copy nginx configuration
 COPY admin/nginx.conf /etc/nginx/conf.d/default.conf
 
-# Expose port
-EXPOSE 80
+# IMPORTANT on Render Docker web services: listen on 10000
+EXPOSE 10000
 
 # Start nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -30,8 +30,8 @@ COPY --from=builder /app/frontend/dist /usr/share/nginx/html
 # Copy nginx configuration
 COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
 
-# Expose port
-EXPOSE 80
+# IMPORTANT on Render Docker web services: listen on 10000
+EXPOSE 10000
 
 # Start nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/admin/nginx.conf
+++ b/admin/nginx.conf
@@ -1,19 +1,27 @@
 server {
-    listen 80;
+    # Render Docker web services expect the container to listen on 10000
+    listen 10000 default_server;
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;
 
-    # Handle client-side routing
+    # --- SPA fallback: this is the key bit ---
     location / {
+        # Try the exact file, then a folder index, else serve index.html
         try_files $uri $uri/ /index.html;
     }
 
-    # Cache static assets
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
+    # Static assets: cache aggressively
+    location ~* \.(?:js|mjs|css|png|jpg|jpeg|gif|svg|ico|woff2?|ttf|eot)$ {
+        access_log off;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
     }
+
+    # Gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
 
     # Security headers
     add_header X-Frame-Options "SAMEORIGIN" always;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,19 +1,27 @@
 server {
-    listen 80;
+    # Render Docker web services expect the container to listen on 10000
+    listen 10000 default_server;
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;
 
-    # Handle client-side routing
+    # --- SPA fallback: this is the key bit ---
     location / {
+        # Try the exact file, then a folder index, else serve index.html
         try_files $uri $uri/ /index.html;
     }
 
-    # Cache static assets
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
+    # Static assets: cache aggressively
+    location ~* \.(?:js|mjs|css|png|jpg|jpeg|gif|svg|ico|woff2?|ttf|eot)$ {
+        access_log off;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
     }
+
+    # Gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
 
     # Security headers
     add_header X-Frame-Options "SAMEORIGIN" always;


### PR DESCRIPTION
Configure Nginx and Dockerfiles for Render Web Service deployment, including port changes, optimized static asset caching, and gzip compression.

---
<a href="https://cursor.com/background-agent?bcId=bc-496ee957-f8a1-45e9-b0d7-0ebe6f484100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-496ee957-f8a1-45e9-b0d7-0ebe6f484100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

