### PR TITLE
Scan for i18n issues and missing keys

### DIFF
--- a/add-missing-keys-de.js
+++ b/add-missing-keys-de.js
@@ -1,0 +1,237 @@
+const fs = require('fs');
+
+// Read the current German translation file
+const deTranslations = JSON.parse(fs.readFileSync('/workspace/frontend/public/locales/de/translation.json', 'utf8'));
+
+// Add the critical missing keys in German
+const criticalMissingKeys = {
+  // Messages page
+  "messagesPage": {
+    "searchPlaceholder": "Gespräche suchen...",
+    "filters": {
+      "all": "Alle",
+      "unread": "Ungelesen"
+    },
+    "noConversationsFound": "Keine Gespräche gefunden",
+    "selectConversationToView": "Wählen Sie ein Gespräch zum Anzeigen",
+    "conversationFallbackTitle": "Unbekannter Benutzer",
+    "attachFile": "Datei anhängen",
+    "addEmoji": "Emoji hinzufügen",
+    "typeMessagePlaceholder": "Nachricht eingeben...",
+    "unknownUser": "Unbekannter Benutzer",
+    "youPrefix": "Sie: ",
+    "noMessagesYet": "Noch keine Nachrichten",
+    "newGroupButton": "Neue Gruppe",
+    "noConversationSelectedTitle": "Kein Gespräch ausgewählt",
+    "noConversationSelectedSubtitle": "Wählen Sie ein Gespräch aus der Liste aus, um mit dem Messaging zu beginnen",
+    "noConversationsYet": "Noch keine Gespräche"
+  },
+
+  // Create group chat modal
+  "createGroupChatModal": {
+    "error": {
+      "minParticipants": "Bitte wählen Sie mindestens 2 Teilnehmer aus"
+    },
+    "title": "Gruppenchat erstellen",
+    "groupNameLabel": "Gruppenname",
+    "groupNamePlaceholder": "Gruppenname eingeben...",
+    "selectParticipantsLabel": "Teilnehmer auswählen",
+    "createButton": "Gruppe erstellen"
+  },
+
+  // Order request detail modal
+  "orderRequestDetailModal": {
+    "title": "Bestelldetails",
+    "orderId": "Bestell-ID",
+    "date": "Datum",
+    "status": "Status",
+    "total": "Gesamt",
+    "viewDaycareProfile": "Krippenprofil anzeigen",
+    "lineItems": "Positionen",
+    "product": "Produkt",
+    "quantity": "Menge",
+    "price": "Preis",
+    "notes": "Notizen"
+  },
+
+  // Service request detail modal
+  "serviceRequestDetailModal": {
+    "title": "Serviceanfrage-Details",
+    "requestId": "Anfrage-ID",
+    "serviceName": "Service-Name",
+    "viewDaycareProfile": "Krippenprofil anzeigen",
+    "date": "Datum",
+    "status": "Status",
+    "preferredDate": "Bevorzugtes Datum",
+    "noPreferredDate": "Kein bevorzugtes Datum festgelegt",
+    "notes": "Notizen"
+  },
+
+  // Service upload modal
+  "serviceUploadModal": {
+    "editTitle": "Service bearbeiten",
+    "addTitle": "Neuen Service hinzufügen",
+    "labels": {
+      "title": "Service-Titel",
+      "description": "Beschreibung",
+      "category": "Kategorie",
+      "deliveryType": "Lieferart",
+      "availability": "Verfügbarkeit",
+      "priceInfo": "Preisinformationen",
+      "tags": "Tags",
+      "image": "Service-Bild"
+    },
+    "placeholders": {
+      "availability": "z.B. Montag-Freitag 9-17 Uhr",
+      "priceInfo": "z.B. CHF 50/Stunde",
+      "tags": "z.B. Beratung, Schulung, Support"
+    },
+    "imageHelpText": "Laden Sie ein Bild hoch, das Ihren Service repräsentiert"
+  },
+
+  // Content upload modal
+  "contentUploadModal": {
+    "fileUpload": {
+      "browse": "Dateien durchsuchen",
+      "dragAndDrop": "Dateien hier hineinziehen oder klicken zum Durchsuchen",
+      "selected": "Ausgewählt: {{fileName}}"
+    },
+    "error": {
+      "selectFileOrLink": "Bitte wählen Sie eine Datei aus oder geben Sie einen Link ein"
+    },
+    "contentType": {
+      "eLearning": "E-Learning-Inhalt",
+      "hrPolicy": "HR-Richtlinie",
+      "statePolicy": "Staatsrichtlinie"
+    },
+    "labels": {
+      "descriptionPreview": "Beschreibungsvorschau",
+      "description": "Beschreibung",
+      "title": "Titel",
+      "category": "Kategorie",
+      "contentType": "Inhaltstyp",
+      "language": "Sprache",
+      "duration": "Dauer",
+      "lessons": "Anzahl der Lektionen",
+      "linkUrl": "Link-URL",
+      "accessRoles": "Zugriffsrollen",
+      "status": "Status",
+      "documentTitle": "Dokumenttitel",
+      "fileType": "Dateityp",
+      "version": "Version",
+      "country": "Land",
+      "regionCanton": "Region/Kanton",
+      "policyType": "Richtlinientyp",
+      "criticality": "Kritikalität",
+      "markAsCritical": "Als kritisch markieren",
+      "effectiveDate": "Gültigkeitsdatum",
+      "externalLink": "Externer Link",
+      "uploadFile": "Datei hochladen"
+    },
+    "placeholders": {
+      "duration": "z.B. 2 Stunden",
+      "linkUrl": "https://beispiel.com",
+      "version": "z.B. 1.0",
+      "externalLink": "https://beispiel.com"
+    },
+    "statusOptions": {
+      "draft": "Entwurf",
+      "published": "Veröffentlicht",
+      "archived": "Archiviert"
+    },
+    "criticalityOptions": {
+      "critical": "Kritisch",
+      "normal": "Normal"
+    },
+    "fileUpload": {
+      "eLearningAllowedTypes": "Erlaubt: PDF, MP4, DOC, DOCX",
+      "hrPolicyAllowedTypes": "Erlaubt: PDF, DOC, DOCX"
+    },
+    "buttons": {
+      "uploading": "Hochladen...",
+      "upload": "Hochladen"
+    }
+  },
+
+  // Navbar
+  "navbar": {
+    "toggleNavigation": "Navigation umschalten",
+    "goBackPreviousPage": "Zurück zur vorherigen Seite",
+    "viewShoppingCart": "Warenkorb anzeigen",
+    "newMessages": "Neue Nachrichten",
+    "noNewNotifications": "Keine neuen Benachrichtigungen",
+    "viewAll": "Alle anzeigen",
+    "signOut": "Abmelden"
+  },
+
+  // Notifications
+  "notifications": {
+    "errorTitle": "Fehler"
+  },
+
+  // Notifications page
+  "notificationsPage": {
+    "clearAll": "Alle löschen",
+    "emptyState": {
+      "title": "Keine Benachrichtigungen",
+      "message": "Sie haben noch keine Benachrichtigungen"
+    }
+  },
+
+  // Order request modal
+  "orderRequestModal": {
+    "labels": {
+      "product": "Produkt",
+      "supplier": "Lieferant",
+      "quantity": "Menge",
+      "notes": "Notizen"
+    },
+    "placeholders": {
+      "notes": "Fügen Sie spezielle Anweisungen hinzu..."
+    }
+  },
+
+  // Organization profile form
+  "organizationProfileForm": {
+    "accessDenied": "Zugriff verweigert",
+    "title": "Organisationsprofil",
+    "subtitle": "Vervollständigen Sie die Profilinformationen Ihrer Organisation",
+    "labels": {
+      "capacity": "Kapazität",
+      "pedagogy": "Pädagogische Erklärung",
+      "languages": "Sprachen"
+    },
+    "placeholders": {
+      "pedagogy": "Beschreiben Sie Ihren pädagogischen Ansatz...",
+      "languages": "z.B. Englisch, Französisch, Deutsch"
+    },
+    "helpText": {
+      "commaSeparated": "Trennen Sie mehrere Elemente durch Kommas"
+    },
+    "saveButton": "Profil speichern"
+  }
+};
+
+// Add the critical missing keys to the translations
+Object.keys(criticalMissingKeys).forEach(namespace => {
+  if (!deTranslations[namespace]) {
+    deTranslations[namespace] = {};
+  }
+  
+  // Merge the new keys
+  Object.keys(criticalMissingKeys[namespace]).forEach(key => {
+    if (typeof criticalMissingKeys[namespace][key] === 'object') {
+      if (!deTranslations[namespace][key]) {
+        deTranslations[namespace][key] = {};
+      }
+      Object.assign(deTranslations[namespace][key], criticalMissingKeys[namespace][key]);
+    } else {
+      deTranslations[namespace][key] = criticalMissingKeys[namespace][key];
+    }
+  });
+});
+
+// Write the updated German translation file
+fs.writeFileSync('/workspace/frontend/public/locales/de/translation.json', JSON.stringify(deTranslations, null, 2));
+
+console.log('✅ Added critical missing translation keys to German locale file');

--- a/add-missing-keys-fr.js
+++ b/add-missing-keys-fr.js
@@ -1,0 +1,237 @@
+const fs = require('fs');
+
+// Read the current French translation file
+const frTranslations = JSON.parse(fs.readFileSync('/workspace/frontend/public/locales/fr/translation.json', 'utf8'));
+
+// Add the critical missing keys in French
+const criticalMissingKeys = {
+  // Messages page
+  "messagesPage": {
+    "searchPlaceholder": "Rechercher des conversations...",
+    "filters": {
+      "all": "Toutes",
+      "unread": "Non lues"
+    },
+    "noConversationsFound": "Aucune conversation trouvée",
+    "selectConversationToView": "Sélectionnez une conversation à afficher",
+    "conversationFallbackTitle": "Utilisateur inconnu",
+    "attachFile": "Joindre un fichier",
+    "addEmoji": "Ajouter un emoji",
+    "typeMessagePlaceholder": "Tapez un message...",
+    "unknownUser": "Utilisateur inconnu",
+    "youPrefix": "Vous : ",
+    "noMessagesYet": "Aucun message pour le moment",
+    "newGroupButton": "Nouveau groupe",
+    "noConversationSelectedTitle": "Aucune conversation sélectionnée",
+    "noConversationSelectedSubtitle": "Choisissez une conversation dans la liste pour commencer à échanger des messages",
+    "noConversationsYet": "Aucune conversation pour le moment"
+  },
+
+  // Create group chat modal
+  "createGroupChatModal": {
+    "error": {
+      "minParticipants": "Veuillez sélectionner au moins 2 participants"
+    },
+    "title": "Créer un chat de groupe",
+    "groupNameLabel": "Nom du groupe",
+    "groupNamePlaceholder": "Entrez le nom du groupe...",
+    "selectParticipantsLabel": "Sélectionner les participants",
+    "createButton": "Créer le groupe"
+  },
+
+  // Order request detail modal
+  "orderRequestDetailModal": {
+    "title": "Détails de la commande",
+    "orderId": "ID de commande",
+    "date": "Date",
+    "status": "Statut",
+    "total": "Total",
+    "viewDaycareProfile": "Voir le profil de la crèche",
+    "lineItems": "Articles",
+    "product": "Produit",
+    "quantity": "Quantité",
+    "price": "Prix",
+    "notes": "Notes"
+  },
+
+  // Service request detail modal
+  "serviceRequestDetailModal": {
+    "title": "Détails de la demande de service",
+    "requestId": "ID de demande",
+    "serviceName": "Nom du service",
+    "viewDaycareProfile": "Voir le profil de la crèche",
+    "date": "Date",
+    "status": "Statut",
+    "preferredDate": "Date préférée",
+    "noPreferredDate": "Aucune date préférée définie",
+    "notes": "Notes"
+  },
+
+  // Service upload modal
+  "serviceUploadModal": {
+    "editTitle": "Modifier le service",
+    "addTitle": "Ajouter un nouveau service",
+    "labels": {
+      "title": "Titre du service",
+      "description": "Description",
+      "category": "Catégorie",
+      "deliveryType": "Type de livraison",
+      "availability": "Disponibilité",
+      "priceInfo": "Informations sur les prix",
+      "tags": "Étiquettes",
+      "image": "Image du service"
+    },
+    "placeholders": {
+      "availability": "ex: Lundi-Vendredi 9h-17h",
+      "priceInfo": "ex: CHF 50/heure",
+      "tags": "ex: consultation, formation, support"
+    },
+    "imageHelpText": "Téléchargez une image qui représente votre service"
+  },
+
+  // Content upload modal
+  "contentUploadModal": {
+    "fileUpload": {
+      "browse": "Parcourir les fichiers",
+      "dragAndDrop": "Glissez-déposez les fichiers ici, ou cliquez pour parcourir",
+      "selected": "Sélectionné : {{fileName}}"
+    },
+    "error": {
+      "selectFileOrLink": "Veuillez sélectionner un fichier ou entrer un lien"
+    },
+    "contentType": {
+      "eLearning": "Contenu d'apprentissage en ligne",
+      "hrPolicy": "Politique RH",
+      "statePolicy": "Politique d'état"
+    },
+    "labels": {
+      "descriptionPreview": "Aperçu de la description",
+      "description": "Description",
+      "title": "Titre",
+      "category": "Catégorie",
+      "contentType": "Type de contenu",
+      "language": "Langue",
+      "duration": "Durée",
+      "lessons": "Nombre de leçons",
+      "linkUrl": "URL du lien",
+      "accessRoles": "Rôles d'accès",
+      "status": "Statut",
+      "documentTitle": "Titre du document",
+      "fileType": "Type de fichier",
+      "version": "Version",
+      "country": "Pays",
+      "regionCanton": "Région/Canton",
+      "policyType": "Type de politique",
+      "criticality": "Criticité",
+      "markAsCritical": "Marquer comme critique",
+      "effectiveDate": "Date d'entrée en vigueur",
+      "externalLink": "Lien externe",
+      "uploadFile": "Télécharger un fichier"
+    },
+    "placeholders": {
+      "duration": "ex: 2 heures",
+      "linkUrl": "https://exemple.com",
+      "version": "ex: 1.0",
+      "externalLink": "https://exemple.com"
+    },
+    "statusOptions": {
+      "draft": "Brouillon",
+      "published": "Publié",
+      "archived": "Archivé"
+    },
+    "criticalityOptions": {
+      "critical": "Critique",
+      "normal": "Normal"
+    },
+    "fileUpload": {
+      "eLearningAllowedTypes": "Autorisé : PDF, MP4, DOC, DOCX",
+      "hrPolicyAllowedTypes": "Autorisé : PDF, DOC, DOCX"
+    },
+    "buttons": {
+      "uploading": "Téléchargement...",
+      "upload": "Télécharger"
+    }
+  },
+
+  // Navbar
+  "navbar": {
+    "toggleNavigation": "Basculer la navigation",
+    "goBackPreviousPage": "Retour à la page précédente",
+    "viewShoppingCart": "Voir le panier",
+    "newMessages": "Nouveaux messages",
+    "noNewNotifications": "Aucune nouvelle notification",
+    "viewAll": "Voir tout",
+    "signOut": "Se déconnecter"
+  },
+
+  // Notifications
+  "notifications": {
+    "errorTitle": "Erreur"
+  },
+
+  // Notifications page
+  "notificationsPage": {
+    "clearAll": "Tout effacer",
+    "emptyState": {
+      "title": "Aucune notification",
+      "message": "Vous n'avez pas encore de notifications"
+    }
+  },
+
+  // Order request modal
+  "orderRequestModal": {
+    "labels": {
+      "product": "Produit",
+      "supplier": "Fournisseur",
+      "quantity": "Quantité",
+      "notes": "Notes"
+    },
+    "placeholders": {
+      "notes": "Ajoutez des instructions spéciales..."
+    }
+  },
+
+  // Organization profile form
+  "organizationProfileForm": {
+    "accessDenied": "Accès refusé",
+    "title": "Profil de l'organisation",
+    "subtitle": "Complétez les informations du profil de votre organisation",
+    "labels": {
+      "capacity": "Capacité",
+      "pedagogy": "Déclaration pédagogique",
+      "languages": "Langues"
+    },
+    "placeholders": {
+      "pedagogy": "Décrivez votre approche éducative...",
+      "languages": "ex: Anglais, Français, Allemand"
+    },
+    "helpText": {
+      "commaSeparated": "Séparez plusieurs éléments par des virgules"
+    },
+    "saveButton": "Enregistrer le profil"
+  }
+};
+
+// Add the critical missing keys to the translations
+Object.keys(criticalMissingKeys).forEach(namespace => {
+  if (!frTranslations[namespace]) {
+    frTranslations[namespace] = {};
+  }
+  
+  // Merge the new keys
+  Object.keys(criticalMissingKeys[namespace]).forEach(key => {
+    if (typeof criticalMissingKeys[namespace][key] === 'object') {
+      if (!frTranslations[namespace][key]) {
+        frTranslations[namespace][key] = {};
+      }
+      Object.assign(frTranslations[namespace][key], criticalMissingKeys[namespace][key]);
+    } else {
+      frTranslations[namespace][key] = criticalMissingKeys[namespace][key];
+    }
+  });
+});
+
+// Write the updated French translation file
+fs.writeFileSync('/workspace/frontend/public/locales/fr/translation.json', JSON.stringify(frTranslations, null, 2));
+
+console.log('✅ Added critical missing translation keys to French locale file');

--- a/add-missing-keys.js
+++ b/add-missing-keys.js
@@ -1,0 +1,271 @@
+const fs = require('fs');
+const path = require('path');
+
+// Read the current English translation file
+const enTranslations = JSON.parse(fs.readFileSync('/workspace/frontend/public/locales/en/translation.json', 'utf8'));
+
+// Function to set a nested key in an object
+function setNestedKey(obj, keyPath, value) {
+  const keys = keyPath.split('.');
+  let current = obj;
+  
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i];
+    if (!(key in current) || typeof current[key] !== 'object') {
+      current[key] = {};
+    }
+    current = current[key];
+  }
+  
+  current[keys[keys.length - 1]] = value;
+}
+
+// Add the most critical missing keys
+const criticalMissingKeys = {
+  // Messages page
+  "messagesPage": {
+    "searchPlaceholder": "Search conversations...",
+    "filters": {
+      "all": "All",
+      "unread": "Unread"
+    },
+    "noConversationsFound": "No conversations found",
+    "selectConversationToView": "Select a conversation to view",
+    "conversationFallbackTitle": "Unknown User",
+    "attachFile": "Attach file",
+    "addEmoji": "Add emoji",
+    "typeMessagePlaceholder": "Type a message...",
+    "unknownUser": "Unknown User",
+    "youPrefix": "You: ",
+    "noMessagesYet": "No messages yet",
+    "newGroupButton": "New Group",
+    "noConversationSelectedTitle": "No conversation selected",
+    "noConversationSelectedSubtitle": "Choose a conversation from the list to start messaging",
+    "noConversationsYet": "No conversations yet"
+  },
+
+  // Create group chat modal
+  "createGroupChatModal": {
+    "error": {
+      "minParticipants": "Please select at least 2 participants"
+    },
+    "title": "Create Group Chat",
+    "groupNameLabel": "Group Name",
+    "groupNamePlaceholder": "Enter group name...",
+    "selectParticipantsLabel": "Select Participants",
+    "createButton": "Create Group"
+  },
+
+  // Order request detail modal
+  "orderRequestDetailModal": {
+    "title": "Order Details",
+    "orderId": "Order ID",
+    "date": "Date",
+    "status": "Status",
+    "total": "Total",
+    "viewDaycareProfile": "View Daycare Profile",
+    "lineItems": "Line Items",
+    "product": "Product",
+    "quantity": "Quantity",
+    "price": "Price",
+    "notes": "Notes"
+  },
+
+  // Service request detail modal
+  "serviceRequestDetailModal": {
+    "title": "Service Request Details",
+    "requestId": "Request ID",
+    "serviceName": "Service Name",
+    "viewDaycareProfile": "View Daycare Profile",
+    "date": "Date",
+    "status": "Status",
+    "preferredDate": "Preferred Date",
+    "noPreferredDate": "No preferred date set",
+    "notes": "Notes"
+  },
+
+  // Service upload modal
+  "serviceUploadModal": {
+    "editTitle": "Edit Service",
+    "addTitle": "Add New Service",
+    "labels": {
+      "title": "Service Title",
+      "description": "Description",
+      "category": "Category",
+      "deliveryType": "Delivery Type",
+      "availability": "Availability",
+      "priceInfo": "Price Information",
+      "tags": "Tags",
+      "image": "Service Image"
+    },
+    "placeholders": {
+      "availability": "e.g., Monday-Friday 9AM-5PM",
+      "priceInfo": "e.g., CHF 50/hour",
+      "tags": "e.g., consultation, training, support"
+    },
+    "imageHelpText": "Upload an image that represents your service"
+  },
+
+  // Content upload modal
+  "contentUploadModal": {
+    "fileUpload": {
+      "browse": "Browse Files",
+      "dragAndDrop": "Drag and drop files here, or click to browse",
+      "selected": "Selected: {{fileName}}"
+    },
+    "error": {
+      "selectFileOrLink": "Please select a file or enter a link"
+    },
+    "contentType": {
+      "eLearning": "E-Learning Content",
+      "hrPolicy": "HR Policy",
+      "statePolicy": "State Policy"
+    },
+    "labels": {
+      "descriptionPreview": "Description Preview",
+      "description": "Description",
+      "title": "Title",
+      "category": "Category",
+      "contentType": "Content Type",
+      "language": "Language",
+      "duration": "Duration",
+      "lessons": "Number of Lessons",
+      "linkUrl": "Link URL",
+      "accessRoles": "Access Roles",
+      "status": "Status",
+      "documentTitle": "Document Title",
+      "fileType": "File Type",
+      "version": "Version",
+      "country": "Country",
+      "regionCanton": "Region/Canton",
+      "policyType": "Policy Type",
+      "criticality": "Criticality",
+      "markAsCritical": "Mark as Critical",
+      "effectiveDate": "Effective Date",
+      "externalLink": "External Link",
+      "uploadFile": "Upload File"
+    },
+    "placeholders": {
+      "duration": "e.g., 2 hours",
+      "linkUrl": "https://example.com",
+      "version": "e.g., 1.0",
+      "externalLink": "https://example.com"
+    },
+    "statusOptions": {
+      "draft": "Draft",
+      "published": "Published",
+      "archived": "Archived"
+    },
+    "criticalityOptions": {
+      "critical": "Critical",
+      "normal": "Normal"
+    },
+    "fileUpload": {
+      "eLearningAllowedTypes": "Allowed: PDF, MP4, DOC, DOCX",
+      "hrPolicyAllowedTypes": "Allowed: PDF, DOC, DOCX"
+    },
+    "buttons": {
+      "uploading": "Uploading...",
+      "upload": "Upload"
+    }
+  },
+
+  // Navbar
+  "navbar": {
+    "toggleNavigation": "Toggle navigation",
+    "goBackPreviousPage": "Go back to previous page",
+    "viewShoppingCart": "View shopping cart",
+    "newMessages": "New messages",
+    "noNewNotifications": "No new notifications",
+    "viewAll": "View all",
+    "signOut": "Sign out"
+  },
+
+  // Notifications
+  "notifications": {
+    "errorTitle": "Error"
+  },
+
+  // Notifications page
+  "notificationsPage": {
+    "clearAll": "Clear All",
+    "emptyState": {
+      "title": "No notifications",
+      "message": "You don't have any notifications yet"
+    }
+  },
+
+  // Order request modal
+  "orderRequestModal": {
+    "labels": {
+      "product": "Product",
+      "supplier": "Supplier",
+      "quantity": "Quantity",
+      "notes": "Notes"
+    },
+    "placeholders": {
+      "notes": "Add any special instructions..."
+    }
+  },
+
+  // Organization profile form
+  "organizationProfileForm": {
+    "accessDenied": "Access denied",
+    "title": "Organization Profile",
+    "subtitle": "Complete your organization's profile information",
+    "labels": {
+      "capacity": "Capacity",
+      "pedagogy": "Pedagogy Statement",
+      "languages": "Languages"
+    },
+    "placeholders": {
+      "pedagogy": "Describe your educational approach...",
+      "languages": "e.g., English, French, German"
+    },
+    "helpText": {
+      "commaSeparated": "Separate multiple items with commas"
+    },
+    "saveButton": "Save Profile"
+  }
+};
+
+// Add the critical missing keys to the translations
+Object.keys(criticalMissingKeys).forEach(namespace => {
+  if (!enTranslations[namespace]) {
+    enTranslations[namespace] = {};
+  }
+  
+  // Merge the new keys
+  Object.keys(criticalMissingKeys[namespace]).forEach(key => {
+    if (typeof criticalMissingKeys[namespace][key] === 'object') {
+      if (!enTranslations[namespace][key]) {
+        enTranslations[namespace][key] = {};
+      }
+      Object.assign(enTranslations[namespace][key], criticalMissingKeys[namespace][key]);
+    } else {
+      enTranslations[namespace][key] = criticalMissingKeys[namespace][key];
+    }
+  });
+});
+
+// Write the updated English translation file
+fs.writeFileSync('/workspace/frontend/public/locales/en/translation.json', JSON.stringify(enTranslations, null, 2));
+
+console.log('✅ Added critical missing translation keys to English locale file');
+console.log('📝 Added keys for:');
+console.log('  - messagesPage');
+console.log('  - createGroupChatModal');
+console.log('  - orderRequestDetailModal');
+console.log('  - serviceRequestDetailModal');
+console.log('  - serviceUploadModal');
+console.log('  - contentUploadModal');
+console.log('  - navbar');
+console.log('  - notifications');
+console.log('  - notificationsPage');
+console.log('  - orderRequestModal');
+console.log('  - organizationProfileForm');
+
+console.log('\n🔄 Next steps:');
+console.log('1. Add the same keys to French and German locale files');
+console.log('2. Test the frontend to see if translation issues are resolved');
+console.log('3. Run the scanner again to check for remaining missing keys');

