### PR TITLE
Align uploads with AppUser identities

### DIFF
--- a/api/prisma/migrations/20250926_unify_asset_appuser/migration.sql
+++ b/api/prisma/migrations/20250926_unify_asset_appuser/migration.sql
@@ -1,0 +1,16 @@
+ALTER TABLE "AppUser" RENAME COLUMN "clerkUserId" TO "clerkId";
+
+ALTER INDEX IF EXISTS "AppUser_clerkUserId_key" RENAME TO "AppUser_clerkId_key";
+
+ALTER TABLE "AppUser"
+  ADD COLUMN IF NOT EXISTS "email" TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "AppUser_email_key" ON "AppUser"("email");
+
+ALTER TABLE "assets" DROP CONSTRAINT IF EXISTS "assets_uploadedBy_fkey";
+
+ALTER TABLE "assets" RENAME COLUMN "uploadedBy" TO "uploadedById";
+
+ALTER TABLE "assets"
+  ADD CONSTRAINT "assets_uploadedById_fkey"
+  FOREIGN KEY ("uploadedById") REFERENCES "AppUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -150,7 +150,6 @@ model User {
 
   // Relations
   organizations UserOrganization[]
-  assets        Asset[]
   applications  JobApplication[]
   subscriptions UserSubscription[]
   mainSubscriptions Subscription[] // Main subscription model
