### PR TITLE
Debug module import errors

### DIFF
--- a/api/src/content-moderation/content-moderation.module.ts
+++ b/api/src/content-moderation/content-moderation.module.ts
@@ -6,7 +6,6 @@ import { AuthModule } from '../auth/auth.module';
 
 @Module({
   imports: [PrismaModule, AuthModule],
-import { AuthModule } from '../auth/auth.module';
   controllers: [ContentModerationController],
   providers: [ContentModerationService],
   exports: [ContentModerationService],

--- a/api/src/email-notification/email-notification.module.ts
+++ b/api/src/email-notification/email-notification.module.ts
@@ -7,7 +7,6 @@ import { AuthModule } from '../auth/auth.module';
 
 @Module({
   imports: [PrismaModule, AuthModule],
-import { AuthModule } from '../auth/auth.module';
   controllers: [EmailNotificationController],
   providers: [EmailNotificationService, EmailTemplateService],
   exports: [EmailNotificationService, EmailTemplateService],

--- a/api/src/profiles/profiles.module.ts
+++ b/api/src/profiles/profiles.module.ts
@@ -6,7 +6,6 @@ import { AuthModule } from '../auth/auth.module';
 
 @Module({
   imports: [PrismaModule, AuthModule],
-import { AuthModule } from '../auth/auth.module';
   controllers: [ProfileController],
   providers: [ProfilesService],
   exports: [ProfilesService],

--- a/api/src/security/security.module.ts
+++ b/api/src/security/security.module.ts
@@ -5,6 +5,7 @@ import { HealthController } from './health.controller';
 import { ClamAVService } from './clamav.service';
 import { MimeValidationService } from './mime-validation.service';
 import { QuarantineStorageService } from './quarantine-storage.service';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
   imports: [ConfigModule, AuthModule],

--- a/api/src/subscription-management/subscription-management.module.ts
+++ b/api/src/subscription-management/subscription-management.module.ts
@@ -10,7 +10,6 @@ import { EmailNotificationModule } from '../email-notification/email-notificatio
 
 @Module({
   imports: [PrismaModule, EmailNotificationModule, AuthModule],
-import { AuthModule } from '../auth/auth.module';
   controllers: [SubscriptionManagementController],
   providers: [
     SubscriptionManagementService,

--- a/api/src/system-monitoring/system-monitoring.module.ts
+++ b/api/src/system-monitoring/system-monitoring.module.ts
@@ -6,7 +6,6 @@ import { AuthModule } from '../auth/auth.module';
 
 @Module({
   imports: [PrismaModule, AuthModule],
-import { AuthModule } from '../auth/auth.module';
   controllers: [SystemMonitoringController],
   providers: [SystemMonitoringService],
   exports: [SystemMonitoringService],

--- a/api/src/translation/translation.module.ts
+++ b/api/src/translation/translation.module.ts
@@ -6,7 +6,6 @@ import { AuthModule } from '../auth/auth.module';
 
 @Module({
   imports: [PrismaModule, AuthModule],
-import { AuthModule } from '../auth/auth.module';
   controllers: [TranslationController],
   providers: [TranslationService],
   exports: [TranslationService],


### PR DESCRIPTION
Remove duplicate `AuthModule` imports from `@Module` decorators and add a missing `AuthModule` import to `security.module.ts`.

This fixes multiple TypeScript compilation errors (TS1005, TS2561, TS18004, TS2304) caused by misplaced or missing import statements, allowing the build to succeed.

---
<a href="https://cursor.com/background-agent?bcId=bc-8adc5c8c-5e9e-41d2-884e-1a0dd03d07d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8adc5c8c-5e9e-41d2-884e-1a0dd03d07d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