--- a/extract-all-missing-keys.js
+++ b/extract-all-missing-keys.js
@@ -1,0 +1,106 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Read the English translation file
+const enTranslations = JSON.parse(fs.readFileSync('/workspace/frontend/public/locales/en/translation.json', 'utf8'));
+
+// Function to check if a key exists in nested object
+function keyExists(obj, keyPath) {
+  const keys = keyPath.split('.');
+  let current = obj;
+  
+  for (const key of keys) {
+    if (current && typeof current === 'object' && key in current) {
+      current = current[key];
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Function to set a nested key in an object
+function setNestedKey(obj, keyPath, value) {
+  const keys = keyPath.split('.');
+  let current = obj;
+  
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i];
+    if (!(key in current) || typeof current[key] !== 'object') {
+      current[key] = {};
+    }
+    current = current[key];
+  }
+  
+  current[keys[keys.length - 1]] = value;
+}
+
+// Find all t() calls in the codebase
+try {
+  const result = execSync('grep -r "t(\'" /workspace/frontend --include="*.tsx" --include="*.ts" | grep -v node_modules | grep -v test', { encoding: 'utf8' });
+  const lines = result.split('\n').filter(line => line.trim());
+  
+  console.log('=== Extracting Missing Translation Keys ===');
+  const usedKeys = new Set();
+  const missingKeys = [];
+  
+  lines.forEach(line => {
+    const matches = line.match(/t\(['"`]([^'"`]+)['"`]\)/g);
+    if (matches) {
+      matches.forEach(match => {
+        const keyMatch = match.match(/t\(['"`]([^'"`]+)['"`]\)/);
+        if (keyMatch) {
+          const key = keyMatch[1];
+          usedKeys.add(key);
+          if (!keyExists(enTranslations, key)) {
+            missingKeys.push(key);
+          }
+        }
+      });
+    }
+  });
+  
+  console.log(`Total keys used in code: ${usedKeys.size}`);
+  console.log(`Missing keys: ${missingKeys.length}`);
+  
+  // Group missing keys by namespace
+  const groupedKeys = {};
+  missingKeys.forEach(key => {
+    const parts = key.split('.');
+    const namespace = parts[0];
+    if (!groupedKeys[namespace]) {
+      groupedKeys[namespace] = [];
+    }
+    groupedKeys[namespace].push(key);
+  });
+  
+  console.log('\n=== Missing Keys by Namespace ===');
+  Object.keys(groupedKeys).sort().forEach(namespace => {
+    console.log(`\n${namespace}:`);
+    groupedKeys[namespace].forEach(key => {
+      console.log(`  - ${key}`);
+    });
+  });
+  
+  // Generate suggested translations for missing keys
+  console.log('\n=== Suggested Translations ===');
+  console.log('Add these to your translation files:');
+  
+  const suggestedTranslations = {};
+  missingKeys.forEach(key => {
+    // Generate a suggested translation based on the key
+    const parts = key.split('.');
+    const lastPart = parts[parts.length - 1];
+    
+    // Convert camelCase to Title Case
+    const titleCase = lastPart.replace(/([A-Z])/g, ' $1').replace(/^./, str => str.toUpperCase());
+    
+    setNestedKey(suggestedTranslations, key, titleCase);
+  });
+  
+  console.log(JSON.stringify(suggestedTranslations, null, 2));
+  
+} catch (error) {
+  console.error('Error running grep:', error.message);
+}

--- a/find-missing-keys.js
+++ b/find-missing-keys.js
@@ -1,0 +1,81 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Read the English translation file
+const enTranslations = JSON.parse(fs.readFileSync('/workspace/frontend/public/locales/en/translation.json', 'utf8'));
+
+// Function to check if a key exists in nested object
+function keyExists(obj, keyPath) {
+  const keys = keyPath.split('.');
+  let current = obj;
+  
+  for (const key of keys) {
+    if (current && typeof current === 'object' && key in current) {
+      current = current[key];
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Function to flatten object to get all possible keys
+function flattenKeys(obj, prefix = '') {
+  let keys = [];
+  for (const key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      const newKey = prefix ? `${prefix}.${key}` : key;
+      if (typeof obj[key] === 'object' && obj[key] !== null) {
+        keys = keys.concat(flattenKeys(obj[key], newKey));
+      } else {
+        keys.push(newKey);
+      }
+    }
+  }
+  return keys;
+}
+
+// Get all available keys
+const availableKeys = flattenKeys(enTranslations);
+console.log('Total available keys:', availableKeys.length);
+
+// Find all t() calls in the codebase
+try {
+  const result = execSync('grep -r "t(\'" /workspace/frontend --include="*.tsx" --include="*.ts" | head -20', { encoding: 'utf8' });
+  const lines = result.split('\n').filter(line => line.trim());
+  
+  console.log('\n=== Translation Keys Used in Code ===');
+  const usedKeys = new Set();
+  
+  lines.forEach(line => {
+    const matches = line.match(/t\(['"`]([^'"`]+)['"`]\)/g);
+    if (matches) {
+      matches.forEach(match => {
+        const keyMatch = match.match(/t\(['"`]([^'"`]+)['"`]\)/);
+        if (keyMatch) {
+          const key = keyMatch[1];
+          usedKeys.add(key);
+          const exists = keyExists(enTranslations, key);
+          console.log(`${exists ? '✅' : '❌'} ${key}`);
+        }
+      });
+    }
+  });
+  
+  console.log(`\nTotal keys used in code: ${usedKeys.size}`);
+  
+  // Find missing keys
+  const missingKeys = [];
+  usedKeys.forEach(key => {
+    if (!keyExists(enTranslations, key)) {
+      missingKeys.push(key);
+    }
+  });
+  
+  console.log(`\n=== Missing Keys (${missingKeys.length}) ===`);
+  missingKeys.forEach(key => console.log(`❌ ${key}`));
+  
+} catch (error) {
+  console.error('Error running grep:', error.message);
+}

--- a/frontend/i18n-report.json
+++ b/frontend/i18n-report.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2025-10-05T17:15:51.971Z",
+  "generatedAt": "2025-10-05T17:58:03.768Z",
   "summary": {
     "hardcodedCount": 0,
     "missingKeyCount": 0,
-    "unusedKeyCount": 1251,
+    "unusedKeyCount": 1614,
     "langs": [
       "en",
       "fr",
@@ -2206,13 +2206,1057 @@
       "suggestion": "Remove unused key \"contactPerson\" from namespace \"translation\" in en, fr, de"
     },
     {
-      "key": "translation:createAccount",
+      "key": "translation:contentUploadModal.buttons.upload",
       "locales": [
         "en",
         "fr",
         "de"
       ],
-      "suggestion": "Remove unused key \"createAccount\" from namespace \"translation\" in en, fr, de"
+      "suggestion": "Remove unused key \"contentUploadModal.buttons.upload\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.buttons.upload",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.buttons.upload\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.buttons.upload",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.buttons.upload\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.buttons.uploading",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.buttons.uploading\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.buttons.uploading",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.buttons.uploading\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.buttons.uploading",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.buttons.uploading\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.contentType.eLearning",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.contentType.eLearning\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.contentType.eLearning",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.contentType.eLearning\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.contentType.eLearning",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.contentType.eLearning\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.contentType.hrPolicy",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.contentType.hrPolicy\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.contentType.hrPolicy",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.contentType.hrPolicy\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.contentType.hrPolicy",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.contentType.hrPolicy\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.contentType.statePolicy",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.contentType.statePolicy\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.contentType.statePolicy",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.contentType.statePolicy\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.contentType.statePolicy",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.contentType.statePolicy\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.criticalityOptions.critical",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.criticalityOptions.critical\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.criticalityOptions.critical",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.criticalityOptions.critical\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.criticalityOptions.critical",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.criticalityOptions.critical\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.criticalityOptions.normal",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.criticalityOptions.normal\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.criticalityOptions.normal",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.criticalityOptions.normal\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.criticalityOptions.normal",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.criticalityOptions.normal\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.error.selectFileOrLink",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.error.selectFileOrLink\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.error.selectFileOrLink",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.error.selectFileOrLink\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.error.selectFileOrLink",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.error.selectFileOrLink\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.fileUpload.eLearningAllowedTypes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.fileUpload.eLearningAllowedTypes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.fileUpload.eLearningAllowedTypes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.fileUpload.eLearningAllowedTypes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.fileUpload.eLearningAllowedTypes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.fileUpload.eLearningAllowedTypes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.fileUpload.hrPolicyAllowedTypes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.fileUpload.hrPolicyAllowedTypes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.fileUpload.hrPolicyAllowedTypes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.fileUpload.hrPolicyAllowedTypes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.fileUpload.hrPolicyAllowedTypes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.fileUpload.hrPolicyAllowedTypes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.accessRoles",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.accessRoles\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.accessRoles",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.accessRoles\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.accessRoles",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.accessRoles\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.category",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.category\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.category",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.category\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.category",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.category\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.contentType",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.contentType\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.contentType",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.contentType\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.contentType",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.contentType\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.country",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.country\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.country",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.country\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.country",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.country\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.criticality",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.criticality\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.criticality",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.criticality\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.criticality",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.criticality\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.descriptionPreview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.descriptionPreview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.descriptionPreview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.descriptionPreview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.descriptionPreview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.descriptionPreview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.documentTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.documentTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.documentTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.documentTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.documentTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.documentTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.duration",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.duration\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.duration",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.duration\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.duration",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.duration\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.effectiveDate",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.effectiveDate\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.effectiveDate",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.effectiveDate\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.effectiveDate",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.effectiveDate\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.externalLink",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.externalLink\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.externalLink",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.externalLink\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.externalLink",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.externalLink\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.fileType",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.fileType\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.fileType",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.fileType\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.fileType",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.fileType\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.language",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.language\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.language",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.language\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.language",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.language\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.lessons",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.lessons\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.lessons",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.lessons\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.lessons",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.lessons\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.linkUrl",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.linkUrl\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.linkUrl",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.linkUrl\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.linkUrl",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.linkUrl\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.markAsCritical",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.markAsCritical\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.markAsCritical",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.markAsCritical\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.markAsCritical",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.markAsCritical\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.policyType",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.policyType\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.policyType",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.policyType\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.policyType",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.policyType\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.regionCanton",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.regionCanton\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.regionCanton",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.regionCanton\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.regionCanton",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.regionCanton\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.status",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.status\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.status",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.status\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.status",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.status\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.uploadFile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.uploadFile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.uploadFile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.uploadFile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.uploadFile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.uploadFile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.version",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.version\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.version",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.version\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.labels.version",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.labels.version\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.placeholders.duration",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.placeholders.duration\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.placeholders.duration",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.placeholders.duration\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.placeholders.duration",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.placeholders.duration\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.placeholders.externalLink",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.placeholders.externalLink\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.placeholders.externalLink",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.placeholders.externalLink\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.placeholders.externalLink",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.placeholders.externalLink\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.placeholders.linkUrl",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.placeholders.linkUrl\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.placeholders.linkUrl",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.placeholders.linkUrl\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.placeholders.linkUrl",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.placeholders.linkUrl\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.placeholders.version",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.placeholders.version\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.placeholders.version",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.placeholders.version\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.placeholders.version",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.placeholders.version\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.statusOptions.archived",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.statusOptions.archived\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.statusOptions.archived",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.statusOptions.archived\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.statusOptions.archived",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.statusOptions.archived\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.statusOptions.draft",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.statusOptions.draft\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.statusOptions.draft",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.statusOptions.draft\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.statusOptions.draft",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.statusOptions.draft\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.statusOptions.published",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.statusOptions.published\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.statusOptions.published",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.statusOptions.published\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contentUploadModal.statusOptions.published",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contentUploadModal.statusOptions.published\" from namespace \"translation\" in en, fr, de"
     },
     {
       "key": "translation:createAccount",
@@ -2231,6 +3275,177 @@
         "de"
       ],
       "suggestion": "Remove unused key \"createAccount\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createAccount",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createAccount\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createGroupChatModal.createButton",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createGroupChatModal.createButton\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createGroupChatModal.createButton",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createGroupChatModal.createButton\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createGroupChatModal.createButton",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createGroupChatModal.createButton\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createGroupChatModal.error.minParticipants",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createGroupChatModal.error.minParticipants\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createGroupChatModal.error.minParticipants",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createGroupChatModal.error.minParticipants\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createGroupChatModal.error.minParticipants",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createGroupChatModal.error.minParticipants\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createGroupChatModal.groupNameLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createGroupChatModal.groupNameLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createGroupChatModal.groupNameLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createGroupChatModal.groupNameLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createGroupChatModal.groupNameLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createGroupChatModal.groupNameLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createGroupChatModal.groupNamePlaceholder",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createGroupChatModal.groupNamePlaceholder\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createGroupChatModal.groupNamePlaceholder",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createGroupChatModal.groupNamePlaceholder\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createGroupChatModal.groupNamePlaceholder",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createGroupChatModal.groupNamePlaceholder\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createGroupChatModal.selectParticipantsLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createGroupChatModal.selectParticipantsLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createGroupChatModal.selectParticipantsLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createGroupChatModal.selectParticipantsLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createGroupChatModal.selectParticipantsLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createGroupChatModal.selectParticipantsLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createGroupChatModal.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createGroupChatModal.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createGroupChatModal.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createGroupChatModal.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createGroupChatModal.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createGroupChatModal.title\" from namespace \"translation\" in en, fr, de"
     },
     {
       "key": "translation:dashboardPage.activeUsers",
@@ -5365,13 +6580,85 @@
       "suggestion": "Remove unused key \"marketplacePage.title\" from namespace \"translation\" in en, fr, de"
     },
     {
-      "key": "translation:messagesPage.conversations",
+      "key": "translation:messagesPage.addEmoji",
       "locales": [
         "en",
         "fr",
         "de"
       ],
-      "suggestion": "Remove unused key \"messagesPage.conversations\" from namespace \"translation\" in en, fr, de"
+      "suggestion": "Remove unused key \"messagesPage.addEmoji\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.addEmoji",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.addEmoji\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.addEmoji",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.addEmoji\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.attachFile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.attachFile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.attachFile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.attachFile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.attachFile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.attachFile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.conversationFallbackTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.conversationFallbackTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.conversationFallbackTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.conversationFallbackTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.conversationFallbackTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.conversationFallbackTitle\" from namespace \"translation\" in en, fr, de"
     },
     {
       "key": "translation:messagesPage.conversations",
@@ -5390,6 +6677,96 @@
         "de"
       ],
       "suggestion": "Remove unused key \"messagesPage.conversations\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.conversations",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.conversations\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.filters.all",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.filters.all\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.filters.all",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.filters.all\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.filters.all",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.filters.all\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.filters.unread",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.filters.unread\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.filters.unread",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.filters.unread\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.filters.unread",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.filters.unread\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.newGroupButton",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.newGroupButton\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.newGroupButton",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.newGroupButton\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.newGroupButton",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.newGroupButton\" from namespace \"translation\" in en, fr, de"
     },
     {
       "key": "translation:messagesPage.newMessage",
@@ -5419,13 +6796,193 @@
       "suggestion": "Remove unused key \"messagesPage.newMessage\" from namespace \"translation\" in en, fr, de"
     },
     {
-      "key": "translation:messagesPage.title",
+      "key": "translation:messagesPage.noConversationSelectedSubtitle",
       "locales": [
         "en",
         "fr",
         "de"
       ],
-      "suggestion": "Remove unused key \"messagesPage.title\" from namespace \"translation\" in en, fr, de"
+      "suggestion": "Remove unused key \"messagesPage.noConversationSelectedSubtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.noConversationSelectedSubtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.noConversationSelectedSubtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.noConversationSelectedSubtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.noConversationSelectedSubtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.noConversationSelectedTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.noConversationSelectedTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.noConversationSelectedTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.noConversationSelectedTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.noConversationSelectedTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.noConversationSelectedTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.noConversationsFound",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.noConversationsFound\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.noConversationsFound",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.noConversationsFound\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.noConversationsFound",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.noConversationsFound\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.noConversationsYet",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.noConversationsYet\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.noConversationsYet",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.noConversationsYet\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.noConversationsYet",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.noConversationsYet\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.noMessagesYet",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.noMessagesYet\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.noMessagesYet",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.noMessagesYet\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.noMessagesYet",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.noMessagesYet\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.searchPlaceholder",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.searchPlaceholder\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.searchPlaceholder",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.searchPlaceholder\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.searchPlaceholder",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.searchPlaceholder\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.selectConversationToView",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.selectConversationToView\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.selectConversationToView",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.selectConversationToView\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.selectConversationToView",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.selectConversationToView\" from namespace \"translation\" in en, fr, de"
     },
     {
       "key": "translation:messagesPage.title",
@@ -5444,6 +7001,96 @@
         "de"
       ],
       "suggestion": "Remove unused key \"messagesPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.typeMessagePlaceholder",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.typeMessagePlaceholder\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.typeMessagePlaceholder",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.typeMessagePlaceholder\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.typeMessagePlaceholder",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.typeMessagePlaceholder\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.unknownUser",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.unknownUser\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.unknownUser",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.unknownUser\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.unknownUser",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.unknownUser\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.youPrefix",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.youPrefix\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.youPrefix",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.youPrefix\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.youPrefix",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.youPrefix\" from namespace \"translation\" in en, fr, de"
     },
     {
       "key": "translation:navbar.dashboard",
@@ -5471,6 +7118,33 @@
         "de"
       ],
       "suggestion": "Remove unused key \"navbar.dashboard\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.goBackPreviousPage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.goBackPreviousPage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.goBackPreviousPage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.goBackPreviousPage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.goBackPreviousPage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.goBackPreviousPage\" from namespace \"translation\" in en, fr, de"
     },
     {
       "key": "translation:navbar.login",
@@ -5552,6 +7226,60 @@
         "de"
       ],
       "suggestion": "Remove unused key \"navbar.messages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.newMessages",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.newMessages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.newMessages",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.newMessages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.newMessages",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.newMessages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.noNewNotifications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.noNewNotifications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.noNewNotifications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.noNewNotifications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.noNewNotifications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.noNewNotifications\" from namespace \"translation\" in en, fr, de"
     },
     {
       "key": "translation:navbar.notifications",
@@ -5662,13 +7390,31 @@
       "suggestion": "Remove unused key \"navbar.settings\" from namespace \"translation\" in en, fr, de"
     },
     {
-      "key": "translation:navbar.signup",
+      "key": "translation:navbar.signOut",
       "locales": [
         "en",
         "fr",
         "de"
       ],
-      "suggestion": "Remove unused key \"navbar.signup\" from namespace \"translation\" in en, fr, de"
+      "suggestion": "Remove unused key \"navbar.signOut\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.signOut",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.signOut\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.signOut",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.signOut\" from namespace \"translation\" in en, fr, de"
     },
     {
       "key": "translation:navbar.signup",
@@ -5687,6 +7433,42 @@
         "de"
       ],
       "suggestion": "Remove unused key \"navbar.signup\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.signup",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.signup\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.toggleNavigation",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.toggleNavigation\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.toggleNavigation",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.toggleNavigation\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.toggleNavigation",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.toggleNavigation\" from namespace \"translation\" in en, fr, de"
     },
     {
       "key": "translation:navbar.userMenu.logout",
@@ -5770,6 +7552,87 @@
       "suggestion": "Remove unused key \"navbar.userMenu.settings\" from namespace \"translation\" in en, fr, de"
     },
     {
+      "key": "translation:navbar.viewAll",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.viewAll\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.viewAll",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.viewAll\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.viewAll",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.viewAll\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.viewShoppingCart",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.viewShoppingCart\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.viewShoppingCart",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.viewShoppingCart\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.viewShoppingCart",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.viewShoppingCart\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notifications.errorTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notifications.errorTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notifications.errorTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notifications.errorTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notifications.errorTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notifications.errorTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
       "key": "translation:notifications.settingsUpdated",
       "locales": [
         "en",
@@ -5822,6 +7685,87 @@
         "de"
       ],
       "suggestion": "Remove unused key \"notifications.successTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notificationsPage.clearAll",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notificationsPage.clearAll\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notificationsPage.clearAll",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notificationsPage.clearAll\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notificationsPage.clearAll",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notificationsPage.clearAll\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notificationsPage.emptyState.message",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notificationsPage.emptyState.message\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notificationsPage.emptyState.message",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notificationsPage.emptyState.message\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notificationsPage.emptyState.message",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notificationsPage.emptyState.message\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notificationsPage.emptyState.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notificationsPage.emptyState.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notificationsPage.emptyState.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notificationsPage.emptyState.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notificationsPage.emptyState.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notificationsPage.emptyState.title\" from namespace \"translation\" in en, fr, de"
     },
     {
       "key": "translation:notificationsPage.notifications",
@@ -5905,13 +7849,436 @@
       "suggestion": "Remove unused key \"notificationsPage.unread\" from namespace \"translation\" in en, fr, de"
     },
     {
-      "key": "translation:organizationName",
+      "key": "translation:orderRequestDetailModal.date",
       "locales": [
         "en",
         "fr",
         "de"
       ],
-      "suggestion": "Remove unused key \"organizationName\" from namespace \"translation\" in en, fr, de"
+      "suggestion": "Remove unused key \"orderRequestDetailModal.date\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.date",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.date\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.date",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.date\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.lineItems",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.lineItems\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.lineItems",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.lineItems\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.lineItems",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.lineItems\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.notes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.notes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.notes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.notes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.notes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.notes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.orderId",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.orderId\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.orderId",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.orderId\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.orderId",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.orderId\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.price",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.price\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.price",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.price\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.price",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.price\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.product",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.product\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.product",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.product\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.product",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.product\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.quantity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.quantity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.quantity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.quantity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.quantity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.quantity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.status",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.status\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.status",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.status\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.status",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.status\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.total",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.total\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.total",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.total\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.total",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.total\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.viewDaycareProfile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.viewDaycareProfile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.viewDaycareProfile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.viewDaycareProfile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestDetailModal.viewDaycareProfile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestDetailModal.viewDaycareProfile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestModal.labels.notes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestModal.labels.notes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestModal.labels.notes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestModal.labels.notes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestModal.labels.notes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestModal.labels.notes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestModal.labels.product",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestModal.labels.product\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestModal.labels.product",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestModal.labels.product\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestModal.labels.product",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestModal.labels.product\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestModal.labels.quantity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestModal.labels.quantity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestModal.labels.quantity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestModal.labels.quantity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestModal.labels.quantity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestModal.labels.quantity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestModal.labels.supplier",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestModal.labels.supplier\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestModal.labels.supplier",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestModal.labels.supplier\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestModal.labels.supplier",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestModal.labels.supplier\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestModal.placeholders.notes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestModal.placeholders.notes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestModal.placeholders.notes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestModal.placeholders.notes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:orderRequestModal.placeholders.notes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"orderRequestModal.placeholders.notes\" from namespace \"translation\" in en, fr, de"
     },
     {
       "key": "translation:organizationName",
@@ -5930,6 +8297,231 @@
         "de"
       ],
       "suggestion": "Remove unused key \"organizationName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.accessDenied",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.accessDenied\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.accessDenied",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.accessDenied\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.accessDenied",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.accessDenied\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.helpText.commaSeparated",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.helpText.commaSeparated\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.helpText.commaSeparated",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.helpText.commaSeparated\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.helpText.commaSeparated",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.helpText.commaSeparated\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.labels.capacity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.labels.capacity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.labels.capacity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.labels.capacity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.labels.capacity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.labels.capacity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.labels.languages",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.labels.languages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.labels.languages",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.labels.languages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.labels.languages",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.labels.languages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.labels.pedagogy",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.labels.pedagogy\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.labels.pedagogy",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.labels.pedagogy\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.labels.pedagogy",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.labels.pedagogy\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.placeholders.languages",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.placeholders.languages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.placeholders.languages",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.placeholders.languages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.placeholders.languages",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.placeholders.languages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.placeholders.pedagogy",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.placeholders.pedagogy\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.placeholders.pedagogy",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.placeholders.pedagogy\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.placeholders.pedagogy",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.placeholders.pedagogy\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.saveButton",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.saveButton\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.saveButton",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.saveButton\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.saveButton",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.saveButton\" from namespace \"translation\" in en, fr, de"
     },
     {
       "key": "translation:organizationProfileForm.saveSuccess",
@@ -5957,6 +8549,60 @@
         "de"
       ],
       "suggestion": "Remove unused key \"organizationProfileForm.saveSuccess\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.subtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.subtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.subtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.subtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.subtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.subtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.title\" from namespace \"translation\" in en, fr, de"
     },
     {
       "key": "translation:parentDashboardPage.findCreche",
@@ -7606,13 +10252,247 @@
       "suggestion": "Remove unused key \"serviceProviderSupportPage.title\" from namespace \"translation\" in en, fr, de"
     },
     {
-      "key": "translation:serviceType",
+      "key": "translation:serviceRequestDetailModal.date",
       "locales": [
         "en",
         "fr",
         "de"
       ],
-      "suggestion": "Remove unused key \"serviceType\" from namespace \"translation\" in en, fr, de"
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.date\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.date",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.date\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.date",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.date\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.noPreferredDate",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.noPreferredDate\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.noPreferredDate",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.noPreferredDate\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.noPreferredDate",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.noPreferredDate\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.notes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.notes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.notes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.notes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.notes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.notes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.preferredDate",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.preferredDate\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.preferredDate",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.preferredDate\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.preferredDate",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.preferredDate\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.requestId",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.requestId\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.requestId",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.requestId\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.requestId",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.requestId\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.serviceName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.serviceName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.serviceName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.serviceName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.serviceName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.serviceName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.status",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.status\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.status",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.status\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.status",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.status\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.viewDaycareProfile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.viewDaycareProfile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.viewDaycareProfile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.viewDaycareProfile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceRequestDetailModal.viewDaycareProfile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceRequestDetailModal.viewDaycareProfile\" from namespace \"translation\" in en, fr, de"
     },
     {
       "key": "translation:serviceType",
@@ -7631,6 +10511,393 @@
         "de"
       ],
       "suggestion": "Remove unused key \"serviceType\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceType",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceType\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.addTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.addTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.addTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.addTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.addTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.addTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.editTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.editTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.editTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.editTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.editTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.editTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.imageHelpText",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.imageHelpText\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.imageHelpText",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.imageHelpText\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.imageHelpText",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.imageHelpText\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.availability",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.availability\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.availability",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.availability\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.availability",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.availability\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.category",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.category\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.category",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.category\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.category",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.category\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.deliveryType",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.deliveryType\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.deliveryType",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.deliveryType\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.deliveryType",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.deliveryType\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.image",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.image\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.image",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.image\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.image",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.image\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.priceInfo",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.priceInfo\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.priceInfo",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.priceInfo\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.priceInfo",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.priceInfo\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.tags",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.tags\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.tags",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.tags\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.tags",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.tags\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.labels.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.labels.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.placeholders.availability",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.placeholders.availability\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.placeholders.availability",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.placeholders.availability\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.placeholders.availability",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.placeholders.availability\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.placeholders.priceInfo",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.placeholders.priceInfo\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.placeholders.priceInfo",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.placeholders.priceInfo\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.placeholders.priceInfo",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.placeholders.priceInfo\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.placeholders.tags",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.placeholders.tags\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.placeholders.tags",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.placeholders.tags\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceUploadModal.placeholders.tags",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceUploadModal.placeholders.tags\" from namespace \"translation\" in en, fr, de"
     },
     {
       "key": "translation:settingsPage.account",

--- a/frontend/i18n-report.json
+++ b/frontend/i18n-report.json
@@ -1,0 +1,11281 @@
+{
+  "generatedAt": "2025-10-05T17:15:51.971Z",
+  "summary": {
+    "hardcodedCount": 0,
+    "missingKeyCount": 0,
+    "unusedKeyCount": 1251,
+    "langs": [
+      "en",
+      "fr",
+      "de"
+    ],
+    "defaultNs": "translation",
+    "namespaces": [
+      "translation"
+    ],
+    "localesRoot": "/workspace/frontend/public/locales"
+  },
+  "hardcoded": [],
+  "missingKeys": [],
+  "unusedKeys": [
+    {
+      "key": "translation:adminContentManagementDashboardPage.announcements",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminContentManagementDashboardPage.announcements\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminContentManagementDashboardPage.announcements",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminContentManagementDashboardPage.announcements\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminContentManagementDashboardPage.announcements",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminContentManagementDashboardPage.announcements\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminContentManagementDashboardPage.content",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminContentManagementDashboardPage.content\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminContentManagementDashboardPage.content",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminContentManagementDashboardPage.content\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminContentManagementDashboardPage.content",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminContentManagementDashboardPage.content\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminContentManagementDashboardPage.policies",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminContentManagementDashboardPage.policies\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminContentManagementDashboardPage.policies",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminContentManagementDashboardPage.policies\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminContentManagementDashboardPage.policies",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminContentManagementDashboardPage.policies\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminContentManagementDashboardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminContentManagementDashboardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminContentManagementDashboardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminContentManagementDashboardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminContentManagementDashboardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminContentManagementDashboardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminDiscountTerminationsPage.manage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminDiscountTerminationsPage.manage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminDiscountTerminationsPage.manage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminDiscountTerminationsPage.manage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminDiscountTerminationsPage.manage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminDiscountTerminationsPage.manage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminDiscountTerminationsPage.terminations",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminDiscountTerminationsPage.terminations\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminDiscountTerminationsPage.terminations",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminDiscountTerminationsPage.terminations\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminDiscountTerminationsPage.terminations",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminDiscountTerminationsPage.terminations\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminDiscountTerminationsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminDiscountTerminationsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminDiscountTerminationsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminDiscountTerminationsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminDiscountTerminationsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminDiscountTerminationsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.branding.faviconLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.branding.faviconLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.branding.faviconLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.branding.faviconLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.branding.faviconLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.branding.faviconLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.branding.logoLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.branding.logoLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.branding.logoLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.branding.logoLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.branding.logoLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.branding.logoLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.branding.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.branding.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.branding.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.branding.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.branding.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.branding.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.general.descriptionLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.general.descriptionLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.general.descriptionLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.general.descriptionLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.general.descriptionLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.general.descriptionLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.general.nameLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.general.nameLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.general.nameLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.general.nameLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.general.nameLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.general.nameLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.general.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.general.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.general.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.general.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.general.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.general.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminPlatformSettings.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminPlatformSettings.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminSystemMonitoringPage.logs",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminSystemMonitoringPage.logs\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminSystemMonitoringPage.logs",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminSystemMonitoringPage.logs\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminSystemMonitoringPage.logs",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminSystemMonitoringPage.logs\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminSystemMonitoringPage.monitoring",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminSystemMonitoringPage.monitoring\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminSystemMonitoringPage.monitoring",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminSystemMonitoringPage.monitoring\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminSystemMonitoringPage.monitoring",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminSystemMonitoringPage.monitoring\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminSystemMonitoringPage.performance",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminSystemMonitoringPage.performance\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminSystemMonitoringPage.performance",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminSystemMonitoringPage.performance\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminSystemMonitoringPage.performance",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminSystemMonitoringPage.performance\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminSystemMonitoringPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminSystemMonitoringPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminSystemMonitoringPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminSystemMonitoringPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:adminSystemMonitoringPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"adminSystemMonitoringPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:alreadyHaveAccount",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"alreadyHaveAccount\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:alreadyHaveAccount",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"alreadyHaveAccount\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:alreadyHaveAccount",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"alreadyHaveAccount\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:appName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"appName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:appName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"appName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:appName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"appName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.add",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.add\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.add",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.add\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.add",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.add\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.addToFavorites",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.addToFavorites\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.addToFavorites",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.addToFavorites\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.addToFavorites",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.addToFavorites\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.applyFilters",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.applyFilters\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.applyFilters",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.applyFilters\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.applyFilters",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.applyFilters\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.applyNow",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.applyNow\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.applyNow",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.applyNow\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.applyNow",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.applyNow\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.cancel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.cancel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.cancel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.cancel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.cancel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.cancel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.close",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.close\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.close",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.close\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.close",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.close\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.confirmApply",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.confirmApply\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.confirmApply",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.confirmApply\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.confirmApply",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.confirmApply\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.delete",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.delete\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.delete",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.delete\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.delete",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.delete\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.dismiss",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.dismiss\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.dismiss",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.dismiss\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.dismiss",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.dismiss\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.edit",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.edit\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.edit",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.edit\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.edit",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.edit\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.favorited",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.favorited\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.favorited",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.favorited\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.favorited",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.favorited\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.goBack",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.goBack\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.goBack",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.goBack\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.goBack",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.goBack\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.goToLogin",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.goToLogin\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.goToLogin",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.goToLogin\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.goToLogin",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.goToLogin\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.inviteToApply",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.inviteToApply\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.inviteToApply",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.inviteToApply\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.inviteToApply",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.inviteToApply\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.inviteToInterview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.inviteToInterview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.inviteToInterview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.inviteToInterview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.inviteToInterview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.inviteToInterview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.login",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.login\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.login",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.login\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.login",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.login\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.remove",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.remove\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.remove",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.remove\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.remove",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.remove\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.resetFilters",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.resetFilters\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.resetFilters",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.resetFilters\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.resetFilters",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.resetFilters\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.save",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.save\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.save",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.save\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.save",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.save\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.saveChanges",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.saveChanges\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.saveChanges",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.saveChanges\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.saveChanges",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.saveChanges\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.sendMessage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.sendMessage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.sendMessage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.sendMessage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.sendMessage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.sendMessage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.signup",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.signup\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.signup",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.signup\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.signup",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.signup\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.submit",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.submit\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.submit",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.submit\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.submit",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.submit\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.submitEnquiry",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.submitEnquiry\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.submitEnquiry",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.submitEnquiry\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.submitEnquiry",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.submitEnquiry\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.submitRequest",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.submitRequest\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.submitRequest",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.submitRequest\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.submitRequest",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.submitRequest\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.submitTicket",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.submitTicket\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.submitTicket",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.submitTicket\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.submitTicket",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.submitTicket\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.view",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.view\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.view",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.view\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.view",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.view\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.viewDetails",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.viewDetails\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.viewDetails",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.viewDetails\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.viewDetails",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.viewDetails\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.viewMyEnquiries",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.viewMyEnquiries\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.viewMyEnquiries",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.viewMyEnquiries\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:buttons.viewMyEnquiries",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"buttons.viewMyEnquiries\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:candidateProfilePage.experience",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"candidateProfilePage.experience\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:candidateProfilePage.experience",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"candidateProfilePage.experience\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:candidateProfilePage.experience",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"candidateProfilePage.experience\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:candidateProfilePage.profile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"candidateProfilePage.profile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:candidateProfilePage.profile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"candidateProfilePage.profile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:candidateProfilePage.profile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"candidateProfilePage.profile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:candidateProfilePage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"candidateProfilePage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:candidateProfilePage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"candidateProfilePage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:candidateProfilePage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"candidateProfilePage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:canton",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"canton\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:canton",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"canton\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:canton",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"canton\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:capacity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"capacity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:capacity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"capacity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:capacity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"capacity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:childAge",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"childAge\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:childAge",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"childAge\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:childAge",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"childAge\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:chooseRole",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"chooseRole\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:chooseRole",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"chooseRole\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:chooseRole",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"chooseRole\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.actions",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.actions\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.actions",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.actions\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.actions",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.actions\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.active",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.active\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.active",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.active\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.active",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.active\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.address",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.address\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.address",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.address\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.address",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.address\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.completed",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.completed\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.completed",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.completed\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.completed",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.completed\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.createdAt",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.createdAt\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.createdAt",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.createdAt\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.createdAt",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.createdAt\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.date",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.date\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.date",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.date\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.date",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.date\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.email",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.email\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.email",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.email\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.email",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.email\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.error",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.error\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.error",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.error\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.error",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.error\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.inactive",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.inactive\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.inactive",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.inactive\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.inactive",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.inactive\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.loading",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.loading\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.loading",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.loading\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.loading",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.loading\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.name",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.name\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.name",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.name\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.name",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.name\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.no",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.no\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.no",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.no\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.no",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.no\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.ok",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.ok\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.ok",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.ok\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.ok",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.ok\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.pending",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.pending\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.pending",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.pending\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.pending",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.pending\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.perMonth",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.perMonth\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.perMonth",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.perMonth\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.perMonth",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.perMonth\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.perYear",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.perYear\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.perYear",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.perYear\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.perYear",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.perYear\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.phone",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.phone\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.phone",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.phone\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.phone",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.phone\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.save10Percent",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.save10Percent\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.save10Percent",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.save10Percent\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.save10Percent",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.save10Percent\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.status",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.status\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.status",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.status\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.status",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.status\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.success",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.success\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.success",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.success\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.success",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.success\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.updatedAt",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.updatedAt\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.updatedAt",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.updatedAt\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.updatedAt",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.updatedAt\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.yes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.yes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.yes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.yes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:common.yes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"common.yes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:confirmPassword",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"confirmPassword\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:confirmPassword",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"confirmPassword\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:confirmPassword",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"confirmPassword\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contactPerson",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contactPerson\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contactPerson",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contactPerson\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:contactPerson",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"contactPerson\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createAccount",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createAccount\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createAccount",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createAccount\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:createAccount",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"createAccount\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.activeUsers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.activeUsers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.activeUsers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.activeUsers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.activeUsers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.activeUsers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.activityEcoToys",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.activityEcoToys\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.activityEcoToys",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.activityEcoToys\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.activityEcoToys",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.activityEcoToys\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.activityJohn",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.activityJohn\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.activityJohn",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.activityJohn\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.activityJohn",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.activityJohn\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.activityLina",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.activityLina\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.activityLina",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.activityLina\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.activityLina",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.activityLina\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.activityParent",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.activityParent\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.activityParent",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.activityParent\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.activityParent",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.activityParent\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.announcements",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.announcements\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.announcements",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.announcements\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.announcements",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.announcements\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.browseMarketplace",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.browseMarketplace\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.browseMarketplace",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.browseMarketplace\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.browseMarketplace",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.browseMarketplace\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.defaultUser",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.defaultUser\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.defaultUser",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.defaultUser\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.defaultUser",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.defaultUser\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.manageUsers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.manageUsers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.manageUsers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.manageUsers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.manageUsers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.manageUsers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.newOrders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.newOrders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.newOrders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.newOrders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.newOrders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.newOrders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.notifications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.notifications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.notifications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.notifications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.notifications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.notifications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.openJobs",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.openJobs\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.openJobs",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.openJobs\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.openJobs",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.openJobs\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.overview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.overview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.overview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.overview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.overview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.overview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.overviewSubtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.overviewSubtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.overviewSubtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.overviewSubtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.overviewSubtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.overviewSubtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.pageViews",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.pageViews\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.pageViews",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.pageViews\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.pageViews",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.pageViews\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.platformSettings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.platformSettings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.platformSettings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.platformSettings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.platformSettings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.platformSettings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.postNewJob",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.postNewJob\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.postNewJob",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.postNewJob\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.postNewJob",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.postNewJob\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.quickActions",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.quickActions\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.quickActions",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.quickActions\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.quickActions",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.quickActions\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.quickLinks",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.quickLinks\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.quickLinks",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.quickLinks\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.quickLinks",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.quickLinks\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.recentActivity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.recentActivity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.recentActivity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.recentActivity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.recentActivity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.recentActivity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.timeAgo.hours",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.timeAgo.hours\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.timeAgo.hours",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.timeAgo.hours\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.timeAgo.hours",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.timeAgo.hours\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.timeAgo.minutes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.timeAgo.minutes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.timeAgo.minutes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.timeAgo.minutes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.timeAgo.minutes",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.timeAgo.minutes\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.timeAgo.yesterday",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.timeAgo.yesterday\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.timeAgo.yesterday",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.timeAgo.yesterday\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.timeAgo.yesterday",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.timeAgo.yesterday\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.upcomingMeetings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.upcomingMeetings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.upcomingMeetings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.upcomingMeetings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.upcomingMeetings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.upcomingMeetings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.viewDetailsFor",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.viewDetailsFor\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.viewDetailsFor",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.viewDetailsFor\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.viewDetailsFor",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.viewDetailsFor\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.welcome",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.welcome\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.welcome",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.welcome\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dashboardPage.welcome",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dashboardPage.welcome\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:designSystemPage.components",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"designSystemPage.components\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:designSystemPage.components",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"designSystemPage.components\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:designSystemPage.components",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"designSystemPage.components\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:designSystemPage.guidelines",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"designSystemPage.guidelines\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:designSystemPage.guidelines",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"designSystemPage.guidelines\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:designSystemPage.guidelines",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"designSystemPage.guidelines\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:designSystemPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"designSystemPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:designSystemPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"designSystemPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:designSystemPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"designSystemPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dontHaveAccount",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dontHaveAccount\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dontHaveAccount",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dontHaveAccount\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:dontHaveAccount",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"dontHaveAccount\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorApplicationsPage.applications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorApplicationsPage.applications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorApplicationsPage.applications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorApplicationsPage.applications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorApplicationsPage.applications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorApplicationsPage.applications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorApplicationsPage.status",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorApplicationsPage.status\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorApplicationsPage.status",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorApplicationsPage.status\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorApplicationsPage.status",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorApplicationsPage.status\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorApplicationsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorApplicationsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorApplicationsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorApplicationsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorApplicationsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorApplicationsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorDashboardPage.applications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorDashboardPage.applications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorDashboardPage.applications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorDashboardPage.applications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorDashboardPage.applications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorDashboardPage.applications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorDashboardPage.jobBoard",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorDashboardPage.jobBoard\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorDashboardPage.jobBoard",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorDashboardPage.jobBoard\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorDashboardPage.jobBoard",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorDashboardPage.jobBoard\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorDashboardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorDashboardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorDashboardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorDashboardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorDashboardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorDashboardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorDashboardPage.welcome",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorDashboardPage.welcome\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorDashboardPage.welcome",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorDashboardPage.welcome\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorDashboardPage.welcome",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorDashboardPage.welcome\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorJobBoardPage.apply",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorJobBoardPage.apply\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorJobBoardPage.apply",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorJobBoardPage.apply\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorJobBoardPage.apply",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorJobBoardPage.apply\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorJobBoardPage.jobs",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorJobBoardPage.jobs\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorJobBoardPage.jobs",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorJobBoardPage.jobs\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorJobBoardPage.jobs",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorJobBoardPage.jobs\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorJobBoardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorJobBoardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorJobBoardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorJobBoardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorJobBoardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorJobBoardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorProfilePage.experience",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorProfilePage.experience\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorProfilePage.experience",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorProfilePage.experience\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorProfilePage.experience",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorProfilePage.experience\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorProfilePage.profile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorProfilePage.profile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorProfilePage.profile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorProfilePage.profile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorProfilePage.profile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorProfilePage.profile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorProfilePage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorProfilePage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorProfilePage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorProfilePage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorProfilePage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorProfilePage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorSupportPage.help",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorSupportPage.help\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorSupportPage.help",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorSupportPage.help\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorSupportPage.help",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorSupportPage.help\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorSupportPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorSupportPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorSupportPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorSupportPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:educatorSupportPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"educatorSupportPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:eLearningPage.courses",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"eLearningPage.courses\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:eLearningPage.courses",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"eLearningPage.courses\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:eLearningPage.courses",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"eLearningPage.courses\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:eLearningPage.progress",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"eLearningPage.progress\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:eLearningPage.progress",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"eLearningPage.progress\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:eLearningPage.progress",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"eLearningPage.progress\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:eLearningPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"eLearningPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:eLearningPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"eLearningPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:eLearningPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"eLearningPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:errors.unknown",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"errors.unknown\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:errors.unknown",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"errors.unknown\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:errors.unknown",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"errors.unknown\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:fileGalleryPage.files",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"fileGalleryPage.files\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:fileGalleryPage.files",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"fileGalleryPage.files\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:fileGalleryPage.files",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"fileGalleryPage.files\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:fileGalleryPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"fileGalleryPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:fileGalleryPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"fileGalleryPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:fileGalleryPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"fileGalleryPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:fileGalleryPage.upload",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"fileGalleryPage.upload\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:fileGalleryPage.upload",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"fileGalleryPage.upload\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:fileGalleryPage.upload",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"fileGalleryPage.upload\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:firstName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"firstName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:firstName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"firstName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:firstName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"firstName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationAnalyticsPage.metrics",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationAnalyticsPage.metrics\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationAnalyticsPage.metrics",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationAnalyticsPage.metrics\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationAnalyticsPage.metrics",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationAnalyticsPage.metrics\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationAnalyticsPage.overview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationAnalyticsPage.overview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationAnalyticsPage.overview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationAnalyticsPage.overview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationAnalyticsPage.overview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationAnalyticsPage.overview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationAnalyticsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationAnalyticsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationAnalyticsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationAnalyticsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationAnalyticsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationAnalyticsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationDashboardPage.overview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationDashboardPage.overview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationDashboardPage.overview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationDashboardPage.overview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationDashboardPage.overview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationDashboardPage.overview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationDashboardPage.quickActions",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationDashboardPage.quickActions\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationDashboardPage.quickActions",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationDashboardPage.quickActions\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationDashboardPage.quickActions",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationDashboardPage.quickActions\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationDashboardPage.recentActivity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationDashboardPage.recentActivity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationDashboardPage.recentActivity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationDashboardPage.recentActivity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationDashboardPage.recentActivity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationDashboardPage.recentActivity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationDashboardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationDashboardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationDashboardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationDashboardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationDashboardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationDashboardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationDashboardPage.welcome",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationDashboardPage.welcome\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationDashboardPage.welcome",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationDashboardPage.welcome\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationDashboardPage.welcome",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationDashboardPage.welcome\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationLeadsPage.contactedLeads",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationLeadsPage.contactedLeads\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationLeadsPage.contactedLeads",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationLeadsPage.contactedLeads\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationLeadsPage.contactedLeads",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationLeadsPage.contactedLeads\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationLeadsPage.leads",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationLeadsPage.leads\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationLeadsPage.leads",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationLeadsPage.leads\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationLeadsPage.leads",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationLeadsPage.leads\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationLeadsPage.newLeads",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationLeadsPage.newLeads\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationLeadsPage.newLeads",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationLeadsPage.newLeads\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationLeadsPage.newLeads",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationLeadsPage.newLeads\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationLeadsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationLeadsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationLeadsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationLeadsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationLeadsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationLeadsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationOrdersAppointmentsPage.appointments",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationOrdersAppointmentsPage.appointments\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationOrdersAppointmentsPage.appointments",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationOrdersAppointmentsPage.appointments\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationOrdersAppointmentsPage.appointments",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationOrdersAppointmentsPage.appointments\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationOrdersAppointmentsPage.orders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationOrdersAppointmentsPage.orders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationOrdersAppointmentsPage.orders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationOrdersAppointmentsPage.orders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationOrdersAppointmentsPage.orders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationOrdersAppointmentsPage.orders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationOrdersAppointmentsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationOrdersAppointmentsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationOrdersAppointmentsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationOrdersAppointmentsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationOrdersAppointmentsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationOrdersAppointmentsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationOrganisationProfilePage.profile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationOrganisationProfilePage.profile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationOrganisationProfilePage.profile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationOrganisationProfilePage.profile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationOrganisationProfilePage.profile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationOrganisationProfilePage.profile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationOrganisationProfilePage.settings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationOrganisationProfilePage.settings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationOrganisationProfilePage.settings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationOrganisationProfilePage.settings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationOrganisationProfilePage.settings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationOrganisationProfilePage.settings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationOrganisationProfilePage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationOrganisationProfilePage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationOrganisationProfilePage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationOrganisationProfilePage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationOrganisationProfilePage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationOrganisationProfilePage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationSupportPage.help",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationSupportPage.help\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationSupportPage.help",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationSupportPage.help\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationSupportPage.help",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationSupportPage.help\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationSupportPage.tickets",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationSupportPage.tickets\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationSupportPage.tickets",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationSupportPage.tickets\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationSupportPage.tickets",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationSupportPage.tickets\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationSupportPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationSupportPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationSupportPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationSupportPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:foundationSupportPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"foundationSupportPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:hidePassword",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"hidePassword\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:hidePassword",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"hidePassword\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:hidePassword",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"hidePassword\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:hrProceduresPage.guidelines",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"hrProceduresPage.guidelines\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:hrProceduresPage.guidelines",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"hrProceduresPage.guidelines\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:hrProceduresPage.guidelines",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"hrProceduresPage.guidelines\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:hrProceduresPage.procedures",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"hrProceduresPage.procedures\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:hrProceduresPage.procedures",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"hrProceduresPage.procedures\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:hrProceduresPage.procedures",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"hrProceduresPage.procedures\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:hrProceduresPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"hrProceduresPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:hrProceduresPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"hrProceduresPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:hrProceduresPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"hrProceduresPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:joinPlatform",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"joinPlatform\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:joinPlatform",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"joinPlatform\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:joinPlatform",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"joinPlatform\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languages",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languages",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languages",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.deLong",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.deLong\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.deLong",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.deLong\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.deLong",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.deLong\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.deShort",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.deShort\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.deShort",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.deShort\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.deShort",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.deShort\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.enLong",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.enLong\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.enLong",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.enLong\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.enLong",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.enLong\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.enShort",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.enShort\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.enShort",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.enShort\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.enShort",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.enShort\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.frLong",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.frLong\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.frLong",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.frLong\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.frLong",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.frLong\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.frShort",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.frShort\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.frShort",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.frShort\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.frShort",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.frShort\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.selectLanguage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.selectLanguage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.selectLanguage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.selectLanguage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:languageSwitcher.selectLanguage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"languageSwitcher.selectLanguage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:lastName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"lastName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:lastName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"lastName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:lastName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"lastName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loading",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loading\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loading",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loading\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loading",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loading\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.emailLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.emailLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.emailLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.emailLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.emailLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.emailLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.emailPlaceholder",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.emailPlaceholder\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.emailPlaceholder",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.emailPlaceholder\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.emailPlaceholder",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.emailPlaceholder\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.errorBothFields",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.errorBothFields\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.errorBothFields",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.errorBothFields\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.errorBothFields",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.errorBothFields\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.facebook",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.facebook\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.facebook",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.facebook\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.facebook",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.facebook\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.findCrecheHere",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.findCrecheHere\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.findCrecheHere",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.findCrecheHere\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.findCrecheHere",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.findCrecheHere\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.forgotPassword",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.forgotPassword\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.forgotPassword",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.forgotPassword\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.forgotPassword",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.forgotPassword\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.forgotPasswordTBD",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.forgotPasswordTBD\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.forgotPasswordTBD",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.forgotPasswordTBD\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.forgotPasswordTBD",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.forgotPasswordTBD\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.google",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.google\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.google",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.google\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.google",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.google\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.loggingIn",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.loggingIn\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.loggingIn",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.loggingIn\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.loggingIn",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.loggingIn\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.noAccount",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.noAccount\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.noAccount",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.noAccount\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.noAccount",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.noAccount\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.orContinueWith",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.orContinueWith\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.orContinueWith",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.orContinueWith\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.orContinueWith",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.orContinueWith\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.parentLookingForCreche",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.parentLookingForCreche\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.parentLookingForCreche",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.parentLookingForCreche\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.parentLookingForCreche",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.parentLookingForCreche\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.passwordLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.passwordLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.passwordLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.passwordLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.passwordLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.passwordLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.passwordPlaceholder",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.passwordPlaceholder\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.passwordPlaceholder",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.passwordPlaceholder\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.passwordPlaceholder",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.passwordPlaceholder\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.socialLoginTBD",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.socialLoginTBD\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.socialLoginTBD",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.socialLoginTBD\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.socialLoginTBD",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.socialLoginTBD\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.subtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.subtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.subtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.subtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.subtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.subtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.viewPlans",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.viewPlans\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.viewPlans",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.viewPlans\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.viewPlans",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.viewPlans\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.viewPlansPrompt",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.viewPlansPrompt\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.viewPlansPrompt",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.viewPlansPrompt\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:loginPage.viewPlansPrompt",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"loginPage.viewPlansPrompt\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.emptyStates.noProductSuppliers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.emptyStates.noProductSuppliers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.emptyStates.noProductSuppliers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.emptyStates.noProductSuppliers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.emptyStates.noProductSuppliers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.emptyStates.noProductSuppliers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.emptyStates.noServiceProviders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.emptyStates.noServiceProviders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.emptyStates.noServiceProviders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.emptyStates.noServiceProviders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.emptyStates.noServiceProviders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.emptyStates.noServiceProviders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.serviceCard.bookAppointment",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.serviceCard.bookAppointment\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.serviceCard.bookAppointment",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.serviceCard.bookAppointment\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.serviceCard.bookAppointment",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.serviceCard.bookAppointment\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.serviceCard.categoryLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.serviceCard.categoryLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.serviceCard.categoryLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.serviceCard.categoryLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.serviceCard.categoryLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.serviceCard.categoryLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.serviceCard.viewProvider",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.serviceCard.viewProvider\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.serviceCard.viewProvider",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.serviceCard.viewProvider\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.serviceCard.viewProvider",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.serviceCard.viewProvider\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.tabs.productSuppliers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.tabs.productSuppliers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.tabs.productSuppliers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.tabs.productSuppliers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.tabs.productSuppliers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.tabs.productSuppliers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.tabs.serviceProviders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.tabs.serviceProviders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.tabs.serviceProviders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.tabs.serviceProviders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.tabs.serviceProviders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.tabs.serviceProviders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:marketplacePage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"marketplacePage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.conversations",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.conversations\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.conversations",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.conversations\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.conversations",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.conversations\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.newMessage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.newMessage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.newMessage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.newMessage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.newMessage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.newMessage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:messagesPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"messagesPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.dashboard",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.dashboard\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.dashboard",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.dashboard\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.dashboard",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.dashboard\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.login",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.login\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.login",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.login\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.login",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.login\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.logout",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.logout\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.logout",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.logout\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.logout",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.logout\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.messages",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.messages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.messages",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.messages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.messages",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.messages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.notifications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.notifications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.notifications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.notifications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.notifications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.notifications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.profile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.profile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.profile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.profile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.profile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.profile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.searchPlaceholder",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.searchPlaceholder\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.searchPlaceholder",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.searchPlaceholder\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.searchPlaceholder",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.searchPlaceholder\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.settings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.settings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.settings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.settings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.settings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.settings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.signup",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.signup\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.signup",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.signup\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.signup",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.signup\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.userMenu.logout",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.userMenu.logout\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.userMenu.logout",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.userMenu.logout\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.userMenu.logout",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.userMenu.logout\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.userMenu.profile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.userMenu.profile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.userMenu.profile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.userMenu.profile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.userMenu.profile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.userMenu.profile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.userMenu.settings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.userMenu.settings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.userMenu.settings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.userMenu.settings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:navbar.userMenu.settings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"navbar.userMenu.settings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notifications.settingsUpdated",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notifications.settingsUpdated\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notifications.settingsUpdated",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notifications.settingsUpdated\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notifications.settingsUpdated",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notifications.settingsUpdated\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notifications.successTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notifications.successTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notifications.successTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notifications.successTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notifications.successTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notifications.successTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notificationsPage.notifications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notificationsPage.notifications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notificationsPage.notifications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notificationsPage.notifications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notificationsPage.notifications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notificationsPage.notifications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notificationsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notificationsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notificationsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notificationsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notificationsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notificationsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notificationsPage.unread",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notificationsPage.unread\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notificationsPage.unread",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notificationsPage.unread\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:notificationsPage.unread",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"notificationsPage.unread\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.saveSuccess",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.saveSuccess\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.saveSuccess",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.saveSuccess\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:organizationProfileForm.saveSuccess",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"organizationProfileForm.saveSuccess\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentDashboardPage.findCreche",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentDashboardPage.findCreche\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentDashboardPage.findCreche",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentDashboardPage.findCreche\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentDashboardPage.findCreche",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentDashboardPage.findCreche\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentDashboardPage.myChildren",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentDashboardPage.myChildren\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentDashboardPage.myChildren",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentDashboardPage.myChildren\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentDashboardPage.myChildren",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentDashboardPage.myChildren\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentDashboardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentDashboardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentDashboardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentDashboardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentDashboardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentDashboardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentDashboardPage.welcome",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentDashboardPage.welcome\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentDashboardPage.welcome",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentDashboardPage.welcome\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentDashboardPage.welcome",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentDashboardPage.welcome\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentEnquiriesPage.enquiries",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentEnquiriesPage.enquiries\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentEnquiriesPage.enquiries",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentEnquiriesPage.enquiries\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentEnquiriesPage.enquiries",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentEnquiriesPage.enquiries\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentEnquiriesPage.newEnquiry",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentEnquiriesPage.newEnquiry\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentEnquiriesPage.newEnquiry",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentEnquiriesPage.newEnquiry\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentEnquiriesPage.newEnquiry",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentEnquiriesPage.newEnquiry\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentEnquiriesPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentEnquiriesPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentEnquiriesPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentEnquiriesPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentEnquiriesPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentEnquiriesPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.authenticatedSuccessMessage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.authenticatedSuccessMessage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.authenticatedSuccessMessage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.authenticatedSuccessMessage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.authenticatedSuccessMessage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.authenticatedSuccessMessage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.errorAllFields",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.errorAllFields\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.errorAllFields",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.errorAllFields\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.errorAllFields",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.errorAllFields\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.form",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.form\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.form",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.form\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.form",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.form\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.labels.yourEmail",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.labels.yourEmail\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.labels.yourEmail",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.labels.yourEmail\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.labels.yourEmail",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.labels.yourEmail\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.labels.yourFullName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.labels.yourFullName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.labels.yourFullName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.labels.yourFullName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.labels.yourFullName",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.labels.yourFullName\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.labels.yourPhone",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.labels.yourPhone\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.labels.yourPhone",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.labels.yourPhone\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.labels.yourPhone",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.labels.yourPhone\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.submit",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.submit\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.submit",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.submit\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.submit",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.submit\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.subtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.subtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.subtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.subtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.subtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.subtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.thankYouTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.thankYouTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.thankYouTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.thankYouTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.thankYouTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.thankYouTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentLeadFormPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentLeadFormPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentSupportPage.faq",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentSupportPage.faq\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentSupportPage.faq",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentSupportPage.faq\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentSupportPage.faq",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentSupportPage.faq\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentSupportPage.help",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentSupportPage.help\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentSupportPage.help",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentSupportPage.help\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentSupportPage.help",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentSupportPage.help\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentSupportPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentSupportPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentSupportPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentSupportPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:parentSupportPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"parentSupportPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:partnerDetailPage.onlyFoundationsRequestService",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"partnerDetailPage.onlyFoundationsRequestService\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:partnerDetailPage.onlyFoundationsRequestService",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"partnerDetailPage.onlyFoundationsRequestService\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:partnerDetailPage.onlyFoundationsRequestService",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"partnerDetailPage.onlyFoundationsRequestService\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:partnerDetailPage.requestSubmittedAlert",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"partnerDetailPage.requestSubmittedAlert\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:partnerDetailPage.requestSubmittedAlert",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"partnerDetailPage.requestSubmittedAlert\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:partnerDetailPage.requestSubmittedAlert",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"partnerDetailPage.requestSubmittedAlert\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:partnersPage.becomePartner",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"partnersPage.becomePartner\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:partnersPage.becomePartner",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"partnersPage.becomePartner\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:partnersPage.becomePartner",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"partnersPage.becomePartner\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:partnersPage.partners",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"partnersPage.partners\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:partnersPage.partners",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"partnersPage.partners\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:partnersPage.partners",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"partnersPage.partners\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:partnersPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"partnersPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:partnersPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"partnersPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:partnersPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"partnersPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:phoneNumber",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"phoneNumber\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:phoneNumber",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"phoneNumber\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:phoneNumber",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"phoneNumber\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:preferredLocation",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"preferredLocation\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:preferredLocation",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"preferredLocation\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:preferredLocation",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"preferredLocation\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.billing",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.billing\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.billing",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.billing\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.billing",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.billing\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.choosePlan",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.choosePlan\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.choosePlan",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.choosePlan\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.choosePlan",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.choosePlan\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.features",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.features\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.features",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.features\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.features",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.features\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.plans",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.plans\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.plans",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.plans\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.plans",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.plans\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.popular",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.popular\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.popular",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.popular\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.popular",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.popular\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.selectAndContinue",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.selectAndContinue\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.selectAndContinue",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.selectAndContinue\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.selectAndContinue",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.selectAndContinue\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.subtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.subtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.subtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.subtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.subtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.subtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.subtitleSignup",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.subtitleSignup\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.subtitleSignup",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.subtitleSignup\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.subtitleSignup",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.subtitleSignup\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.suppliersAndProvidersTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.suppliersAndProvidersTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.suppliersAndProvidersTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.suppliersAndProvidersTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.suppliersAndProvidersTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.suppliersAndProvidersTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.titleSignup",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.titleSignup\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.titleSignup",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.titleSignup\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.titleSignup",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.titleSignup\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.whatYouGet",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.whatYouGet\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.whatYouGet",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.whatYouGet\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:pricingPage.whatYouGet",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"pricingPage.whatYouGet\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:productCategory",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"productCategory\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:productCategory",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"productCategory\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:productCategory",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"productCategory\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:recruitmentPage.candidates",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"recruitmentPage.candidates\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:recruitmentPage.candidates",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"recruitmentPage.candidates\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:recruitmentPage.candidates",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"recruitmentPage.candidates\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:recruitmentPage.jobs",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"recruitmentPage.jobs\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:recruitmentPage.jobs",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"recruitmentPage.jobs\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:recruitmentPage.jobs",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"recruitmentPage.jobs\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:recruitmentPage.postJob",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"recruitmentPage.postJob\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:recruitmentPage.postJob",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"recruitmentPage.postJob\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:recruitmentPage.postJob",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"recruitmentPage.postJob\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:recruitmentPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"recruitmentPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:recruitmentPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"recruitmentPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:recruitmentPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"recruitmentPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:rememberMe",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"rememberMe\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:rememberMe",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"rememberMe\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:rememberMe",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"rememberMe\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:resetPassword",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"resetPassword\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:resetPassword",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"resetPassword\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:resetPassword",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"resetPassword\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderAnalyticsPage.overview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderAnalyticsPage.overview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderAnalyticsPage.overview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderAnalyticsPage.overview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderAnalyticsPage.overview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderAnalyticsPage.overview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderAnalyticsPage.performance",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderAnalyticsPage.performance\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderAnalyticsPage.performance",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderAnalyticsPage.performance\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderAnalyticsPage.performance",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderAnalyticsPage.performance\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderAnalyticsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderAnalyticsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderAnalyticsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderAnalyticsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderAnalyticsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderAnalyticsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderDashboardPage.requests",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderDashboardPage.requests\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderDashboardPage.requests",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderDashboardPage.requests\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderDashboardPage.requests",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderDashboardPage.requests\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderDashboardPage.services",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderDashboardPage.services\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderDashboardPage.services",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderDashboardPage.services\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderDashboardPage.services",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderDashboardPage.services\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderDashboardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderDashboardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderDashboardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderDashboardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderDashboardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderDashboardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderDashboardPage.welcome",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderDashboardPage.welcome\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderDashboardPage.welcome",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderDashboardPage.welcome\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderDashboardPage.welcome",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderDashboardPage.welcome\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderListingsPage.addService",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderListingsPage.addService\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderListingsPage.addService",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderListingsPage.addService\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderListingsPage.addService",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderListingsPage.addService\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderListingsPage.listings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderListingsPage.listings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderListingsPage.listings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderListingsPage.listings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderListingsPage.listings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderListingsPage.listings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderListingsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderListingsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderListingsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderListingsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderListingsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderListingsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderRequestsPage.pending",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderRequestsPage.pending\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderRequestsPage.pending",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderRequestsPage.pending\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderRequestsPage.pending",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderRequestsPage.pending\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderRequestsPage.requests",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderRequestsPage.requests\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderRequestsPage.requests",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderRequestsPage.requests\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderRequestsPage.requests",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderRequestsPage.requests\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderRequestsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderRequestsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderRequestsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderRequestsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderRequestsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderRequestsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderSupportPage.help",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderSupportPage.help\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderSupportPage.help",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderSupportPage.help\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderSupportPage.help",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderSupportPage.help\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderSupportPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderSupportPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderSupportPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderSupportPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceProviderSupportPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceProviderSupportPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceType",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceType\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceType",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceType\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:serviceType",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"serviceType\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.account",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.account\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.account",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.account\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.account",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.account\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.appearance",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.appearance\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.appearance",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.appearance\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.appearance",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.appearance\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.billingSubscription",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.billingSubscription\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.billingSubscription",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.billingSubscription\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.billingSubscription",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.billingSubscription\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.general",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.general\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.general",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.general\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.general",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.general\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.language",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.language\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.language",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.language\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.language",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.language\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.loading",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.loading\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.loading",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.loading\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.loading",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.loading\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.noSectionsAvailable",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.noSectionsAvailable\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.noSectionsAvailable",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.noSectionsAvailable\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.noSectionsAvailable",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.noSectionsAvailable\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.notifications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.notifications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.notifications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.notifications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.notifications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.notifications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.organizationProfile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.organizationProfile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.organizationProfile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.organizationProfile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.organizationProfile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.organizationProfile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.privacySecurity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.privacySecurity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.privacySecurity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.privacySecurity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.privacySecurity",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.privacySecurity\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.unsavedChangesPrompt",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.unsavedChangesPrompt\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.unsavedChangesPrompt",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.unsavedChangesPrompt\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.unsavedChangesPrompt",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.unsavedChangesPrompt\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.userPreferences",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.userPreferences\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.userPreferences",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.userPreferences\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:settingsPage.userPreferences",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"settingsPage.userPreferences\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:showPassword",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"showPassword\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:showPassword",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"showPassword\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:showPassword",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"showPassword\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.admins",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.admins\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.admins",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.admins\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.admins",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.admins\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.allUsers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.allUsers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.allUsers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.allUsers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.allUsers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.allUsers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.analytics",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.analytics\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.analytics",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.analytics\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.analytics",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.analytics\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.applications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.applications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.applications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.applications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.applications",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.applications\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.billingSubscription",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.billingSubscription\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.billingSubscription",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.billingSubscription\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.billingSubscription",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.billingSubscription\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.candidatePool",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.candidatePool\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.candidatePool",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.candidatePool\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.candidatePool",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.candidatePool\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.content",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.content\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.content",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.content\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.content",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.content\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.currentPlan",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.currentPlan\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.currentPlan",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.currentPlan\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.currentPlan",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.currentPlan\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.dashboard",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.dashboard\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.dashboard",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.dashboard\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.dashboard",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.dashboard\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.designSystem",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.designSystem\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.designSystem",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.designSystem\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.designSystem",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.designSystem\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.discountTerminations",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.discountTerminations\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.discountTerminations",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.discountTerminations\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.discountTerminations",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.discountTerminations\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.eLearning",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.eLearning\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.eLearning",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.eLearning\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.eLearning",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.eLearning\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.fileGallery",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.fileGallery\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.fileGallery",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.fileGallery\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.fileGallery",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.fileGallery\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.foundations",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.foundations\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.foundations",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.foundations\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.foundations",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.foundations\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.homeFindCreche",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.homeFindCreche\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.homeFindCreche",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.homeFindCreche\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.homeFindCreche",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.homeFindCreche\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.hrProcedures",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.hrProcedures\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.hrProcedures",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.hrProcedures\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.hrProcedures",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.hrProcedures\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.jobBoard",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.jobBoard\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.jobBoard",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.jobBoard\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.jobBoard",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.jobBoard\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.jobListings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.jobListings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.jobListings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.jobListings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.jobListings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.jobListings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.managePlan",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.managePlan\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.managePlan",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.managePlan\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.managePlan",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.managePlan\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.manageSubscriptionDesc",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.manageSubscriptionDesc\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.manageSubscriptionDesc",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.manageSubscriptionDesc\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.manageSubscriptionDesc",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.manageSubscriptionDesc\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.marketplace",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.marketplace\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.marketplace",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.marketplace\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.marketplace",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.marketplace\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.messages",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.messages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.messages",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.messages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.messages",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.messages\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.myProfile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.myProfile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.myProfile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.myProfile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.myProfile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.myProfile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.myRequests",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.myRequests\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.myRequests",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.myRequests\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.myRequests",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.myRequests\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.orders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.orders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.orders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.orders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.orders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.orders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.ordersAppointments",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.ordersAppointments\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.ordersAppointments",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.ordersAppointments\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.ordersAppointments",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.ordersAppointments\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.organisationProfile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.organisationProfile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.organisationProfile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.organisationProfile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.organisationProfile",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.organisationProfile\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.parentLeads",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.parentLeads\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.parentLeads",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.parentLeads\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.parentLeads",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.parentLeads\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.parents",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.parents\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.parents",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.parents\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.parents",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.parents\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.partners",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.partners\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.partners",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.partners\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.partners",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.partners\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.platformSettings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.platformSettings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.platformSettings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.platformSettings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.platformSettings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.platformSettings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.premiumPlan",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.premiumPlan\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.premiumPlan",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.premiumPlan\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.premiumPlan",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.premiumPlan\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.premiumPlanDesc",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.premiumPlanDesc\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.premiumPlanDesc",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.premiumPlanDesc\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.premiumPlanDesc",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.premiumPlanDesc\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.productMarketplace",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.productMarketplace\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.productMarketplace",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.productMarketplace\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.productMarketplace",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.productMarketplace\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.products",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.products\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.products",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.products\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.products",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.products\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.productSuppliers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.productSuppliers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.productSuppliers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.productSuppliers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.productSuppliers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.productSuppliers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.recruitment",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.recruitment\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.recruitment",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.recruitment\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.recruitment",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.recruitment\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.serviceMarketplace",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.serviceMarketplace\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.serviceMarketplace",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.serviceMarketplace\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.serviceMarketplace",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.serviceMarketplace\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.serviceProviders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.serviceProviders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.serviceProviders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.serviceProviders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.serviceProviders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.serviceProviders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.services",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.services\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.services",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.services\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.services",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.services\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.settings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.settings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.settings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.settings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.settings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.settings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.statePolicies",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.statePolicies\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.statePolicies",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.statePolicies\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.statePolicies",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.statePolicies\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.support",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.support\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.support",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.support\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.support",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.support\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.supportFAQ",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.supportFAQ\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.supportFAQ",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.supportFAQ\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.supportFAQ",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.supportFAQ\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.systemMonitoring",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.systemMonitoring\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.systemMonitoring",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.systemMonitoring\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.systemMonitoring",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.systemMonitoring\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.users",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.users\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.users",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.users\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:sidebar.users",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"sidebar.users\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signIn",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signIn\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signIn",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signIn\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signIn",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signIn\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signOut",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signOut\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signOut",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signOut\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signOut",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signOut\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.admin.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.admin.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.admin.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.admin.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.admin.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.admin.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.admin.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.admin.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.admin.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.admin.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.admin.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.admin.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.createAccountTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.createAccountTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.createAccountTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.createAccountTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.createAccountTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.createAccountTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.detailsTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.detailsTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.detailsTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.detailsTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.detailsTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.detailsTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.educator.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.educator.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.educator.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.educator.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.educator.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.educator.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.educator.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.educator.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.educator.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.educator.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.educator.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.educator.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.cantonRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.cantonRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.cantonRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.cantonRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.cantonRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.cantonRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.capacityRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.capacityRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.capacityRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.capacityRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.capacityRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.capacityRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.categoryRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.categoryRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.categoryRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.categoryRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.categoryRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.categoryRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.childAgeRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.childAgeRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.childAgeRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.childAgeRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.childAgeRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.childAgeRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.childStartDateRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.childStartDateRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.childStartDateRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.childStartDateRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.childStartDateRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.childStartDateRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.emailInvalid",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.emailInvalid\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.emailInvalid",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.emailInvalid\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.emailInvalid",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.emailInvalid\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.emailRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.emailRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.emailRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.emailRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.emailRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.emailRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.organisationNameRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.organisationNameRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.organisationNameRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.organisationNameRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.organisationNameRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.organisationNameRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.passwordRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.passwordRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.passwordRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.passwordRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.passwordRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.passwordRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.passwordsNoMatch",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.passwordsNoMatch\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.passwordsNoMatch",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.passwordsNoMatch\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.passwordsNoMatch",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.passwordsNoMatch\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.passwordTooShort",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.passwordTooShort\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.passwordTooShort",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.passwordTooShort\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.passwordTooShort",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.passwordTooShort\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.phoneRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.phoneRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.phoneRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.phoneRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.phoneRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.phoneRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.serviceTypeRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.serviceTypeRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.serviceTypeRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.serviceTypeRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.serviceTypeRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.serviceTypeRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.termsRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.termsRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.termsRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.termsRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.errors.termsRequired",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.errors.termsRequired\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.foundation.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.foundation.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.foundation.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.foundation.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.foundation.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.foundation.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.foundation.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.foundation.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.foundation.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.foundation.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.foundation.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.foundation.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.parent.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.parent.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.parent.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.parent.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.parent.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.parent.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.parent.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.parent.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.parent.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.parent.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.parent.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.parent.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.placeholders.select",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.placeholders.select\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.placeholders.select",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.placeholders.select\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.placeholders.select",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.placeholders.select\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.productSupplier.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.productSupplier.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.productSupplier.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.productSupplier.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.productSupplier.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.productSupplier.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.productSupplier.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.productSupplier.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.productSupplier.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.productSupplier.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.productSupplier.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.productSupplier.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.progressStep1",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.progressStep1\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.progressStep1",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.progressStep1\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.progressStep1",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.progressStep1\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.progressStep2",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.progressStep2\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.progressStep2",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.progressStep2\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.progressStep2",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.progressStep2\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.roleDescription",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.roleDescription\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.roleDescription",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.roleDescription\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.roleDescription",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.roleDescription\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.roleLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.roleLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.roleLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.roleLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.roleLabel",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.roleLabel\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.roles.foundation",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.roles.foundation\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.roles.foundation",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.roles.foundation\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.roles.foundation",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.roles.foundation\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.roles.parent",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.roles.parent\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.roles.parent",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.roles.parent\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.roles.parent",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.roles.parent\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.roles.serviceProvider",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.roles.serviceProvider\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.roles.serviceProvider",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.roles.serviceProvider\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.roles.serviceProvider",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.roles.serviceProvider\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.roles.supplier",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.roles.supplier\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.roles.supplier",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.roles.supplier\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.roles.supplier",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.roles.supplier\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.selectRoleTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.selectRoleTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.selectRoleTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.selectRoleTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.selectRoleTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.selectRoleTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.serviceProvider.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.serviceProvider.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.serviceProvider.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.serviceProvider.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.serviceProvider.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.serviceProvider.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.serviceProvider.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.serviceProvider.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.serviceProvider.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.serviceProvider.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.serviceProvider.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.serviceProvider.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.submissionSuccessMessage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.submissionSuccessMessage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.submissionSuccessMessage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.submissionSuccessMessage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.submissionSuccessMessage",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.submissionSuccessMessage\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.submissionSuccessTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.submissionSuccessTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.submissionSuccessTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.submissionSuccessTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.submissionSuccessTitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.submissionSuccessTitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.subtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.subtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.subtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.subtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.subtitle",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.subtitle\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.superAdmin.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.superAdmin.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.superAdmin.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.superAdmin.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.superAdmin.description",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.superAdmin.description\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.superAdmin.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.superAdmin.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.superAdmin.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.superAdmin.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.superAdmin.label",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.superAdmin.label\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.verificationCode",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.verificationCode\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.verificationCode",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.verificationCode\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.verificationCode",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.verificationCode\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.verifyEmail",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.verifyEmail\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.verifyEmail",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.verifyEmail\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.verifyEmail",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.verifyEmail\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.verifyEmailDescription",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.verifyEmailDescription\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.verifyEmailDescription",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.verifyEmailDescription\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:signupPage.verifyEmailDescription",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"signupPage.verifyEmailDescription\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:statePoliciesPage.compliance",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"statePoliciesPage.compliance\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:statePoliciesPage.compliance",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"statePoliciesPage.compliance\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:statePoliciesPage.compliance",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"statePoliciesPage.compliance\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:statePoliciesPage.policies",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"statePoliciesPage.policies\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:statePoliciesPage.policies",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"statePoliciesPage.policies\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:statePoliciesPage.policies",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"statePoliciesPage.policies\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:statePoliciesPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"statePoliciesPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:statePoliciesPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"statePoliciesPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:statePoliciesPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"statePoliciesPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:stockStatus.discontinued",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"stockStatus.discontinued\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:stockStatus.discontinued",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"stockStatus.discontinued\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:stockStatus.discontinued",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"stockStatus.discontinued\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:stockStatus.instock",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"stockStatus.instock\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:stockStatus.instock",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"stockStatus.instock\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:stockStatus.instock",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"stockStatus.instock\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:stockStatus.lowstock",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"stockStatus.lowstock\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:stockStatus.lowstock",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"stockStatus.lowstock\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:stockStatus.lowstock",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"stockStatus.lowstock\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:stockStatus.outofstock",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"stockStatus.outofstock\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:stockStatus.outofstock",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"stockStatus.outofstock\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:stockStatus.outofstock",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"stockStatus.outofstock\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierAnalyticsPage.overview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierAnalyticsPage.overview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierAnalyticsPage.overview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierAnalyticsPage.overview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierAnalyticsPage.overview",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierAnalyticsPage.overview\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierAnalyticsPage.sales",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierAnalyticsPage.sales\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierAnalyticsPage.sales",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierAnalyticsPage.sales\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierAnalyticsPage.sales",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierAnalyticsPage.sales\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierAnalyticsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierAnalyticsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierAnalyticsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierAnalyticsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierAnalyticsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierAnalyticsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierDashboardPage.orders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierDashboardPage.orders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierDashboardPage.orders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierDashboardPage.orders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierDashboardPage.orders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierDashboardPage.orders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierDashboardPage.products",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierDashboardPage.products\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierDashboardPage.products",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierDashboardPage.products\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierDashboardPage.products",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierDashboardPage.products\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierDashboardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierDashboardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierDashboardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierDashboardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierDashboardPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierDashboardPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierDashboardPage.welcome",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierDashboardPage.welcome\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierDashboardPage.welcome",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierDashboardPage.welcome\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierDashboardPage.welcome",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierDashboardPage.welcome\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierOrdersPage.orders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierOrdersPage.orders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierOrdersPage.orders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierOrdersPage.orders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierOrdersPage.orders",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierOrdersPage.orders\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierOrdersPage.pending",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierOrdersPage.pending\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierOrdersPage.pending",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierOrdersPage.pending\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierOrdersPage.pending",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierOrdersPage.pending\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierOrdersPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierOrdersPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierOrdersPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierOrdersPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierOrdersPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierOrdersPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierProductListingsPage.addProduct",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierProductListingsPage.addProduct\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierProductListingsPage.addProduct",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierProductListingsPage.addProduct\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierProductListingsPage.addProduct",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierProductListingsPage.addProduct\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierProductListingsPage.listings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierProductListingsPage.listings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierProductListingsPage.listings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierProductListingsPage.listings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierProductListingsPage.listings",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierProductListingsPage.listings\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierProductListingsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierProductListingsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierProductListingsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierProductListingsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierProductListingsPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierProductListingsPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierSupportPage.help",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierSupportPage.help\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierSupportPage.help",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierSupportPage.help\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierSupportPage.help",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierSupportPage.help\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierSupportPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierSupportPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierSupportPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierSupportPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:supplierSupportPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"supplierSupportPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:usersPage.allUsers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"usersPage.allUsers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:usersPage.allUsers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"usersPage.allUsers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:usersPage.allUsers",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"usersPage.allUsers\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:usersPage.roles",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"usersPage.roles\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:usersPage.roles",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"usersPage.roles\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:usersPage.roles",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"usersPage.roles\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:usersPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"usersPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:usersPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"usersPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:usersPage.title",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"usersPage.title\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:welcomeBack",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"welcomeBack\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:welcomeBack",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"welcomeBack\" from namespace \"translation\" in en, fr, de"
+    },
+    {
+      "key": "translation:welcomeBack",
+      "locales": [
+        "en",
+        "fr",
+        "de"
+      ],
+      "suggestion": "Remove unused key \"welcomeBack\" from namespace \"translation\" in en, fr, de"
+    }
+  ]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,10 @@
     "test:unit": "vitest",
     "test:e2e": "playwright test --reporter=list",
     "test:e2e:ui": "playwright test --ui",
-    "test": "pnpm run test:unit && pnpm run test:e2e"
+    "test": "pnpm run test:unit && pnpm run test:e2e",
+    "test:i18n": "ts-node ../scan-i18n.ts --src \"**/*.{ts,tsx,js,jsx}\" --locales \"public/locales\" --languages \"en,fr,de\" --defaultNs \"translation\" --report table --out i18n-report.json",
+    "test:i18n:json": "ts-node ../scan-i18n.ts --src \"**/*.{ts,tsx,js,jsx}\" --locales \"public/locales\" --languages \"en,fr,de\" --defaultNs \"translation\" --report json",
+    "test:i18n:fail": "ts-node ../scan-i18n.ts --src \"**/*.{ts,tsx,js,jsx}\" --locales \"public/locales\" --languages \"en,fr,de\" --defaultNs \"translation\" --report table --failOnMissing"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
@@ -25,6 +28,9 @@
     "serve": "^14.2.1"
   },
   "devDependencies": {
+    "@babel/parser": "^7.25.9",
+    "@babel/traverse": "^7.25.9",
+    "@babel/types": "^7.25.9",
     "@playwright/test": "^1.55.1",
     "@tailwindcss/forms": "^0.5.9",
     "@testing-library/jest-dom": "^6.0.0",
@@ -32,11 +38,14 @@
     "@types/node": "^22.14.0",
     "@vitejs/plugin-react": "^5.0.0",
     "autoprefixer": "^10.4.20",
+    "globby": "^14.1.0",
     "jsdom": "^27.0.0",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.15",
+    "ts-node": "^10.9.2",
     "typescript": "~5.8.2",
     "vite": "^6.2.0",
-    "vitest": "^2.0.0"
+    "vitest": "^2.0.0",
+    "yargs": "^17.7.2"
   }
 }

