### PR TITLE
Link courses to AppUser creator

### DIFF
--- a/api/prisma/migrations/20250927124803_course_creator_appuser/migration.sql
+++ b/api/prisma/migrations/20250927124803_course_creator_appuser/migration.sql
@@ -1,0 +1,6 @@
+-- DropForeignKey
+ALTER TABLE "public"."courses" DROP CONSTRAINT "courses_createdBy_fkey";
+
+-- AddForeignKey
+ALTER TABLE "public"."courses" ADD CONSTRAINT "courses_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "public"."AppUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -160,7 +160,6 @@ model User {
   certificates      Certificate[]
   courseDiscussions CourseDiscussion[]
   discussionReplies DiscussionReply[]
-  createdCourses    Course[]           @relation("CourseCreator")
 
   // Enhanced messaging relations
   conversations    ConversationParticipant[]
@@ -625,7 +624,7 @@ model Course {
 
   // Relations
   category     CourseCategory?    @relation(fields: [categoryId], references: [id], onDelete: SetNull)
-  creator      User               @relation("CourseCreator", fields: [createdBy], references: [id])
+  creator      AppUser            @relation("CourseCreator", fields: [createdBy], references: [id])
   modules      CourseModule[]
   enrollments  CourseEnrollment[]
   discussions  CourseDiscussion[]
@@ -1237,6 +1236,7 @@ model AppUser {
 
   assets      Asset[]   @relation("AssetUploadedBy")
   roleHistory AppUserRoleHistory[]
+  createdCourses Course[] @relation("CourseCreator")
 }
 
 model AppUserRoleHistory {

--- a/api/src/content/content.service.ts
+++ b/api/src/content/content.service.ts
@@ -170,8 +170,9 @@ export class ContentService {
           creator: {
             select: {
               id: true,
-              firstName: true,
-              lastName: true,
+              clerkId: true,
+              email: true,
+              role: true,
             },
           },
           modules: {

--- a/api/src/elearning/elearning.controller.ts
+++ b/api/src/elearning/elearning.controller.ts
@@ -30,7 +30,7 @@ export class ElearningController {
   @Post('courses')
   @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.EDUCATOR)
   createCourse(@Body() createCourseDto: CreateCourseDto, @Request() req) {
-    const createdBy = req.context.userId;
+    const createdBy = req.context.appUserId;
     return this.elearningService.createCourse(createCourseDto, createdBy);
   }
 

--- a/api/src/elearning/elearning.service.ts
+++ b/api/src/elearning/elearning.service.ts
@@ -12,7 +12,10 @@ export class ElearningService {
   constructor(private prisma: PrismaService) {}
 
   // Course Management
-  async createCourse(createCourseDto: CreateCourseDto, createdBy: string) {
+  async createCourse(
+    createCourseDto: CreateCourseDto,
+    createdByAppUserId: string,
+  ) {
     return this.prisma.course.create({
       data: {
         title: createCourseDto.title,
@@ -23,7 +26,7 @@ export class ElearningService {
         estimatedDuration: createCourseDto.estimatedDuration,
         thumbnailUrl: createCourseDto.thumbnailUrl,
         status: createCourseDto.status,
-        createdBy,
+        createdBy: createdByAppUserId,
       },
       include: {
         category: true,


### PR DESCRIPTION
## Summary
- repoint the course creator relation to AppUser and expose matching fields in the content service
- ensure course creation paths now supply AppUser identifiers when persisting
- add a migration to drop the old User foreign key and link courses to AppUser

## Testing
- attempted to run `npx prisma migrate dev --name course-app-user-relation --create-only` but it failed because no PostgreSQL service is available in the container


------
https://chatgpt.com/codex/tasks/task_e_68d7dc2a5918832584024bf1290b98f2