@@ -244,18 +243,18 @@ model UserOrganization {
 }
 
 model Asset {
-  id         String    @id @default(uuid())
-  kind       AssetKind
-  filename   String
-  publicUrl  String
-  storageKey String
-  mimeType   String?
-  size       Int?
-  uploadedBy String
-  createdAt  DateTime  @default(now())
+  id           String   @id @default(uuid())
+  kind         AssetKind
+  filename     String
+  publicUrl    String
+  storageKey   String
+  mimeType     String?
+  size         Int?
+  uploadedById String
+  createdAt    DateTime @default(now())
 
   // Relations
-  uploader User @relation(fields: [uploadedBy], references: [id])
+  uploader AppUser @relation("AssetUploadedBy", fields: [uploadedById], references: [id], onDelete: Restrict)
 
   // Organization asset relations
   organizationLogos  Organization[] @relation("OrganizationLogo")
@@ -1229,12 +1228,14 @@ model MaintenanceSchedule {
 
 // New Role Management Tables
 model AppUser {
-  id          String   @id @default(uuid())
-  clerkUserId String   @unique
-  role        UserRole @default(PARENT)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id          String    @id @default(uuid())
+  clerkId     String    @unique
+  email       String?   @unique
+  role        UserRole  @default(PARENT)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 
+  assets      Asset[]   @relation("AssetUploadedBy")
   roleHistory AppUserRoleHistory[]
 }
 
@@ -1243,7 +1244,7 @@ model AppUserRoleHistory {
   userId       String
   previousRole UserRole?
   newRole      UserRole
-  changedBy    String // clerkUserId of actor OR 'system/webhook'
+  changedBy    String // clerkId of actor OR 'system/webhook'
   reason       String?
   changedAt    DateTime  @default(now())
 

--- a/api/scripts/backfill-app-users.ts
+++ b/api/scripts/backfill-app-users.ts
@@ -1,0 +1,95 @@
+import { PrismaClient, UserRole } from '@prisma/client';
+import { createClerkClient } from '@clerk/clerk-sdk-node';
+
+const prisma = new PrismaClient();
+
+function coerceRole(role: any): UserRole {
+  if (role && Object.values(UserRole).includes(role)) {
+    return role;
+  }
+  return UserRole.PARENT;
+}
+
+async function main() {
+  const secretKey = process.env.CLERK_SECRET_KEY;
+  if (!secretKey) {
+    throw new Error('CLERK_SECRET_KEY must be set to run this script.');
+  }
+
+  const clerk = createClerkClient({ secretKey });
+  const pageSize = 100;
+  let offset = 0;
+  let processed = 0;
+
+  // Clerk returns paginated lists using offset/limit
+  /* eslint-disable no-constant-condition */
+  while (true) {
+    const users = await clerk.users.getUserList({
+      limit: pageSize,
+      offset,
+    });
+
+    if (!users || users.length === 0) {
+      break;
+    }
+
+    for (const user of users) {
+      const clerkId = user.id;
+      const primaryEmail = user.email_addresses?.[0]?.email_address || `${clerkId}@missing-email.local`;
+      const firstName = user.first_name || 'Unknown';
+      const lastName = user.last_name || 'User';
+      const role = coerceRole((user.publicMetadata as any)?.role || (user.privateMetadata as any)?.intendedRole);
+
+      const appUser = await prisma.appUser.upsert({
+        where: { clerkId },
+        update: {
+          email: primaryEmail,
+          role,
+        },
+        create: {
+          clerkId,
+          email: primaryEmail,
+          role,
+        },
+        select: { id: true, role: true },
+      });
+
+      await prisma.user.upsert({
+        where: { clerkId },
+        update: {
+          email: primaryEmail,
+          firstName,
+          lastName,
+          role: appUser.role,
+        },
+        create: {
+          id: appUser.id,
+          clerkId,
+          email: primaryEmail,
+          firstName,
+          lastName,
+          role: appUser.role,
+        },
+      });
+
+      processed += 1;
+    }
+
+    offset += users.length;
+    if (users.length < pageSize) {
+      break;
+    }
+  }
+  /* eslint-enable no-constant-condition */
+
+  console.log(`Backfill complete. Processed ${processed} Clerk users.`);
+}
+
+main()
+  .catch(error => {
+    console.error('Backfill failed:', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/api/scripts/seed-once.js
+++ b/api/scripts/seed-once.js
@@ -36,8 +36,8 @@ async function main() {
     // 2) Seed SUPER_ADMIN AppUser if SEED_CLERK_USER_ID provided
     if (seedClerkUserId) {
       await prisma.appUser.upsert({
-        where: { clerkUserId: seedClerkUserId },
-        create: { clerkUserId: seedClerkUserId, role: 'SUPER_ADMIN' },
+        where: { clerkId: seedClerkUserId },
+        create: { clerkId: seedClerkUserId, role: 'SUPER_ADMIN' },
         update: { role: 'SUPER_ADMIN' },
       });
       console.log('🌱 Seed: AppUser upserted to SUPER_ADMIN for', seedClerkUserId);

--- a/api/scripts/test-seed.ts
+++ b/api/scripts/test-seed.ts
@@ -3,44 +3,44 @@ import { PrismaClient, UserRole } from '@prisma/client';
 const prisma = new PrismaClient();
 
 interface TestUser {
-  clerkUserId: string;
+  clerkId: string;
   role: UserRole;
   email: string;
 }
 
 const testUsers: TestUser[] = [
   {
-    clerkUserId: 'user_test_super_admin',
+    clerkId: 'user_test_super_admin',
     role: UserRole.SUPER_ADMIN,
     email: 'super.admin@test.com',
   },
   {
-    clerkUserId: 'user_test_admin',
+    clerkId: 'user_test_admin',
     role: UserRole.ADMIN,
     email: 'admin@test.com',
   },
   {
-    clerkUserId: 'user_test_foundation',
+    clerkId: 'user_test_foundation',
     role: UserRole.FOUNDATION,
     email: 'foundation@test.com',
   },
   {
-    clerkUserId: 'user_test_supplier',
+    clerkId: 'user_test_supplier',
     role: UserRole.PRODUCT_SUPPLIER,
     email: 'supplier@test.com',
   },
   {
-    clerkUserId: 'user_test_service',
+    clerkId: 'user_test_service',
     role: UserRole.SERVICE_PROVIDER,
     email: 'service@test.com',
   },
   {
-    clerkUserId: 'user_test_educator',
+    clerkId: 'user_test_educator',
     role: UserRole.EDUCATOR,
     email: 'educator@test.com',
   },
   {
-    clerkUserId: 'user_test_parent',
+    clerkId: 'user_test_parent',
     role: UserRole.PARENT,
     email: 'parent@test.com',
   },
@@ -53,16 +53,24 @@ async function seedTestData() {
   await prisma.appUserRoleHistory.deleteMany({
     where: {
       user: {
-        clerkUserId: {
+        clerkId: {
           startsWith: 'user_test_',
         },
       },
     },
   });
 
+  await prisma.user.deleteMany({
+    where: {
+      clerkId: {
+        startsWith: 'user_test_',
+      },
+    },
+  });
+
   await prisma.appUser.deleteMany({
     where: {
-      clerkUserId: {
+      clerkId: {
         startsWith: 'user_test_',
       },
     },
@@ -72,7 +80,26 @@ async function seedTestData() {
   for (const testUser of testUsers) {
     const user = await prisma.appUser.create({
       data: {
-        clerkUserId: testUser.clerkUserId,
+        clerkId: testUser.clerkId,
+        role: testUser.role,
+        email: testUser.email,
+      },
+    });
+
+    await prisma.user.upsert({
+      where: { clerkId: testUser.clerkId },
+      update: {
+        email: testUser.email,
+        firstName: 'Test',
+        lastName: 'User',
+        role: testUser.role,
+      },
+      create: {
+        id: user.id,
+        clerkId: testUser.clerkId,
+        email: testUser.email,
+        firstName: 'Test',
+        lastName: 'User',
         role: testUser.role,
       },
     });
@@ -105,7 +132,7 @@ async function seedTestData() {
 
   // Create a role change history for testing
   const adminUser = await prisma.appUser.findUnique({
-    where: { clerkUserId: 'user_test_admin' },
+    where: { clerkId: 'user_test_admin' },
   });
 
   if (adminUser) {

--- a/api/src/admin/role-management/role-management.controller.ts
+++ b/api/src/admin/role-management/role-management.controller.ts
@@ -23,11 +23,11 @@ interface ChangeRoleDto {
 export class RoleManagementController {
   constructor(private prisma: PrismaService) {}
 
-  @Get('users/:clerkUserId')
+  @Get('users/:clerkId')
   @Roles(UserRole.SUPER_ADMIN, UserRole.ADMIN)
-  async getUserRole(@Param('clerkUserId') clerkUserId: string) {
+  async getUserRole(@Param('clerkId') clerkId: string) {
     const appUser = await this.prisma.appUser.findUnique({
-      where: { clerkUserId },
+      where: { clerkId },
       include: {
         roleHistory: {
           orderBy: { changedAt: 'desc' },
@@ -46,11 +46,11 @@ export class RoleManagementController {
     };
   }
 
-  @Patch('users/:clerkUserId/role')
+  @Patch('users/:clerkId/role')
   @HttpCode(204)
   @Roles(UserRole.SUPER_ADMIN, UserRole.ADMIN)
   async changeUserRole(
-    @Param('clerkUserId') targetClerkId: string,
+    @Param('clerkId') targetClerkId: string,
     @Body() dto: ChangeRoleDto,
     @Req() req: any
   ) {
@@ -68,14 +68,14 @@ export class RoleManagementController {
     await this.prisma.$transaction(async (tx) => {
       // Get or create user
       let appUser = await tx.appUser.findUnique({
-        where: { clerkUserId: targetClerkId },
+        where: { clerkId: targetClerkId },
       });
 
       if (!appUser) {
         // Create user if doesn't exist
         appUser = await tx.appUser.create({
           data: {
-            clerkUserId: targetClerkId,
+            clerkId: targetClerkId,
             role: dto.role,
           },
         });
@@ -96,7 +96,7 @@ export class RoleManagementController {
             userId: appUser.id,
             previousRole,
             newRole: dto.role,
-            changedBy: req.context.userId,
+            changedBy: req.context.clerkUserId ?? req.context.userId,
             reason: dto.reason || 'Admin role change',
           },
         });
@@ -131,7 +131,7 @@ export class RoleManagementController {
         include: {
           user: {
             select: {
-              clerkUserId: true,
+              clerkId: true,
             },
           },
         },

--- a/api/src/auth/guards/clerk-auth.guard.ts
+++ b/api/src/auth/guards/clerk-auth.guard.ts
@@ -98,7 +98,7 @@ export class ClerkAuthGuard implements CanActivate {
 
       if (this.authDebug) {
         const req = context.switchToHttp().getRequest();
-        // eslint-disable-next-line no-console
+         
         console.log('🔐 Auth Debug:', {
           path: req.url,
           method: req.method,
@@ -119,29 +119,30 @@ export class ClerkAuthGuard implements CanActivate {
 
       // Populate request.context (user role from AppUser), so RolesGuard can authorize
       try {
-        let appUser = await this.prisma.appUser.findUnique({ where: { clerkUserId: payload.sub } });
+        let appUser = await this.prisma.appUser.findUnique({ where: { clerkId: payload.sub } });
         if (!appUser) {
           if (this.authDebug) {
-            // eslint-disable-next-line no-console
+             
             console.log('🔐 Auth Debug: AppUser missing, creating baseline user with PARENT role', { userId: payload.sub });
           }
           // Create a baseline user; admins can later promote via role management
           appUser = await this.prisma.appUser.create({
-            data: { clerkUserId: payload.sub, role: 'PARENT' },
+            data: { clerkId: payload.sub, role: 'PARENT' },
           });
         }
         request.context = {
           userId: payload.sub,
           role: appUser.role,
           appUserId: appUser.id,
+          clerkUserId: payload.sub,
         };
         if (this.authDebug) {
-          // eslint-disable-next-line no-console
+           
           console.log('🔐 Auth Debug: request.context populated', request.context);
         }
       } catch (e) {
         if (this.authDebug) {
-          // eslint-disable-next-line no-console
+           
           console.error('🔐 Auth Debug: failed to load/create AppUser', e);
         }
         // non-fatal; RolesGuard will handle missing context
@@ -150,10 +151,10 @@ export class ClerkAuthGuard implements CanActivate {
     } catch (error: any) {
       const reason = error?.reason || error?.message || 'unknown';
       const action = error?.action;
-      // eslint-disable-next-line no-console
+       
       console.error('Token verification failed:', { reason, action });
       if (reason === 'jwk-failed-to-resolve' && !this.jwtKey) {
-        // eslint-disable-next-line no-console
+         
         console.error('Clerk JWK fetch failed. Set CLERK_JWT_KEY env with your instance JWT public key to enable offline verification.');
       }
       throw new UnauthorizedException('Invalid token');

--- a/api/src/auth/middleware/role-context.middleware.ts
+++ b/api/src/auth/middleware/role-context.middleware.ts
@@ -35,14 +35,14 @@ export class RoleContextMiddleware implements NestMiddleware {
     try {
       // Fetch user from AppUser table
       let appUser = await this.prisma.appUser.findUnique({
-        where: { clerkUserId },
+        where: { clerkId: clerkUserId },
       });
 
       if (!appUser) {
         // Self-heal: create baseline user
         appUser = await this.prisma.appUser.create({
-          data: { 
-            clerkUserId,
+          data: {
+            clerkId: clerkUserId,
             role: 'PARENT', // Safe default
           },
         });
@@ -61,6 +61,7 @@ export class RoleContextMiddleware implements NestMiddleware {
         userId: clerkUserId,
         role: appUser.role,
         appUserId: appUser.id,
+        clerkUserId,
       };
 
       next();

--- a/api/src/content/content.controller.ts
+++ b/api/src/content/content.controller.ts
@@ -36,14 +36,14 @@ export class ContentController {
         throw new Error('No file provided');
       }
       
-      if (!req.context?.userId) {
+      if (!req.context?.appUserId) {
         throw new Error('User not authenticated');
       }
 
       const result = await this.contentService.uploadElearningContent(
         file,
         body,
-        req.context.userId,
+        req.context.appUserId,
       );
       
       return {
@@ -72,14 +72,14 @@ export class ContentController {
         throw new Error('No file provided');
       }
       
-      if (!req.context?.userId) {
+      if (!req.context?.appUserId) {
         throw new Error('User not authenticated');
       }
 
       const result = await this.contentService.uploadHrDocument(
         file,
         body,
-        req.context.userId,
+        req.context.appUserId,
       );
       
       return {
@@ -108,14 +108,14 @@ export class ContentController {
         throw new Error('No file provided');
       }
       
-      if (!req.context?.userId) {
+      if (!req.context?.appUserId) {
         throw new Error('User not authenticated');
       }
 
       const result = await this.contentService.uploadStatePolicy(
         file,
         body,
-        req.context.userId,
+        req.context.appUserId,
       );
       
       return {

--- a/api/src/content/content.service.ts
+++ b/api/src/content/content.service.ts
@@ -13,14 +13,14 @@ export class ContentService {
   async uploadElearningContent(
     file: Express.Multer.File,
     body: any,
-    userId: string,
+    appUserId: string,
   ) {
     try {
       // Upload file to R2
       const uploadResult = await this.r2Service.uploadFile(
         file,
         AssetKind.DOCUMENT,
-        userId,
+        appUserId,
       );
 
       // Create course record
@@ -31,7 +31,7 @@ export class ContentService {
           difficultyLevel: body.difficultyLevel || 'beginner',
           estimatedDuration: parseInt(body.estimatedDuration) || 60,
           status: 'DRAFT',
-          createdBy: userId,
+          createdBy: appUserId,
         },
       });
 
@@ -75,14 +75,14 @@ export class ContentService {
   async uploadHrDocument(
     file: Express.Multer.File,
     body: any,
-    userId: string,
+    appUserId: string,
   ) {
     try {
       // Upload file to R2
       const uploadResult = await this.r2Service.uploadFile(
         file,
         AssetKind.DOCUMENT,
-        userId,
+        appUserId,
       );
 
       // Create HR document record (using a generic content table or extending existing)
@@ -95,7 +95,7 @@ export class ContentService {
           storageKey: uploadResult.key,
           mimeType: file.mimetype,
           size: file.size,
-          uploadedBy: userId,
+          uploadedById: appUserId,
         },
       });
 
@@ -120,14 +120,14 @@ export class ContentService {
   async uploadStatePolicy(
     file: Express.Multer.File,
     body: any,
-    userId: string,
+    appUserId: string,
   ) {
     try {
       // Upload file to R2
       const uploadResult = await this.r2Service.uploadFile(
         file,
         AssetKind.DOCUMENT,
-        userId,
+        appUserId,
       );
 
       // Create state policy record
@@ -139,7 +139,7 @@ export class ContentService {
           storageKey: uploadResult.key,
           mimeType: file.mimetype,
           size: file.size,
-          uploadedBy: userId,
+          uploadedById: appUserId,
         },
       });
 

--- a/api/src/frontend-settings/frontend-settings.controller.ts
+++ b/api/src/frontend-settings/frontend-settings.controller.ts
@@ -8,6 +8,7 @@ import {
   Request,
   UseInterceptors,
   UploadedFile,
+  BadRequestException,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { FrontendSettingsService } from './frontend-settings.service';
@@ -62,11 +63,11 @@ export class FrontendSettingsController {
         throw new Error('No file provided');
       }
       
-      if (!req.context?.userId) {
-        throw new Error('User not authenticated');
+      const appUserId = req.context?.appUserId;
+      if (!appUserId) {
+        throw new BadRequestException('Missing authenticated user');
       }
-
-      const result = await this.frontendSettingsService.uploadLogo(file, req.context.userId);
+      const result = await this.frontendSettingsService.uploadLogo(file, appUserId);
       
       return {
         success: true,
@@ -94,11 +95,11 @@ export class FrontendSettingsController {
         throw new Error('No file provided');
       }
       
-      if (!req.context?.userId) {
-        throw new Error('User not authenticated');
+      const appUserId = req.context?.appUserId;
+      if (!appUserId) {
+        throw new BadRequestException('Missing authenticated user');
       }
-
-      const result = await this.frontendSettingsService.uploadFavicon(file, req.context.userId);
+      const result = await this.frontendSettingsService.uploadFavicon(file, appUserId);
       
       return {
         success: true,
@@ -126,11 +127,11 @@ export class FrontendSettingsController {
         throw new Error('No file provided');
       }
       
-      if (!req.context?.userId) {
-        throw new Error('User not authenticated');
+      const appUserId = req.context?.appUserId;
+      if (!appUserId) {
+        throw new BadRequestException('Missing authenticated user');
       }
-
-      const result = await this.frontendSettingsService.uploadOgImage(file, req.context.userId);
+      const result = await this.frontendSettingsService.uploadOgImage(file, appUserId);
       
       return {
         success: true,
@@ -158,11 +159,11 @@ export class FrontendSettingsController {
         throw new Error('No file provided');
       }
       
-      if (!req.context?.userId) {
-        throw new Error('User not authenticated');
+      const appUserId = req.context?.appUserId;
+      if (!appUserId) {
+        throw new BadRequestException('Missing authenticated user');
       }
-
-      const result = await this.frontendSettingsService.uploadAdminLogo(file, req.context.userId);
+      const result = await this.frontendSettingsService.uploadAdminLogo(file, appUserId);
       
       return {
         success: true,
@@ -190,11 +191,11 @@ export class FrontendSettingsController {
         throw new Error('No file provided');
       }
       
-      if (!req.context?.userId) {
-        throw new Error('User not authenticated');
+      const appUserId = req.context?.appUserId;
+      if (!appUserId) {
+        throw new BadRequestException('Missing authenticated user');
       }
-
-      const result = await this.frontendSettingsService.uploadAdminFavicon(file, req.context.userId);
+      const result = await this.frontendSettingsService.uploadAdminFavicon(file, appUserId);
       
       return {
         success: true,

--- a/api/src/frontend-settings/frontend-settings.service.ts
+++ b/api/src/frontend-settings/frontend-settings.service.ts
@@ -116,9 +116,9 @@ export class FrontendSettingsService {
     return settings;
   }
 
-  async uploadLogo(file: Express.Multer.File, uploadedBy: string) {
+  async uploadLogo(file: Express.Multer.File, uploadedById: string) {
     // Use the existing upload service
-    const uploadResult = await this.uploadService.uploadFile(file, uploadedBy, AssetKind.FRONTEND_LOGO);
+    const uploadResult = await this.uploadService.uploadFile(file, uploadedById, AssetKind.FRONTEND_LOGO);
 
     // Update frontend settings with new logo
     const settings = await this.getSettings();
@@ -130,9 +130,9 @@ export class FrontendSettingsService {
     return uploadResult;
   }
 
-  async uploadFavicon(file: Express.Multer.File, uploadedBy: string) {
+  async uploadFavicon(file: Express.Multer.File, uploadedById: string) {
     // Use the existing upload service
-    const uploadResult = await this.uploadService.uploadFile(file, uploadedBy, AssetKind.FRONTEND_FAVICON);
+    const uploadResult = await this.uploadService.uploadFile(file, uploadedById, AssetKind.FRONTEND_FAVICON);
 
     // Update frontend settings with new favicon
     const settings = await this.getSettings();
@@ -144,9 +144,9 @@ export class FrontendSettingsService {
     return uploadResult;
   }
 
-  async uploadOgImage(file: Express.Multer.File, uploadedBy: string) {
+  async uploadOgImage(file: Express.Multer.File, uploadedById: string) {
     // Use the existing upload service
-    const uploadResult = await this.uploadService.uploadFile(file, uploadedBy, AssetKind.FRONTEND_OG_IMAGE);
+    const uploadResult = await this.uploadService.uploadFile(file, uploadedById, AssetKind.FRONTEND_OG_IMAGE);
 
     // Update frontend settings with new OG image
     const settings = await this.getSettings();
@@ -158,9 +158,9 @@ export class FrontendSettingsService {
     return uploadResult;
   }
 
-  async uploadAdminLogo(file: Express.Multer.File, uploadedBy: string) {
+  async uploadAdminLogo(file: Express.Multer.File, uploadedById: string) {
     // Use the existing upload service
-    const uploadResult = await this.uploadService.uploadFile(file, uploadedBy, AssetKind.ADMIN_LOGO);
+    const uploadResult = await this.uploadService.uploadFile(file, uploadedById, AssetKind.ADMIN_LOGO);
 
     // Update frontend settings with new admin logo
     const settings = await this.getSettings();
@@ -172,9 +172,9 @@ export class FrontendSettingsService {
     return uploadResult;
   }
 
-  async uploadAdminFavicon(file: Express.Multer.File, uploadedBy: string) {
+  async uploadAdminFavicon(file: Express.Multer.File, uploadedById: string) {
     // Use the existing upload service
-    const uploadResult = await this.uploadService.uploadFile(file, uploadedBy, AssetKind.ADMIN_FAVICON);
+    const uploadResult = await this.uploadService.uploadFile(file, uploadedById, AssetKind.ADMIN_FAVICON);
 
     // Update frontend settings with new admin favicon
     const settings = await this.getSettings();

--- a/api/src/health/health.controller.ts
+++ b/api/src/health/health.controller.ts
@@ -139,7 +139,7 @@ export class HealthController {
         this.prisma.appUser.findMany({
           take: 5,
           orderBy: { createdAt: 'desc' },
-          select: { id: true, clerkUserId: true, role: true, createdAt: true },
+          select: { id: true, clerkId: true, role: true, createdAt: true, email: true },
         }).catch(() => []),
         this.prisma.frontendSettings.findFirst({
           include: {
@@ -225,16 +225,16 @@ export class HealthController {
   @ApiOperation({ summary: 'List AppUsers (sanitized, queryable)' })
   @ApiResponse({ status: 200, description: 'Returns app users' })
   async listAppUsers(
-    @Query('clerkUserId') clerkUserId?: string,
+    @Query('clerkId') clerkId?: string,
     @Query('limit') limit?: string,
   ) {
     const take = Math.min(Math.max(parseInt(limit || '20', 10) || 20, 1), 100);
     // @ts-ignore - model exists
     const appUsers = await this.prisma.appUser.findMany({
-      where: clerkUserId ? { clerkUserId } : {},
+      where: clerkId ? { clerkId } : {},
       take,
       orderBy: { createdAt: 'desc' },
-      select: { id: true, clerkUserId: true, role: true, createdAt: true },
+      select: { id: true, clerkId: true, role: true, createdAt: true, email: true },
     });
     return { success: true, data: appUsers, count: appUsers.length, timestamp: new Date().toISOString() };
   }

--- a/api/src/mock-database.service.ts
+++ b/api/src/mock-database.service.ts
@@ -25,7 +25,7 @@ export interface MockAsset {
   mimeType: string;
   size: number;
   kind: string;
-  uploadedBy: string;
+  uploadedById: string;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/api/src/mock-frontend-settings.controller.ts
+++ b/api/src/mock-frontend-settings.controller.ts
@@ -29,7 +29,7 @@ export class MockFrontendSettingsController {
         throw new Error('No file provided');
       }
       
-      const userId = req.context?.userId || 'mock-user-id';
+      const userId = req.context?.appUserId || req.context?.userId || 'mock-user-id';
       const result = await this.frontendSettingsService.uploadLogo(file, userId);
       
       return {
@@ -58,7 +58,7 @@ export class MockFrontendSettingsController {
         throw new Error('No file provided');
       }
       
-      const userId = req.context?.userId || 'mock-user-id';
+      const userId = req.context?.appUserId || req.context?.userId || 'mock-user-id';
       const result = await this.frontendSettingsService.uploadFavicon(file, userId);
       
       return {
@@ -87,7 +87,7 @@ export class MockFrontendSettingsController {
         throw new Error('No file provided');
       }
       
-      const userId = req.context?.userId || 'mock-user-id';
+      const userId = req.context?.appUserId || req.context?.userId || 'mock-user-id';
       const result = await this.frontendSettingsService.uploadOgImage(file, userId);
       
       return {
@@ -116,7 +116,7 @@ export class MockFrontendSettingsController {
         throw new Error('No file provided');
       }
       
-      const userId = req.context?.userId || 'mock-user-id';
+      const userId = req.context?.appUserId || req.context?.userId || 'mock-user-id';
       const result = await this.frontendSettingsService.uploadAdminLogo(file, userId);
       
       return {
@@ -145,7 +145,7 @@ export class MockFrontendSettingsController {
         throw new Error('No file provided');
       }
       
-      const userId = req.context?.userId || 'mock-user-id';
+      const userId = req.context?.appUserId || req.context?.userId || 'mock-user-id';
       const result = await this.frontendSettingsService.uploadAdminFavicon(file, userId);
       
       return {

--- a/api/src/mock-frontend-settings.service.ts
+++ b/api/src/mock-frontend-settings.service.ts
@@ -24,7 +24,7 @@ export interface UploadResult {
     mimeType: string;
     size: number;
     kind: string;
-    uploadedBy: string;
+    uploadedById: string;
     createdAt: Date;
     updatedAt: Date;
   };
@@ -63,7 +63,7 @@ export class MockFrontendSettingsService {
     return await this.mockDb.updateFrontendSettings(updates);
   }
 
-  async uploadLogo(file: Express.Multer.File, uploadedBy: string): Promise<UploadResult> {
+  async uploadLogo(file: Express.Multer.File, uploadedById: string): Promise<UploadResult> {
     this.logger.log('Uploading logo', { filename: file.originalname, size: file.size });
     
     const asset = await this.mockDb.createAsset({
@@ -72,7 +72,7 @@ export class MockFrontendSettingsService {
       mimeType: file.mimetype,
       size: file.size,
       kind: 'FRONTEND_LOGO',
-      uploadedBy,
+      uploadedById,
     });
 
     const publicUrl = `https://mock-assets.pc-solutions.com/${asset.filename}`;
@@ -83,7 +83,7 @@ export class MockFrontendSettingsService {
     return { asset, publicUrl };
   }
 
-  async uploadFavicon(file: Express.Multer.File, uploadedBy: string): Promise<UploadResult> {
+  async uploadFavicon(file: Express.Multer.File, uploadedById: string): Promise<UploadResult> {
     this.logger.log('Uploading favicon', { filename: file.originalname, size: file.size });
     
     const asset = await this.mockDb.createAsset({
@@ -92,7 +92,7 @@ export class MockFrontendSettingsService {
       mimeType: file.mimetype,
       size: file.size,
       kind: 'FRONTEND_FAVICON',
-      uploadedBy,
+      uploadedById,
     });
 
     const publicUrl = `https://mock-assets.pc-solutions.com/${asset.filename}`;
@@ -103,7 +103,7 @@ export class MockFrontendSettingsService {
     return { asset, publicUrl };
   }
 
-  async uploadOgImage(file: Express.Multer.File, uploadedBy: string): Promise<UploadResult> {
+  async uploadOgImage(file: Express.Multer.File, uploadedById: string): Promise<UploadResult> {
     this.logger.log('Uploading OG image', { filename: file.originalname, size: file.size });
     
     const asset = await this.mockDb.createAsset({
@@ -112,7 +112,7 @@ export class MockFrontendSettingsService {
       mimeType: file.mimetype,
       size: file.size,
       kind: 'FRONTEND_OG_IMAGE',
-      uploadedBy,
+      uploadedById,
     });
 
     const publicUrl = `https://mock-assets.pc-solutions.com/${asset.filename}`;
@@ -123,7 +123,7 @@ export class MockFrontendSettingsService {
     return { asset, publicUrl };
   }
 
-  async uploadAdminLogo(file: Express.Multer.File, uploadedBy: string): Promise<UploadResult> {
+  async uploadAdminLogo(file: Express.Multer.File, uploadedById: string): Promise<UploadResult> {
     this.logger.log('Uploading admin logo', { filename: file.originalname, size: file.size });
     
     const asset = await this.mockDb.createAsset({
@@ -132,7 +132,7 @@ export class MockFrontendSettingsService {
       mimeType: file.mimetype,
       size: file.size,
       kind: 'ADMIN_LOGO',
-      uploadedBy,
+      uploadedById,
     });
 
     const publicUrl = `https://mock-assets.pc-solutions.com/${asset.filename}`;
@@ -143,7 +143,7 @@ export class MockFrontendSettingsService {
     return { asset, publicUrl };
   }
 
-  async uploadAdminFavicon(file: Express.Multer.File, uploadedBy: string): Promise<UploadResult> {
+  async uploadAdminFavicon(file: Express.Multer.File, uploadedById: string): Promise<UploadResult> {
     this.logger.log('Uploading admin favicon', { filename: file.originalname, size: file.size });
     
     const asset = await this.mockDb.createAsset({
@@ -152,7 +152,7 @@ export class MockFrontendSettingsService {
       mimeType: file.mimetype,
       size: file.size,
       kind: 'ADMIN_FAVICON',
-      uploadedBy,
+      uploadedById,
     });
 
     const publicUrl = `https://mock-assets.pc-solutions.com/${asset.filename}`;

--- a/api/src/sync/reconcile.service.ts
+++ b/api/src/sync/reconcile.service.ts
@@ -45,14 +45,14 @@ export class ReconcileService {
           await this.reconcileUser(user);
         } catch (error) {
           this.logger.error(
-            `Failed to reconcile user ${user.clerkUserId}: ${error?.message || error}`,
+            `Failed to reconcile user ${user.clerkId}: ${error?.message || error}`,
           );
-          
+
           // Could enqueue to outbox for retry
           await this.prisma.outbox.create({
             data: {
               topic: 'mirror.role',
-              payload: { clerkUserId: user.clerkUserId, role: user.role },
+              payload: { clerkUserId: user.clerkId, role: user.role },
             },
           }).catch(() => {}); // Best effort
         }
@@ -65,21 +65,21 @@ export class ReconcileService {
     this.logger.log(`Reconciliation complete. Processed ${processed} users`);
   }
 
-  private async reconcileUser(user: { clerkUserId: string; role: string }) {
-    const clerkUser = await this.clerk.users.getUser(user.clerkUserId);
+  private async reconcileUser(user: { clerkId: string; role: string }) {
+    const clerkUser = await this.clerk.users.getUser(user.clerkId);
     const publicRole = (clerkUser.publicMetadata as any)?.role;
-    
+
     if (publicRole !== user.role) {
       this.logger.log(
-        `Reconciling role mismatch for ${user.clerkUserId}: ` +
+        `Reconciling role mismatch for ${user.clerkId}: ` +
         `Clerk=${publicRole}, DB=${user.role}`
       );
-      
+
       // Update Clerk to match DB (DB is source of truth)
-      await this.clerk.users.updateUser(user.clerkUserId, {
-        publicMetadata: { 
-          ...(clerkUser.publicMetadata as any), 
-          role: user.role 
+      await this.clerk.users.updateUser(user.clerkId, {
+        publicMetadata: {
+          ...(clerkUser.publicMetadata as any),
+          role: user.role
         },
         unsafeMetadata: { 
           ...(clerkUser.unsafeMetadata as any), 

--- a/api/src/types/express.d.ts
+++ b/api/src/types/express.d.ts
@@ -2,6 +2,15 @@ declare global {
   namespace Express {
     interface Request {
       id: string;
+      clerk?: {
+        userId: string;
+      };
+      context?: {
+        userId: string;
+        appUserId: string;
+        clerkUserId?: string;
+        role?: string;
+      };
     }
   }
 }

--- a/api/src/upload/cloudflare-r2.service.ts
+++ b/api/src/upload/cloudflare-r2.service.ts
@@ -59,16 +59,16 @@ export class CloudflareR2Service {
     filename: string,
     mimeType: string,
     assetKind: AssetKind,
-    userId: string,
+    appUserId: string,
   ): Promise<PresignedUploadData> {
-    const key = this.generateStorageKey(filename, assetKind, userId);
+    const key = this.generateStorageKey(filename, assetKind, appUserId);
     
     const command = new PutObjectCommand({
       Bucket: this.bucketName,
       Key: key,
       ContentType: mimeType,
       Metadata: {
-        'uploaded-by': userId,
+        'uploaded-by': appUserId,
         'asset-kind': assetKind,
         'original-filename': filename,
       },
@@ -96,7 +96,7 @@ export class CloudflareR2Service {
   async uploadFile(
     file: Express.Multer.File,
     assetKind: AssetKind,
-    userId: string,
+    appUserId: string,
   ): Promise<UploadResult> {
     try {
       // Validate file first
@@ -107,7 +107,7 @@ export class CloudflareR2Service {
         throw new BadRequestException('File storage is not properly configured. Please contact administrator.');
       }
 
-      const key = this.generateStorageKey(file.originalname, assetKind, userId);
+      const key = this.generateStorageKey(file.originalname, assetKind, appUserId);
       
       const command = new PutObjectCommand({
         Bucket: this.bucketName,
@@ -115,7 +115,7 @@ export class CloudflareR2Service {
         Body: file.buffer,
         ContentType: file.mimetype,
         Metadata: {
-          'uploaded-by': userId,
+          'uploaded-by': appUserId,
           'asset-kind': assetKind,
           'original-filename': file.originalname,
         },
@@ -141,7 +141,7 @@ export class CloudflareR2Service {
         error: error.message,
         filename: file?.originalname,
         assetKind,
-        userId,
+        userId: appUserId,
         stack: error.stack,
       });
       
@@ -245,12 +245,11 @@ export class CloudflareR2Service {
   /**
    * Generate storage key for file organization
    */
-  private generateStorageKey(filename: string, assetKind: AssetKind, userId: string): string {
+  private generateStorageKey(filename: string, assetKind: AssetKind, appUserId: string): string {
     const timestamp = Date.now();
-    const extension = filename.split('.').pop()?.toLowerCase() || '';
     const sanitizedFilename = filename.replace(/[^a-zA-Z0-9.-]/g, '_');
-    
-    return `${assetKind.toLowerCase()}/${userId}/${timestamp}-${sanitizedFilename}`;
+
+    return `${assetKind.toLowerCase()}/${appUserId}/${timestamp}-${sanitizedFilename}`;
   }
 
   /**

--- a/api/src/upload/upload.controller.ts
+++ b/api/src/upload/upload.controller.ts
@@ -56,9 +56,13 @@ export class UploadController {
     @Request() req,
   ): Promise<PresignedUploadData> {
     const { filename, mimeType, assetKind } = presignedUploadDto;
-    const userId = req.context.userId;
+    const appUserId = req.context?.appUserId;
 
-    this.logger.log(`Generating presigned URL for user ${userId}: ${filename} (${assetKind})`);
+    if (!appUserId) {
+      throw new BadRequestException('Missing authenticated user');
+    }
+
+    this.logger.log(`Generating presigned URL for user ${appUserId}: ${filename} (${assetKind})`);
 
     try {
       // Validate file type and size
@@ -70,7 +74,7 @@ export class UploadController {
 
       this.r2Service.validateFile(mockFile, assetKind);
 
-      const result = await this.r2Service.generatePresignedUpload(filename, mimeType, assetKind, userId);
+      const result = await this.r2Service.generatePresignedUpload(filename, mimeType, assetKind, appUserId);
       
       this.logger.log(`Presigned URL generated successfully for ${filename}`);
       return result;
@@ -116,9 +120,13 @@ export class UploadController {
     }
 
     const { assetKind } = uploadFileDto;
-    const userId = req.context.userId;
+    const appUserId = req.context?.appUserId;
 
-    this.logger.log(`Uploading file for user ${userId}: ${file.originalname} (${assetKind}, ${file.size} bytes)`);
+    if (!appUserId) {
+      throw new BadRequestException('Missing authenticated user');
+    }
+
+    this.logger.log(`Uploading file for user ${appUserId}: ${file.originalname} (${assetKind}, ${file.size} bytes)`);
 
     try {
       // Validate file
@@ -131,7 +139,7 @@ export class UploadController {
       }
 
       // Upload to R2
-      const uploadResult = await this.r2Service.uploadFile(file, assetKind, userId);
+      const uploadResult = await this.r2Service.uploadFile(file, assetKind, appUserId);
 
       // Save to database
       const asset = await this.uploadService.createAsset({
@@ -141,7 +149,7 @@ export class UploadController {
         storageKey: uploadResult.key,
         mimeType: uploadResult.mimeType,
         size: uploadResult.size,
-        uploadedBy: userId,
+        uploadedById: appUserId,
       });
 
       this.logger.log(`File uploaded successfully: ${asset.id} (${uploadResult.key})`);
@@ -174,12 +182,16 @@ export class UploadController {
   @ApiResponse({ status: 404, description: 'Asset not found' })
   @ApiResponse({ status: 403, description: 'Access denied' })
   async getAsset(@Param('id') id: string, @Request() req) {
-    const userId = req.context.userId;
+    const appUserId = req.context?.appUserId;
 
-    this.logger.log(`Getting asset ${id} for user ${userId}`);
+    if (!appUserId) {
+      throw new BadRequestException('Missing authenticated user');
+    }
+
+    this.logger.log(`Getting asset ${id} for user ${appUserId}`);
 
     try {
-      const asset = await this.uploadService.getAsset(id, userId);
+      const asset = await this.uploadService.getAsset(id, appUserId);
 
       return {
         success: true,
@@ -207,13 +219,16 @@ export class UploadController {
     @Request() req,
     @Body() query: { kind?: AssetKind; limit?: number; offset?: number } = {},
   ) {
-    const userId = req.context.userId;
+    const appUserId = req.context?.appUserId;
+    if (!appUserId) {
+      throw new BadRequestException('Missing authenticated user');
+    }
     const { kind, limit = 50, offset = 0 } = query;
 
-    this.logger.log(`Getting assets for user ${userId} (kind: ${kind}, limit: ${limit}, offset: ${offset})`);
+    this.logger.log(`Getting assets for user ${appUserId} (kind: ${kind}, limit: ${limit}, offset: ${offset})`);
 
     try {
-      const assets = await this.uploadService.getUserAssets(userId, { kind, limit, offset });
+      const assets = await this.uploadService.getUserAssets(appUserId, { kind, limit, offset });
 
       return {
         success: true,
@@ -229,7 +244,7 @@ export class UploadController {
         total: assets.length,
       };
     } catch (error) {
-      this.logger.error(`Failed to get assets for user ${userId}:`, error);
+      this.logger.error(`Failed to get assets for user ${appUserId}:`, error);
       throw new HttpException('Failed to retrieve assets', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -240,19 +255,23 @@ export class UploadController {
   @ApiResponse({ status: 404, description: 'Asset not found' })
   @ApiResponse({ status: 403, description: 'Access denied' })
   async deleteAsset(@Param('id') id: string, @Request() req) {
-    const userId = req.context.userId;
+    const appUserId = req.context?.appUserId;
 
-    this.logger.log(`Deleting asset ${id} for user ${userId}`);
+    if (!appUserId) {
+      throw new BadRequestException('Missing authenticated user');
+    }
+
+    this.logger.log(`Deleting asset ${id} for user ${appUserId}`);
 
     try {
       // Get asset to verify ownership and get storage key
-      const asset = await this.uploadService.getAsset(id, userId);
+      const asset = await this.uploadService.getAsset(id, appUserId);
       
       // Delete from R2
       await this.r2Service.deleteFile(asset.storageKey);
       
       // Delete from database
-      await this.uploadService.deleteAsset(id, userId);
+      await this.uploadService.deleteAsset(id, appUserId);
 
       this.logger.log(`Asset deleted successfully: ${id}`);
 
@@ -272,13 +291,17 @@ export class UploadController {
   @ApiResponse({ status: 404, description: 'Asset not found' })
   @ApiResponse({ status: 403, description: 'Access denied' })
   async generateDownloadUrl(@Param('id') id: string, @Request() req) {
-    const userId = req.context.userId;
+    const appUserId = req.context?.appUserId;
 
-    this.logger.log(`Generating download URL for asset ${id} (user: ${userId})`);
+    if (!appUserId) {
+      throw new BadRequestException('Missing authenticated user');
+    }
+
+    this.logger.log(`Generating download URL for asset ${id} (user: ${appUserId})`);
 
     try {
       // Get asset to verify ownership
-      const asset = await this.uploadService.getAsset(id, userId);
+      const asset = await this.uploadService.getAsset(id, appUserId);
       
       // Generate presigned download URL
       const downloadUrl = await this.r2Service.generatePresignedDownloadUrl(asset.storageKey);
@@ -300,9 +323,13 @@ export class UploadController {
   @ApiResponse({ status: 200, description: 'Cleanup completed successfully' })
   @ApiResponse({ status: 403, description: 'Access denied' })
   async cleanupOrphanedFiles(@Request() req) {
-    const userId = req.context.userId;
+    const appUserId = req.context?.appUserId;
 
-    this.logger.log(`Starting orphaned files cleanup (initiated by user: ${userId})`);
+    if (!appUserId) {
+      throw new BadRequestException('Missing authenticated user');
+    }
+
+    this.logger.log(`Starting orphaned files cleanup (initiated by user: ${appUserId})`);
 
     try {
       const result = await this.uploadService.cleanupOrphanedFiles();

--- a/api/src/upload/upload.service.ts
+++ b/api/src/upload/upload.service.ts
@@ -10,7 +10,7 @@ export interface CreateAssetData {
   storageKey: string;
   mimeType: string;
   size: number;
-  uploadedBy: string;
+  uploadedById: string;
 }
 
 export interface GetAssetsOptions {
@@ -46,15 +46,15 @@ export class UploadService {
           storageKey: data.storageKey,
           mimeType: data.mimeType,
           size: data.size,
-          uploadedBy: data.uploadedBy,
+          uploadedById: data.uploadedById,
         },
         include: {
           uploader: {
             select: {
               id: true,
-              firstName: true,
-              lastName: true,
               email: true,
+              clerkId: true,
+              role: true,
             },
           },
         },
@@ -71,16 +71,16 @@ export class UploadService {
   /**
    * Get asset by ID with ownership verification
    */
-  async getAsset(assetId: string, userId: string) {
+  async getAsset(assetId: string, appUserId: string) {
     const asset = await this.prisma.asset.findUnique({
       where: { id: assetId },
       include: {
         uploader: {
           select: {
             id: true,
-            firstName: true,
-            lastName: true,
             email: true,
+            clerkId: true,
+            role: true,
           },
         },
       },
@@ -91,7 +91,7 @@ export class UploadService {
     }
 
     // Check ownership (user can only access their own assets unless admin)
-    if (asset.uploadedBy !== userId) {
+    if (asset.uploadedById !== appUserId) {
       // In a real implementation, you might want to check if user is admin here
       throw new ForbiddenException('Access denied');
     }
@@ -102,11 +102,11 @@ export class UploadService {
   /**
    * Get user's assets with optional filtering
    */
-  async getUserAssets(userId: string, options: GetAssetsOptions = {}) {
+  async getUserAssets(appUserId: string, options: GetAssetsOptions = {}) {
     const { kind, limit = 50, offset = 0 } = options;
 
     const where = {
-      uploadedBy: userId,
+      uploadedById: appUserId,
       ...(kind && { kind }),
     };
 
@@ -119,9 +119,9 @@ export class UploadService {
         uploader: {
           select: {
             id: true,
-            firstName: true,
-            lastName: true,
             email: true,
+            clerkId: true,
+            role: true,
           },
         },
       },
@@ -133,9 +133,9 @@ export class UploadService {
   /**
    * Delete asset from database and R2
    */
-  async deleteAsset(assetId: string, userId: string) {
+  async deleteAsset(assetId: string, appUserId: string) {
     // Get asset to verify ownership
-    const asset = await this.getAsset(assetId, userId);
+    const asset = await this.getAsset(assetId, appUserId);
 
     try {
       // Delete from database first
@@ -156,16 +156,16 @@ export class UploadService {
   /**
    * Update asset metadata
    */
-  async updateAsset(assetId: string, userId: string, updates: Partial<CreateAssetData>) {
+  async updateAsset(assetId: string, appUserId: string, updates: Partial<CreateAssetData>) {
     // Verify ownership
-    await this.getAsset(assetId, userId);
+    await this.getAsset(assetId, appUserId);
 
     const asset = await this.prisma.asset.update({
       where: { id: assetId },
       data: {
         ...updates,
         // Don't allow changing uploadedBy
-        uploadedBy: undefined,
+        uploadedById: undefined,
       },
     });
 
@@ -176,16 +176,16 @@ export class UploadService {
   /**
    * Get asset statistics for user
    */
-  async getAssetStats(userId: string) {
+  async getAssetStats(appUserId: string) {
     const stats = await this.prisma.asset.groupBy({
       by: ['kind'],
-      where: { uploadedBy: userId },
+      where: { uploadedById: appUserId },
       _count: { id: true },
       _sum: { size: true },
     });
 
     const totalSize = await this.prisma.asset.aggregate({
-      where: { uploadedBy: userId },
+      where: { uploadedById: appUserId },
       _sum: { size: true },
       _count: { id: true },
     });
@@ -271,11 +271,11 @@ export class UploadService {
   /**
    * Upload file and create asset record
    */
-  async uploadFile(file: Express.Multer.File, uploadedBy: string, kind: AssetKind) {
+  async uploadFile(file: Express.Multer.File, uploadedById: string, kind: AssetKind) {
     try {
       // Upload to R2
-      const uploadResult = await this.r2Service.uploadFile(file, kind, uploadedBy);
-      
+      const uploadResult = await this.r2Service.uploadFile(file, kind, uploadedById);
+
       // Create asset record
       const asset = await this.createAsset({
         kind,
@@ -284,7 +284,7 @@ export class UploadService {
         storageKey: uploadResult.key,
         mimeType: file.mimetype,
         size: file.size,
-        uploadedBy,
+        uploadedById,
       });
 
       return {
@@ -307,7 +307,7 @@ export class UploadService {
     userId: string,
   ) {
     // Verify asset ownership
-    const asset = await this.getAsset(assetId, userId);
+    await this.getAsset(assetId, userId);
 
     // Verify organization access (user should be part of the organization)
     const organization = await this.prisma.organization.findUnique({

--- a/api/src/webhooks/clerk-webhook.controller.ts
+++ b/api/src/webhooks/clerk-webhook.controller.ts
@@ -1,11 +1,10 @@
-import { 
-  Controller, 
-  Post, 
-  Req, 
-  Res, 
-  HttpCode, 
+import {
+  Controller,
+  Post,
+  Req,
+  Res,
+  HttpCode,
   Logger,
-  BadRequestException 
 } from '@nestjs/common';
 import { Webhook } from 'svix';
 import { Request, Response } from 'express';
@@ -117,7 +116,7 @@ export class ClerkWebhookController {
   }
 
   private async handleUserCreated(data: any) {
-    const clerkUserId: string = data.id;
+    const clerkId: string = data.id;
     
     // Check for intended role in private metadata (from invitation flow)
     // or unsafe metadata (from signup flow)
@@ -130,21 +129,48 @@ export class ClerkWebhookController {
     const validRole = this.isValidRole(intendedRole) ? intendedRole : 'PARENT';
     
     // Create user in our database
+    const primaryEmail = data.email_addresses?.[0]?.email_address || `${clerkId}@missing-email.local`;
+    const firstName = data.first_name || 'Unknown';
+    const lastName = data.last_name || 'User';
+
     const appUser = await this.prisma.appUser.upsert({
-      where: { clerkUserId },
-      create: { 
-        clerkUserId, 
+      where: { clerkId },
+      create: {
+        clerkId,
+        email: primaryEmail,
         role: validRole as UserRole,
       },
-      update: {}, // No-op if exists
+      update: {
+        role: validRole as UserRole,
+        email: primaryEmail,
+      },
+      select: { id: true, role: true },
+    });
+
+    await this.prisma.user.upsert({
+      where: { clerkId },
+      create: {
+        id: appUser.id,
+        clerkId,
+        email: primaryEmail,
+        firstName,
+        lastName,
+        role: validRole as UserRole,
+      },
+      update: {
+        email: primaryEmail,
+        firstName,
+        lastName,
+        role: validRole as UserRole,
+      },
     });
     
     // Sync role to Clerk public metadata
-    const clerkUser = await this.clerk.users.getUser(clerkUserId);
+    const clerkUser = await this.clerk.users.getUser(clerkId);
     const currentPublicRole = (clerkUser.publicMetadata as any)?.role;
     
     if (currentPublicRole !== appUser.role) {
-      await this.clerk.users.updateUser(clerkUserId, {
+      await this.clerk.users.updateUser(clerkId, {
         publicMetadata: { 
           ...(clerkUser.publicMetadata as any), 
           role: appUser.role 
@@ -156,58 +182,86 @@ export class ClerkWebhookController {
       });
     }
     
-    this.logger.log(`User created: ${clerkUserId} with role ${appUser.role}`);
+    this.logger.log(`User created: ${clerkId} with role ${appUser.role}`);
   }
 
   private async handleUserUpdated(data: any) {
-    const clerkUserId: string = data.id;
+    const clerkId: string = data.id;
     const unsafeRole = data.unsafe_metadata?.role;
     const publicRole = data.public_metadata?.role;
-    
+    const primaryEmail = data.email_addresses?.[0]?.email_address || `${clerkId}@missing-email.local`;
+    const firstName = data.first_name || 'Unknown';
+    const lastName = data.last_name || 'User';
+
     // Get user from our database (source of truth)
     const appUser = await this.prisma.appUser.findUnique({
-      where: { clerkUserId },
+      where: { clerkId },
     });
-    
+
     if (!appUser) {
       // User doesn't exist in our DB, create it
       await this.handleUserCreated(data);
       return;
     }
-    
+
+    await this.prisma.appUser.update({
+      where: { id: appUser.id },
+      data: { email: primaryEmail },
+    });
+
+    await this.prisma.user.update({
+      where: { clerkId },
+      data: {
+        email: primaryEmail,
+        firstName,
+        lastName,
+      },
+    }).catch(async () => {
+      await this.prisma.user.create({
+        data: {
+          id: appUser.id,
+          clerkId,
+          email: primaryEmail,
+          firstName,
+          lastName,
+          role: appUser.role,
+        },
+      });
+    });
+
     // If someone changed Clerk metadata outside our system, revert to DB truth
     if (publicRole && publicRole !== appUser.role) {
       this.logger.warn(
-        `Reverting unauthorized role change for ${clerkUserId}: ` +
+        `Reverting unauthorized role change for ${clerkId}: ` +
         `${publicRole} -> ${appUser.role}`
       );
-      
-      await this.clerk.users.updateUser(clerkUserId, {
-        publicMetadata: { 
-          ...(data.public_metadata ?? {}), 
-          role: appUser.role 
+
+      await this.clerk.users.updateUser(clerkId, {
+        publicMetadata: {
+          ...(data.public_metadata ?? {}),
+          role: appUser.role
         },
       });
     }
-    
+
     // Always scrub unsafe metadata role
     if (typeof unsafeRole !== 'undefined') {
-      await this.clerk.users.updateUser(clerkUserId, {
-        unsafeMetadata: { 
-          ...(data.unsafe_metadata ?? {}), 
-          role: undefined 
+      await this.clerk.users.updateUser(clerkId, {
+        unsafeMetadata: {
+          ...(data.unsafe_metadata ?? {}),
+          role: undefined
         },
       });
     }
   }
 
   private async handleUserDeleted(data: any) {
-    const clerkUserId: string = data.id;
+    const clerkId: string = data.id;
     
     // Soft delete or hard delete based on your requirements
     // For now, we'll keep the user but mark as deleted
     const appUser = await this.prisma.appUser.findUnique({
-      where: { clerkUserId },
+      where: { clerkId },
     });
     
     if (appUser) {
@@ -223,7 +277,7 @@ export class ClerkWebhookController {
       });
     }
     
-    this.logger.log(`User deleted: ${clerkUserId}`);
+    this.logger.log(`User deleted: ${clerkId}`);
   }
 
   private isValidRole(role: any): boolean {

--- a/api/test/auth/role-system.integration.spec.ts
+++ b/api/test/auth/role-system.integration.spec.ts
@@ -117,7 +117,7 @@ describe('Role System Integration Tests', () => {
       
       // Verify role changed in database
       const appUser = await prisma.appUser.findUnique({
-        where: { clerkUserId: targetUserId },
+        where: { clerkId: targetUserId },
         include: { roleHistory: { orderBy: { changedAt: 'desc' }, take: 1 } }
       });
       
@@ -178,7 +178,7 @@ describe('Role System Integration Tests', () => {
       
       // Simulate what the middleware would do
       let appUser = await prisma.appUser.findUnique({
-        where: { clerkUserId: newClerkUserId }
+        where: { clerkId: newClerkUserId }
       });
       
       expect(appUser).toBeNull();
@@ -186,7 +186,7 @@ describe('Role System Integration Tests', () => {
       // Create user
       appUser = await prisma.appUser.create({
         data: {
-          clerkUserId: newClerkUserId,
+          clerkId: newClerkUserId,
           role: UserRole.PARENT
         }
       });

--- a/api/test/auth/webhook.integration.spec.ts
+++ b/api/test/auth/webhook.integration.spec.ts
@@ -108,7 +108,7 @@ describe('Webhook Integration Tests', () => {
       
       // Verify user created
       const appUser = await prisma.appUser.findUnique({
-        where: { clerkUserId: userId }
+        where: { clerkId: userId }
       });
       
       expect(appUser).toBeTruthy();
@@ -117,6 +117,7 @@ describe('Webhook Integration Tests', () => {
       // Cleanup
       if (appUser) {
         await prisma.appUser.delete({ where: { id: appUser.id } });
+        await prisma.user.delete({ where: { clerkId: userId } }).catch(() => {});
       }
     });
 
@@ -149,7 +150,7 @@ describe('Webhook Integration Tests', () => {
       
       // Verify user created with default role
       const appUser = await prisma.appUser.findUnique({
-        where: { clerkUserId: userId }
+        where: { clerkId: userId }
       });
       
       expect(appUser).toBeTruthy();
@@ -158,6 +159,7 @@ describe('Webhook Integration Tests', () => {
       // Cleanup
       if (appUser) {
         await prisma.appUser.delete({ where: { id: appUser.id } });
+        await prisma.user.delete({ where: { clerkId: userId } }).catch(() => {});
       }
     });
   });
@@ -203,13 +205,14 @@ describe('Webhook Integration Tests', () => {
       
       // Verify only one user created
       const count = await prisma.appUser.count({
-        where: { clerkUserId: userId }
+        where: { clerkId: userId }
       });
       
       expect(count).toBe(1);
       
       // Cleanup
-      await prisma.appUser.deleteMany({ where: { clerkUserId: userId } });
+      await prisma.appUser.deleteMany({ where: { clerkId: userId } });
+      await prisma.user.deleteMany({ where: { clerkId: userId } });
     });
   });
 });

--- a/docs/DEPLOYMENT_VERIFICATION.md
+++ b/docs/DEPLOYMENT_VERIFICATION.md
@@ -136,7 +136,7 @@ curl -H "Authorization: Bearer ADMIN_TOKEN" \
 ### Migrate Existing Users:
 ```sql
 -- Insert missing users from users table to AppUser
-INSERT INTO "AppUser" ("id", "clerkUserId", "role", "createdAt", "updatedAt")
+INSERT INTO "AppUser" ("id", "clerkId", "role", "createdAt", "updatedAt")
 SELECT 
   gen_random_uuid(),
   u."clerkId",
@@ -144,7 +144,7 @@ SELECT
   u."createdAt",
   u."updatedAt"
 FROM users u
-LEFT JOIN "AppUser" au ON au."clerkUserId" = u."clerkId"
+LEFT JOIN "AppUser" au ON au."clerkId" = u."clerkId"
 WHERE au.id IS NULL;
 ```
 
@@ -154,7 +154,7 @@ WHERE au.id IS NULL;
 INSERT INTO "Outbox" ("topic", "payload", "createdAt")
 SELECT 
   'mirror.role',
-  jsonb_build_object('clerkUserId', "clerkUserId", 'role', "role"),
+  jsonb_build_object('clerkId', "clerkId", 'role', "role"),
   NOW()
 FROM "AppUser";
 ```
@@ -173,7 +173,7 @@ LIMIT 10;
 ```sql
 SELECT 
   h.*,
-  au."clerkUserId"
+  au."clerkId"
 FROM "AppUserRoleHistory" h
 JOIN "AppUser" au ON au.id = h."userId"
 ORDER BY h."changedAt" DESC
@@ -185,7 +185,7 @@ LIMIT 10;
 -- Users in old table not in new
 SELECT COUNT(*) as missing_migrations
 FROM users u
-LEFT JOIN "AppUser" au ON au."clerkUserId" = u."clerkId"
+LEFT JOIN "AppUser" au ON au."clerkId" = u."clerkId"
 WHERE au.id IS NULL;
 ```
 
@@ -204,7 +204,7 @@ SELECT 'Role Changes', COUNT(*)::text FROM "AppUserRoleHistory"
 UNION ALL
 SELECT 'Missing Migrations', COUNT(*)::text FROM (
   SELECT 1 FROM users u 
-  LEFT JOIN "AppUser" au ON au."clerkUserId" = u."clerkId" 
+  LEFT JOIN "AppUser" au ON au."clerkId" = u."clerkId"
   WHERE au.id IS NULL
 ) as missing;
 ```

--- a/docs/ROLE_SYSTEM_QUICK_REFERENCE.md
+++ b/docs/ROLE_SYSTEM_QUICK_REFERENCE.md
@@ -21,8 +21,8 @@ npm run test:auth
 - `GET /api/users/me` - Get current user info
 
 ### Role Management (Admin/Super Admin only)
-- `GET /api/admin/role-management/users/:clerkUserId` - Get user role and history
-- `PATCH /api/admin/role-management/users/:clerkUserId/role` - Change user role
+- `GET /api/admin/role-management/users/:clerkId` - Get user role and history
+- `PATCH /api/admin/role-management/users/:clerkId/role` - Change user role
 - `GET /api/admin/role-management/history` - Get all role changes
 
 ### Health Checks (Public)

--- a/docs/ROLE_SYSTEM_TESTING_PLAN.md
+++ b/docs/ROLE_SYSTEM_TESTING_PLAN.md
@@ -75,8 +75,8 @@ NODE_ENV=test
 ### Phase 4: Admin API Testing
 
 #### 4.1 Role Management Endpoints
-- [ ] Test GET /admin/role-management/users/:clerkUserId
-- [ ] Test PATCH /admin/role-management/users/:clerkUserId/role
+- [ ] Test GET /admin/role-management/users/:clerkId
+- [ ] Test PATCH /admin/role-management/users/:clerkId/role
 - [ ] Test GET /admin/role-management/history
 - [ ] Verify audit logging
 


### PR DESCRIPTION
## Summary
- re-point Asset ownership to AppUser records and add a migration that renames the foreign key column and captures AppUser emails
- update Clerk auth guard, middleware, and webhook handlers to resolve Prisma AppUser IDs, keep request context aligned, and sync legacy users including a backfill script
- refactor upload, content, and frontend branding flows to pass appUserId through Cloudflare uploads, services, and controllers while updating docs and tests accordingly

## Testing
- pnpm --filter api lint

------
https://chatgpt.com/codex/tasks/task_e_68d6d7e5f3108325979fda964660fe2a