--- a/frontend/public/locales/de/translation.json
+++ b/frontend/public/locales/de/translation.json
@@ -55,7 +55,14 @@
       "profile": "Profil",
       "settings": "Einstellungen",
       "logout": "Abmelden"
-    }
+    },
+    "toggleNavigation": "Navigation umschalten",
+    "goBackPreviousPage": "Zurück zur vorherigen Seite",
+    "viewShoppingCart": "Warenkorb anzeigen",
+    "newMessages": "Neue Nachrichten",
+    "noNewNotifications": "Keine neuen Benachrichtigungen",
+    "viewAll": "Alle anzeigen",
+    "signOut": "Abmelden"
   },
   "sidebar": {
     "dashboard": "Armaturenbrett",
@@ -141,7 +148,8 @@
   },
   "notifications": {
     "successTitle": "Erfolg",
-    "settingsUpdated": "Einstellungen erfolgreich aktualisiert"
+    "settingsUpdated": "Einstellungen erfolgreich aktualisiert",
+    "errorTitle": "Fehler"
   },
   "hidePassword": "Passwort verbergen",
   "showPassword": "Passwort anzeigen",
@@ -337,7 +345,23 @@
     }
   },
   "organizationProfileForm": {
-    "saveSuccess": "Organisationsprofil erfolgreich gespeichert"
+    "saveSuccess": "Organisationsprofil erfolgreich gespeichert",
+    "accessDenied": "Zugriff verweigert",
+    "title": "Organisationsprofil",
+    "subtitle": "Vervollständigen Sie die Profilinformationen Ihrer Organisation",
+    "labels": {
+      "capacity": "Kapazität",
+      "pedagogy": "Pädagogische Erklärung",
+      "languages": "Sprachen"
+    },
+    "placeholders": {
+      "pedagogy": "Beschreiben Sie Ihren pädagogischen Ansatz...",
+      "languages": "z.B. Englisch, Französisch, Deutsch"
+    },
+    "helpText": {
+      "commaSeparated": "Trennen Sie mehrere Elemente durch Kommas"
+    },
+    "saveButton": "Profil speichern"
   },
   "foundationDashboardPage": {
     "title": "Foundation Dashboard",
@@ -503,12 +527,35 @@
   "messagesPage": {
     "title": "Nachrichten",
     "conversations": "Gespräche",
-    "newMessage": "Neue Nachricht"
+    "newMessage": "Neue Nachricht",
+    "searchPlaceholder": "Gespräche suchen...",
+    "filters": {
+      "all": "Alle",
+      "unread": "Ungelesen"
+    },
+    "noConversationsFound": "Keine Gespräche gefunden",
+    "selectConversationToView": "Wählen Sie ein Gespräch zum Anzeigen",
+    "conversationFallbackTitle": "Unbekannter Benutzer",
+    "attachFile": "Datei anhängen",
+    "addEmoji": "Emoji hinzufügen",
+    "typeMessagePlaceholder": "Nachricht eingeben...",
+    "unknownUser": "Unbekannter Benutzer",
+    "youPrefix": "Sie: ",
+    "noMessagesYet": "Noch keine Nachrichten",
+    "newGroupButton": "Neue Gruppe",
+    "noConversationSelectedTitle": "Kein Gespräch ausgewählt",
+    "noConversationSelectedSubtitle": "Wählen Sie ein Gespräch aus der Liste aus, um mit dem Messaging zu beginnen",
+    "noConversationsYet": "Noch keine Gespräche"
   },
   "notificationsPage": {
     "title": "Benachrichtigungen",
     "notifications": "Alle Benachrichtigungen",
-    "unread": "Ungelesen"
+    "unread": "Ungelesen",
+    "clearAll": "Alle löschen",
+    "emptyState": {
+      "title": "Keine Benachrichtigungen",
+      "message": "Sie haben noch keine Benachrichtigungen"
+    }
   },
   "fileGalleryPage": {
     "title": "Dateigalerie",
@@ -563,5 +610,127 @@
     "title": "Designsystem",
     "components": "Komponenten",
     "guidelines": "Richtlinien"
+  },
+  "createGroupChatModal": {
+    "error": {
+      "minParticipants": "Bitte wählen Sie mindestens 2 Teilnehmer aus"
+    },
+    "title": "Gruppenchat erstellen",
+    "groupNameLabel": "Gruppenname",
+    "groupNamePlaceholder": "Gruppenname eingeben...",
+    "selectParticipantsLabel": "Teilnehmer auswählen",
+    "createButton": "Gruppe erstellen"
+  },
+  "orderRequestDetailModal": {
+    "title": "Bestelldetails",
+    "orderId": "Bestell-ID",
+    "date": "Datum",
+    "status": "Status",
+    "total": "Gesamt",
+    "viewDaycareProfile": "Krippenprofil anzeigen",
+    "lineItems": "Positionen",
+    "product": "Produkt",
+    "quantity": "Menge",
+    "price": "Preis",
+    "notes": "Notizen"
+  },
+  "serviceRequestDetailModal": {
+    "title": "Serviceanfrage-Details",
+    "requestId": "Anfrage-ID",
+    "serviceName": "Service-Name",
+    "viewDaycareProfile": "Krippenprofil anzeigen",
+    "date": "Datum",
+    "status": "Status",
+    "preferredDate": "Bevorzugtes Datum",
+    "noPreferredDate": "Kein bevorzugtes Datum festgelegt",
+    "notes": "Notizen"
+  },
+  "serviceUploadModal": {
+    "editTitle": "Service bearbeiten",
+    "addTitle": "Neuen Service hinzufügen",
+    "labels": {
+      "title": "Service-Titel",
+      "description": "Beschreibung",
+      "category": "Kategorie",
+      "deliveryType": "Lieferart",
+      "availability": "Verfügbarkeit",
+      "priceInfo": "Preisinformationen",
+      "tags": "Tags",
+      "image": "Service-Bild"
+    },
+    "placeholders": {
+      "availability": "z.B. Montag-Freitag 9-17 Uhr",
+      "priceInfo": "z.B. CHF 50/Stunde",
+      "tags": "z.B. Beratung, Schulung, Support"
+    },
+    "imageHelpText": "Laden Sie ein Bild hoch, das Ihren Service repräsentiert"
+  },
+  "contentUploadModal": {
+    "fileUpload": {
+      "eLearningAllowedTypes": "Erlaubt: PDF, MP4, DOC, DOCX",
+      "hrPolicyAllowedTypes": "Erlaubt: PDF, DOC, DOCX"
+    },
+    "error": {
+      "selectFileOrLink": "Bitte wählen Sie eine Datei aus oder geben Sie einen Link ein"
+    },
+    "contentType": {
+      "eLearning": "E-Learning-Inhalt",
+      "hrPolicy": "HR-Richtlinie",
+      "statePolicy": "Staatsrichtlinie"
+    },
+    "labels": {
+      "descriptionPreview": "Beschreibungsvorschau",
+      "description": "Beschreibung",
+      "title": "Titel",
+      "category": "Kategorie",
+      "contentType": "Inhaltstyp",
+      "language": "Sprache",
+      "duration": "Dauer",
+      "lessons": "Anzahl der Lektionen",
+      "linkUrl": "Link-URL",
+      "accessRoles": "Zugriffsrollen",
+      "status": "Status",
+      "documentTitle": "Dokumenttitel",
+      "fileType": "Dateityp",
+      "version": "Version",
+      "country": "Land",
+      "regionCanton": "Region/Kanton",
+      "policyType": "Richtlinientyp",
+      "criticality": "Kritikalität",
+      "markAsCritical": "Als kritisch markieren",
+      "effectiveDate": "Gültigkeitsdatum",
+      "externalLink": "Externer Link",
+      "uploadFile": "Datei hochladen"
+    },
+    "placeholders": {
+      "duration": "z.B. 2 Stunden",
+      "linkUrl": "https://beispiel.com",
+      "version": "z.B. 1.0",
+      "externalLink": "https://beispiel.com"
+    },
+    "statusOptions": {
+      "draft": "Entwurf",
+      "published": "Veröffentlicht",
+      "archived": "Archiviert"
+    },
+    "criticalityOptions": {
+      "critical": "Kritisch",
+      "normal": "Normal"
+    },
+    "buttons": {
+      "uploading": "Hochladen...",
+      "upload": "Hochladen"
+    }
+  },
+  "orderRequestModal": {
+    "labels": {
+      "product": "Produkt",
+      "supplier": "Lieferant",
+      "quantity": "Menge",
+      "notes": "Notizen"
+    },
+    "placeholders": {
+      "notes": "Fügen Sie spezielle Anweisungen hinzu..."
+    }
   }
 }

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -3,7 +3,7 @@
   "languageSwitcher": {
     "enShort": "EN",
     "enLong": "English",
-    "frShort": "FR", 
+    "frShort": "FR",
     "frLong": "Français",
     "deShort": "DE",
     "deLong": "Deutsch",
@@ -55,7 +55,14 @@
       "profile": "Profile",
       "settings": "Settings",
       "logout": "Sign Out"
-    }
+    },
+    "toggleNavigation": "Toggle navigation",
+    "goBackPreviousPage": "Go back to previous page",
+    "viewShoppingCart": "View shopping cart",
+    "newMessages": "New messages",
+    "noNewNotifications": "No new notifications",
+    "viewAll": "View all",
+    "signOut": "Sign out"
   },
   "sidebar": {
     "dashboard": "Dashboard",
@@ -141,7 +148,8 @@
   },
   "notifications": {
     "successTitle": "Success",
-    "settingsUpdated": "Settings updated successfully"
+    "settingsUpdated": "Settings updated successfully",
+    "errorTitle": "Error"
   },
   "hidePassword": "Hide password",
   "showPassword": "Show password",
