### PR TITLE
Wire dashboard backend to live Prisma models

### DIFF
--- a/api/src/admin/role-management/role-management.controller.ts
+++ b/api/src/admin/role-management/role-management.controller.ts
@@ -27,7 +27,7 @@ export class RoleManagementController {
   @Roles(UserRole.SUPER_ADMIN, UserRole.ADMIN)
   async getUserRole(@Param('clerkId') clerkId: string) {
     const appUser = await this.prisma.appUser.findUnique({
-      where: { clerkId },
+      where: { clerkUserId: clerkId },
       include: {
         roleHistory: {
           orderBy: { changedAt: 'desc' },
@@ -40,9 +40,19 @@ export class RoleManagementController {
       throw new BadRequestException('User not found');
     }
 
+    const normalizedHistory = appUser.roleHistory.map((history: any) => ({
+      ...history,
+      user: history.user
+        ? {
+            ...history.user,
+            clerkId: (history.user as any).clerkUserId,
+          }
+        : history.user,
+    }));
+
     return {
       currentRole: appUser.role,
-      roleHistory: appUser.roleHistory,
+      roleHistory: normalizedHistory,
     };
   }
 
@@ -68,14 +78,14 @@ export class RoleManagementController {
     await this.prisma.$transaction(async (tx) => {
       // Get or create user
       let appUser = await tx.appUser.findUnique({
-        where: { clerkId: targetClerkId },
+        where: { clerkUserId: targetClerkId },
       });
 
       if (!appUser) {
         // Create user if doesn't exist
         appUser = await tx.appUser.create({
           data: {
-            clerkId: targetClerkId,
+            clerkUserId: targetClerkId,
             role: dto.role,
           },
         });
@@ -131,7 +141,7 @@ export class RoleManagementController {
         include: {
           user: {
             select: {
-              clerkId: true,
+              clerkUserId: true,
             },
           },
         },
@@ -139,8 +149,18 @@ export class RoleManagementController {
       this.prisma.appUserRoleHistory.count(),
     ]);
 
+    const normalized = history.map((entry: any) => ({
+      ...entry,
+      user: entry.user
+        ? {
+            ...entry.user,
+            clerkId: entry.user.clerkUserId,
+          }
+        : entry.user,
+    }));
+
     return {
-      data: history,
+      data: normalized,
       total,
       limit: take,
       offset: skip,

--- a/api/src/auth/guards/clerk-auth.guard.ts
+++ b/api/src/auth/guards/clerk-auth.guard.ts
@@ -119,23 +119,40 @@ export class ClerkAuthGuard implements CanActivate {
 
       // Populate request.context (user role from AppUser), so RolesGuard can authorize
       try {
-        let appUser = await this.prisma.appUser.findUnique({ where: { clerkId: payload.sub } });
+        let appUser = await this.prisma.appUser.findUnique({ where: { clerkUserId: payload.sub } });
         if (!appUser) {
           if (this.authDebug) {
-             
+
             console.log('🔐 Auth Debug: AppUser missing, creating baseline user with PARENT role', { userId: payload.sub });
           }
           // Create a baseline user; admins can later promote via role management
           appUser = await this.prisma.appUser.create({
-            data: { clerkId: payload.sub, role: 'PARENT' },
+            data: { clerkUserId: payload.sub, role: 'PARENT' },
           });
         }
+        const domainUser = await this.prisma.user.upsert({
+          where: { clerkId: payload.sub },
+          create: {
+            id: appUser.id,
+            clerkId: payload.sub,
+            email: `${payload.sub}@pending.local`,
+            firstName: 'Unknown',
+            lastName: 'User',
+            role: appUser.role,
+          },
+          update: {
+            role: appUser.role,
+          },
+        });
+
         request.context = {
-          userId: payload.sub,
+          userId: domainUser.id,
           role: appUser.role,
           appUserId: appUser.id,
-          clerkUserId: payload.sub,
         };
+        if (payload.sub) {
+          (request.context as any).clerkUserId = payload.sub;
+        }
         if (this.authDebug) {
            
           console.log('🔐 Auth Debug: request.context populated', request.context);

--- a/api/src/auth/middleware/role-context.middleware.ts
+++ b/api/src/auth/middleware/role-context.middleware.ts
@@ -35,14 +35,14 @@ export class RoleContextMiddleware implements NestMiddleware {
     try {
       // Fetch user from AppUser table
       let appUser = await this.prisma.appUser.findUnique({
-        where: { clerkId: clerkUserId },
+        where: { clerkUserId },
       });
 
       if (!appUser) {
         // Self-heal: create baseline user
         appUser = await this.prisma.appUser.create({
           data: {
-            clerkId: clerkUserId,
+            clerkUserId,
             role: 'PARENT', // Safe default
           },
         });
@@ -56,12 +56,31 @@ export class RoleContextMiddleware implements NestMiddleware {
         });
       }
 
+      // Ensure domain user exists
+      const userRecord = await this.prisma.user.upsert({
+        where: { clerkId: clerkUserId },
+        create: {
+          id: appUser.id,
+          clerkId: clerkUserId,
+          email: `${clerkUserId}@pending.local`,
+          firstName: 'Unknown',
+          lastName: 'User',
+          role: appUser.role,
+        },
+        update: {
+          role: appUser.role,
+        },
+      });
+
       // Attach context to request
       req.context = {
-        userId: clerkUserId,
+        userId: userRecord.id,
         role: appUser.role,
         appUserId: appUser.id,
       };
+      if (clerkUserId) {
+        (req.context as any).clerkUserId = clerkUserId;
+      }
 
       next();
     } catch (error) {

--- a/api/src/content/content.service.ts
+++ b/api/src/content/content.service.ts
@@ -95,7 +95,7 @@ export class ContentService {
           storageKey: uploadResult.key,
           mimeType: file.mimetype,
           size: file.size,
-          uploadedById: appUserId,
+          uploadedBy: appUserId,
         },
       });
 
@@ -139,7 +139,7 @@ export class ContentService {
           storageKey: uploadResult.key,
           mimeType: file.mimetype,
           size: file.size,
-          uploadedById: appUserId,
+          uploadedBy: appUserId,
         },
       });
 

--- a/api/src/dashboard/dashboard.controller.ts
+++ b/api/src/dashboard/dashboard.controller.ts
@@ -206,6 +206,81 @@ export class DashboardController {
     };
   }
 
+  @Get('foundation/appointments')
+  @Roles(UserRole.FOUNDATION)
+  @ApiOperation({ summary: 'Get service requests and orders relevant to the foundation' })
+  @ApiResponse({ status: 200, description: 'Appointments retrieved successfully' })
+  async getFoundationAppointments(@Request() req) {
+    const userId = req.context.userId;
+
+    const userOrganizations = await this.prisma.userOrganization.findMany({
+      where: { userId },
+      include: { organization: true },
+    });
+
+    const organizationIds = userOrganizations.map((uo) => uo.organizationId);
+
+    if (organizationIds.length === 0) {
+      return {
+        success: true,
+        data: {
+          serviceRequests: [],
+          orders: [],
+        },
+      };
+    }
+
+    const [serviceRequests, orders] = await Promise.all([
+      this.prisma.serviceRequest.findMany({
+        where: {
+          organizationId: { in: organizationIds },
+        },
+        include: {
+          organization: true,
+          service: {
+            include: {
+              provider: {
+                include: {
+                  organization: true,
+                },
+              },
+            },
+          },
+        },
+        orderBy: [
+          { scheduledAt: 'asc' },
+          { createdAt: 'desc' },
+        ],
+      }),
+      this.prisma.order.findMany({
+        where: {
+          organizationId: { in: organizationIds },
+        },
+        include: {
+          organization: true,
+          items: {
+            include: {
+              product: {
+                include: {
+                  supplier: true,
+                },
+              },
+            },
+          },
+        },
+        orderBy: { createdAt: 'desc' },
+      }),
+    ]);
+
+    return {
+      success: true,
+      data: {
+        serviceRequests,
+        orders,
+      },
+    };
+  }
+
   @Get('educator/stats')
   @Roles(UserRole.EDUCATOR)
   @ApiOperation({ summary: 'Get educator dashboard stats' })

--- a/api/src/frontend-settings/frontend-settings.service.ts
+++ b/api/src/frontend-settings/frontend-settings.service.ts
@@ -116,9 +116,9 @@ export class FrontendSettingsService {
     return settings;
   }
 
-  async uploadLogo(file: Express.Multer.File, uploadedById: string) {
+  async uploadLogo(file: Express.Multer.File, uploadedBy: string) {
     // Use the existing upload service
-    const uploadResult = await this.uploadService.uploadFile(file, uploadedById, AssetKind.FRONTEND_LOGO);
+    const uploadResult = await this.uploadService.uploadFile(file, uploadedBy, AssetKind.FRONTEND_LOGO);
 
     // Update frontend settings with new logo
     const settings = await this.getSettings();
@@ -130,9 +130,9 @@ export class FrontendSettingsService {
     return uploadResult;
   }
 
-  async uploadFavicon(file: Express.Multer.File, uploadedById: string) {
+  async uploadFavicon(file: Express.Multer.File, uploadedBy: string) {
     // Use the existing upload service
-    const uploadResult = await this.uploadService.uploadFile(file, uploadedById, AssetKind.FRONTEND_FAVICON);
+    const uploadResult = await this.uploadService.uploadFile(file, uploadedBy, AssetKind.FRONTEND_FAVICON);
 
     // Update frontend settings with new favicon
     const settings = await this.getSettings();
@@ -144,9 +144,9 @@ export class FrontendSettingsService {
     return uploadResult;
   }
 
-  async uploadOgImage(file: Express.Multer.File, uploadedById: string) {
+  async uploadOgImage(file: Express.Multer.File, uploadedBy: string) {
     // Use the existing upload service
-    const uploadResult = await this.uploadService.uploadFile(file, uploadedById, AssetKind.FRONTEND_OG_IMAGE);
+    const uploadResult = await this.uploadService.uploadFile(file, uploadedBy, AssetKind.FRONTEND_OG_IMAGE);
 
     // Update frontend settings with new OG image
     const settings = await this.getSettings();
@@ -158,9 +158,9 @@ export class FrontendSettingsService {
     return uploadResult;
   }
 
-  async uploadAdminLogo(file: Express.Multer.File, uploadedById: string) {
+  async uploadAdminLogo(file: Express.Multer.File, uploadedBy: string) {
     // Use the existing upload service
-    const uploadResult = await this.uploadService.uploadFile(file, uploadedById, AssetKind.ADMIN_LOGO);
+    const uploadResult = await this.uploadService.uploadFile(file, uploadedBy, AssetKind.ADMIN_LOGO);
 
     // Update frontend settings with new admin logo
     const settings = await this.getSettings();
@@ -172,9 +172,9 @@ export class FrontendSettingsService {
     return uploadResult;
   }
 
-  async uploadAdminFavicon(file: Express.Multer.File, uploadedById: string) {
+  async uploadAdminFavicon(file: Express.Multer.File, uploadedBy: string) {
     // Use the existing upload service
-    const uploadResult = await this.uploadService.uploadFile(file, uploadedById, AssetKind.ADMIN_FAVICON);
+    const uploadResult = await this.uploadService.uploadFile(file, uploadedBy, AssetKind.ADMIN_FAVICON);
 
     // Update frontend settings with new admin favicon
     const settings = await this.getSettings();

--- a/api/src/health/health.controller.ts
+++ b/api/src/health/health.controller.ts
@@ -139,7 +139,7 @@ export class HealthController {
         this.prisma.appUser.findMany({
           take: 5,
           orderBy: { createdAt: 'desc' },
-          select: { id: true, clerkId: true, role: true, createdAt: true, email: true },
+          select: { id: true, clerkUserId: true, role: true, createdAt: true },
         }).catch(() => []),
         this.prisma.frontendSettings.findFirst({
           include: {
@@ -165,7 +165,10 @@ export class HealthController {
           },
           samples: {
             users,
-            appUsers,
+            appUsers: appUsers.map(appUser => ({
+              ...appUser,
+              clerkId: (appUser as any).clerkUserId,
+            })),
             frontendSettings: settings
               ? {
                   id: settings.id,
@@ -231,11 +234,15 @@ export class HealthController {
     const take = Math.min(Math.max(parseInt(limit || '20', 10) || 20, 1), 100);
     // @ts-ignore - model exists
     const appUsers = await this.prisma.appUser.findMany({
-      where: clerkId ? { clerkId } : {},
+      where: clerkId ? { clerkUserId: clerkId } : {},
       take,
       orderBy: { createdAt: 'desc' },
-      select: { id: true, clerkId: true, role: true, createdAt: true, email: true },
+      select: { id: true, clerkUserId: true, role: true, createdAt: true },
     });
-    return { success: true, data: appUsers, count: appUsers.length, timestamp: new Date().toISOString() };
+    const transformed = appUsers.map(user => ({
+      ...user,
+      clerkId: user.clerkUserId,
+    }));
+    return { success: true, data: transformed, count: transformed.length, timestamp: new Date().toISOString() };
   }
 }

--- a/api/src/mock-database.service.ts
+++ b/api/src/mock-database.service.ts
@@ -25,7 +25,7 @@ export interface MockAsset {
   mimeType: string;
   size: number;
   kind: string;
-  uploadedById: string;
+  uploadedBy: string;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/api/src/mock-frontend-settings.service.ts
+++ b/api/src/mock-frontend-settings.service.ts
@@ -24,7 +24,7 @@ export interface UploadResult {
     mimeType: string;
     size: number;
     kind: string;
-    uploadedById: string;
+    uploadedBy: string;
     createdAt: Date;
     updatedAt: Date;
   };
@@ -63,7 +63,7 @@ export class MockFrontendSettingsService {
     return await this.mockDb.updateFrontendSettings(updates);
   }
 
-  async uploadLogo(file: Express.Multer.File, uploadedById: string): Promise<UploadResult> {
+  async uploadLogo(file: Express.Multer.File, uploadedBy: string): Promise<UploadResult> {
     this.logger.log('Uploading logo', { filename: file.originalname, size: file.size });
     
     const asset = await this.mockDb.createAsset({
@@ -72,7 +72,7 @@ export class MockFrontendSettingsService {
       mimeType: file.mimetype,
       size: file.size,
       kind: 'FRONTEND_LOGO',
-      uploadedById,
+      uploadedBy,
     });
 
     const publicUrl = `https://mock-assets.pc-solutions.com/${asset.filename}`;
@@ -83,7 +83,7 @@ export class MockFrontendSettingsService {
     return { asset, publicUrl };
   }
 
-  async uploadFavicon(file: Express.Multer.File, uploadedById: string): Promise<UploadResult> {
+  async uploadFavicon(file: Express.Multer.File, uploadedBy: string): Promise<UploadResult> {
     this.logger.log('Uploading favicon', { filename: file.originalname, size: file.size });
     
     const asset = await this.mockDb.createAsset({
@@ -92,7 +92,7 @@ export class MockFrontendSettingsService {
       mimeType: file.mimetype,
       size: file.size,
       kind: 'FRONTEND_FAVICON',
-      uploadedById,
+      uploadedBy,
     });
 
     const publicUrl = `https://mock-assets.pc-solutions.com/${asset.filename}`;
@@ -103,7 +103,7 @@ export class MockFrontendSettingsService {
     return { asset, publicUrl };
   }
 
-  async uploadOgImage(file: Express.Multer.File, uploadedById: string): Promise<UploadResult> {
+  async uploadOgImage(file: Express.Multer.File, uploadedBy: string): Promise<UploadResult> {
     this.logger.log('Uploading OG image', { filename: file.originalname, size: file.size });
     
     const asset = await this.mockDb.createAsset({
@@ -112,7 +112,7 @@ export class MockFrontendSettingsService {
       mimeType: file.mimetype,
       size: file.size,
       kind: 'FRONTEND_OG_IMAGE',
-      uploadedById,
+      uploadedBy,
     });
 
     const publicUrl = `https://mock-assets.pc-solutions.com/${asset.filename}`;
@@ -123,7 +123,7 @@ export class MockFrontendSettingsService {
     return { asset, publicUrl };
   }
 
-  async uploadAdminLogo(file: Express.Multer.File, uploadedById: string): Promise<UploadResult> {
+  async uploadAdminLogo(file: Express.Multer.File, uploadedBy: string): Promise<UploadResult> {
     this.logger.log('Uploading admin logo', { filename: file.originalname, size: file.size });
     
     const asset = await this.mockDb.createAsset({
@@ -132,7 +132,7 @@ export class MockFrontendSettingsService {
       mimeType: file.mimetype,
       size: file.size,
       kind: 'ADMIN_LOGO',
-      uploadedById,
+      uploadedBy,
     });
 
     const publicUrl = `https://mock-assets.pc-solutions.com/${asset.filename}`;
@@ -143,7 +143,7 @@ export class MockFrontendSettingsService {
     return { asset, publicUrl };
   }
 
-  async uploadAdminFavicon(file: Express.Multer.File, uploadedById: string): Promise<UploadResult> {
+  async uploadAdminFavicon(file: Express.Multer.File, uploadedBy: string): Promise<UploadResult> {
     this.logger.log('Uploading admin favicon', { filename: file.originalname, size: file.size });
     
     const asset = await this.mockDb.createAsset({
@@ -152,7 +152,7 @@ export class MockFrontendSettingsService {
       mimeType: file.mimetype,
       size: file.size,
       kind: 'ADMIN_FAVICON',
-      uploadedById,
+      uploadedBy,
     });
 
     const publicUrl = `https://mock-assets.pc-solutions.com/${asset.filename}`;

--- a/api/src/profiles/profiles.controller.ts
+++ b/api/src/profiles/profiles.controller.ts
@@ -69,21 +69,9 @@ export class ProfileController {
   @ApiResponse({ status: 200, description: 'Profile retrieved successfully' })
   async getMyProfile(@Request() req) {
     const userId = req.context.userId;
-    
-    const user = await this.prisma.user.findUnique({
-      where: { id: userId },
-      include: {
-        organizations: {
-          include: {
-            organization: true
-          }
-        }
-      }
-    });
+    const clerkUserId = req.context?.clerkUserId;
 
-    if (!user) {
-      throw new Error('User not found');
-    }
+    const user = await this.ensureDomainUser(userId, clerkUserId, req.context?.role);
 
     return {
       success: true,
@@ -91,12 +79,67 @@ export class ProfileController {
     };
   }
 
+  private async ensureDomainUser(
+    userId: string,
+    clerkUserId?: string,
+    role?: UserRole,
+  ) {
+    const include = {
+      organizations: {
+        include: {
+          organization: {
+            include: {
+              members: {
+                include: {
+                  user: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    } as const;
+
+    let user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      include,
+    });
+
+    if (!user && clerkUserId) {
+      user = await this.prisma.user.findUnique({
+        where: { clerkId: clerkUserId },
+        include,
+      });
+    }
+
+    if (!user && clerkUserId) {
+      user = await this.prisma.user.create({
+        data: {
+          id: userId,
+          clerkId: clerkUserId,
+          email: `${clerkUserId}@pending.local`,
+          firstName: 'Unknown',
+          lastName: 'User',
+          role: role ?? UserRole.PARENT,
+        },
+        include,
+      });
+    }
+
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    return user;
+  }
+
   @Put('me')
   @ApiOperation({ summary: 'Update current user profile' })
   @ApiResponse({ status: 200, description: 'Profile updated successfully' })
   async updateMyProfile(@Request() req, @Body() updateData: UpdateProfileDto) {
     const userId = req.context.userId;
-    
+    await this.ensureDomainUser(userId, req.context?.clerkUserId, req.context?.role);
+
     // Update user basic info
     const updatedUser = await this.prisma.user.update({
       where: { id: userId },
@@ -156,12 +199,21 @@ export class ProfileController {
   @ApiResponse({ status: 200, description: 'Organizations retrieved successfully' })
   async getMyOrganizations(@Request() req) {
     const userId = req.context.userId;
-    
+    await this.ensureDomainUser(userId, req.context?.clerkUserId, req.context?.role);
+
     const organizations = await this.prisma.userOrganization.findMany({
       where: { userId },
       include: {
-        organization: true
-      }
+        organization: {
+          include: {
+            members: {
+              include: {
+                user: true,
+              },
+            },
+          },
+        },
+      },
     });
 
     return {
@@ -170,12 +222,38 @@ export class ProfileController {
     };
   }
 
+  @Get('support/contacts')
+  @ApiOperation({ summary: 'List admin and super admin contacts for support' })
+  @ApiResponse({ status: 200, description: 'Support contacts retrieved successfully' })
+  async getSupportContacts() {
+    const admins = await this.prisma.user.findMany({
+      where: {
+        role: {
+          in: [UserRole.ADMIN, UserRole.SUPER_ADMIN],
+        },
+      },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        email: true,
+      },
+      orderBy: [{ firstName: 'asc' }, { lastName: 'asc' }],
+    });
+
+    return {
+      success: true,
+      data: admins,
+    };
+  }
+
   @Post('me/organizations')
   @ApiOperation({ summary: 'Create new organization for user' })
   @ApiResponse({ status: 201, description: 'Organization created successfully' })
   async createOrganization(@Request() req, @Body() organizationData: CreateOrganizationDto) {
     const userId = req.context.userId;
-    
+    await this.ensureDomainUser(userId, req.context?.clerkUserId, req.context?.role);
+
     // Create organization
     const organization = await this.prisma.organization.create({
       data: {
@@ -220,7 +298,8 @@ export class ProfileController {
   @ApiResponse({ status: 200, description: 'Parent leads retrieved successfully' })
   async getMyParentLeads(@Request() req) {
     const userId = req.context.userId;
-    
+    await this.ensureDomainUser(userId, req.context?.clerkUserId, req.context?.role);
+
     // Get user's organizations
     const userOrganizations = await this.prisma.userOrganization.findMany({
       where: { userId },
@@ -249,6 +328,7 @@ export class ProfileController {
   @ApiResponse({ status: 200, description: 'Parent lead updated successfully' })
   async updateParentLead(@Request() req, @Param('leadId') leadId: string, @Body() updateData: { status: string }) {
     const userId = req.context.userId;
+    await this.ensureDomainUser(userId, req.context?.clerkUserId, req.context?.role);
     
     // Verify user has access to this lead
     const userOrganizations = await this.prisma.userOrganization.findMany({

--- a/api/src/sync/reconcile.service.ts
+++ b/api/src/sync/reconcile.service.ts
@@ -42,17 +42,17 @@ export class ReconcileService {
       
       for (const user of users) {
         try {
-          await this.reconcileUser(user);
+          await this.reconcileUser({ clerkUserId: user.clerkUserId, role: user.role });
         } catch (error) {
           this.logger.error(
-            `Failed to reconcile user ${user.clerkId}: ${error?.message || error}`,
+            `Failed to reconcile user ${user.clerkUserId}: ${error?.message || error}`,
           );
 
           // Could enqueue to outbox for retry
           await this.prisma.outbox.create({
             data: {
               topic: 'mirror.role',
-              payload: { clerkUserId: user.clerkId, role: user.role },
+              payload: { clerkUserId: user.clerkUserId, role: user.role },
             },
           }).catch(() => {}); // Best effort
         }
@@ -65,18 +65,18 @@ export class ReconcileService {
     this.logger.log(`Reconciliation complete. Processed ${processed} users`);
   }
 
-  private async reconcileUser(user: { clerkId: string; role: string }) {
-    const clerkUser = await this.clerk.users.getUser(user.clerkId);
+  private async reconcileUser(user: { clerkUserId: string; role: string }) {
+    const clerkUser = await this.clerk.users.getUser(user.clerkUserId);
     const publicRole = (clerkUser.publicMetadata as any)?.role;
 
     if (publicRole !== user.role) {
       this.logger.log(
-        `Reconciling role mismatch for ${user.clerkId}: ` +
+        `Reconciling role mismatch for ${user.clerkUserId}: ` +
         `Clerk=${publicRole}, DB=${user.role}`
       );
 
       // Update Clerk to match DB (DB is source of truth)
-      await this.clerk.users.updateUser(user.clerkId, {
+      await this.clerk.users.updateUser(user.clerkUserId, {
         publicMetadata: {
           ...(clerkUser.publicMetadata as any),
           role: user.role

--- a/api/src/upload/upload.controller.ts
+++ b/api/src/upload/upload.controller.ts
@@ -155,7 +155,7 @@ export class UploadController {
         storageKey: uploadResult.key,
         mimeType: uploadResult.mimeType,
         size: uploadResult.size,
-        uploadedById: appUserId,
+        uploadedBy: appUserId,
       });
 
       this.logger.log(`File uploaded successfully: ${asset.id} (${uploadResult.key})`);

--- a/api/src/upload/upload.service.ts
+++ b/api/src/upload/upload.service.ts
@@ -10,7 +10,7 @@ export interface CreateAssetData {
   storageKey: string;
   mimeType: string;
   size: number;
-  uploadedById: string;
+  uploadedBy: string;
 }
 
 export interface GetAssetsOptions {
@@ -46,14 +46,14 @@ export class UploadService {
           storageKey: data.storageKey,
           mimeType: data.mimeType,
           size: data.size,
-          uploadedById: data.uploadedById,
+          uploadedBy: data.uploadedBy,
         },
         include: {
           uploader: {
             select: {
               id: true,
-              email: true,
               clerkId: true,
+              email: true,
               role: true,
             },
           },
@@ -78,8 +78,8 @@ export class UploadService {
         uploader: {
           select: {
             id: true,
-            email: true,
             clerkId: true,
+            email: true,
             role: true,
           },
         },
@@ -91,7 +91,7 @@ export class UploadService {
     }
 
     // Check ownership (user can only access their own assets unless admin)
-    if (asset.uploadedById !== appUserId) {
+    if (asset.uploadedBy !== appUserId) {
       // In a real implementation, you might want to check if user is admin here
       throw new ForbiddenException('Access denied');
     }
@@ -106,7 +106,7 @@ export class UploadService {
     const { kind, limit = 50, offset = 0 } = options;
 
     const where = {
-      uploadedById: appUserId,
+      uploadedBy: appUserId,
       ...(kind && { kind }),
     };
 
@@ -119,8 +119,8 @@ export class UploadService {
         uploader: {
           select: {
             id: true,
-            email: true,
             clerkId: true,
+            email: true,
             role: true,
           },
         },
@@ -165,7 +165,7 @@ export class UploadService {
       data: {
         ...updates,
         // Don't allow changing uploadedBy
-        uploadedById: undefined,
+        uploadedBy: undefined,
       },
     });
 
@@ -179,13 +179,13 @@ export class UploadService {
   async getAssetStats(appUserId: string) {
     const stats = await this.prisma.asset.groupBy({
       by: ['kind'],
-      where: { uploadedById: appUserId },
+      where: { uploadedBy: appUserId },
       _count: { id: true },
       _sum: { size: true },
     });
 
     const totalSize = await this.prisma.asset.aggregate({
-      where: { uploadedById: appUserId },
+      where: { uploadedBy: appUserId },
       _sum: { size: true },
       _count: { id: true },
     });
@@ -271,10 +271,10 @@ export class UploadService {
   /**
    * Upload file and create asset record
    */
-  async uploadFile(file: Express.Multer.File, uploadedById: string, kind: AssetKind) {
+  async uploadFile(file: Express.Multer.File, uploadedBy: string, kind: AssetKind) {
     try {
       // Upload to R2
-      const uploadResult = await this.r2Service.uploadFile(file, kind, uploadedById);
+      const uploadResult = await this.r2Service.uploadFile(file, kind, uploadedBy);
 
       // Create asset record
       const asset = await this.createAsset({
@@ -284,7 +284,7 @@ export class UploadService {
         storageKey: uploadResult.key,
         mimeType: file.mimetype,
         size: file.size,
-        uploadedById,
+        uploadedBy,
       });
 
       return {

--- a/api/src/webhooks/clerk-webhook.controller.ts
+++ b/api/src/webhooks/clerk-webhook.controller.ts
@@ -134,17 +134,15 @@ export class ClerkWebhookController {
     const lastName = data.last_name || 'User';
 
     const appUser = await this.prisma.appUser.upsert({
-      where: { clerkId },
+      where: { clerkUserId: clerkId },
       create: {
-        clerkId,
-        email: primaryEmail,
+        clerkUserId: clerkId,
         role: validRole as UserRole,
       },
       update: {
         role: validRole as UserRole,
-        email: primaryEmail,
       },
-      select: { id: true, role: true },
+      select: { id: true, role: true, clerkUserId: true },
     });
 
     await this.prisma.user.upsert({
@@ -195,7 +193,7 @@ export class ClerkWebhookController {
 
     // Get user from our database (source of truth)
     const appUser = await this.prisma.appUser.findUnique({
-      where: { clerkId },
+      where: { clerkUserId: clerkId },
     });
 
     if (!appUser) {
@@ -203,11 +201,6 @@ export class ClerkWebhookController {
       await this.handleUserCreated(data);
       return;
     }
-
-    await this.prisma.appUser.update({
-      where: { id: appUser.id },
-      data: { email: primaryEmail },
-    });
 
     await this.prisma.user.update({
       where: { clerkId },
@@ -261,7 +254,7 @@ export class ClerkWebhookController {
     // Soft delete or hard delete based on your requirements
     // For now, we'll keep the user but mark as deleted
     const appUser = await this.prisma.appUser.findUnique({
-      where: { clerkId },
+      where: { clerkUserId: clerkId },
     });
     
     if (appUser) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,11 @@ import ParentLeadFormPage from './pages/ParentLeadFormPage';
 import RecruitmentPage from './pages/RecruitmentPage';
 import HRProceduresPage from './pages/HRProceduresPage';
 import StatePoliciesPage from './pages/StatePoliciesPage';
+import FoundationLeadsPage from './pages/foundation/FoundationLeadsPage';
+import FoundationAppointmentsPage from './pages/foundation/FoundationAppointmentsPage';
+import FoundationAnalyticsPage from './pages/foundation/FoundationAnalyticsPage';
+import FoundationOrganisationProfilePage from './pages/foundation/FoundationOrganisationProfilePage';
+import FoundationSupportPage from './pages/foundation/FoundationSupportPage';
 
 function App() {
   console.log('App component rendering');
@@ -95,27 +100,27 @@ function App() {
       } />
       <Route path="/foundation/leads" element={
         <ProtectedRoute>
-          <div>Foundation Leads Page</div>
+          <FoundationLeadsPage />
         </ProtectedRoute>
       } />
       <Route path="/foundation/orders-appointments" element={
         <ProtectedRoute>
-          <div>Foundation Orders and Appointments Page</div>
+          <FoundationAppointmentsPage />
         </ProtectedRoute>
       } />
       <Route path="/foundation/analytics" element={
         <ProtectedRoute>
-          <div>Foundation Analytics Page</div>
+          <FoundationAnalyticsPage />
         </ProtectedRoute>
       } />
       <Route path="/foundation/organisation-profile" element={
         <ProtectedRoute>
-          <div>Foundation Organisation Profile Page</div>
+          <FoundationOrganisationProfilePage />
         </ProtectedRoute>
       } />
       <Route path="/foundation/support" element={
         <ProtectedRoute>
-          <div>Foundation Support Page</div>
+          <FoundationSupportPage />
         </ProtectedRoute>
       } />
       

--- a/frontend/src/components/dashboard/FoundationDashboardLayout.tsx
+++ b/frontend/src/components/dashboard/FoundationDashboardLayout.tsx
@@ -1,0 +1,346 @@
+import React, { ReactNode, useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useClerk, useUser } from '@clerk/clerk-react';
+import {
+  HomeIcon,
+  UsersIcon,
+  ChartBarIcon,
+  ShoppingBagIcon,
+  AcademicCapIcon,
+  BriefcaseIcon,
+  InboxIcon,
+  Cog6ToothIcon,
+  LifebuoyIcon,
+  DocumentDuplicateIcon,
+  ChatBubbleLeftRightIcon,
+  BuildingStorefrontIcon,
+  CalendarDaysIcon,
+  ArrowRightOnRectangleIcon,
+  EnvelopeOpenIcon,
+  Bars3Icon,
+  XMarkIcon,
+  MagnifyingGlassIcon,
+} from '@heroicons/react/24/outline';
+import Card from '../ui/Card';
+import Button from '../ui/Button';
+
+interface NavItem {
+  label: string;
+  path: string;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  external?: boolean;
+}
+
+interface NavSection {
+  title: string;
+  items: NavItem[];
+}
+
+interface FoundationDashboardLayoutProps {
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+}
+
+const navSections: NavSection[] = [
+  {
+    title: 'Overview',
+    items: [
+      { label: 'Dashboard', path: '/foundation/dashboard', icon: HomeIcon },
+      { label: 'Participants', path: '/foundation/leads', icon: UsersIcon },
+      { label: 'Appointments', path: '/foundation/orders-appointments', icon: CalendarDaysIcon },
+      { label: 'Analytics', path: '/foundation/analytics', icon: ChartBarIcon },
+    ],
+  },
+  {
+    title: 'Operations',
+    items: [
+      { label: 'Marketplace', path: '/marketplace', icon: BuildingStorefrontIcon },
+      { label: 'Recruitment', path: '/recruitment', icon: BriefcaseIcon },
+      { label: 'E-Learning', path: '/e-learning', icon: AcademicCapIcon },
+      { label: 'Resources', path: '/file-gallery', icon: DocumentDuplicateIcon },
+    ],
+  },
+  {
+    title: 'Communication',
+    items: [
+      { label: 'Messages', path: '/messages', icon: ChatBubbleLeftRightIcon },
+      { label: 'Marketplace Inbox', path: '/marketplace', icon: InboxIcon },
+      { label: 'Support', path: '/foundation/support', icon: LifebuoyIcon },
+    ],
+  },
+  {
+    title: 'Administration',
+    items: [
+      { label: 'Billing', path: '/billing/settings', icon: ShoppingBagIcon },
+      { label: 'Organisation Profile', path: '/foundation/organisation-profile', icon: Cog6ToothIcon },
+      { label: 'Settings', path: '/settings', icon: Cog6ToothIcon },
+    ],
+  },
+];
+
+const FoundationDashboardLayout: React.FC<FoundationDashboardLayoutProps> = ({
+  title,
+  subtitle,
+  children,
+}) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { signOut } = useClerk();
+  const { user } = useUser();
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+
+  const handleNavigation = (item: NavItem) => {
+    if (item.external) {
+      window.open(item.path, '_blank');
+      return;
+    }
+
+    setMobileNavOpen(false);
+    navigate(item.path);
+  };
+
+  const initials = user?.fullName
+    ? user.fullName
+        .split(' ')
+        .map((part) => part.charAt(0))
+        .join('')
+        .slice(0, 2)
+    : user?.emailAddresses?.[0]?.emailAddress?.charAt(0) ?? 'U';
+
+  const activePath = location.pathname;
+
+  const renderNavItems = () => (
+    <nav className="flex-1 space-y-6 overflow-y-auto">
+      {navSections.map((section) => (
+        <div key={section.title}>
+          <p className="px-2 text-xs font-semibold uppercase tracking-wide text-gray-400">
+            {section.title}
+          </p>
+          <ul className="mt-2 space-y-1">
+            {section.items.map((item) => {
+              const isActive = activePath === item.path || activePath.startsWith(`${item.path}/`);
+              const ItemIcon = item.icon;
+
+              return (
+                <li key={item.label}>
+                  <button
+                    type="button"
+                    onClick={() => handleNavigation(item)}
+                    className={`flex w-full items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-swiss-mint/70 ${
+                      isActive
+                        ? 'bg-swiss-mint/10 text-swiss-teal'
+                        : 'text-gray-600 hover:bg-gray-50 hover:text-swiss-teal'
+                    }`}
+                  >
+                    <ItemIcon className="h-5 w-5" />
+                    <span>{item.label}</span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+    </nav>
+  );
+
+  const signOutUser = async () => {
+    await signOut();
+    navigate('/login');
+  };
+
+  return (
+    <div className="min-h-screen bg-page-bg text-swiss-charcoal">
+      <div className="flex min-h-screen">
+        {/* Desktop Sidebar */}
+        <aside className="hidden w-72 flex-col border-r border-gray-200 bg-white p-6 lg:flex">
+          <div className="flex items-center gap-3 pb-6">
+            <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-swiss-mint text-white font-semibold">
+              PC
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-gray-500">Pro Crèche Solutions</p>
+              <p className="text-lg font-bold text-swiss-charcoal">Foundation</p>
+            </div>
+          </div>
+
+          {renderNavItems()}
+
+          <div className="mt-6">
+            <Card className="p-4 bg-gradient-to-br from-swiss-mint/10 via-white to-swiss-mint/5 border border-swiss-mint/20">
+              <p className="text-sm font-medium text-swiss-charcoal">Astrid, you're on</p>
+              <p className="mt-1 text-lg font-semibold text-swiss-teal">Premium Plan</p>
+              <p className="mt-2 text-xs text-gray-500">Manage billing and usage</p>
+              <Button
+                variant="primary"
+                size="sm"
+                className="mt-4 w-full"
+                onClick={() => navigate('/billing/settings')}
+              >
+                Manage Plan
+              </Button>
+            </Card>
+          </div>
+
+          <div className="mt-6 flex items-center justify-between rounded-xl bg-gray-50 p-4 text-sm">
+            <div>
+              <p className="font-semibold">{user?.fullName || user?.emailAddresses?.[0]?.emailAddress}</p>
+              <p className="text-xs text-gray-500">{user?.publicMetadata?.role || 'Foundation Admin'}</p>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="px-2 text-gray-500 hover:text-swiss-coral"
+              onClick={signOutUser}
+            >
+              <ArrowRightOnRectangleIcon className="h-5 w-5" />
+            </Button>
+          </div>
+        </aside>
+
+        {/* Mobile sidebar */}
+        <div className="lg:hidden">
+          <div
+            className={`fixed inset-0 z-40 bg-black/20 backdrop-blur-sm transition-opacity ${
+              mobileNavOpen ? 'opacity-100 visible' : 'invisible opacity-0'
+            }`}
+            onClick={() => setMobileNavOpen(false)}
+          />
+          <aside
+            className={`fixed inset-y-0 left-0 z-50 w-72 transform bg-white p-6 shadow-xl transition-transform duration-200 ${
+              mobileNavOpen ? 'translate-x-0' : '-translate-x-full'
+            }`}
+          >
+            <div className="flex items-center justify-between pb-6">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">Pro Crèche Solutions</p>
+                <p className="text-lg font-bold text-swiss-charcoal">Foundation</p>
+              </div>
+              <button
+                type="button"
+                className="rounded-full p-2 text-gray-400 hover:bg-gray-100"
+                onClick={() => setMobileNavOpen(false)}
+              >
+                <XMarkIcon className="h-5 w-5" />
+              </button>
+            </div>
+            {renderNavItems()}
+            <div className="mt-6 space-y-4 text-sm">
+              <Button className="w-full" onClick={() => navigate('/billing/settings')}>
+                Manage Plan
+              </Button>
+              <button
+                type="button"
+                onClick={signOutUser}
+                className="flex w-full items-center justify-center gap-2 rounded-lg border border-red-200 px-3 py-2 text-red-600"
+              >
+                <ArrowRightOnRectangleIcon className="h-5 w-5" />
+                Sign out
+              </button>
+            </div>
+          </aside>
+        </div>
+
+        {/* Main content */}
+        <div className="flex flex-1 flex-col">
+          <header className="sticky top-0 z-30 border-b border-gray-200 bg-white/90 backdrop-blur">
+            <div className="flex items-center gap-4 px-4 py-4 sm:px-6 lg:px-8">
+              <button
+                type="button"
+                className="rounded-xl border border-gray-200 p-2 text-gray-500 transition-colors hover:border-swiss-mint hover:text-swiss-teal lg:hidden"
+                onClick={() => setMobileNavOpen(true)}
+              >
+                <Bars3Icon className="h-5 w-5" />
+              </button>
+              <div className="hidden flex-1 items-center gap-3 rounded-full border border-gray-200 bg-white px-4 py-2 text-sm text-gray-500 md:flex">
+                <MagnifyingGlassIcon className="h-5 w-5 text-gray-400" />
+                <input
+                  type="search"
+                  placeholder="Search the platform..."
+                  className="w-full border-0 bg-transparent p-0 text-sm focus:outline-none"
+                />
+              </div>
+              <div className="flex flex-1 items-center justify-end gap-2">
+                <span className="hidden rounded-full border border-swiss-mint/50 bg-swiss-mint/10 px-3 py-1 text-xs font-medium text-swiss-teal sm:inline-flex">
+                  Foundation Workspace
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="hidden items-center gap-2 text-swiss-teal hover:text-swiss-mint md:inline-flex"
+                  onClick={() => navigate('/recruitment')}
+                >
+                  <BriefcaseIcon className="h-4 w-4" />
+                  New Posting
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="hidden items-center gap-2 text-swiss-teal hover:text-swiss-mint md:inline-flex"
+                  onClick={() => navigate('/messages')}
+                >
+                  <EnvelopeOpenIcon className="h-4 w-4" />
+                  Message Centre
+                </Button>
+                <button
+                  type="button"
+                  className="rounded-full p-2 text-gray-500 transition-colors hover:bg-gray-100 hover:text-swiss-teal"
+                  onClick={() => navigate('/foundation/support')}
+                  aria-label="Support"
+                >
+                  <LifebuoyIcon className="h-5 w-5" />
+                </button>
+                <button
+                  type="button"
+                  className="rounded-full p-2 text-gray-500 transition-colors hover:bg-gray-100 hover:text-swiss-teal"
+                  onClick={() => navigate('/messages')}
+                  aria-label="Notifications"
+                >
+                  <InboxIcon className="h-5 w-5" />
+                </button>
+                <div className="flex items-center gap-3 rounded-full border border-gray-200 bg-white px-3 py-2">
+                  <div className="flex h-9 w-9 items-center justify-center rounded-full bg-swiss-mint text-white text-sm font-semibold">
+                    {initials}
+                  </div>
+                  <div className="hidden text-left text-xs sm:block">
+                    <p className="font-semibold text-swiss-charcoal">{user?.fullName || 'Team Member'}</p>
+                    <p className="text-gray-500">{user?.publicMetadata?.role || 'Foundation Admin'}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </header>
+
+          <main className="flex-1 bg-page-bg px-4 pb-10 pt-8 sm:px-6 lg:px-10">
+            <div className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <p className="text-sm font-medium text-swiss-teal">{title}</p>
+                <h1 className="mt-1 text-3xl font-bold text-swiss-charcoal">{subtitle}</h1>
+                <p className="mt-1 text-sm text-gray-500">
+                  Monitor operations, track enrolments, and manage your foundation from one place.
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button onClick={() => navigate('/parent-lead-form')} className="hidden sm:inline-flex">
+                  Invite Parent
+                </Button>
+                <Button
+                  variant="outline"
+                  className="border-swiss-mint text-swiss-teal hover:bg-swiss-mint/10"
+                  onClick={() => navigate('/recruitment')}
+                >
+                  Add Educator
+                </Button>
+              </div>
+            </div>
+
+            {children}
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FoundationDashboardLayout;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,156 +1,725 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useUser } from '@clerk/clerk-react';
-import { ChartBarIcon, UsersIcon, ShoppingCartIcon, BriefcaseIcon, CogIcon as SettingsIcon } from '@heroicons/react/24/outline';
+import { useAuth, useUser } from '@clerk/clerk-react';
+import {
+  UsersIcon,
+  ClipboardDocumentCheckIcon,
+  ChartBarIcon,
+  ShoppingBagIcon,
+  BriefcaseIcon,
+  AcademicCapIcon,
+  CalendarDaysIcon,
+  ArrowTrendingUpIcon,
+  ArrowTrendingDownIcon,
+  ChatBubbleLeftRightIcon,
+  EnvelopeOpenIcon,
+} from '@heroicons/react/24/outline';
 import Card from '../components/ui/Card';
-import DashboardTopBar from '../components/ui/DashboardTopBar';
-import { useTranslation } from 'react-i18next';
-import { APP_NAME } from '../constants';
+import Button from '../components/ui/Button';
+import FoundationDashboardLayout from '../components/dashboard/FoundationDashboardLayout';
+import { apiCall } from '../utils/api';
+
+type FoundationStats = {
+  totalJobListings: number;
+  totalApplications: number;
+  totalOrders: number;
+  totalServiceRequests: number;
+  activeJobListings: number;
+  pendingApplications: number;
+};
+
+type ActivityItem = {
+  id: string;
+  type: string;
+  title: string;
+  description: string;
+  timestamp: string;
+  status?: string;
+};
+
+type Lead = {
+  id: string;
+  parentName: string;
+  childName: string;
+  status: string;
+  createdAt: string;
+  preferredLocation?: string | null;
+  preferredLanguages?: string[] | null;
+};
+
+type ServiceRequest = {
+  id: string;
+  description?: string | null;
+  status: string;
+  createdAt: string;
+  scheduledAt?: string | null;
+  service?: {
+    title: string;
+    provider?: {
+      organization?: {
+        name: string;
+      };
+    };
+  };
+};
+
+type Order = {
+  id: string;
+  status: string;
+  createdAt: string;
+  totalAmount: number;
+};
+
+type OrganizationMember = {
+  id: string;
+  user: {
+    id: string;
+    firstName: string | null;
+    lastName: string | null;
+    email: string;
+  };
+};
+
+type FoundationOrganization = {
+  id: string;
+  name: string;
+  type?: string;
+  canton?: string | null;
+  region?: string | null;
+  languages?: string[] | null;
+  capacity?: number | null;
+  pedagogy?: string[] | null;
+  members?: OrganizationMember[];
+};
+
+type ProfileResponse = {
+  id: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  clerkId: string;
+  organizations?: Array<{
+    organization: FoundationOrganization;
+  }>;
+};
+
+type AppointmentsResponse = {
+  serviceRequests: ServiceRequest[];
+  orders: Order[];
+};
+
+type StatCard = {
+  title: string;
+  value: number;
+  meta: string;
+  trendPercentage: number;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  accent: string;
+};
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat('de-CH', { style: 'currency', currency: 'CHF' }).format(value);
 
 const DashboardPage: React.FC = () => {
-  const { t } = useTranslation();
-  const { user, isLoaded } = useUser();
   const navigate = useNavigate();
+  const { user: clerkUser } = useUser();
+  const { getToken } = useAuth();
 
-  // Debug logging
-  console.log('DashboardPage render:', { user, isLoaded });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [stats, setStats] = useState<FoundationStats | null>(null);
+  const [activities, setActivities] = useState<ActivityItem[]>([]);
+  const [leads, setLeads] = useState<Lead[]>([]);
+  const [appointments, setAppointments] = useState<AppointmentsResponse>({ serviceRequests: [], orders: [] });
+  const [organization, setOrganization] = useState<FoundationOrganization | null>(null);
+  const [teamRecipients, setTeamRecipients] = useState<Array<{ id: string; label: string }>>([]);
+  const [selectedRecipientId, setSelectedRecipientId] = useState<string>('');
+  const [quickMessage, setQuickMessage] = useState('');
+  const [quickMessageStatus, setQuickMessageStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle');
 
-  if (!isLoaded) {
-    return (
-      <div className="min-h-screen bg-page-bg flex items-center justify-center">
-        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-swiss-mint"></div>
-      </div>
-    );
-  }
+  useEffect(() => {
+    fetchDashboardData();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  if (!user) {
-    console.log('DashboardPage: No user found, redirecting to login');
-    return (
-      <div className="min-h-screen bg-page-bg flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold text-swiss-charcoal mb-4">Not Authenticated</h1>
-          <p className="text-gray-600">Please log in to access the dashboard.</p>
+  const fetchDashboardData = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const token = await getToken();
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${token}`,
+      };
+
+      const profileResponse = await apiCall('/profiles/me', { headers });
+      if (!profileResponse.ok) {
+        throw new Error('Failed to load profile details.');
+      }
+      const profileJson = await profileResponse.json();
+      const profileData: ProfileResponse = profileJson.data ?? profileJson;
+
+      const foundationLink = profileData.organizations?.find(
+        (link) => link.organization?.type === 'FOUNDATION' || link.organization?.type === undefined,
+      );
+
+      if (!foundationLink) {
+        throw new Error('No foundation organization is linked to this account.');
+      }
+
+      setOrganization(foundationLink.organization);
+
+      const foundationId = foundationLink.organization.id;
+
+      const [statsResponse, activitiesResponse, leadsResponse, appointmentsResponse] = await Promise.all([
+        apiCall('/dashboard/foundation/stats', { headers }),
+        apiCall('/dashboard/foundation/activities', { headers }),
+        apiCall(`/leads/parent-leads?foundationId=${foundationId}`, { headers }),
+        apiCall('/dashboard/foundation/appointments', { headers }),
+      ]);
+
+      if (statsResponse.ok) {
+        const statsJson = await statsResponse.json();
+        setStats(statsJson.data ?? statsJson);
+      }
+
+      if (activitiesResponse.ok) {
+        const activitiesJson = await activitiesResponse.json();
+        setActivities((activitiesJson.data ?? activitiesJson) as ActivityItem[]);
+      }
+
+      if (leadsResponse.ok) {
+        const leadsJson = await leadsResponse.json();
+        setLeads((leadsJson.data ?? leadsJson) as Lead[]);
+      }
+
+      if (appointmentsResponse.ok) {
+        const appointmentsJson = await appointmentsResponse.json();
+        setAppointments((appointmentsJson.data ?? appointmentsJson) as AppointmentsResponse);
+      }
+
+      // Prepare recipient list from organization members
+      const members = foundationLink.organization.members || [];
+      const mappedTeam = members
+        .filter((member) => member.user && member.user.id && member.user.id !== profileData.id)
+        .map((member) => ({
+          id: member.user.id,
+          label: `${member.user.firstName ?? ''} ${member.user.lastName ?? ''}`.trim() || member.user.email,
+        }));
+
+      if (mappedTeam.length > 0) {
+        setTeamRecipients(mappedTeam);
+        setSelectedRecipientId(mappedTeam[0].id);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load dashboard data.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const leadSummary = useMemo(() => {
+    const summary = leads.reduce<Record<string, number>>((acc, lead) => {
+      const status = lead.status || 'UNKNOWN';
+      acc[status] = (acc[status] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    const totalLeads = leads.length;
+    const newLeads = summary.NEW ?? 0;
+    const assignedLeads = (summary.ASSIGNED ?? 0) + (summary.CONTACTED ?? 0);
+    const convertedLeads = summary.CONVERTED ?? 0;
+
+    return {
+      totalLeads,
+      newLeads,
+      assignedLeads,
+      convertedLeads,
+      summary,
+    };
+  }, [leads]);
+
+  const upcomingServiceRequests = useMemo(() => {
+    const now = new Date();
+    return [...appointments.serviceRequests]
+      .filter((request) => {
+        if (!request.scheduledAt) return true;
+        const scheduled = new Date(request.scheduledAt);
+        return scheduled >= now;
+      })
+      .sort((a, b) => {
+        const dateA = a.scheduledAt ? new Date(a.scheduledAt).getTime() : new Date(a.createdAt).getTime();
+        const dateB = b.scheduledAt ? new Date(b.scheduledAt).getTime() : new Date(b.createdAt).getTime();
+        return dateA - dateB;
+      })
+      .slice(0, 5);
+  }, [appointments.serviceRequests]);
+
+  const monthlyOrderMetrics = useMemo(() => {
+    const now = new Date();
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+    const ordersThisMonth = appointments.orders.filter((order) => new Date(order.createdAt) >= startOfMonth);
+    const totalSpend = ordersThisMonth.reduce((sum, order) => sum + (order.totalAmount ?? 0), 0);
+    return {
+      ordersThisMonth: ordersThisMonth.length,
+      totalSpend,
+    };
+  }, [appointments.orders]);
+
+  const statCards: StatCard[] = useMemo(() => {
+    const cards: StatCard[] = [];
+    const totalJobs = stats?.totalJobListings ?? 0;
+    const activeJobs = stats?.activeJobListings ?? 0;
+    const jobActivityRatio = totalJobs > 0 ? Math.round((activeJobs / totalJobs) * 100) : 0;
+
+    cards.push({
+      title: 'Active Job Listings',
+      value: activeJobs,
+      meta: `${totalJobs} total listings`,
+      trendPercentage: jobActivityRatio,
+      icon: BriefcaseIcon,
+      accent: 'bg-swiss-mint/10 text-swiss-mint',
+    });
+
+    const totalApplications = stats?.totalApplications ?? 0;
+    const pendingApplications = stats?.pendingApplications ?? 0;
+    const applicationRatio = totalApplications > 0 ? Math.round((pendingApplications / totalApplications) * 100) : 0;
+
+    cards.push({
+      title: 'Pending Applications',
+      value: pendingApplications,
+      meta: `${totalApplications} total applications`,
+      trendPercentage: applicationRatio,
+      icon: ClipboardDocumentCheckIcon,
+      accent: 'bg-swiss-teal/10 text-swiss-teal',
+    });
+
+    const totalOrders = stats?.totalOrders ?? 0;
+    const monthlyOrders = monthlyOrderMetrics.ordersThisMonth;
+    const orderTrend = totalOrders > 0 ? Math.round((monthlyOrders / totalOrders) * 100) : 0;
+
+    cards.push({
+      title: 'Orders this Month',
+      value: monthlyOrders,
+      meta: `${totalOrders} orders lifetime`,
+      trendPercentage: orderTrend,
+      icon: ShoppingBagIcon,
+      accent: 'bg-swiss-coral/10 text-swiss-coral',
+    });
+
+    const totalServiceRequests = stats?.totalServiceRequests ?? 0;
+    const upcomingCount = upcomingServiceRequests.length;
+    const serviceTrend = totalServiceRequests > 0 ? Math.round((upcomingCount / totalServiceRequests) * 100) : 0;
+
+    cards.push({
+      title: 'Upcoming Service Requests',
+      value: upcomingCount,
+      meta: `${totalServiceRequests} requests recorded`,
+      trendPercentage: serviceTrend,
+      icon: CalendarDaysIcon,
+      accent: 'bg-swiss-sand/20 text-swiss-sand-dark',
+    });
+
+    return cards;
+  }, [stats, monthlyOrderMetrics, upcomingServiceRequests.length]);
+
+  const activityIconMap: Record<string, React.ComponentType<React.SVGProps<SVGSVGElement>>> = {
+    application: UsersIcon,
+    order: ShoppingBagIcon,
+    service: AcademicCapIcon,
+    job: BriefcaseIcon,
+  };
+
+  const firstName = useMemo(() => {
+    if (clerkUser?.fullName) {
+      return clerkUser.fullName.split(' ')[0];
+    }
+    if (clerkUser?.firstName) {
+      return clerkUser.firstName;
+    }
+    const email = clerkUser?.emailAddresses?.[0]?.emailAddress;
+    return email ? email.split('@')[0] : 'there';
+  }, [clerkUser]);
+
+  const handleQuickMessage = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!quickMessage.trim() || !selectedRecipientId) {
+      return;
+    }
+
+    try {
+      setQuickMessageStatus('sending');
+      const token = await getToken();
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      };
+
+      const conversationResponse = await apiCall('/messaging/conversations', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          type: 'DIRECT',
+          participantIds: [selectedRecipientId],
+        }),
+      });
+
+      if (!conversationResponse.ok) {
+        throw new Error('Failed to start the conversation.');
+      }
+
+      const conversationJson = await conversationResponse.json();
+      const conversationId = conversationJson.id ?? conversationJson.data?.id;
+      if (!conversationId) {
+        throw new Error('Missing conversation identifier.');
+      }
+
+      const messageResponse = await apiCall('/messaging/messages', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          conversationId,
+          content: quickMessage.trim(),
+          messageType: 'TEXT',
+        }),
+      });
+
+      if (!messageResponse.ok) {
+        throw new Error('Message could not be delivered.');
+      }
+
+      setQuickMessage('');
+      setQuickMessageStatus('sent');
+      setTimeout(() => setQuickMessageStatus('idle'), 2500);
+    } catch (err) {
+      console.error(err);
+      setQuickMessageStatus('error');
+    }
+  };
+
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <div className="flex min-h-[400px] items-center justify-center">
+          <div className="text-center">
+            <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-swiss-mint/40 border-t-swiss-mint" />
+            <p className="mt-4 text-sm text-gray-500">Loading your foundation data…</p>
+          </div>
         </div>
-      </div>
-    );
-  }
+      );
+    }
 
-  console.log('DashboardPage: User found:', user);
+    if (error) {
+      return (
+        <Card className="border border-rose-100 bg-rose-50 p-6 text-rose-700">
+          <h2 className="text-lg font-semibold">We couldn’t load the dashboard</h2>
+          <p className="mt-2 text-sm">{error}</p>
+          <Button className="mt-4" onClick={fetchDashboardData} variant="light">
+            Retry loading data
+          </Button>
+        </Card>
+      );
+    }
 
-  // Get user role from Clerk metadata
-  const userRole = user?.publicMetadata?.role as string;
-  console.log('DashboardPage: User role:', userRole);
+    return (
+      <>
+        <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {statCards.map((stat) => {
+            const IconComponent = stat.icon;
+            const isPositive = stat.trendPercentage >= 0;
+            const TrendIcon = isPositive ? ArrowTrendingUpIcon : ArrowTrendingDownIcon;
+            return (
+              <Card key={stat.title} className="p-5" hoverEffect>
+                <div className="flex items-start justify-between">
+                  <div className={`flex h-12 w-12 items-center justify-center rounded-xl ${stat.accent}`}>
+                    <IconComponent className="h-6 w-6" />
+                  </div>
+                  <span
+                    className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-semibold ${
+                      isPositive ? 'bg-emerald-100 text-emerald-600' : 'bg-rose-100 text-rose-600'
+                    }`}
+                  >
+                    <TrendIcon className="h-4 w-4" />
+                    {Math.abs(stat.trendPercentage)}%
+                  </span>
+                </div>
+                <p className="mt-6 text-3xl font-bold text-swiss-charcoal">{stat.value}</p>
+                <p className="text-sm font-medium text-gray-500">{stat.title}</p>
+                <p className="mt-1 text-xs text-gray-400">{stat.meta}</p>
+              </Card>
+            );
+          })}
+        </section>
 
-  const stats = [
-    { name: 'Active Users', value: '1,234', icon: UsersIcon, color: 'text-swiss-mint', bgColor: 'bg-swiss-mint/10', trend: '+5%' },
-    { name: 'New Orders', value: '56', icon: ShoppingCartIcon, color: 'text-swiss-sand', bgColor: 'bg-swiss-sand/20', trend: '+12%' },
-    { name: 'Open Jobs', value: '12', icon: BriefcaseIcon, color: 'text-swiss-teal', bgColor: 'bg-swiss-teal/10', trend: '-2%' },
-    { name: 'Page Views', value: '25,678', icon: ChartBarIcon, color: 'text-swiss-coral', bgColor: 'bg-swiss-coral/10', trend: '+8%' },
-  ];
+        <section className="mt-8 grid grid-cols-1 gap-6 xl:grid-cols-3">
+          <div className="space-y-6 xl:col-span-2">
+            <Card className="p-6">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h2 className="text-xl font-semibold text-swiss-charcoal">Recent Activity</h2>
+                  <p className="text-sm text-gray-500">Live updates from recruiting, marketplace, and service teams.</p>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-swiss-teal hover:text-swiss-mint"
+                  onClick={() => navigate('/foundation/analytics')}
+                >
+                  View analytics
+                </Button>
+              </div>
+              <ul className="mt-6 space-y-4">
+                {activities.length === 0 && (
+                  <li className="rounded-xl border border-dashed border-gray-200 p-6 text-center text-sm text-gray-500">
+                    No activity recorded yet — once your team starts working, updates will appear here.
+                  </li>
+                )}
+                {activities.map((activity) => {
+                  const ActivityIcon = activityIconMap[activity.type] ?? ChartBarIcon;
+                  const timestamp = new Date(activity.timestamp);
+                  return (
+                    <li
+                      key={activity.id}
+                      className="flex items-start gap-4 rounded-xl border border-transparent p-3 transition-colors hover:border-swiss-mint/20 hover:bg-swiss-mint/5"
+                    >
+                      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-swiss-mint/10 text-swiss-teal">
+                        <ActivityIcon className="h-6 w-6" />
+                      </div>
+                      <div className="flex-1">
+                        <p className="text-sm text-swiss-charcoal">
+                          <span className="font-semibold">{activity.title}</span>
+                        </p>
+                        <p className="mt-1 text-sm text-gray-500">{activity.description}</p>
+                        <p className="mt-2 text-xs text-gray-400">
+                          {timestamp.toLocaleDateString()} • {timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                          {activity.status ? ` • ${activity.status}` : ''}
+                        </p>
+                      </div>
+                      <Button
+                        variant="light"
+                        size="sm"
+                        className="text-xs font-semibold"
+                        onClick={() => navigate('/messages')}
+                        leftIcon={ChatBubbleLeftRightIcon}
+                      >
+                        Follow up
+                      </Button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </Card>
 
-  const quickLinksData = [
-    {nameKey: 'Browse Marketplace', path: '/marketplace', icon: ShoppingCartIcon},
-    {nameKey: 'Post New Job', path: '/recruitment', icon: BriefcaseIcon},
-    {nameKey: 'Manage Users', path: '/users', icon: UsersIcon},
-    {nameKey: 'Platform Settings', path: '/settings', icon: SettingsIcon},
-  ];
-
-  const recentActivityData = [
-      { id:1, user: 'Lina Meier', actionKey: 'posted a new job listing', timeRaw: 15, timeUnit: 'minutes', avatarSeed: 'lina'},
-      { id:2, user: 'EcoToys GmbH', actionKey: 'updated their product catalog', timeRaw: 1, timeUnit: 'hours', avatarSeed: 'ecotoys'},
-      { id:3, user: 'John Smith', actionKey: 'applied for Lead Educator position', timeRaw: 3, timeUnit: 'hours', avatarSeed: 'john'},
-      { id:4, user: 'Parent Example', actionKey: 'submitted a childcare inquiry', timeRaw: 5, timeUnit: 'hours', avatarSeed: 'parent'},
-  ];
-  
-  const formatTimeAgo = (timeRaw: number, timeUnit: 'minutes' | 'hours' | 'yesterday') => {
-    if (timeUnit === 'yesterday') return 'Yesterday';
-    return `${timeRaw} ${timeUnit} ago`;
-  }
-
-  return (
-    <div className="min-h-screen bg-page-bg">
-      <DashboardTopBar />
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="space-y-8">
-          <div>
-            <h1 className="text-3xl font-bold text-swiss-charcoal">
-              Welcome, {user?.fullName?.split(' ')[0] || user?.emailAddresses?.[0]?.emailAddress || 'User'}!
-            </h1>
-            <p className="text-gray-500 mt-1">Overview of your {APP_NAME} dashboard</p>
+            <Card className="p-6">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h2 className="text-xl font-semibold text-swiss-charcoal">Upcoming Service Requests</h2>
+                  <p className="text-sm text-gray-500">Stay ahead of scheduled maintenance and support engagements.</p>
+                </div>
+              </div>
+              <ul className="mt-4 space-y-3">
+                {upcomingServiceRequests.length === 0 && (
+                  <li className="rounded-xl border border-dashed border-gray-200 p-6 text-center text-sm text-gray-500">
+                    No upcoming service requests. Schedule a new request from the marketplace to see it here.
+                  </li>
+                )}
+                {upcomingServiceRequests.map((request) => {
+                  const scheduledDate = request.scheduledAt
+                    ? new Date(request.scheduledAt)
+                    : new Date(request.createdAt);
+                  return (
+                    <li
+                      key={request.id}
+                      className="flex items-start justify-between gap-4 rounded-xl border border-gray-100 p-4"
+                    >
+                      <div>
+                        <p className="text-sm font-semibold text-swiss-charcoal">
+                          {request.service?.title ?? 'Service request'}
+                        </p>
+                        <p className="mt-1 text-xs text-gray-500">
+                          Provider: {request.service?.provider?.organization?.name ?? 'Pending assignment'}
+                        </p>
+                        <p className="mt-2 text-xs text-gray-400">
+                          Scheduled {scheduledDate.toLocaleDateString()} at {scheduledDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                        </p>
+                      </div>
+                      <span className="rounded-full bg-swiss-mint/10 px-3 py-1 text-xs font-semibold text-swiss-teal">
+                        {request.status}
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </Card>
           </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-        {stats.map((stat) => (
-          <Card key={stat.name} className="p-0 overflow-hidden" hoverEffect>
-            <div className="p-5">
-                <div className="flex justify-between items-start">
-                    <div className={`p-2.5 inline-flex rounded-lg ${stat.bgColor}`}>
-                        <stat.icon className={`h-6 w-6 ${stat.color}`} />
-                    </div>
-                    {stat.trend && (
-                        <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${stat.trend.startsWith('+') ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'}`}>
-                            {stat.trend}
-                        </span>
-                    )}
-                </div>
-                <h3 className="text-3xl font-semibold text-swiss-charcoal mt-3">{stat.value}</h3>
-                <p className="text-sm text-gray-500">{stat.name}</p>
-            </div>
-            <div className={`px-5 py-2.5 text-xs text-center ${stat.bgColor}`}>
-                <button
-                    onClick={() => navigate(`/dashboard/details/${stat.name.toLowerCase().replace(/\s+/g, '-')}`)} 
-                    className={`font-medium ${stat.color} hover:underline focus:outline-none focus:ring-1 focus:ring-offset-1 focus:ring-current rounded`}
-                    aria-label={`View details for ${stat.name}`}
-                >
-                    View Details &rarr;
-                </button>
-            </div>
-          </Card>
-        ))}
-      </div>
-
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <Card className="lg:col-span-2 p-6">
-          <h2 className="text-xl font-semibold text-swiss-charcoal mb-5">Recent Activity</h2>
-          <ul className="space-y-4">
-            {recentActivityData.map(activity => (
-              <li key={activity.id} className="flex items-center p-3 -m-3 rounded-lg hover:bg-gray-50 transition-colors">
-                <img src={`https://picsum.photos/seed/${activity.avatarSeed}/40/40`} className="w-10 h-10 rounded-full mr-4 border border-gray-200" alt={`${activity.user} avatar`} />
-                <div>
-                  <p className="text-sm">
-                    <span className="font-medium text-swiss-charcoal">{activity.user}</span>
-                    <span className="text-gray-600"> {activity.actionKey}.</span>
-                  </p>
-                  <p className="text-xs text-gray-400">{formatTimeAgo(activity.timeRaw, activity.timeUnit as 'minutes' | 'hours' | 'yesterday')}</p>
-                </div>
-              </li>
-            ))}
-          </ul>
-        </Card>
-        <Card className="p-6">
-          <h2 className="text-xl font-semibold text-swiss-charcoal mb-5">Quick Links</h2>
-           <ul className="space-y-2.5">
-            {quickLinksData.map(link => {
-                const LinkIcon = link.icon;
-                return (
-                    <li key={link.nameKey}>
-                        <button
-                        onClick={() => navigate(link.path)}
-                        className="flex items-center text-swiss-teal hover:text-swiss-mint hover:underline font-medium group transition-colors p-2 -m-2 rounded-md hover:bg-swiss-mint/5 w-full text-left focus:outline-none focus:ring-1 focus:ring-offset-1 focus:ring-swiss-mint/70"
-                        aria-label={link.nameKey}
-                        >
-                        <LinkIcon className="w-5 h-5 mr-2.5 text-swiss-teal/70 group-hover:text-swiss-mint transition-colors"/>
-                        {link.nameKey}
-                        </button>
+          <div className="space-y-6">
+            <Card className="p-6">
+              <h2 className="text-xl font-semibold text-swiss-charcoal">Quick Actions</h2>
+              <p className="mt-1 text-sm text-gray-500">Jump into the workflows you manage most.</p>
+              <ul className="mt-4 space-y-3">
+                {[
+                  {
+                    label: 'Add Parent Lead',
+                    description: 'Capture a new family enquiry in seconds.',
+                    onClick: () => navigate('/parent-lead-form'),
+                    icon: UsersIcon,
+                  },
+                  {
+                    label: 'Post Job Opening',
+                    description: 'Publish opportunities for educators to apply.',
+                    onClick: () => navigate('/recruitment'),
+                    icon: BriefcaseIcon,
+                  },
+                  {
+                    label: 'Order Supplies',
+                    description: 'Request classroom materials from trusted partners.',
+                    onClick: () => navigate('/marketplace'),
+                    icon: ShoppingBagIcon,
+                  },
+                  {
+                    label: 'Review Analytics',
+                    description: 'Monitor enrolment and staffing performance.',
+                    onClick: () => navigate('/foundation/analytics'),
+                    icon: ChartBarIcon,
+                  },
+                ].map((action) => {
+                  const ActionIcon = action.icon;
+                  return (
+                    <li key={action.label}>
+                      <button
+                        type="button"
+                        onClick={action.onClick}
+                        className="flex w-full items-start gap-3 rounded-xl border border-transparent px-3 py-3 text-left transition-colors hover:border-swiss-mint/20 hover:bg-swiss-mint/5 focus:outline-none focus:ring-2 focus:ring-swiss-mint/40"
+                      >
+                        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-swiss-mint/10 text-swiss-teal">
+                          <ActionIcon className="h-5 w-5" />
+                        </div>
+                        <div>
+                          <p className="text-sm font-semibold text-swiss-charcoal">{action.label}</p>
+                          <p className="text-xs text-gray-500">{action.description}</p>
+                        </div>
+                      </button>
                     </li>
-                );
-            })}
-          </ul>
-        </Card>
-      </div>
-        </div>
-      </div>
-    </div>
+                  );
+                })}
+              </ul>
+            </Card>
+
+            <Card className="p-6">
+              <h2 className="text-xl font-semibold text-swiss-charcoal">Quick Message</h2>
+              <p className="mt-1 text-sm text-gray-500">Send a quick update to your foundation colleagues.</p>
+              {teamRecipients.length === 0 ? (
+                <div className="mt-4 rounded-xl border border-dashed border-gray-200 p-4 text-sm text-gray-500">
+                  Add your colleagues to the foundation in order to message them directly.
+                </div>
+              ) : (
+                <form className="mt-4 space-y-3" onSubmit={handleQuickMessage}>
+                  <label className="block text-xs font-semibold uppercase tracking-wide text-gray-400" htmlFor="quick-message-recipient">
+                    Recipient
+                  </label>
+                  <select
+                    id="quick-message-recipient"
+                    className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 focus:border-swiss-mint focus:outline-none focus:ring-2 focus:ring-swiss-mint/20"
+                    value={selectedRecipientId}
+                    onChange={(event) => setSelectedRecipientId(event.target.value)}
+                  >
+                    {teamRecipients.map((recipient) => (
+                      <option key={recipient.id} value={recipient.id}>
+                        {recipient.label}
+                      </option>
+                    ))}
+                  </select>
+                  <label className="block text-xs font-semibold uppercase tracking-wide text-gray-400" htmlFor="quick-message-body">
+                    Message
+                  </label>
+                  <textarea
+                    id="quick-message-body"
+                    className="h-28 w-full resize-none rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-600 focus:border-swiss-mint focus:outline-none focus:ring-2 focus:ring-swiss-mint/20"
+                    placeholder="Share an update with your team…"
+                    value={quickMessage}
+                    onChange={(event) => setQuickMessage(event.target.value)}
+                  />
+                  <Button type="submit" className="w-full" leftIcon={EnvelopeOpenIcon} disabled={quickMessageStatus === 'sending'}>
+                    {quickMessageStatus === 'sending' ? 'Sending…' : 'Send Message'}
+                  </Button>
+                  {quickMessageStatus === 'sent' && (
+                    <p className="text-center text-xs font-medium text-emerald-600">Message delivered to the selected teammate.</p>
+                  )}
+                  {quickMessageStatus === 'error' && (
+                    <p className="text-center text-xs font-medium text-rose-600">Something went wrong. Please try again.</p>
+                  )}
+                </form>
+              )}
+            </Card>
+
+            <Card className="p-6">
+              <h2 className="text-xl font-semibold text-swiss-charcoal">Foundation Snapshot</h2>
+              <p className="mt-1 text-sm text-gray-500">Key details from your organisation profile.</p>
+              <dl className="mt-4 space-y-3 text-sm text-gray-600">
+                <div className="flex items-start justify-between gap-4">
+                  <dt className="font-medium text-swiss-charcoal">Location</dt>
+                  <dd>{organization?.canton || organization?.region || 'Not specified'}</dd>
+                </div>
+                <div className="flex items-start justify-between gap-4">
+                  <dt className="font-medium text-swiss-charcoal">Languages</dt>
+                  <dd>{organization?.languages?.length ? organization.languages.join(', ') : 'Not specified'}</dd>
+                </div>
+                <div className="flex items-start justify-between gap-4">
+                  <dt className="font-medium text-swiss-charcoal">Capacity</dt>
+                  <dd>{organization?.capacity ? `${organization.capacity} children` : 'Not specified'}</dd>
+                </div>
+                <div className="flex items-start justify-between gap-4">
+                  <dt className="font-medium text-swiss-charcoal">Pedagogies</dt>
+                  <dd>{organization?.pedagogy?.length ? organization.pedagogy.join(', ') : 'Not documented'}</dd>
+                </div>
+                <div className="flex items-start justify-between gap-4">
+                  <dt className="font-medium text-swiss-charcoal">Lead Conversion</dt>
+                  <dd>
+                    {leadSummary.totalLeads === 0
+                      ? 'No leads yet'
+                      : `${leadSummary.convertedLeads} of ${leadSummary.totalLeads} converted`}
+                  </dd>
+                </div>
+              </dl>
+              <Button
+                variant="light"
+                className="mt-4 w-full"
+                onClick={() => navigate('/foundation/organisation-profile')}
+              >
+                Manage organisation profile
+              </Button>
+            </Card>
+
+            <Card className="p-6">
+              <h2 className="text-xl font-semibold text-swiss-charcoal">Marketplace Summary</h2>
+              <p className="mt-1 text-sm text-gray-500">Current month spend across orders and service bookings.</p>
+              <div className="mt-4 rounded-2xl bg-swiss-mint/10 p-5 text-center">
+                <p className="text-sm font-semibold uppercase tracking-wide text-swiss-teal">This month</p>
+                <p className="mt-2 text-3xl font-bold text-swiss-charcoal">
+                  {formatCurrency(monthlyOrderMetrics.totalSpend)}
+                </p>
+                <p className="mt-1 text-xs text-gray-500">
+                  {monthlyOrderMetrics.ordersThisMonth} order{monthlyOrderMetrics.ordersThisMonth === 1 ? '' : 's'} processed
+                </p>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="mt-3 text-swiss-teal hover:text-swiss-mint"
+                  onClick={() => navigate('/marketplace')}
+                >
+                  Open marketplace
+                </Button>
+              </div>
+            </Card>
+          </div>
+        </section>
+      </>
+    );
+  };
+
+  return (
+    <FoundationDashboardLayout title="Foundation Dashboard" subtitle={`Welcome, ${firstName}!`}>
+      {renderContent()}
+    </FoundationDashboardLayout>
   );
 };
 

--- a/frontend/src/pages/foundation/FoundationAnalyticsPage.tsx
+++ b/frontend/src/pages/foundation/FoundationAnalyticsPage.tsx
@@ -1,0 +1,292 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useAuth } from '@clerk/clerk-react';
+import {
+  ChartBarIcon,
+  UsersIcon,
+  ClipboardDocumentCheckIcon,
+  ShoppingBagIcon,
+  SparklesIcon,
+} from '@heroicons/react/24/outline';
+import Card from '../../components/ui/Card';
+import FoundationDashboardLayout from '../../components/dashboard/FoundationDashboardLayout';
+import { apiCall } from '../../utils/api';
+
+type FoundationStats = {
+  totalJobListings: number;
+  totalApplications: number;
+  totalOrders: number;
+  totalServiceRequests: number;
+  activeJobListings: number;
+  pendingApplications: number;
+};
+
+type Lead = {
+  id: string;
+  status: string;
+  createdAt: string;
+};
+
+type AppointmentsResponse = {
+  serviceRequests: Array<{ status: string; createdAt: string; scheduledAt?: string | null }>;
+  orders: Array<{ totalAmount: number; createdAt: string }>;
+};
+
+type ProfileResponse = {
+  organizations?: Array<{
+    organization: {
+      id: string;
+      type?: string;
+    };
+  }>;
+};
+
+const statusPalette: Record<string, string> = {
+  NEW: 'bg-blue-50 text-blue-600',
+  ASSIGNED: 'bg-amber-50 text-amber-600',
+  IN_PROGRESS: 'bg-indigo-50 text-indigo-600',
+  CONVERTED: 'bg-emerald-50 text-emerald-600',
+  LOST: 'bg-rose-50 text-rose-600',
+};
+
+const FoundationAnalyticsPage: React.FC = () => {
+  const { getToken } = useAuth();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [stats, setStats] = useState<FoundationStats | null>(null);
+  const [leads, setLeads] = useState<Lead[]>([]);
+  const [appointments, setAppointments] = useState<AppointmentsResponse>({ serviceRequests: [], orders: [] });
+
+  useEffect(() => {
+    fetchAnalytics();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const fetchAnalytics = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const token = await getToken();
+      const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
+
+      const profileResponse = await apiCall('/profiles/me', { headers });
+      if (!profileResponse.ok) {
+        throw new Error('Unable to load foundation details');
+      }
+      const profileJson = await profileResponse.json();
+      const profileData: ProfileResponse = profileJson.data ?? profileJson;
+      const foundationLink = profileData.organizations?.find(
+        (link) => link.organization?.type === 'FOUNDATION' || link.organization?.type === undefined,
+      );
+
+      if (!foundationLink) {
+        throw new Error('No foundation organisation associated with this account.');
+      }
+
+      const [statsResponse, leadsResponse, appointmentsResponse] = await Promise.all([
+        apiCall('/dashboard/foundation/stats', { headers }),
+        apiCall(`/leads/parent-leads?foundationId=${foundationLink.organization.id}`, { headers }),
+        apiCall('/dashboard/foundation/appointments', { headers }),
+      ]);
+
+      if (!statsResponse.ok || !leadsResponse.ok || !appointmentsResponse.ok) {
+        throw new Error('Failed to load analytics data from the server.');
+      }
+
+      const statsJson = await statsResponse.json();
+      const leadsJson = await leadsResponse.json();
+      const appointmentsJson = await appointmentsResponse.json();
+
+      setStats(statsJson.data ?? statsJson);
+      setLeads((leadsJson.data ?? leadsJson) as Lead[]);
+      setAppointments(appointmentsJson.data ?? appointmentsJson);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to load analytics at this time.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const leadMetrics = useMemo(() => {
+    const byStatus = leads.reduce<Record<string, number>>((acc, lead) => {
+      acc[lead.status] = (acc[lead.status] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    const createdThisMonth = leads.filter((lead) => {
+      const created = new Date(lead.createdAt);
+      const now = new Date();
+      return created.getFullYear() === now.getFullYear() && created.getMonth() === now.getMonth();
+    }).length;
+
+    return {
+      total: leads.length,
+      byStatus,
+      createdThisMonth,
+    };
+  }, [leads]);
+
+  const orderMetrics = useMemo(() => {
+    const totalValue = appointments.orders.reduce((sum, order) => sum + (order.totalAmount ?? 0), 0);
+    const thisMonthValue = appointments.orders.reduce((sum, order) => {
+      const created = new Date(order.createdAt);
+      const now = new Date();
+      if (created.getFullYear() === now.getFullYear() && created.getMonth() === now.getMonth()) {
+        return sum + (order.totalAmount ?? 0);
+      }
+      return sum;
+    }, 0);
+    return {
+      count: appointments.orders.length,
+      totalValue,
+      thisMonthValue,
+    };
+  }, [appointments.orders]);
+
+  const serviceMetrics = useMemo(() => {
+    const upcoming = appointments.serviceRequests.filter((req) => {
+      if (!req.createdAt) return false;
+      if (!req.scheduledAt) return true;
+      return new Date(req.scheduledAt) >= new Date();
+    }).length;
+    return {
+      total: appointments.serviceRequests.length,
+      upcoming,
+    };
+  }, [appointments.serviceRequests]);
+
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <div className="flex min-h-[320px] items-center justify-center">
+          <div className="text-center">
+            <div className="mx-auto h-10 w-10 animate-spin rounded-full border-4 border-swiss-mint/30 border-t-swiss-mint" />
+            <p className="mt-3 text-sm text-gray-500">Calculating analytics…</p>
+          </div>
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <Card className="border border-rose-100 bg-rose-50 p-6 text-rose-700">
+          <h2 className="text-lg font-semibold">We couldn’t load your analytics</h2>
+          <p className="mt-2 text-sm">{error}</p>
+        </Card>
+      );
+    }
+
+    return (
+      <div className="space-y-6">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+          <Card className="p-5">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">Total leads</p>
+            <p className="mt-3 text-3xl font-bold text-swiss-charcoal">{leadMetrics.total}</p>
+            <p className="text-xs text-gray-500">{leadMetrics.createdThisMonth} created this month</p>
+          </Card>
+          <Card className="p-5">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">Job listings</p>
+            <p className="mt-3 text-3xl font-bold text-swiss-charcoal">{stats?.activeJobListings ?? 0}</p>
+            <p className="text-xs text-gray-500">{stats?.totalJobListings ?? 0} total listings</p>
+          </Card>
+          <Card className="p-5">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">Marketplace orders</p>
+            <p className="mt-3 text-3xl font-bold text-swiss-charcoal">{orderMetrics.count}</p>
+            <p className="text-xs text-gray-500">
+              {new Intl.NumberFormat('de-CH', { style: 'currency', currency: 'CHF' }).format(orderMetrics.thisMonthValue)} spent this month
+            </p>
+          </Card>
+          <Card className="p-5">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">Service requests</p>
+            <p className="mt-3 text-3xl font-bold text-swiss-charcoal">{serviceMetrics.total}</p>
+            <p className="text-xs text-gray-500">{serviceMetrics.upcoming} upcoming engagements</p>
+          </Card>
+        </div>
+
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <Card className="p-6">
+            <div className="flex items-center justify-between">
+              <h2 className="text-xl font-semibold text-swiss-charcoal">Lead pipeline distribution</h2>
+              <UsersIcon className="h-6 w-6 text-swiss-teal" />
+            </div>
+            <ul className="mt-6 space-y-3">
+              {Object.entries(leadMetrics.byStatus).map(([status, count]) => (
+                <li key={status} className="flex items-center justify-between rounded-xl bg-white p-3 shadow-sm">
+                  <div className="flex items-center gap-3">
+                    <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${statusPalette[status] ?? 'bg-gray-50 text-gray-600'}`}>
+                      {status}
+                    </span>
+                    <span className="text-sm text-swiss-charcoal">{statusOptionsLabel(status)}</span>
+                  </div>
+                  <span className="text-sm font-semibold text-swiss-charcoal">{count}</span>
+                </li>
+              ))}
+              {Object.keys(leadMetrics.byStatus).length === 0 && (
+                <li className="rounded-xl border border-dashed border-gray-200 p-6 text-center text-sm text-gray-500">
+                  No leads have been created yet.
+                </li>
+              )}
+            </ul>
+          </Card>
+
+          <Card className="p-6">
+            <div className="flex items-center justify-between">
+              <h2 className="text-xl font-semibold text-swiss-charcoal">Operational snapshot</h2>
+              <ChartBarIcon className="h-6 w-6 text-swiss-teal" />
+            </div>
+            <dl className="mt-6 space-y-3 text-sm text-gray-600">
+              <div className="flex items-center justify-between">
+                <dt className="flex items-center gap-2 font-medium text-swiss-charcoal">
+                  <ClipboardDocumentCheckIcon className="h-4 w-4 text-swiss-teal" /> Pending applications
+                </dt>
+                <dd className="font-semibold text-swiss-charcoal">{stats?.pendingApplications ?? 0}</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="flex items-center gap-2 font-medium text-swiss-charcoal">
+                  <ShoppingBagIcon className="h-4 w-4 text-swiss-teal" /> Lifetime marketplace spend
+                </dt>
+                <dd className="font-semibold text-swiss-charcoal">
+                  {new Intl.NumberFormat('de-CH', { style: 'currency', currency: 'CHF' }).format(orderMetrics.totalValue)}
+                </dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="flex items-center gap-2 font-medium text-swiss-charcoal">
+                  <SparklesIcon className="h-4 w-4 text-swiss-teal" /> Conversion rate
+                </dt>
+                <dd className="font-semibold text-swiss-charcoal">
+                  {leadMetrics.total === 0
+                    ? '—'
+                    : `${Math.round(((leadMetrics.byStatus.CONVERTED ?? 0) / leadMetrics.total) * 100)}%`}
+                </dd>
+              </div>
+            </dl>
+          </Card>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <FoundationDashboardLayout title="Analytics" subtitle="Understand how your foundation is performing">
+      {renderContent()}
+    </FoundationDashboardLayout>
+  );
+};
+
+const statusOptionsLabel = (status: string) => {
+  switch (status) {
+    case 'NEW':
+      return 'New enquiries';
+    case 'ASSIGNED':
+      return 'Assigned to team';
+    case 'IN_PROGRESS':
+      return 'In progress';
+    case 'CONVERTED':
+      return 'Converted families';
+    case 'LOST':
+      return 'Closed';
+    default:
+      return status;
+  }
+};
+
+export default FoundationAnalyticsPage;

--- a/frontend/src/pages/foundation/FoundationAppointmentsPage.tsx
+++ b/frontend/src/pages/foundation/FoundationAppointmentsPage.tsx
@@ -1,0 +1,231 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useAuth } from '@clerk/clerk-react';
+import { CalendarDaysIcon, TruckIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
+import Card from '../../components/ui/Card';
+import Button from '../../components/ui/Button';
+import FoundationDashboardLayout from '../../components/dashboard/FoundationDashboardLayout';
+import { apiCall } from '../../utils/api';
+
+type ServiceRequest = {
+  id: string;
+  description?: string | null;
+  status: string;
+  createdAt: string;
+  scheduledAt?: string | null;
+  organization?: {
+    name: string;
+  };
+  service?: {
+    title: string;
+    provider?: {
+      organization?: {
+        name: string;
+      };
+    };
+  };
+};
+
+type Order = {
+  id: string;
+  status: string;
+  createdAt: string;
+  totalAmount: number;
+  organization?: {
+    name: string;
+  };
+};
+
+type AppointmentsResponse = {
+  serviceRequests: ServiceRequest[];
+  orders: Order[];
+};
+
+const statusColor: Record<string, string> = {
+  PENDING: 'bg-amber-50 text-amber-700',
+  CONFIRMED: 'bg-emerald-50 text-emerald-700',
+  COMPLETED: 'bg-blue-50 text-blue-700',
+  CANCELLED: 'bg-rose-50 text-rose-700',
+};
+
+const FoundationAppointmentsPage: React.FC = () => {
+  const { getToken } = useAuth();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<AppointmentsResponse>({ serviceRequests: [], orders: [] });
+
+  useEffect(() => {
+    fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const fetchData = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const token = await getToken();
+      const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
+      const response = await apiCall('/dashboard/foundation/appointments', { headers });
+      if (!response.ok) {
+        throw new Error('Unable to fetch appointments');
+      }
+      const json = await response.json();
+      setData(json.data ?? json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to load appointments');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const upcomingRequests = useMemo(() => {
+    const now = new Date();
+    return [...data.serviceRequests]
+      .sort((a, b) => {
+        const aDate = a.scheduledAt ? new Date(a.scheduledAt).getTime() : new Date(a.createdAt).getTime();
+        const bDate = b.scheduledAt ? new Date(b.scheduledAt).getTime() : new Date(b.createdAt).getTime();
+        return aDate - bDate;
+      })
+      .filter((request) => {
+        if (!request.scheduledAt) return true;
+        return new Date(request.scheduledAt) >= now;
+      });
+  }, [data.serviceRequests]);
+
+  const recentOrders = useMemo(() => {
+    return [...data.orders].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  }, [data.orders]);
+
+  const totalUpcomingValue = useMemo(() => {
+    return recentOrders.reduce((sum, order) => sum + (order.totalAmount ?? 0), 0);
+  }, [recentOrders]);
+
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <div className="flex min-h-[300px] items-center justify-center">
+          <div className="text-center">
+            <div className="mx-auto h-10 w-10 animate-spin rounded-full border-4 border-swiss-mint/30 border-t-swiss-mint" />
+            <p className="mt-3 text-sm text-gray-500">Loading appointments and requests…</p>
+          </div>
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <Card className="border border-rose-100 bg-rose-50 p-6 text-rose-700">
+          <h2 className="text-lg font-semibold">We couldn’t load your appointments</h2>
+          <p className="mt-2 text-sm">{error}</p>
+          <Button className="mt-4" variant="light" onClick={fetchData}>
+            Retry loading data
+          </Button>
+        </Card>
+      );
+    }
+
+    return (
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <Card className="p-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-swiss-charcoal">Upcoming service requests</h2>
+              <p className="text-sm text-gray-500">Keep track of visits scheduled with marketplace partners.</p>
+            </div>
+            <Button variant="ghost" size="sm" onClick={fetchData} leftIcon={ArrowPathIcon}>
+              Refresh
+            </Button>
+          </div>
+
+          <ul className="mt-6 space-y-4">
+            {upcomingRequests.length === 0 && (
+              <li className="rounded-xl border border-dashed border-gray-200 p-6 text-center text-sm text-gray-500">
+                No service requests scheduled. Create a request from the marketplace to see it listed here.
+              </li>
+            )}
+            {upcomingRequests.map((request) => {
+              const scheduledDate = request.scheduledAt
+                ? new Date(request.scheduledAt)
+                : new Date(request.createdAt);
+              return (
+                <li key={request.id} className="rounded-xl border border-gray-100 p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <p className="text-sm font-semibold text-swiss-charcoal">{request.service?.title ?? 'Service request'}</p>
+                      <p className="mt-1 text-xs text-gray-500">
+                        Provider: {request.service?.provider?.organization?.name ?? 'Pending assignment'}
+                      </p>
+                      {request.description && (
+                        <p className="mt-2 text-xs text-gray-500">{request.description}</p>
+                      )}
+                    </div>
+                    <span
+                      className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${
+                        statusColor[request.status] ?? 'bg-gray-50 text-gray-600'
+                      }`}
+                    >
+                      {request.status}
+                    </span>
+                  </div>
+                  <div className="mt-3 flex items-center gap-2 text-xs text-gray-500">
+                    <CalendarDaysIcon className="h-4 w-4 text-swiss-teal" />
+                    <span>{scheduledDate.toLocaleDateString()} at {scheduledDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </Card>
+
+        <Card className="p-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-swiss-charcoal">Recent marketplace orders</h2>
+              <p className="text-sm text-gray-500">Deliveries and purchases made by your foundation.</p>
+            </div>
+            <div className="rounded-xl bg-swiss-mint/10 px-4 py-2 text-sm font-semibold text-swiss-teal">
+              Total value: {new Intl.NumberFormat('de-CH', { style: 'currency', currency: 'CHF' }).format(totalUpcomingValue)}
+            </div>
+          </div>
+
+          <ul className="mt-6 space-y-4">
+            {recentOrders.length === 0 && (
+              <li className="rounded-xl border border-dashed border-gray-200 p-6 text-center text-sm text-gray-500">
+                No marketplace orders recorded yet.
+              </li>
+            )}
+            {recentOrders.map((order) => (
+              <li key={order.id} className="rounded-xl border border-gray-100 p-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="text-sm font-semibold text-swiss-charcoal">Order #{order.id.slice(0, 8)}</p>
+                    <p className="mt-1 text-xs text-gray-500">
+                      Ordered on {new Date(order.createdAt).toLocaleDateString()} by {order.organization?.name ?? 'Your foundation'}
+                    </p>
+                    <p className="mt-2 text-xs text-gray-500">
+                      Value:{' '}
+                      {new Intl.NumberFormat('de-CH', { style: 'currency', currency: 'CHF' }).format(order.totalAmount ?? 0)}
+                    </p>
+                  </div>
+                  <span
+                    className={`inline-flex items-center gap-2 rounded-full bg-swiss-mint/10 px-3 py-1 text-xs font-semibold text-swiss-teal`}
+                  >
+                    <TruckIcon className="h-4 w-4" />
+                    {order.status}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      </div>
+    );
+  };
+
+  return (
+    <FoundationDashboardLayout title="Appointments & Marketplace" subtitle="Coordinate service visits and track orders">
+      {renderContent()}
+    </FoundationDashboardLayout>
+  );
+};
+
+export default FoundationAppointmentsPage;

--- a/frontend/src/pages/foundation/FoundationLeadsPage.tsx
+++ b/frontend/src/pages/foundation/FoundationLeadsPage.tsx
@@ -1,0 +1,320 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useAuth } from '@clerk/clerk-react';
+import { FunnelIcon, CheckCircleIcon, ClockIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import Card from '../../components/ui/Card';
+import Button from '../../components/ui/Button';
+import FoundationDashboardLayout from '../../components/dashboard/FoundationDashboardLayout';
+import { apiCall } from '../../utils/api';
+
+type Lead = {
+  id: string;
+  parentName: string;
+  parentEmail: string;
+  parentPhone?: string | null;
+  childName: string;
+  childAge: number;
+  status: string;
+  preferredLocation?: string | null;
+  preferredLanguages?: string[] | null;
+  createdAt: string;
+};
+
+type ProfileResponse = {
+  organizations?: Array<{
+    organization: {
+      id: string;
+      type?: string;
+      name: string;
+    };
+  }>;
+};
+
+type LeadStatus = 'NEW' | 'ASSIGNED' | 'IN_PROGRESS' | 'CONVERTED' | 'LOST' | string;
+
+const statusOptions: Array<{ value: LeadStatus; label: string }> = [
+  { value: 'NEW', label: 'New enquiry' },
+  { value: 'ASSIGNED', label: 'Assigned to team' },
+  { value: 'IN_PROGRESS', label: 'In progress' },
+  { value: 'CONVERTED', label: 'Converted' },
+  { value: 'LOST', label: 'Closed - not pursuing' },
+];
+
+const statusBadgeStyles: Record<string, string> = {
+  NEW: 'bg-blue-50 text-blue-700 border-blue-200',
+  ASSIGNED: 'bg-amber-50 text-amber-700 border-amber-200',
+  IN_PROGRESS: 'bg-indigo-50 text-indigo-700 border-indigo-200',
+  CONVERTED: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  LOST: 'bg-rose-50 text-rose-700 border-rose-200',
+};
+
+const FoundationLeadsPage: React.FC = () => {
+  const { getToken } = useAuth();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [leads, setLeads] = useState<Lead[]>([]);
+  const [foundationId, setFoundationId] = useState<string | null>(null);
+  const [activeFilter, setActiveFilter] = useState<'all' | LeadStatus>('all');
+  const [updatingLeadId, setUpdatingLeadId] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchLeads();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const fetchLeads = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const token = await getToken();
+      const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
+
+      const profileResponse = await apiCall('/profiles/me', { headers });
+      if (!profileResponse.ok) {
+        throw new Error('Unable to load foundation details');
+      }
+      const profileJson = await profileResponse.json();
+      const profileData: ProfileResponse = profileJson.data ?? profileJson;
+      const foundationLink = profileData.organizations?.find(
+        (link) => link.organization?.type === 'FOUNDATION' || link.organization?.type === undefined,
+      );
+
+      if (!foundationLink) {
+        throw new Error('You are not linked to a foundation organisation yet.');
+      }
+
+      setFoundationId(foundationLink.organization.id);
+
+      const leadsResponse = await apiCall(`/leads/parent-leads?foundationId=${foundationLink.organization.id}`, { headers });
+      if (!leadsResponse.ok) {
+        throw new Error('Failed to fetch leads from the server');
+      }
+
+      const leadsJson = await leadsResponse.json();
+      setLeads((leadsJson.data ?? leadsJson) as Lead[]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to load leads at this time.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const filteredLeads = useMemo(() => {
+    if (activeFilter === 'all') {
+      return leads;
+    }
+    return leads.filter((lead) => lead.status === activeFilter);
+  }, [activeFilter, leads]);
+
+  const summary = useMemo(() => {
+    return leads.reduce(
+      (acc, lead) => {
+        const status = lead.status || 'NEW';
+        acc.total += 1;
+        acc.byStatus[status] = (acc.byStatus[status] ?? 0) + 1;
+        if (status === 'NEW') acc.new += 1;
+        if (status === 'ASSIGNED' || status === 'IN_PROGRESS') acc.active += 1;
+        if (status === 'CONVERTED') acc.converted += 1;
+        return acc;
+      },
+      { total: 0, new: 0, active: 0, converted: 0, byStatus: {} as Record<string, number> },
+    );
+  }, [leads]);
+
+  const updateLeadStatus = async (leadId: string, status: LeadStatus) => {
+    try {
+      setUpdatingLeadId(leadId);
+      const token = await getToken();
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      };
+
+      const response = await apiCall(`/leads/parent-leads/${leadId}/status`, {
+        method: 'PATCH',
+        headers,
+        body: JSON.stringify({ status }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to update lead status');
+      }
+
+      setLeads((prev) => prev.map((lead) => (lead.id === leadId ? { ...lead, status } : lead)));
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : 'Could not update the lead status.');
+    } finally {
+      setUpdatingLeadId(null);
+    }
+  };
+
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <div className="flex min-h-[300px] items-center justify-center">
+          <div className="text-center">
+            <div className="mx-auto h-10 w-10 animate-spin rounded-full border-4 border-swiss-mint/30 border-t-swiss-mint" />
+            <p className="mt-3 text-sm text-gray-500">Loading parent leads…</p>
+          </div>
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <Card className="border border-rose-100 bg-rose-50 p-6 text-rose-700">
+          <h2 className="text-lg font-semibold">We couldn’t load the leads</h2>
+          <p className="mt-2 text-sm">{error}</p>
+          <Button className="mt-4" variant="light" onClick={fetchLeads}>
+            Retry loading leads
+          </Button>
+        </Card>
+      );
+    }
+
+    if (!foundationId) {
+      return (
+        <Card className="border border-amber-100 bg-amber-50 p-6 text-amber-700">
+          <h2 className="text-lg font-semibold">Foundation organisation missing</h2>
+          <p className="mt-2 text-sm">
+            Link this account to a foundation organisation to start collecting and managing parent leads.
+          </p>
+        </Card>
+      );
+    }
+
+    return (
+      <div className="space-y-6">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+          <Card className="p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">Total leads</p>
+            <p className="mt-2 text-3xl font-bold text-swiss-charcoal">{summary.total}</p>
+          </Card>
+          <Card className="p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">New today</p>
+            <p className="mt-2 text-3xl font-bold text-swiss-charcoal">{summary.new}</p>
+          </Card>
+          <Card className="p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">Active pipeline</p>
+            <p className="mt-2 text-3xl font-bold text-swiss-charcoal">{summary.active}</p>
+          </Card>
+          <Card className="p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">Converted</p>
+            <p className="mt-2 text-3xl font-bold text-swiss-charcoal">{summary.converted}</p>
+          </Card>
+        </div>
+
+        <Card className="p-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-swiss-charcoal">Lead pipeline</h2>
+              <p className="text-sm text-gray-500">Monitor family enquiries and track their progress through onboarding.</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                variant={activeFilter === 'all' ? 'primary' : 'light'}
+                size="sm"
+                onClick={() => setActiveFilter('all')}
+              >
+                All leads
+              </Button>
+              {statusOptions.map((option) => (
+                <Button
+                  key={option.value}
+                  variant={activeFilter === option.value ? 'primary' : 'light'}
+                  size="sm"
+                  onClick={() => setActiveFilter(option.value)}
+                >
+                  {option.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-6 overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200 text-left text-sm">
+              <thead>
+                <tr className="text-xs uppercase tracking-wide text-gray-500">
+                  <th className="py-3 pr-4">Family</th>
+                  <th className="py-3 pr-4">Child</th>
+                  <th className="py-3 pr-4">Preferences</th>
+                  <th className="py-3 pr-4">Status</th>
+                  <th className="py-3 pr-4 text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {filteredLeads.length === 0 && (
+                  <tr>
+                    <td colSpan={5} className="py-6 text-center text-sm text-gray-500">
+                      No leads found for this filter.
+                    </td>
+                  </tr>
+                )}
+                {filteredLeads.map((lead) => (
+                  <tr key={lead.id} className="transition-colors hover:bg-swiss-mint/5">
+                    <td className="py-4 pr-4">
+                      <p className="font-semibold text-swiss-charcoal">{lead.parentName}</p>
+                      <p className="text-xs text-gray-500">{lead.parentEmail}</p>
+                      {lead.parentPhone && <p className="text-xs text-gray-500">{lead.parentPhone}</p>}
+                    </td>
+                    <td className="py-4 pr-4">
+                      <p className="font-medium text-swiss-charcoal">{lead.childName}</p>
+                      <p className="text-xs text-gray-500">{lead.childAge} years old</p>
+                    </td>
+                    <td className="py-4 pr-4 text-xs text-gray-500">
+                      <div className="space-y-1">
+                        {lead.preferredLocation && <p>Location: {lead.preferredLocation}</p>}
+                        {lead.preferredLanguages?.length ? <p>Languages: {lead.preferredLanguages.join(', ')}</p> : null}
+                        <p>Received: {new Date(lead.createdAt).toLocaleDateString()}</p>
+                      </div>
+                    </td>
+                    <td className="py-4 pr-4">
+                      <span
+                        className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-semibold ${
+                          statusBadgeStyles[lead.status] ?? 'bg-gray-50 text-gray-600 border-gray-200'
+                        }`}
+                      >
+                        {lead.status === 'CONVERTED' ? (
+                          <CheckCircleIcon className="h-4 w-4" />
+                        ) : lead.status === 'NEW' ? (
+                          <ClockIcon className="h-4 w-4" />
+                        ) : lead.status === 'LOST' ? (
+                          <XMarkIcon className="h-4 w-4" />
+                        ) : (
+                          <FunnelIcon className="h-4 w-4" />
+                        )}
+                        {statusOptions.find((option) => option.value === lead.status)?.label ?? lead.status}
+                      </span>
+                    </td>
+                    <td className="py-4 pr-4 text-right">
+                      <select
+                        className="rounded-lg border border-gray-200 px-2 py-1 text-xs text-gray-700 focus:border-swiss-mint focus:outline-none focus:ring-2 focus:ring-swiss-mint/20"
+                        value={lead.status}
+                        onChange={(event) => updateLeadStatus(lead.id, event.target.value as LeadStatus)}
+                        disabled={updatingLeadId === lead.id}
+                      >
+                        {statusOptions.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      </div>
+    );
+  };
+
+  return (
+    <FoundationDashboardLayout title="Participant Leads" subtitle="Manage family enquiries and track conversions">
+      {renderContent()}
+    </FoundationDashboardLayout>
+  );
+};
+
+export default FoundationLeadsPage;

--- a/frontend/src/pages/foundation/FoundationOrganisationProfilePage.tsx
+++ b/frontend/src/pages/foundation/FoundationOrganisationProfilePage.tsx
@@ -1,0 +1,316 @@
+import React, { useEffect, useState } from 'react';
+import { useAuth } from '@clerk/clerk-react';
+import Card from '../../components/ui/Card';
+import Button from '../../components/ui/Button';
+import FoundationDashboardLayout from '../../components/dashboard/FoundationDashboardLayout';
+import { apiCall } from '../../utils/api';
+
+type OrganizationMember = {
+  id: string;
+  user: {
+    firstName: string | null;
+    lastName: string | null;
+    email: string;
+  };
+};
+
+type Organization = {
+  id: string;
+  name: string;
+  canton?: string | null;
+  languages?: string[] | null;
+  capacity?: number | null;
+  pedagogy?: string[] | null;
+  contactPerson?: string | null;
+  phoneNumber?: string | null;
+  bookingLink?: string | null;
+  members?: OrganizationMember[];
+};
+
+type ProfileResponse = {
+  firstName?: string | null;
+  lastName?: string | null;
+  phoneNumber?: string | null;
+  organizations?: Array<{
+    organization: Organization;
+  }>;
+};
+
+type UpdatePayload = {
+  firstName?: string;
+  lastName?: string;
+  phoneNumber?: string;
+  organizationName?: string;
+  contactPerson?: string;
+  canton?: string;
+  languages?: string[];
+  capacity?: number;
+  pedagogy?: string[];
+  bookingLink?: string;
+};
+
+const FoundationOrganisationProfilePage: React.FC = () => {
+  const { getToken } = useAuth();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [profile, setProfile] = useState<ProfileResponse | null>(null);
+  const [organization, setOrganization] = useState<Organization | null>(null);
+  const [formValues, setFormValues] = useState<UpdatePayload>({});
+
+  useEffect(() => {
+    fetchProfile();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const fetchProfile = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const token = await getToken();
+      const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
+      const response = await apiCall('/profiles/me', { headers });
+      if (!response.ok) {
+        throw new Error('Unable to load profile information');
+      }
+      const json = await response.json();
+      const data: ProfileResponse = json.data ?? json;
+      setProfile(data);
+      const foundationLink = data.organizations?.find((link) => link.organization);
+      if (foundationLink) {
+        setOrganization(foundationLink.organization);
+        setFormValues({
+          firstName: data.firstName ?? undefined,
+          lastName: data.lastName ?? undefined,
+          phoneNumber: data.phoneNumber ?? undefined,
+          organizationName: foundationLink.organization.name,
+          contactPerson: foundationLink.organization.contactPerson ?? undefined,
+          canton: foundationLink.organization.canton ?? undefined,
+          languages: foundationLink.organization.languages ?? [],
+          capacity: foundationLink.organization.capacity ?? undefined,
+          pedagogy: foundationLink.organization.pedagogy ?? [],
+          bookingLink: foundationLink.organization.bookingLink ?? undefined,
+        });
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to load profile.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleInputChange = (field: keyof UpdatePayload, value: string | number | string[]) => {
+    setFormValues((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleArrayInput = (field: keyof UpdatePayload, value: string) => {
+    const items = value
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
+    handleInputChange(field, items);
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    try {
+      setSuccess(null);
+      setError(null);
+      const token = await getToken();
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      };
+      const response = await apiCall('/profiles/me', {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify(formValues),
+      });
+      if (!response.ok) {
+        throw new Error('Failed to update profile');
+      }
+      setSuccess('Profile updated successfully');
+      fetchProfile();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to save changes.');
+    }
+  };
+
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <div className="flex min-h-[320px] items-center justify-center">
+          <div className="text-center">
+            <div className="mx-auto h-10 w-10 animate-spin rounded-full border-4 border-swiss-mint/30 border-t-swiss-mint" />
+            <p className="mt-3 text-sm text-gray-500">Loading organisation profile…</p>
+          </div>
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <Card className="border border-rose-100 bg-rose-50 p-6 text-rose-700">
+          <h2 className="text-lg font-semibold">We couldn’t load the organisation profile</h2>
+          <p className="mt-2 text-sm">{error}</p>
+          <Button className="mt-4" variant="light" onClick={fetchProfile}>
+            Retry loading profile
+          </Button>
+        </Card>
+      );
+    }
+
+    if (!organization) {
+      return (
+        <Card className="border border-amber-100 bg-amber-50 p-6 text-amber-700">
+          <h2 className="text-lg font-semibold">Foundation organisation missing</h2>
+          <p className="mt-2 text-sm">Link this account to a foundation organisation to configure its profile.</p>
+        </Card>
+      );
+    }
+
+    return (
+      <div className="space-y-6">
+        <Card className="p-6">
+          <h2 className="text-xl font-semibold text-swiss-charcoal">Organisation details</h2>
+          <p className="mt-1 text-sm text-gray-500">Update information shared across your foundation dashboards and marketplace.</p>
+          <form className="mt-6 space-y-5" onSubmit={handleSubmit}>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <label className="text-sm font-medium text-swiss-charcoal">
+                Organisation name
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-swiss-mint focus:outline-none focus:ring-2 focus:ring-swiss-mint/20"
+                  value={formValues.organizationName ?? ''}
+                  onChange={(event) => handleInputChange('organizationName', event.target.value)}
+                />
+              </label>
+              <label className="text-sm font-medium text-swiss-charcoal">
+                Contact person
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-swiss-mint focus:outline-none focus:ring-2 focus:ring-swiss-mint/20"
+                  value={formValues.contactPerson ?? ''}
+                  onChange={(event) => handleInputChange('contactPerson', event.target.value)}
+                />
+              </label>
+              <label className="text-sm font-medium text-swiss-charcoal">
+                Canton / Region
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-swiss-mint focus:outline-none focus:ring-2 focus:ring-swiss-mint/20"
+                  value={formValues.canton ?? ''}
+                  onChange={(event) => handleInputChange('canton', event.target.value)}
+                />
+              </label>
+              <label className="text-sm font-medium text-swiss-charcoal">
+                Booking link
+                <input
+                  type="url"
+                  className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-swiss-mint focus:outline-none focus:ring-2 focus:ring-swiss-mint/20"
+                  value={formValues.bookingLink ?? ''}
+                  onChange={(event) => handleInputChange('bookingLink', event.target.value)}
+                />
+              </label>
+              <label className="text-sm font-medium text-swiss-charcoal">
+                Languages (comma separated)
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-swiss-mint focus:outline-none focus:ring-2 focus:ring-swiss-mint/20"
+                  value={(formValues.languages ?? []).join(', ')}
+                  onChange={(event) => handleArrayInput('languages', event.target.value)}
+                />
+              </label>
+              <label className="text-sm font-medium text-swiss-charcoal">
+                Pedagogies (comma separated)
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-swiss-mint focus:outline-none focus:ring-2 focus:ring-swiss-mint/20"
+                  value={(formValues.pedagogy ?? []).join(', ')}
+                  onChange={(event) => handleArrayInput('pedagogy', event.target.value)}
+                />
+              </label>
+              <label className="text-sm font-medium text-swiss-charcoal">
+                Capacity
+                <input
+                  type="number"
+                  min={0}
+                  className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-swiss-mint focus:outline-none focus:ring-2 focus:ring-swiss-mint/20"
+                  value={formValues.capacity ?? ''}
+                  onChange={(event) => handleInputChange('capacity', Number(event.target.value))}
+                />
+              </label>
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+              <label className="text-sm font-medium text-swiss-charcoal">
+                Director first name
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-swiss-mint focus:outline-none focus:ring-2 focus:ring-swiss-mint/20"
+                  value={formValues.firstName ?? ''}
+                  onChange={(event) => handleInputChange('firstName', event.target.value)}
+                />
+              </label>
+              <label className="text-sm font-medium text-swiss-charcoal">
+                Director last name
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-swiss-mint focus:outline-none focus:ring-2 focus:ring-swiss-mint/20"
+                  value={formValues.lastName ?? ''}
+                  onChange={(event) => handleInputChange('lastName', event.target.value)}
+                />
+              </label>
+              <label className="text-sm font-medium text-swiss-charcoal">
+                Contact phone number
+                <input
+                  type="tel"
+                  className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-swiss-mint focus:outline-none focus:ring-2 focus:ring-swiss-mint/20"
+                  value={formValues.phoneNumber ?? ''}
+                  onChange={(event) => handleInputChange('phoneNumber', event.target.value)}
+                />
+              </label>
+            </div>
+
+            <div className="flex items-center justify-between">
+              <div>
+                {success && <p className="text-sm font-semibold text-emerald-600">{success}</p>}
+                {!success && <p className="text-xs text-gray-500">Changes will update across the foundation dashboard instantly.</p>}
+              </div>
+              <Button type="submit">Save changes</Button>
+            </div>
+          </form>
+        </Card>
+
+        <Card className="p-6">
+          <h2 className="text-xl font-semibold text-swiss-charcoal">Team members</h2>
+          <p className="mt-1 text-sm text-gray-500">Team members listed here can access the foundation dashboard and receive quick messages.</p>
+          <ul className="mt-4 space-y-2">
+            {organization.members?.length ? (
+              organization.members.map((member) => (
+                <li key={member.id} className="flex items-center justify-between rounded-xl border border-gray-100 px-4 py-3 text-sm">
+                  <span className="font-medium text-swiss-charcoal">
+                    {`${member.user.firstName ?? ''} ${member.user.lastName ?? ''}`.trim() || member.user.email}
+                  </span>
+                  <span className="text-xs text-gray-500">{member.user.email}</span>
+                </li>
+              ))
+            ) : (
+              <li className="rounded-xl border border-dashed border-gray-200 p-6 text-center text-sm text-gray-500">
+                No team members linked yet.
+              </li>
+            )}
+          </ul>
+        </Card>
+      </div>
+    );
+  };
+
+  return (
+    <FoundationDashboardLayout title="Organisation profile" subtitle="Keep your foundation details accurate and up to date">
+      {renderContent()}
+    </FoundationDashboardLayout>
+  );
+};
+
+export default FoundationOrganisationProfilePage;

--- a/frontend/src/pages/foundation/FoundationSupportPage.tsx
+++ b/frontend/src/pages/foundation/FoundationSupportPage.tsx
@@ -1,0 +1,234 @@
+import React, { useEffect, useState } from 'react';
+import { useAuth } from '@clerk/clerk-react';
+import { LifebuoyIcon, ChatBubbleLeftRightIcon, EnvelopeIcon } from '@heroicons/react/24/outline';
+import Card from '../../components/ui/Card';
+import Button from '../../components/ui/Button';
+import FoundationDashboardLayout from '../../components/dashboard/FoundationDashboardLayout';
+import { apiCall } from '../../utils/api';
+
+type SupportContact = {
+  id: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  email?: string | null;
+};
+
+type Conversation = {
+  id: string;
+  type: string;
+  title?: string | null;
+  messages?: Array<{ content: string; createdAt: string }>;
+};
+
+const FoundationSupportPage: React.FC = () => {
+  const { getToken } = useAuth();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [contacts, setContacts] = useState<SupportContact[]>([]);
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [selectedContactId, setSelectedContactId] = useState<string>('');
+  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState<'idle' | 'sending' | 'success' | 'error'>('idle');
+
+  useEffect(() => {
+    fetchSupportData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const fetchSupportData = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const token = await getToken();
+      const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
+
+      const [contactsResponse, conversationsResponse] = await Promise.all([
+        apiCall('/profiles/support/contacts', { headers }),
+        apiCall('/messaging/conversations', { headers }),
+      ]);
+
+      if (!contactsResponse.ok) {
+        throw new Error('Unable to load support contacts');
+      }
+      const contactsJson = await contactsResponse.json();
+      const supportContacts = (contactsJson.data ?? contactsJson) as SupportContact[];
+      setContacts(supportContacts);
+      if (supportContacts.length > 0) {
+        setSelectedContactId(supportContacts[0].id);
+      }
+
+      if (conversationsResponse.ok) {
+        const conversationsJson = await conversationsResponse.json();
+        const allConversations = (conversationsJson.data ?? conversationsJson) as Conversation[];
+        setConversations(allConversations.filter((conversation) => conversation.type === 'SUPPORT'));
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to load support data.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!message.trim() || !selectedContactId) {
+      return;
+    }
+
+    try {
+      setStatus('sending');
+      const token = await getToken();
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      };
+
+      const conversationResponse = await apiCall('/messaging/conversations', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          type: 'SUPPORT',
+          participantIds: [selectedContactId],
+          title: 'Foundation Support Request',
+        }),
+      });
+
+      if (!conversationResponse.ok) {
+        throw new Error('Failed to create support conversation');
+      }
+
+      const conversationJson = await conversationResponse.json();
+      const conversationId = conversationJson.id ?? conversationJson.data?.id;
+      if (!conversationId) {
+        throw new Error('Missing conversation identifier');
+      }
+
+      const messageResponse = await apiCall('/messaging/messages', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          conversationId,
+          content: message.trim(),
+          messageType: 'TEXT',
+        }),
+      });
+
+      if (!messageResponse.ok) {
+        throw new Error('Support message could not be sent');
+      }
+
+      setMessage('');
+      setStatus('success');
+      fetchSupportData();
+      setTimeout(() => setStatus('idle'), 2500);
+    } catch (err) {
+      console.error(err);
+      setStatus('error');
+    }
+  };
+
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <div className="flex min-h-[280px] items-center justify-center">
+          <div className="text-center">
+            <div className="mx-auto h-10 w-10 animate-spin rounded-full border-4 border-swiss-mint/30 border-t-swiss-mint" />
+            <p className="mt-3 text-sm text-gray-500">Contacting support services…</p>
+          </div>
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <Card className="border border-rose-100 bg-rose-50 p-6 text-rose-700">
+          <h2 className="text-lg font-semibold">Support centre unavailable</h2>
+          <p className="mt-2 text-sm">{error}</p>
+          <Button className="mt-4" variant="light" onClick={fetchSupportData}>
+            Retry
+          </Button>
+        </Card>
+      );
+    }
+
+    return (
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <Card className="p-6">
+          <div className="flex items-center gap-3">
+            <div className="rounded-2xl bg-swiss-mint/10 p-3 text-swiss-teal">
+              <LifebuoyIcon className="h-6 w-6" />
+            </div>
+            <div>
+              <h2 className="text-xl font-semibold text-swiss-charcoal">Priority support</h2>
+              <p className="text-sm text-gray-500">Reach our admin team directly for operational or billing issues.</p>
+            </div>
+          </div>
+
+          <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
+            <label className="text-sm font-medium text-swiss-charcoal">
+              Route to
+              <select
+                className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-swiss-mint focus:outline-none focus:ring-2 focus:ring-swiss-mint/20"
+                value={selectedContactId}
+                onChange={(event) => setSelectedContactId(event.target.value)}
+              >
+                {contacts.map((contact) => (
+                  <option key={contact.id} value={contact.id}>
+                    {`${contact.firstName ?? ''} ${contact.lastName ?? ''}`.trim() || contact.email || 'Admin'}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-sm font-medium text-swiss-charcoal">
+              Message
+              <textarea
+                className="mt-1 h-32 w-full resize-none rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-swiss-mint focus:outline-none focus:ring-2 focus:ring-swiss-mint/20"
+                value={message}
+                onChange={(event) => setMessage(event.target.value)}
+                placeholder="Describe the issue you need help with…"
+              />
+            </label>
+            <Button type="submit" leftIcon={EnvelopeIcon} disabled={status === 'sending'} className="w-full">
+              {status === 'sending' ? 'Sending…' : 'Send to support'}
+            </Button>
+            {status === 'success' && <p className="text-sm font-semibold text-emerald-600">Support request sent successfully.</p>}
+            {status === 'error' && <p className="text-sm font-semibold text-rose-600">We couldn’t send your message. Try again.</p>}
+          </form>
+        </Card>
+
+        <Card className="p-6">
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-semibold text-swiss-charcoal">Recent support tickets</h2>
+            <ChatBubbleLeftRightIcon className="h-6 w-6 text-swiss-teal" />
+          </div>
+          <ul className="mt-6 space-y-3">
+            {conversations.length === 0 && (
+              <li className="rounded-xl border border-dashed border-gray-200 p-6 text-center text-sm text-gray-500">
+                No support tickets yet. Send a message to the admin team to start a conversation.
+              </li>
+            )}
+            {conversations.map((conversation) => (
+              <li key={conversation.id} className="rounded-xl border border-gray-100 p-4">
+                <p className="text-sm font-semibold text-swiss-charcoal">{conversation.title ?? 'Support conversation'}</p>
+                <p className="mt-1 text-xs text-gray-500">
+                  Last activity:{' '}
+                  {conversation.messages?.length
+                    ? new Date(conversation.messages[0].createdAt).toLocaleString()
+                    : 'Awaiting response'}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      </div>
+    );
+  };
+
+  return (
+    <FoundationDashboardLayout title="Support" subtitle="Reach the Pro Crèche Solutions team when you need assistance">
+      {renderContent()}
+    </FoundationDashboardLayout>
+  );
+};
+
+export default FoundationSupportPage;


### PR DESCRIPTION
## Summary
- align Clerk auth and role context middleware with the AppUser->User split so request context carries real Prisma identifiers
- harden profile, upload, and content services to create and query assets, organizations, and support data against production tables instead of demo placeholders
- update admin role management, health diagnostics, reconciliation, and Clerk webhook flows to use the correct `clerkUserId` field and surface consistent API responses

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d814927f8c8325891a74f52a71aeac