@@ -337,7 +345,23 @@
     }
   },
   "organizationProfileForm": {
-    "saveSuccess": "Organization profile saved successfully"
+    "saveSuccess": "Organization profile saved successfully",
+    "accessDenied": "Access denied",
+    "title": "Organization Profile",
+    "subtitle": "Complete your organization's profile information",
+    "labels": {
+      "capacity": "Capacity",
+      "pedagogy": "Pedagogy Statement",
+      "languages": "Languages"
+    },
+    "placeholders": {
+      "pedagogy": "Describe your educational approach...",
+      "languages": "e.g., English, French, German"
+    },
+    "helpText": {
+      "commaSeparated": "Separate multiple items with commas"
+    },
+    "saveButton": "Save Profile"
   },
   "foundationDashboardPage": {
     "title": "Foundation Dashboard",
@@ -503,12 +527,35 @@
   "messagesPage": {
     "title": "Messages",
     "conversations": "Conversations",
-    "newMessage": "New Message"
+    "newMessage": "New Message",
+    "searchPlaceholder": "Search conversations...",
+    "filters": {
+      "all": "All",
+      "unread": "Unread"
+    },
+    "noConversationsFound": "No conversations found",
+    "selectConversationToView": "Select a conversation to view",
+    "conversationFallbackTitle": "Unknown User",
+    "attachFile": "Attach file",
+    "addEmoji": "Add emoji",
+    "typeMessagePlaceholder": "Type a message...",
+    "unknownUser": "Unknown User",
+    "youPrefix": "You: ",
+    "noMessagesYet": "No messages yet",
+    "newGroupButton": "New Group",
+    "noConversationSelectedTitle": "No conversation selected",
+    "noConversationSelectedSubtitle": "Choose a conversation from the list to start messaging",
+    "noConversationsYet": "No conversations yet"
   },
   "notificationsPage": {
     "title": "Notifications",
     "notifications": "All Notifications",
-    "unread": "Unread"
+    "unread": "Unread",
+    "clearAll": "Clear All",
+    "emptyState": {
+      "title": "No notifications",
+      "message": "You don't have any notifications yet"
+    }
   },
   "fileGalleryPage": {
     "title": "File Gallery",
@@ -563,5 +610,127 @@
     "title": "Design System",
     "components": "Components",
     "guidelines": "Guidelines"
+  },
+  "createGroupChatModal": {
+    "error": {
+      "minParticipants": "Please select at least 2 participants"
+    },
+    "title": "Create Group Chat",
+    "groupNameLabel": "Group Name",
+    "groupNamePlaceholder": "Enter group name...",
+    "selectParticipantsLabel": "Select Participants",
+    "createButton": "Create Group"
+  },
+  "orderRequestDetailModal": {
+    "title": "Order Details",
+    "orderId": "Order ID",
+    "date": "Date",
+    "status": "Status",
+    "total": "Total",
+    "viewDaycareProfile": "View Daycare Profile",
+    "lineItems": "Line Items",
+    "product": "Product",
+    "quantity": "Quantity",
+    "price": "Price",
+    "notes": "Notes"
+  },
+  "serviceRequestDetailModal": {
+    "title": "Service Request Details",
+    "requestId": "Request ID",
+    "serviceName": "Service Name",
+    "viewDaycareProfile": "View Daycare Profile",
+    "date": "Date",
+    "status": "Status",
+    "preferredDate": "Preferred Date",
+    "noPreferredDate": "No preferred date set",
+    "notes": "Notes"
+  },
+  "serviceUploadModal": {
+    "editTitle": "Edit Service",
+    "addTitle": "Add New Service",
+    "labels": {
+      "title": "Service Title",
+      "description": "Description",
+      "category": "Category",
+      "deliveryType": "Delivery Type",
+      "availability": "Availability",
+      "priceInfo": "Price Information",
+      "tags": "Tags",
+      "image": "Service Image"
+    },
+    "placeholders": {
+      "availability": "e.g., Monday-Friday 9AM-5PM",
+      "priceInfo": "e.g., CHF 50/hour",
+      "tags": "e.g., consultation, training, support"
+    },
+    "imageHelpText": "Upload an image that represents your service"
+  },
+  "contentUploadModal": {
+    "fileUpload": {
+      "eLearningAllowedTypes": "Allowed: PDF, MP4, DOC, DOCX",
+      "hrPolicyAllowedTypes": "Allowed: PDF, DOC, DOCX"
+    },
+    "error": {
+      "selectFileOrLink": "Please select a file or enter a link"
+    },
+    "contentType": {
+      "eLearning": "E-Learning Content",
+      "hrPolicy": "HR Policy",
+      "statePolicy": "State Policy"
+    },
+    "labels": {
+      "descriptionPreview": "Description Preview",
+      "description": "Description",
+      "title": "Title",
+      "category": "Category",
+      "contentType": "Content Type",
+      "language": "Language",
+      "duration": "Duration",
+      "lessons": "Number of Lessons",
+      "linkUrl": "Link URL",
+      "accessRoles": "Access Roles",
+      "status": "Status",
+      "documentTitle": "Document Title",
+      "fileType": "File Type",
+      "version": "Version",
+      "country": "Country",
+      "regionCanton": "Region/Canton",
+      "policyType": "Policy Type",
+      "criticality": "Criticality",
+      "markAsCritical": "Mark as Critical",
+      "effectiveDate": "Effective Date",
+      "externalLink": "External Link",
+      "uploadFile": "Upload File"
+    },
+    "placeholders": {
+      "duration": "e.g., 2 hours",
+      "linkUrl": "https://example.com",
+      "version": "e.g., 1.0",
+      "externalLink": "https://example.com"
+    },
+    "statusOptions": {
+      "draft": "Draft",
+      "published": "Published",
+      "archived": "Archived"
+    },
+    "criticalityOptions": {
+      "critical": "Critical",
+      "normal": "Normal"
+    },
+    "buttons": {
+      "uploading": "Uploading...",
+      "upload": "Upload"
+    }
+  },
+  "orderRequestModal": {
+    "labels": {
+      "product": "Product",
+      "supplier": "Supplier",
+      "quantity": "Quantity",
+      "notes": "Notes"
+    },
+    "placeholders": {
+      "notes": "Add any special instructions..."
+    }
   }
 }

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -55,7 +55,14 @@
       "profile": "Profil",
       "settings": "Paramètres",
       "logout": "Se déconnecter"
-    }
+    },
+    "toggleNavigation": "Basculer la navigation",
+    "goBackPreviousPage": "Retour à la page précédente",
+    "viewShoppingCart": "Voir le panier",
+    "newMessages": "Nouveaux messages",
+    "noNewNotifications": "Aucune nouvelle notification",
+    "viewAll": "Voir tout",
+    "signOut": "Se déconnecter"
   },
   "sidebar": {
     "dashboard": "Tableau de bord",
@@ -141,7 +148,8 @@
   },
   "notifications": {
     "successTitle": "Succès",
-    "settingsUpdated": "Paramètres mis à jour avec succès"
+    "settingsUpdated": "Paramètres mis à jour avec succès",
+    "errorTitle": "Erreur"
   },
   "hidePassword": "Masquer le mot de passe",
   "showPassword": "Montrer le mot de passe",
@@ -337,7 +345,23 @@
     }
   },
   "organizationProfileForm": {
-    "saveSuccess": "Profil de l'organisation a économisé avec succès"
+    "saveSuccess": "Profil de l'organisation a économisé avec succès",
+    "accessDenied": "Accès refusé",
+    "title": "Profil de l'organisation",
+    "subtitle": "Complétez les informations du profil de votre organisation",
+    "labels": {
+      "capacity": "Capacité",
+      "pedagogy": "Déclaration pédagogique",
+      "languages": "Langues"
+    },
+    "placeholders": {
+      "pedagogy": "Décrivez votre approche éducative...",
+      "languages": "ex: Anglais, Français, Allemand"
+    },
+    "helpText": {
+      "commaSeparated": "Séparez plusieurs éléments par des virgules"
+    },
+    "saveButton": "Enregistrer le profil"
   },
   "foundationDashboardPage": {
     "title": "Tableau de bord de base",
@@ -503,12 +527,35 @@
   "messagesPage": {
     "title": "Messages",
     "conversations": "Conversations",
-    "newMessage": "Nouveau message"
+    "newMessage": "Nouveau message",
+    "searchPlaceholder": "Rechercher des conversations...",
+    "filters": {
+      "all": "Toutes",
+      "unread": "Non lues"
+    },
+    "noConversationsFound": "Aucune conversation trouvée",
+    "selectConversationToView": "Sélectionnez une conversation à afficher",
+    "conversationFallbackTitle": "Utilisateur inconnu",
+    "attachFile": "Joindre un fichier",
+    "addEmoji": "Ajouter un emoji",
+    "typeMessagePlaceholder": "Tapez un message...",
+    "unknownUser": "Utilisateur inconnu",
+    "youPrefix": "Vous : ",
+    "noMessagesYet": "Aucun message pour le moment",
+    "newGroupButton": "Nouveau groupe",
+    "noConversationSelectedTitle": "Aucune conversation sélectionnée",
+    "noConversationSelectedSubtitle": "Choisissez une conversation dans la liste pour commencer à échanger des messages",
+    "noConversationsYet": "Aucune conversation pour le moment"
   },
   "notificationsPage": {
     "title": "Notifications",
     "notifications": "Toutes les notifications",
-    "unread": "Non lu"
+    "unread": "Non lu",
+    "clearAll": "Tout effacer",
+    "emptyState": {
+      "title": "Aucune notification",
+      "message": "Vous n'avez pas encore de notifications"
+    }
   },
   "fileGalleryPage": {
     "title": "Galerie de dossiers",
@@ -563,5 +610,127 @@
     "title": "Système de conception",
     "components": "Composants",
     "guidelines": "Lignes directrices"
+  },
+  "createGroupChatModal": {
+    "error": {
+      "minParticipants": "Veuillez sélectionner au moins 2 participants"
+    },
+    "title": "Créer un chat de groupe",
+    "groupNameLabel": "Nom du groupe",
+    "groupNamePlaceholder": "Entrez le nom du groupe...",
+    "selectParticipantsLabel": "Sélectionner les participants",
+    "createButton": "Créer le groupe"
+  },
+  "orderRequestDetailModal": {
+    "title": "Détails de la commande",
+    "orderId": "ID de commande",
+    "date": "Date",
+    "status": "Statut",
+    "total": "Total",
+    "viewDaycareProfile": "Voir le profil de la crèche",
+    "lineItems": "Articles",
+    "product": "Produit",
+    "quantity": "Quantité",
+    "price": "Prix",
+    "notes": "Notes"
+  },
+  "serviceRequestDetailModal": {
+    "title": "Détails de la demande de service",
+    "requestId": "ID de demande",
+    "serviceName": "Nom du service",
+    "viewDaycareProfile": "Voir le profil de la crèche",
+    "date": "Date",
+    "status": "Statut",
+    "preferredDate": "Date préférée",
+    "noPreferredDate": "Aucune date préférée définie",
+    "notes": "Notes"
+  },
+  "serviceUploadModal": {
+    "editTitle": "Modifier le service",
+    "addTitle": "Ajouter un nouveau service",
+    "labels": {
+      "title": "Titre du service",
+      "description": "Description",
+      "category": "Catégorie",
+      "deliveryType": "Type de livraison",
+      "availability": "Disponibilité",
+      "priceInfo": "Informations sur les prix",
+      "tags": "Étiquettes",
+      "image": "Image du service"
+    },
+    "placeholders": {
+      "availability": "ex: Lundi-Vendredi 9h-17h",
+      "priceInfo": "ex: CHF 50/heure",
+      "tags": "ex: consultation, formation, support"
+    },
+    "imageHelpText": "Téléchargez une image qui représente votre service"
+  },
+  "contentUploadModal": {
+    "fileUpload": {
+      "eLearningAllowedTypes": "Autorisé : PDF, MP4, DOC, DOCX",
+      "hrPolicyAllowedTypes": "Autorisé : PDF, DOC, DOCX"
+    },
+    "error": {
+      "selectFileOrLink": "Veuillez sélectionner un fichier ou entrer un lien"
+    },
+    "contentType": {
+      "eLearning": "Contenu d'apprentissage en ligne",
+      "hrPolicy": "Politique RH",
+      "statePolicy": "Politique d'état"
+    },
+    "labels": {
+      "descriptionPreview": "Aperçu de la description",
+      "description": "Description",
+      "title": "Titre",
+      "category": "Catégorie",
+      "contentType": "Type de contenu",
+      "language": "Langue",
+      "duration": "Durée",
+      "lessons": "Nombre de leçons",
+      "linkUrl": "URL du lien",
+      "accessRoles": "Rôles d'accès",
+      "status": "Statut",
+      "documentTitle": "Titre du document",
+      "fileType": "Type de fichier",
+      "version": "Version",
+      "country": "Pays",
+      "regionCanton": "Région/Canton",
+      "policyType": "Type de politique",
+      "criticality": "Criticité",
+      "markAsCritical": "Marquer comme critique",
+      "effectiveDate": "Date d'entrée en vigueur",
+      "externalLink": "Lien externe",
+      "uploadFile": "Télécharger un fichier"
+    },
+    "placeholders": {
+      "duration": "ex: 2 heures",
+      "linkUrl": "https://exemple.com",
+      "version": "ex: 1.0",
+      "externalLink": "https://exemple.com"
+    },
+    "statusOptions": {
+      "draft": "Brouillon",
+      "published": "Publié",
+      "archived": "Archivé"
+    },
+    "criticalityOptions": {
+      "critical": "Critique",
+      "normal": "Normal"
+    },
+    "buttons": {
+      "uploading": "Téléchargement...",
+      "upload": "Télécharger"
+    }
+  },
+  "orderRequestModal": {
+    "labels": {
+      "product": "Produit",
+      "supplier": "Fournisseur",
+      "quantity": "Quantité",
+      "notes": "Notes"
+    },
+    "placeholders": {
+      "notes": "Ajoutez des instructions spéciales..."
+    }
   }
 }

--- a/frontend/tests/unit/i18n-basic.test.ts
+++ b/frontend/tests/unit/i18n-basic.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+
+describe('i18n Scanner Basic Tests', () => {
+  it('should run the scanner without errors and produce valid output', () => {
+    const result = execSync(
+      `ts-node /workspace/scan-i18n.ts --src "**/*.{ts,tsx,js,jsx}" --locales "public/locales" --languages "en,fr,de" --defaultNs "translation" --report table`,
+      { encoding: 'utf8', cwd: '/workspace/frontend' }
+    );
+
+    // Check that the output contains expected sections
+    expect(result).toContain('=== i18n scan results ===');
+    expect(result).toContain('Hardcoded text:');
+    expect(result).toContain('Missing keys:');
+    expect(result).toContain('Unused keys:');
+  });
+
+  it('should generate a JSON report file', () => {
+    const result = execSync(
+      `ts-node /workspace/scan-i18n.ts --src "**/*.{ts,tsx,js,jsx}" --locales "public/locales" --languages "en,fr,de" --defaultNs "translation" --report table --out test-i18n-report.json`,
+      { encoding: 'utf8', cwd: '/workspace/frontend' }
+    );
+
+    // Check that the report file was created
+    const fs = require('fs');
+    expect(fs.existsSync('/workspace/frontend/test-i18n-report.json')).toBe(true);
+    
+    // Clean up
+    fs.unlinkSync('/workspace/frontend/test-i18n-report.json');
+  });
+
+  it('should find unused keys in the current codebase', () => {
+    const result = execSync(
+      `ts-node /workspace/scan-i18n.ts --src "**/*.{ts,tsx,js,jsx}" --locales "public/locales" --languages "en,fr,de" --defaultNs "translation" --report table`,
+      { encoding: 'utf8', cwd: '/workspace/frontend' }
+    );
+
+    // The scanner should find unused keys (we saw 1251 in the previous run)
+    expect(result).toMatch(/Unused keys:\s+\d+/);
+    
+    // Extract the number of unused keys
+    const unusedMatch = result.match(/Unused keys:\s+(\d+)/);
+    expect(unusedMatch).toBeTruthy();
+    
+    const unusedCount = parseInt(unusedMatch![1]);
+    expect(unusedCount).toBeGreaterThan(0);
+  });
+
+  it('should not find hardcoded text issues', () => {
+    const result = execSync(
+      `ts-node /workspace/scan-i18n.ts --src "**/*.{ts,tsx,js,jsx}" --locales "public/locales" --languages "en,fr,de" --defaultNs "translation" --report table`,
+      { encoding: 'utf8', cwd: '/workspace/frontend' }
+    );
+
+    // Should not find hardcoded text issues
+    const hardcodedMatch = result.match(/Hardcoded text:\s+(\d+)/);
+    expect(hardcodedMatch).toBeTruthy();
+    
+    const hardcodedCount = parseInt(hardcodedMatch![1]);
+    expect(hardcodedCount).toBe(0);
+  });
+
+  it('should not find missing key issues', () => {
+    const result = execSync(
+      `ts-node /workspace/scan-i18n.ts --src "**/*.{ts,tsx,js,jsx}" --locales "public/locales" --languages "en,fr,de" --defaultNs "translation" --report table`,
+      { encoding: 'utf8', cwd: '/workspace/frontend' }
+    );
+
+    // Should not find missing key issues
+    const missingMatch = result.match(/Missing keys:\s+(\d+)/);
+    expect(missingMatch).toBeTruthy();
+    
+    const missingCount = parseInt(missingMatch![1]);
+    expect(missingCount).toBe(0);
+  });
+});

--- a/frontend/tests/unit/i18n-scanner.test.ts
+++ b/frontend/tests/unit/i18n-scanner.test.ts
@@ -1,0 +1,398 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+describe('i18n Scanner Tests', () => {
+  const testDir = path.join(__dirname, 'fixtures');
+  const localesDir = path.join(testDir, 'locales');
+  const reportPath = path.join(testDir, 'test-report.json');
+
+  beforeAll(() => {
+    // Create test fixtures directory
+    if (!fs.existsSync(testDir)) {
+      fs.mkdirSync(testDir, { recursive: true });
+    }
+    if (!fs.existsSync(localesDir)) {
+      fs.mkdirSync(localesDir, { recursive: true });
+    }
+
+    // Create test locale files
+    const enTranslations = {
+      "common": {
+        "hello": "Hello",
+        "world": "World",
+        "unusedKey": "This key is not used in code"
+      },
+      "buttons": {
+        "save": "Save",
+        "cancel": "Cancel",
+        "missingKey": "This key is missing in other languages"
+      }
+    };
+
+    const frTranslations = {
+      "common": {
+        "hello": "Bonjour",
+        "world": "Monde"
+        // missing "unusedKey"
+      },
+      "buttons": {
+        "save": "Enregistrer",
+        "cancel": "Annuler"
+        // missing "missingKey"
+      }
+    };
+
+    const deTranslations = {
+      "common": {
+        "hello": "Hallo",
+        "world": "Welt"
+        // missing "unusedKey"
+      },
+      "buttons": {
+        "save": "Speichern",
+        "cancel": "Abbrechen"
+        // missing "missingKey"
+      }
+    };
+
+    // Create language directories and files
+    ['en', 'fr', 'de'].forEach(lang => {
+      const langDir = path.join(localesDir, lang);
+      if (!fs.existsSync(langDir)) {
+        fs.mkdirSync(langDir, { recursive: true });
+      }
+    });
+
+    fs.writeFileSync(
+      path.join(localesDir, 'en', 'translation.json'),
+      JSON.stringify(enTranslations, null, 2)
+    );
+    fs.writeFileSync(
+      path.join(localesDir, 'fr', 'translation.json'),
+      JSON.stringify(frTranslations, null, 2)
+    );
+    fs.writeFileSync(
+      path.join(localesDir, 'de', 'translation.json'),
+      JSON.stringify(deTranslations, null, 2)
+    );
+  });
+
+  afterAll(() => {
+    // Clean up test files
+    if (fs.existsSync(reportPath)) {
+      fs.unlinkSync(reportPath);
+    }
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should detect hardcoded text in JSX', () => {
+    const testFile = path.join(testDir, 'hardcoded-test.tsx');
+    const testCode = `
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const TestComponent = () => {
+  const { t } = useTranslation();
+  
+  return (
+    <div>
+      <h1>Hardcoded Title</h1>
+      <p>This is hardcoded text</p>
+      <button title="Hardcoded tooltip">Click me</button>
+      <input placeholder="Hardcoded placeholder" />
+      <span>{t('common.hello')}</span>
+    </div>
+  );
+};
+
+export default TestComponent;
+`;
+
+    fs.writeFileSync(testFile, testCode);
+
+    try {
+      const result = execSync(
+        `ts-node ../../scan-i18n.ts --src "${testFile}" --locales "${localesDir}" --languages "en,fr,de" --defaultNs "translation" --report json`,
+        { encoding: 'utf8', cwd: __dirname }
+      );
+
+      const report = JSON.parse(result);
+      
+      expect(report.summary.hardcodedCount).toBeGreaterThan(0);
+      expect(report.hardcoded).toHaveLength(4); // h1, p, button title, input placeholder
+      
+      const hardcodedTexts = report.hardcoded.map((h: any) => h.snippet);
+      expect(hardcodedTexts).toContain('Hardcoded Title');
+      expect(hardcodedTexts).toContain('This is hardcoded text');
+      expect(hardcodedTexts).toContain('Hardcoded tooltip');
+      expect(hardcodedTexts).toContain('Hardcoded placeholder');
+
+    } finally {
+      fs.unlinkSync(testFile);
+    }
+  });
+
+  it('should detect missing translation keys', () => {
+    const testFile = path.join(testDir, 'missing-keys-test.tsx');
+    const testCode = `
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const TestComponent = () => {
+  const { t } = useTranslation();
+  
+  return (
+    <div>
+      <span>{t('common.hello')}</span>
+      <span>{t('buttons.save')}</span>
+      <span>{t('buttons.missingKey')}</span>
+      <span>{t('nonexistent.key')}</span>
+    </div>
+  );
+};
+
+export default TestComponent;
+`;
+
+    fs.writeFileSync(testFile, testCode);
+
+    try {
+      const result = execSync(
+        `ts-node ../../scan-i18n.ts --src "${testFile}" --locales "${localesDir}" --languages "en,fr,de" --defaultNs "translation" --report json`,
+        { encoding: 'utf8', cwd: __dirname }
+      );
+
+      const report = JSON.parse(result);
+      
+      expect(report.summary.missingKeyCount).toBeGreaterThan(0);
+      expect(report.missingKeys.length).toBeGreaterThan(0);
+      
+      const missingKeys = report.missingKeys.map((m: any) => m.key);
+      expect(missingKeys).toContain('translation:buttons.missingKey');
+      expect(missingKeys).toContain('translation:nonexistent.key');
+
+    } finally {
+      fs.unlinkSync(testFile);
+    }
+  });
+
+  it('should detect unused translation keys', () => {
+    const testFile = path.join(testDir, 'unused-keys-test.tsx');
+    const testCode = `
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const TestComponent = () => {
+  const { t } = useTranslation();
+  
+  return (
+    <div>
+      <span>{t('common.hello')}</span>
+      <span>{t('buttons.save')}</span>
+    </div>
+  );
+};
+
+export default TestComponent;
+`;
+
+    fs.writeFileSync(testFile, testCode);
+
+    try {
+      const result = execSync(
+        `ts-node ../../scan-i18n.ts --src "${testFile}" --locales "${localesDir}" --languages "en,fr,de" --defaultNs "translation" --report json --checkUnused`,
+        { encoding: 'utf8', cwd: __dirname }
+      );
+
+      const report = JSON.parse(result);
+      
+      expect(report.summary.unusedKeyCount).toBeGreaterThan(0);
+      expect(report.unusedKeys.length).toBeGreaterThan(0);
+      
+      const unusedKeys = report.unusedKeys.map((u: any) => u.key);
+      expect(unusedKeys).toContain('translation:common.unusedKey');
+
+    } finally {
+      fs.unlinkSync(testFile);
+    }
+  });
+
+  it('should ignore i18n-ignore comments', () => {
+    const testFile = path.join(testDir, 'ignore-comments-test.tsx');
+    const testCode = `
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const TestComponent = () => {
+  const { t } = useTranslation();
+  
+  return (
+    <div>
+      <h1>This should be flagged</h1>
+      {/* i18n-ignore */}
+      <p>This should be ignored</p>
+      <span>{t('common.hello')}</span>
+    </div>
+  );
+};
+
+export default TestComponent;
+`;
+
+    fs.writeFileSync(testFile, testCode);
+
+    try {
+      const result = execSync(
+        `ts-node ../../scan-i18n.ts --src "${testFile}" --locales "${localesDir}" --languages "en,fr,de" --defaultNs "translation" --report json`,
+        { encoding: 'utf8', cwd: __dirname }
+      );
+
+      const report = JSON.parse(result);
+      
+      expect(report.summary.hardcodedCount).toBe(1);
+      expect(report.hardcoded[0].snippet).toContain('This should be flagged');
+
+    } finally {
+      fs.unlinkSync(testFile);
+    }
+  });
+
+  it('should handle Trans components correctly', () => {
+    const testFile = path.join(testDir, 'trans-component-test.tsx');
+    const testCode = `
+import React from 'react';
+import { Trans } from 'react-i18next';
+
+const TestComponent = () => {
+  return (
+    <div>
+      <Trans i18nKey="common.hello">Hello</Trans>
+      <Trans i18nKey="buttons.save">Save</Trans>
+      <h1>This should be flagged</h1>
+    </div>
+  );
+};
+
+export default TestComponent;
+`;
+
+    fs.writeFileSync(testFile, testCode);
+
+    try {
+      const result = execSync(
+        `ts-node ../../scan-i18n.ts --src "${testFile}" --locales "${localesDir}" --languages "en,fr,de" --defaultNs "translation" --report json`,
+        { encoding: 'utf8', cwd: __dirname }
+      );
+
+      const report = JSON.parse(result);
+      
+      // Should only flag the h1, not the Trans components
+      expect(report.summary.hardcodedCount).toBe(1);
+      expect(report.hardcoded[0].snippet).toContain('This should be flagged');
+
+    } finally {
+      fs.unlinkSync(testFile);
+    }
+  });
+
+  it('should generate comprehensive report', () => {
+    const testFile = path.join(testDir, 'comprehensive-test.tsx');
+    const testCode = `
+import React from 'react';
+import { useTranslation, Trans } from 'react-i18next';
+
+const TestComponent = () => {
+  const { t } = useTranslation();
+  
+  return (
+    <div>
+      <h1>Hardcoded Title</h1>
+      <p>Hardcoded paragraph</p>
+      <button title="Hardcoded tooltip">Click me</button>
+      <span>{t('common.hello')}</span>
+      <span>{t('buttons.save')}</span>
+      <span>{t('nonexistent.key')}</span>
+      <Trans i18nKey="common.world">World</Trans>
+    </div>
+  );
+};
+
+export default TestComponent;
+`;
+
+    fs.writeFileSync(testFile, testCode);
+
+    try {
+      const result = execSync(
+        `ts-node ../../scan-i18n.ts --src "${testFile}" --locales "${localesDir}" --languages "en,fr,de" --defaultNs "translation" --report json --out "${reportPath}"`,
+        { encoding: 'utf8', cwd: __dirname }
+      );
+
+      const report = JSON.parse(result);
+      
+      // Verify report structure
+      expect(report).toHaveProperty('generatedAt');
+      expect(report).toHaveProperty('summary');
+      expect(report).toHaveProperty('hardcoded');
+      expect(report).toHaveProperty('missingKeys');
+      expect(report).toHaveProperty('unusedKeys');
+      
+      expect(report.summary).toHaveProperty('hardcodedCount');
+      expect(report.summary).toHaveProperty('missingKeyCount');
+      expect(report.summary).toHaveProperty('unusedKeyCount');
+      expect(report.summary).toHaveProperty('langs');
+      expect(report.summary).toHaveProperty('defaultNs');
+      expect(report.summary).toHaveProperty('namespaces');
+      expect(report.summary).toHaveProperty('localesRoot');
+
+      // Verify file was created
+      expect(fs.existsSync(reportPath)).toBe(true);
+
+    } finally {
+      fs.unlinkSync(testFile);
+    }
+  });
+
+  it('should handle different namespace formats', () => {
+    const testFile = path.join(testDir, 'namespace-test.tsx');
+    const testCode = `
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const TestComponent = () => {
+  const { t } = useTranslation();
+  
+  return (
+    <div>
+      <span>{t('common.hello')}</span>
+      <span>{t('translation:buttons.save')}</span>
+      <span>{t('buttons.cancel', { ns: 'translation' })}</span>
+    </div>
+  );
+};
+
+export default TestComponent;
+`;
+
+    fs.writeFileSync(testFile, testCode);
+
+    try {
+      const result = execSync(
+        `ts-node ../../scan-i18n.ts --src "${testFile}" --locales "${localesDir}" --languages "en,fr,de" --defaultNs "translation" --report json`,
+        { encoding: 'utf8', cwd: __dirname }
+      );
+
+      const report = JSON.parse(result);
+      
+      // Should not have any missing keys since all are properly defined
+      expect(report.summary.missingKeyCount).toBe(0);
+
+    } finally {
+      fs.unlinkSync(testFile);
+    }
+  });
+});

--- a/frontend/tests/unit/i18n-simple.test.ts
+++ b/frontend/tests/unit/i18n-simple.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+
+describe('i18n Scanner Simple Tests', () => {
+  it('should run the scanner without errors', () => {
+    const result = execSync(
+      `ts-node /workspace/scan-i18n.ts --src "**/*.{ts,tsx,js,jsx}" --locales "public/locales" --languages "en,fr,de" --defaultNs "translation" --report json`,
+      { encoding: 'utf8', cwd: '/workspace/frontend' }
+    );
+
+    const report = JSON.parse(result);
+    
+    expect(report).toHaveProperty('summary');
+    expect(report.summary).toHaveProperty('hardcodedCount');
+    expect(report.summary).toHaveProperty('missingKeyCount');
+    expect(report.summary).toHaveProperty('unusedKeyCount');
+    expect(report.summary).toHaveProperty('langs');
+    expect(report.summary).toHaveProperty('defaultNs');
+    expect(report.summary).toHaveProperty('namespaces');
+    expect(report.summary).toHaveProperty('localesRoot');
+    
+    expect(report).toHaveProperty('hardcoded');
+    expect(report).toHaveProperty('missingKeys');
+    expect(report).toHaveProperty('unusedKeys');
+    
+    expect(Array.isArray(report.hardcoded)).toBe(true);
+    expect(Array.isArray(report.missingKeys)).toBe(true);
+    expect(Array.isArray(report.unusedKeys)).toBe(true);
+  });
+
+  it('should detect unused keys in the current codebase', () => {
+    const result = execSync(
+      `ts-node /workspace/scan-i18n.ts --src "**/*.{ts,tsx,js,jsx}" --locales "public/locales" --languages "en,fr,de" --defaultNs "translation" --report json`,
+      { encoding: 'utf8', cwd: '/workspace/frontend' }
+    );
+
+    const report = JSON.parse(result);
+    
+    // We expect to find unused keys since the scanner found 1251 unused keys
+    expect(report.summary.unusedKeyCount).toBeGreaterThan(0);
+    expect(report.unusedKeys.length).toBeGreaterThan(0);
+  });
+
+  it('should not find hardcoded text in the current codebase', () => {
+    const result = execSync(
+      `ts-node /workspace/scan-i18n.ts --src "**/*.{ts,tsx,js,jsx}" --locales "public/locales" --languages "en,fr,de" --defaultNs "translation" --report json`,
+      { encoding: 'utf8', cwd: '/workspace/frontend' }
+    );
+
+    const report = JSON.parse(result);
+    
+    // The current codebase should not have hardcoded text issues
+    expect(report.summary.hardcodedCount).toBe(0);
+    expect(report.hardcoded.length).toBe(0);
+  });
+
+  it('should not find missing keys in the current codebase', () => {
+    const result = execSync(
+      `ts-node /workspace/scan-i18n.ts --src "**/*.{ts,tsx,js,jsx}" --locales "public/locales" --languages "en,fr,de" --defaultNs "translation" --report json`,
+      { encoding: 'utf8', cwd: '/workspace/frontend' }
+    );
+
+    const report = JSON.parse(result);
+    
+    // The current codebase should not have missing key issues
+    expect(report.summary.missingKeyCount).toBe(0);
+    expect(report.missingKeys.length).toBe(0);
+  });
+});

--- a/i18n-testing-guide.md
+++ b/i18n-testing-guide.md
@@ -1,0 +1,231 @@
+# i18n Testing and Scanning Guide
+
+This guide explains how to use the comprehensive i18n testing solution that has been implemented for the ProCrèche Solutions platform.
+
+## Overview
+
+The i18n testing solution includes:
+- **Hardcoded text detection**: Finds text that should be internationalized
+- **Missing key detection**: Identifies translation keys used in code but missing from locale files
+- **Unused key detection**: Finds translation keys in locale files that are not used in code
+- **Comprehensive test suite**: Automated tests to verify the scanner functionality
+
+## Files Created
+
+### Core Scanner
+- `/workspace/scan-i18n.ts` - Main scanner script with all functionality
+
+### Test Suite
+- `/workspace/frontend/tests/unit/i18n-basic.test.ts` - Basic functionality tests
+- `/workspace/frontend/tests/unit/i18n-scanner.test.ts` - Comprehensive test suite
+
+### Package Configuration
+- Updated `/workspace/frontend/package.json` with required dependencies and npm scripts
+
+## Dependencies Added
+
+The following dependencies were added to support the i18n scanner:
+
+```json
+{
+  "devDependencies": {
+    "@babel/parser": "^7.25.9",
+    "@babel/traverse": "^7.25.9", 
+    "@babel/types": "^7.25.9",
+    "globby": "^14.1.0",
+    "ts-node": "^10.9.2",
+    "yargs": "^17.7.2"
+  }
+}
+```
+
+## NPM Scripts
+
+The following scripts were added to `package.json`:
+
+```json
+{
+  "scripts": {
+    "test:i18n": "ts-node ../scan-i18n.ts --src \"**/*.{ts,tsx,js,jsx}\" --locales \"public/locales\" --languages \"en,fr,de\" --defaultNs \"translation\" --report table --out i18n-report.json",
+    "test:i18n:json": "ts-node ../scan-i18n.ts --src \"**/*.{ts,tsx,js,jsx}\" --locales \"public/locales\" --languages \"en,fr,de\" --defaultNs \"translation\" --report json",
+    "test:i18n:fail": "ts-node ../scan-i18n.ts --src \"**/*.{ts,tsx,js,jsx}\" --locales \"public/locales\" --languages \"en,fr,de\" --defaultNs \"translation\" --report table --failOnMissing"
+  }
+}
+```
+
+## Usage
+
+### Running the Scanner
+
+#### Basic Scan (Table Output)
+```bash
+cd /workspace/frontend
+pnpm run test:i18n
+```
+
+#### JSON Output
+```bash
+cd /workspace/frontend
+pnpm run test:i18n:json
+```
+
+#### Fail on Missing Keys
+```bash
+cd /workspace/frontend
+pnpm run test:i18n:fail
+```
+
+### Running Tests
+
+#### Run All i18n Tests
+```bash
+cd /workspace/frontend
+pnpm run test:unit tests/unit/i18n-basic.test.ts
+```
+
+#### Run Specific Test
+```bash
+cd /workspace/frontend
+pnpm run test:unit tests/unit/i18n-scanner.test.ts
+```
+
+### Manual Scanner Usage
+
+You can also run the scanner directly with custom parameters:
+
+```bash
+ts-node /workspace/scan-i18n.ts \
+  --src "**/*.{ts,tsx,js,jsx}" \
+  --locales "public/locales" \
+  --languages "en,fr,de" \
+  --defaultNs "translation" \
+  --report table \
+  --out i18n-report.json
+```
+
+## Scanner Features
+
+### 1. Hardcoded Text Detection
+
+The scanner identifies:
+- JSX text outside `<Trans>` components
+- Literal strings in common UI props (placeholder, title, aria-label, etc.)
+- Suspicious string/template literals likely rendered to users
+
+**Example of hardcoded text that would be flagged:**
+```tsx
+// ❌ This would be flagged
+<h1>Welcome to our platform</h1>
+<button title="Click here to continue">Continue</button>
+
+// ✅ This would not be flagged
+<h1>{t('welcome.title')}</h1>
+<button title={t('button.continue.tooltip')}>{t('button.continue')}</button>
+```
+
+### 2. Missing Key Detection
+
+The scanner finds translation keys used in code but missing from locale files:
+
+**Supported patterns:**
+- `t("key")`
+- `i18n.t("key")`
+- `t("ns:key")`
+- `t("key", { ns: "namespace" })`
+- `<Trans i18nKey="key" />`
+- `<Trans i18nKey="ns:key" />`
+
+### 3. Unused Key Detection
+
+The scanner identifies translation keys in locale files that are not used anywhere in the codebase.
+
+## Current Scan Results
+
+Based on the initial scan of the codebase:
+
+- **Hardcoded text**: 0 issues found ✅
+- **Missing keys**: 0 issues found ✅  
+- **Unused keys**: 1,251 keys found ⚠️
+
+The large number of unused keys suggests that many translation keys in the locale files are not being used in the current codebase. This could indicate:
+- Legacy keys that are no longer needed
+- Keys for features that haven't been implemented yet
+- Keys that were added but never integrated
+
+## Configuration Options
+
+The scanner supports various configuration options:
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--src` | Glob pattern for files to scan | `frontend/**/*.{ts,tsx,js,jsx}` |
+| `--ignore` | Glob patterns to ignore | `node_modules/**,**/*.test.*,**/__tests__/**` |
+| `--locales` | Root folder for locale files | `frontend/public/locales` |
+| `--languages` | Comma-separated list of languages | `en,fr,de` |
+| `--defaultNs` | Default namespace | `translation` |
+| `--report` | Output format (table/json/both) | `table` |
+| `--out` | Output file path | None |
+| `--failOnMissing` | Exit with code 2 if missing keys found | `false` |
+| `--checkUnused` | Check for unused keys | `true` |
+| `--minLength` | Minimum text length to flag | `3` |
+
+## Suppressing False Positives
+
+### Per-line suppression
+Add `// i18n-ignore` on the line before the text you want to ignore:
+
+```tsx
+// i18n-ignore
+<h1>This text will be ignored</h1>
+```
+
+### Per-file suppression
+Add `/* i18n-ignore-file */` anywhere in the file:
+
+```tsx
+/* i18n-ignore-file */
+// This entire file will be ignored
+```
+
+## Integration with CI/CD
+
+To integrate with your CI/CD pipeline, use the `--failOnMissing` flag:
+
+```bash
+pnpm run test:i18n:fail
+```
+
+This will:
+- Exit with code 0 if no missing keys are found
+- Exit with code 2 if missing keys are found (causing CI to fail)
+
+## Recommendations
+
+1. **Clean up unused keys**: Review the 1,251 unused keys and remove those that are no longer needed
+2. **Regular scanning**: Run the scanner regularly to catch new issues early
+3. **CI integration**: Add the scanner to your CI pipeline to prevent missing key issues
+4. **Team training**: Educate the team on proper i18n practices to avoid hardcoded text
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Module not found errors**: Ensure all dependencies are installed with `pnpm install`
+2. **TypeScript compilation errors**: The scanner uses ts-node, make sure TypeScript is properly configured
+3. **Large JSON output**: Use `--report table` for human-readable output instead of `--report json`
+
+### Performance
+
+The scanner processes all TypeScript/JavaScript files in the project, which can take some time for large codebases. Consider:
+- Using more specific `--src` patterns to limit the scope
+- Adding more files to `--ignore` patterns
+- Running the scanner on specific directories rather than the entire codebase
+
+## Future Enhancements
+
+Potential improvements to consider:
+1. **Incremental scanning**: Only scan changed files
+2. **IDE integration**: VSCode extension for real-time feedback
+3. **Auto-fix suggestions**: Automatic fixes for common issues
+4. **Translation key validation**: Check for proper key naming conventions
+5. **Pluralization detection**: Identify keys that should use pluralization

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -486,6 +486,15 @@ importers:
         specifier: ^14.2.1
         version: 14.2.5
     devDependencies:
+      '@babel/parser':
+        specifier: ^7.25.9
+        version: 7.28.4
+      '@babel/traverse':
+        specifier: ^7.25.9
+        version: 7.28.4
+      '@babel/types':
+        specifier: ^7.25.9
+        version: 7.28.4
       '@playwright/test':
         specifier: ^1.55.1
         version: 1.55.1
@@ -507,6 +516,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.21(postcss@8.5.6)
+      globby:
+        specifier: ^14.1.0
+        version: 14.1.0
       jsdom:
         specifier: ^27.0.0
         version: 27.0.0(postcss@8.5.6)
@@ -516,6 +528,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.15
         version: 3.4.17(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.8.3))
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@22.15.3)(typescript@5.8.3)
       typescript:
         specifier: ~5.8.2
         version: 5.8.3
@@ -525,6 +540,9 @@ importers:
       vitest:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@22.15.3)(jsdom@27.0.0(postcss@8.5.6))(terser@5.44.0)
+      yargs:
+        specifier: ^17.7.2
+        version: 17.7.2
 
   packages/eslint-config:
     devDependencies:
@@ -2592,6 +2610,10 @@ packages:
 
   '@sinclair/typebox@0.34.41':
     resolution: {integrity: sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==}
+
+  '@sindresorhus/merge-streams@2.3.0':
+    resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
+    engines: {node: '>=18'}
 
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
@@ -4896,6 +4918,10 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  globby@14.1.0:
+    resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
+    engines: {node: '>=18'}
+
   goober@2.1.16:
     resolution: {integrity: sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==}
     peerDependencies:
@@ -6043,6 +6069,10 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  path-type@6.0.0:
+    resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
+    engines: {node: '>=18'}
+
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
@@ -6652,6 +6682,10 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  slash@5.1.0:
+    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
+    engines: {node: '>=14.16'}
+
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
@@ -7235,6 +7269,10 @@ packages:
   undici@7.16.0:
     resolution: {integrity: sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==}
     engines: {node: '>=20.18.1'}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -10368,6 +10406,8 @@ snapshots:
 
   '@sinclair/typebox@0.34.41': {}
 
+  '@sindresorhus/merge-streams@2.3.0': {}
+
   '@sinonjs/commons@3.0.1':
     dependencies:
       type-detect: 4.0.8
@@ -13318,6 +13358,15 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  globby@14.1.0:
+    dependencies:
+      '@sindresorhus/merge-streams': 2.3.0
+      fast-glob: 3.3.3
+      ignore: 7.0.5
+      path-type: 6.0.0
+      slash: 5.1.0
+      unicorn-magic: 0.3.0
+
   goober@2.1.16(csstype@3.1.3):
     dependencies:
       csstype: 3.1.3
@@ -14637,6 +14686,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  path-type@6.0.0: {}
+
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
@@ -15306,6 +15357,8 @@ snapshots:
 
   slash@3.0.0: {}
 
+  slash@5.1.0: {}
+
   snake-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
@@ -15827,7 +15880,6 @@ snapshots:
       typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    optional: true
 
   ts-node@10.9.2(@types/node@22.15.3)(typescript@5.9.2):
     dependencies:
@@ -15999,6 +16051,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici@7.16.0: {}
+
+  unicorn-magic@0.3.0: {}
 
   universalify@0.1.2: {}
 

--- a/scan-i18n.ts
+++ b/scan-i18n.ts
@@ -1,0 +1,717 @@
+import fs from "node:fs";
+import path from "node:path";
+import { parse } from "@babel/parser";
+import traverse, { NodePath } from "@babel/traverse";
+import * as t from "@babel/types";
+import { globby } from "globby";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+type Finding = {
+  file: string;
+  line: number;
+  column: number;
+  kind: "JSXText" | "JSXProp" | "StringLiteral" | "TemplateLiteral";
+  propName?: string;
+  snippet: string;
+  suggestion: string;
+};
+
+type MissingKey = {
+  file?: string;        // where we saw it (first occurrence)
+  line?: number;
+  column?: number;
+  key: string;          // "ns:key.path"
+  localesMissing: string[];
+};
+
+type UnusedKey = {
+  key: string;          // "ns:key.path"
+  locales: string[];    // which locales have this key
+  suggestion: string;
+};
+
+type CollectedKeyRef = {
+  file: string;
+  line: number;
+  column: number;
+  ns: string;
+  key: string; // "key.path"
+  full: string; // "ns:key.path"
+};
+
+const argv = yargs(hideBin(process.argv))
+  .option("src", {
+    type: "string",
+    default: 'frontend/**/*.{ts,tsx,js,jsx}',
+    describe: "Glob for files to scan (comma-separated allowed)",
+  })
+  .option("ignore", {
+    type: "string",
+    default:
+      "node_modules/**,**/*.test.*," +
+      "**/*.spec.*," +
+      "**/__tests__/**," +
+      "**/dist/**,**/build/**," +
+      "**/.next/**,**/coverage/**," +
+      "**/scan-i18n.ts",
+    describe: "Ignore globs (comma-separated)",
+  })
+  .option("out", {
+    type: "string",
+    describe: "Write full JSON report to this path",
+  })
+  .option("report", {
+    type: "string",
+    choices: ["table", "json", "both"],
+    default: "table",
+    describe: "How to print the report to stdout",
+  })
+  .option("minLength", {
+    type: "number",
+    default: 3,
+    describe: "Minimum text length to flag (hardcoded text)",
+  })
+  .option("props", {
+    type: "string",
+    default:
+      "placeholder,title,alt,aria-label,ariaDescription,ariaTitle,label,helperText,caption,headline,buttonText,children,tooltip,emptyText",
+    describe: "JSX props to inspect for literal strings (comma-separated)",
+  })
+  .option("i18nFns", {
+    type: "string",
+    default: "t,i18n.t,useTranslation().t",
+    describe:
+      "Function patterns that count as i18n-wrapped (comma-separated, simple names only except i18n.t special-cased)",
+  })
+  .option("i18nComponents", {
+    type: "string",
+    default: "Trans",
+    describe: "Component names that make children safe (comma-separated)",
+  })
+  .option("locales", {
+    type: "string",
+    default: "frontend/public/locales",
+    describe:
+      "Root folder for locales. Expected structure: <locales>/<lang>/<namespace>.json",
+  })
+  .option("languages", {
+    type: "string",
+    default: "en,fr,de",
+    describe: "Comma-separated list of languages to validate (e.g., en,fr,de)",
+  })
+  .option("namespaces", {
+    type: "string",
+    describe:
+      "Optional comma-separated namespaces whitelist. If omitted, namespaces are inferred from JSON files present.",
+  })
+  .option("defaultNs", {
+    type: "string",
+    default: "translation",
+    describe: "Default namespace when t('key') has no explicit ns",
+  })
+  .option("failOnMissing", {
+    type: "boolean",
+    default: false,
+    describe: "Exit with code 2 if missing translation keys are found",
+  })
+  .option("checkUnused", {
+    type: "boolean",
+    default: true,
+    describe: "Check for unused translation keys",
+  })
+  .help().argv as any;
+
+const SRC_GLOBS = argv.src.split(",").map((s: string) => s.trim());
+const IGNORE_GLOBS = argv.ignore.split(",").map((s: string) => s.trim());
+const PROP_NAMES = new Set(
+  argv.props
+    .split(",")
+    .map((s: string) => s.trim())
+    .filter(Boolean)
+);
+const I18N_COMPONENTS = new Set(
+  argv.i18nComponents
+    .split(",")
+    .map((s: string) => s.trim())
+    .filter(Boolean)
+);
+const I18N_FN_NAMES = new Set(
+  argv.i18nFns
+    .split(",")
+    .map((s: string) => s.trim())
+    .filter(Boolean)
+);
+
+const LOCALES_ROOT = path.resolve(String(argv.locales));
+const LANGS: string[] = String(argv.languages)
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+const DEFAULT_NS: string = String(argv.defaultNs);
+
+let NAMESPACES: string[] =
+  argv.namespaces
+    ?.split(",")
+    .map((s: string) => s.trim())
+    .filter(Boolean) ?? [];
+
+/** Heuristics to skip literals that are probably not user-facing text */
+const NON_TEXT_REGEXES: RegExp[] = [
+  /^\s*$/, // whitespace
+  /^[0-9.,:;!?%+*/<>=(){}[\]_'"`-]+$/, // only punctuation/numbers
+  /^https?:\/\//i, // urls
+  /^[\w.-]+@[\w.-]+\.\w+$/, // emails
+  /^#?[0-9A-Fa-f]{6}$/, // hex color
+  /^[A-Za-z0-9_-]{1,20}$/, // short ids/keys
+];
+
+function looksNonText(s: string, minLen: number) {
+  if (s.length < minLen) return true;
+  return NON_TEXT_REGEXES.some((re) => re.test(s));
+}
+
+function hasI18nIgnoreComment(comments?: (t.Comment | null)[]) {
+  if (!comments) return false;
+  return comments.some((c) => c && /i18n-ignore/.test(c.value));
+}
+
+function isInsideTrans(path: NodePath) {
+  let p: NodePath | null = path;
+  while (p) {
+    if (p.isJSXElement()) {
+      const opening = p.node.openingElement;
+      const name = opening.name;
+      if (t.isJSXIdentifier(name) && I18N_COMPONENTS.has(name.name)) return true;
+    }
+    p = p.parentPath;
+  }
+  return false;
+}
+
+function isArgOfI18nFn(path: NodePath<t.StringLiteral | t.TemplateLiteral>) {
+  const parent = path.parentPath;
+  if (!parent?.isCallExpression()) return false;
+  const callee = parent.node.callee;
+
+  if (t.isIdentifier(callee) && I18N_FN_NAMES.has(callee.name)) return true;
+
+  if (
+    t.isMemberExpression(callee) &&
+    t.isIdentifier(callee.object) &&
+    t.isIdentifier(callee.property) &&
+    callee.object.name === "i18n" &&
+    callee.property.name === "t"
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function getLoc(node: t.Node) {
+  const l = node.loc;
+  return {
+    line: l?.start.line ?? 0,
+    column: l?.start.column ?? 0,
+  };
+}
+
+function snippetFrom(source: string, line: number): string {
+  const lines = source.split(/\r?\n/);
+  const i = Math.max(0, line - 1);
+  return (lines[i] || "").trim().slice(0, 180);
+}
+
+function textFromTemplateLiteral(node: t.TemplateLiteral): string {
+  if (node.expressions.length > 0) return ""; // only static templates
+  return node.quasis.map((q) => q.value.cooked ?? q.value.raw ?? "").join("");
+}
+
+/** ---------- Locale loading / flattening ---------- */
+
+type LocaleMap = Map<string, Set<string>>; // ns => set of keys (key.path)
+
+function flattenJSON(obj: any, prefix = ""): string[] {
+  const keys: string[] = [];
+  if (obj && typeof obj === "object") {
+    for (const k of Object.keys(obj)) {
+      const val = obj[k];
+      const p = prefix ? `${prefix}.${k}` : k;
+      if (val && typeof val === "object") {
+        keys.push(...flattenJSON(val, p));
+      } else {
+        keys.push(p);
+      }
+    }
+  }
+  return keys;
+}
+
+function loadNamespacesFromDisk(): string[] {
+  const set = new Set<string>();
+  for (const lang of LANGS) {
+    const dir = path.join(LOCALES_ROOT, lang);
+    if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) continue;
+    const files = fs.readdirSync(dir).filter((f) => f.endsWith(".json"));
+    for (const f of files) {
+      set.add(path.basename(f, ".json"));
+    }
+  }
+  return [...set].sort();
+}
+
+function loadLocales(): Record<string, LocaleMap> {
+  // locales[lang] => Map(ns => Set(keys))
+  const locales: Record<string, LocaleMap> = {};
+  if (NAMESPACES.length === 0) {
+    NAMESPACES = loadNamespacesFromDisk();
+  }
+
+  for (const lang of LANGS) {
+    const nsMap: LocaleMap = new Map();
+    for (const ns of NAMESPACES) {
+      const file = path.join(LOCALES_ROOT, lang, `${ns}.json`);
+      if (!fs.existsSync(file)) {
+        nsMap.set(ns, new Set()); // missing file => empty keys
+        continue;
+      }
+      try {
+        const raw = fs.readFileSync(file, "utf8");
+        const json = JSON.parse(raw);
+        const flattened = flattenJSON(json);
+        nsMap.set(ns, new Set(flattened));
+      } catch (e) {
+        console.error(`[locale-parse-failed] ${file}: ${(e as Error).message}`);
+        nsMap.set(ns, new Set());
+      }
+    }
+    locales[lang] = nsMap;
+  }
+  return locales;
+}
+
+/** ---------- Scan code ---------- */
+
+async function run() {
+  const files = await globby(SRC_GLOBS, { ignore: IGNORE_GLOBS });
+
+  const hardcoded: Finding[] = [];
+  const keyRefs: CollectedKeyRef[] = [];
+
+  for (const file of files) {
+    let code: string;
+    try {
+      code = fs.readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    if (/i18n-ignore-file/.test(code)) continue;
+
+    let ast: t.File;
+    try {
+      ast = parse(code, {
+        sourceType: "module",
+        plugins: [
+          "jsx",
+          "typescript",
+          "classProperties",
+          "decorators-legacy",
+          "objectRestSpread",
+          "topLevelAwait",
+          "dynamicImport",
+        ],
+      });
+    } catch (err) {
+      console.error(`[parse-failed] ${file}: ${(err as Error).message}`);
+      continue;
+    }
+
+    traverse(ast, {
+      enter(p) {
+        if (hasI18nIgnoreComment((p.node as any).leadingComments)) return;
+
+        /** A) Hardcoded text checks */
+
+        // 1) JSXText
+        if (p.isJSXText()) {
+          const raw = p.node.value;
+          const text = raw.replace(/\s+/g, " ").trim();
+          if (!text) return;
+          if (isInsideTrans(p)) return;
+          if (looksNonText(text, argv.minLength)) return;
+          const { line, column } = getLoc(p.node);
+          hardcoded.push({
+            file,
+            line,
+            column,
+            kind: "JSXText",
+            snippet: snippetFrom(code, line),
+            suggestion: `Wrap with <Trans>...</Trans> or replace with {t("${DEFAULT_NS}:your.key")}.`,
+          });
+        }
+
+        // 2) JSXAttribute stringy props
+        if (p.isJSXAttribute()) {
+          const nameNode = p.node.name;
+          if (!t.isJSXIdentifier(nameNode)) return;
+          const propName = nameNode.name;
+          if (!PROP_NAMES.has(propName)) return;
+          const val = p.node.value;
+          if (!val) return;
+
+          const pushFinding = (node: t.Node) => {
+            const { line, column } = getLoc(node);
+            hardcoded.push({
+              file,
+              line,
+              column,
+              kind: "JSXProp",
+              propName,
+              snippet: snippetFrom(code, line),
+              suggestion: `Use {t("${DEFAULT_NS}:your.key")} or <Trans> for "${propName}".`,
+            });
+          };
+
+          if (t.isStringLiteral(val)) {
+            const text = val.value.trim();
+            if (text && !looksNonText(text, argv.minLength)) pushFinding(p.node);
+          } else if (t.isJSXExpressionContainer(val)) {
+            const expr = val.expression;
+            if (t.isStringLiteral(expr)) {
+              const text = expr.value.trim();
+              if (text && !looksNonText(text, argv.minLength)) pushFinding(p.node);
+            } else if (t.isTemplateLiteral(expr)) {
+              const text = textFromTemplateLiteral(expr).trim();
+              if (text && !looksNonText(text, argv.minLength)) pushFinding(p.node);
+            }
+          }
+        }
+
+        // 3) Suspicious string/template used in UI-ish places
+        if (p.isStringLiteral() || p.isTemplateLiteral()) {
+          // skip if part of JSX attr or element
+          if (
+            p.parentPath?.isJSXAttribute() ||
+            p.parentPath?.isJSXElement() ||
+            p.isJSXAttribute() ||
+            p.isJSXElement()
+          )
+            return;
+
+          // skip if arg of t(...)
+          if (isArgOfI18nFn(p as any)) return;
+
+          if (p.isTemplateLiteral() && p.node.expressions.length > 0) return;
+
+          const raw =
+            p.isStringLiteral()
+              ? p.node.value
+              : textFromTemplateLiteral(p.node);
+          const text = (raw || "").trim();
+          if (!text || looksNonText(text, argv.minLength)) return;
+
+          // heuristic: keys like label/title/text/etc
+          const propLikeNames = new Set([
+            "label",
+            "text",
+            "title",
+            "caption",
+            "helperText",
+            "emptyText",
+            "buttonText",
+            "subtitle",
+            "description",
+            "tooltip",
+            "errorMessage",
+            "successMessage",
+            "message",
+            "cta",
+            "placeholder",
+            "heading",
+          ]);
+
+          let suspicious = false;
+
+          if (p.parentPath?.isObjectProperty()) {
+            const key = p.parentPath.node.key;
+            if (t.isIdentifier(key) && propLikeNames.has(key.name)) suspicious = true;
+            if (t.isStringLiteral(key) && propLikeNames.has(key.value)) suspicious = true;
+          }
+
+          if (!suspicious && p.parentPath?.isCallExpression()) {
+            const callee = p.parentPath.node.callee;
+            if (t.isIdentifier(callee)) {
+              const name = callee.name.toLowerCase();
+              if (["toast", "notify", "alert", "message", "snackbar"].some((n) => name.includes(n))) {
+                suspicious = true;
+              }
+            }
+          }
+
+          if (!suspicious && p.parentPath?.isVariableDeclarator()) {
+            const id = p.parentPath.node.id;
+            if (t.isIdentifier(id)) {
+              const name = id.name.toLowerCase();
+              if (["label", "text", "title", "caption", "heading"].some((n) => name.includes(n))) {
+                suspicious = true;
+              }
+            }
+          }
+
+          if (suspicious) {
+            const { line, column } = getLoc(p.node);
+            hardcoded.push({
+              file,
+              line,
+              column,
+              kind: p.isStringLiteral() ? "StringLiteral" : "TemplateLiteral",
+              snippet: snippetFrom(code, line),
+              suggestion: 'Replace with t("ns:key") or pass a translated value.',
+            });
+          }
+        }
+
+        /** B) Key collection for missing-key checks */
+
+        // t("...") / i18n.t("...") with optional ns in arg or options
+        if (p.isCallExpression()) {
+          const callee = p.node.callee;
+
+          const isT =
+            (t.isIdentifier(callee) && I18N_FN_NAMES.has(callee.name)) ||
+            (t.isMemberExpression(callee) &&
+              t.isIdentifier(callee.object, { name: "i18n" }) &&
+              t.isIdentifier(callee.property, { name: "t" }));
+
+          if (!isT) return;
+
+          const [arg0, arg1] = p.node.arguments;
+
+          if (arg0 && t.isStringLiteral(arg0)) {
+            let rawKey = arg0.value; // "ns:key.path" OR "key.path"
+            let ns = DEFAULT_NS;
+            let key = rawKey;
+
+            // Check for "ns:key"
+            const idx = rawKey.indexOf(":");
+            if (idx > 0) {
+              ns = rawKey.slice(0, idx);
+              key = rawKey.slice(idx + 1);
+            } else {
+              // Maybe options { ns: 'x' }
+              if (arg1 && t.isObjectExpression(arg1)) {
+                for (const prop of arg1.properties) {
+                  if (t.isObjectProperty(prop)) {
+                    const k = prop.key;
+                    if ((t.isIdentifier(k) && k.name === "ns") || (t.isStringLiteral(k) && k.value === "ns")) {
+                      if (t.isStringLiteral(prop.value)) ns = prop.value.value;
+                    }
+                  }
+                }
+              }
+            }
+
+            const { line, column } = getLoc(p.node);
+            keyRefs.push({
+              file,
+              line,
+              column,
+              ns,
+              key,
+              full: `${ns}:${key}`,
+            });
+          }
+        }
+
+        // <Trans i18nKey="..."/>
+        if (p.isJSXOpeningElement()) {
+          const name = p.node.name;
+          if (!t.isJSXIdentifier(name) || !I18N_COMPONENTS.has(name.name)) return;
+
+          const attr = p.node.attributes.find(
+            (a) => t.isJSXAttribute(a) && t.isJSXIdentifier(a.name, { name: "i18nKey" })
+          ) as t.JSXAttribute | undefined;
+
+          if (!attr) return;
+
+          if (attr.value && t.isStringLiteral(attr.value)) {
+            const rawKey = attr.value.value;
+            let ns = DEFAULT_NS;
+            let key = rawKey;
+            const idx = rawKey.indexOf(":");
+            if (idx > 0) {
+              ns = rawKey.slice(0, idx);
+              key = rawKey.slice(idx + 1);
+            }
+            const { line, column } = getLoc(p.node);
+            keyRefs.push({
+              file,
+              line,
+              column,
+              ns,
+              key,
+              full: `${ns}:${key}`,
+            });
+          }
+        }
+      },
+    });
+  }
+
+  /** Load locales and compute missing keys */
+  const locales = loadLocales();
+  const missing: MissingKey[] = [];
+  const unused: UnusedKey[] = [];
+
+  const seen = new Set<string>(); // de-duplicate by ns:key
+  for (const ref of keyRefs) {
+    if (seen.has(ref.full)) continue;
+    seen.add(ref.full);
+
+    const missingLangs: string[] = [];
+    for (const lang of LANGS) {
+      const nsMap = locales[lang];
+      const set = nsMap?.get(ref.ns);
+      if (!set || !set.has(ref.key)) {
+        missingLangs.push(lang);
+      }
+    }
+    if (missingLangs.length > 0) {
+      missing.push({
+        file: ref.file,
+        line: ref.line,
+        column: ref.column,
+        key: ref.full,
+        localesMissing: missingLangs,
+      });
+    }
+  }
+
+  /** C) Find unused keys */
+  if (argv.checkUnused) {
+    const usedKeys = new Set(keyRefs.map(ref => ref.full));
+    
+    for (const lang of LANGS) {
+      const nsMap = locales[lang];
+      for (const [ns, keys] of nsMap) {
+        for (const key of keys) {
+          const fullKey = `${ns}:${key}`;
+          if (!usedKeys.has(fullKey)) {
+            // Check if this key exists in other locales too
+            const localesWithKey = LANGS.filter(l => {
+              const otherNsMap = locales[l];
+              const otherKeys = otherNsMap?.get(ns);
+              return otherKeys?.has(key) ?? false;
+            });
+            
+            if (localesWithKey.length > 0) {
+              unused.push({
+                key: fullKey,
+                locales: localesWithKey,
+                suggestion: `Remove unused key "${key}" from namespace "${ns}" in ${localesWithKey.join(', ')}`
+              });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /** Output */
+  const sortByFileLine = <T extends { file?: string; line?: number }>(arr: T[]) =>
+    arr.sort((a, b) => {
+      const fa = a.file || "";
+      const fb = b.file || "";
+      if (fa !== fb) return fa.localeCompare(fb);
+      return (a.line || 0) - (b.line || 0);
+    });
+
+  const hardcodedSorted = sortByFileLine(hardcoded);
+  const missingSorted = sortByFileLine(missing);
+  const unusedSorted = unused.sort((a, b) => a.key.localeCompare(b.key));
+
+  const printTable = () => {
+    const maxFile = Math.min(
+      50,
+      Math.max(...hardcodedSorted.map((r) => r.file.length).concat(missingSorted.map((m) => (m.file || "").length), [10]))
+    );
+    const pad = (s: string, n: number) => (s.length > n ? s.slice(0, n - 1) + "…" : s).padEnd(n, " ");
+
+    console.log(`\n=== i18n scan results ===`);
+    console.log(`Hardcoded text: ${hardcodedSorted.length}`);
+    console.log(`Missing keys:   ${missingSorted.length}`);
+    console.log(`Unused keys:    ${unusedSorted.length}\n`);
+
+    if (hardcodedSorted.length) {
+      console.log(`-- Hardcoded Text --`);
+      console.log(pad("FILE", maxFile), pad("LINE", 6), pad("KIND", 18), "SNIPPET");
+      console.log("-".repeat(maxFile + 6 + 18 + 10));
+      for (const r of hardcodedSorted) {
+        const kind = r.kind + (r.propName ? `(${r.propName})` : "");
+        console.log(pad(r.file, maxFile), pad(String(r.line), 6), pad(kind, 18), r.snippet);
+      }
+      console.log("");
+    }
+
+    if (missingSorted.length) {
+      console.log(`-- Missing Keys --`);
+      console.log(pad("FILE", maxFile), pad("LINE", 6), pad("KEY (ns:key)", 40), "LOCALES MISSING");
+      console.log("-".repeat(maxFile + 6 + 40 + 18));
+      for (const m of missingSorted) {
+        console.log(
+          pad(m.file || "-", maxFile),
+          pad(String(m.line || "-"), 6),
+          pad(m.key, 40),
+          m.localesMissing.join(", ")
+        );
+      }
+      console.log("");
+    }
+
+    if (unusedSorted.length) {
+      console.log(`-- Unused Keys --`);
+      console.log(pad("KEY (ns:key)", 50), "LOCALES");
+      console.log("-".repeat(50 + 20));
+      for (const u of unusedSorted) {
+        console.log(pad(u.key, 50), u.locales.join(", "));
+      }
+      console.log("");
+    }
+  };
+
+  const jsonPayload = {
+    generatedAt: new Date().toISOString(),
+    summary: {
+      hardcodedCount: hardcodedSorted.length,
+      missingKeyCount: missingSorted.length,
+      unusedKeyCount: unusedSorted.length,
+      langs: LANGS,
+      defaultNs: DEFAULT_NS,
+      namespaces: NAMESPACES,
+      localesRoot: LOCALES_ROOT,
+    },
+    hardcoded: hardcodedSorted,
+    missingKeys: missingSorted,
+    unusedKeys: unusedSorted,
+  };
+
+  if (argv.report === "table" || argv.report === "both") printTable();
+  if (argv.report === "json" || argv.report === "both") {
+    console.log(JSON.stringify(jsonPayload, null, 2));
+  }
+
+  if (argv.out) {
+    fs.writeFileSync(path.resolve(argv.out), JSON.stringify(jsonPayload, null, 2), "utf8");
+    console.log(`Report saved to: ${path.resolve(argv.out)}`);
+  }
+
+  if (argv.failOnMissing && missingSorted.length > 0) {
+    process.exit(2);
+  }
+  process.exit(0);
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Add an i18n scanner to detect hardcoded text, missing translation keys, and unused keys, enhancing internationalization quality.

This PR introduces a new i18n scanner script (`scan-i18n.ts`) and integrates it into the project's testing suite. The scanner helps enforce i18n best practices by automatically identifying hardcoded UI text, translation keys used in code but missing from locale files, and unused translation keys within the locale files themselves. This streamlines the translation workflow and helps maintain a consistent and complete internationalization setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-eaaced09-5c29-4070-aca8-33966f0752d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eaaced09-5c29-4070-aca8-33966f0752d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

