### PR TITLE
Add offline translation fallback and update Swiss locale strings

### DIFF
--- a/frontend/public/locales/de/translation.json
+++ b/frontend/public/locales/de/translation.json
@@ -1,5 +1,5 @@
 {
-  "appName": "ProCrèche Solutions Suisse",
+  "appName": "Pro Crèche Solutions",
   "languageSwitcher": {
     "enShort": "EN",
     "enLong": "English",
@@ -7,128 +7,96 @@
     "frLong": "Français",
     "deShort": "DE",
     "deLong": "Deutsch",
-    "selectLanguage": "Select Language"
+    "selectLanguage": "Sprache wählen"
   },
-  "loading": "Loading...",
+  "loading": {
+    "translations": "Übersetzungen werden geladen..."
+  },
   "buttons": {
-    "save": "Save",
-    "saveChanges": "Save Changes",
-    "cancel": "Cancel",
-    "submit": "Submit",
-    "add": "Add",
-    "edit": "Edit",
-    "delete": "Delete",
-    "viewDetails": "View Details",
-    "goBack": "Go Back",
-    "login": "Log In",
-    "signup": "Sign Up",
-    "applyNow": "Apply Now",
-    "confirmApply": "Confirm Application",
-    "sendMessage": "Send Message",
-    "inviteToApply": "Invite to Apply",
-    "inviteToInterview": "Invite to Interview",
-    "addToFavorites": "Add to Favorites",
-    "favorited": "Favorited",
-    "submitEnquiry": "Submit Enquiry",
-    "viewMyEnquiries": "View My Enquiries",
-    "submitTicket": "Submit Ticket",
-    "goToLogin": "Go to Login",
-    "close": "Close",
-    "view": "View",
-    "resetFilters": "Reset Filters",
-    "applyFilters": "Apply Filters",
-    "submitRequest": "Submit Request",
-    "remove": "Remove",
-    "dismiss": "Dismiss"
+    "save": "Speichern",
+    "saveChanges": "Änderungen speichern",
+    "cancel": "Abbrechen",
+    "submit": "Absenden",
+    "add": "Hinzufügen",
+    "edit": "Bearbeiten",
+    "delete": "Löschen",
+    "viewDetails": "Details anzeigen",
+    "goBack": "Zurück",
+    "login": "Anmelden",
+    "signup": "Registrieren",
+    "applyNow": "Jetzt bewerben",
+    "confirmApply": "Bewerbung bestätigen",
+    "sendMessage": "Nachricht senden",
+    "inviteToApply": "Zur Bewerbung einladen",
+    "inviteToInterview": "Zum Gespräch einladen",
+    "addToFavorites": "Zu Favoriten hinzufügen",
+    "favorited": "Favorisiert",
+    "submitEnquiry": "Anfrage senden",
+    "viewMyEnquiries": "Meine Anfragen",
+    "submitTicket": "Ticket senden",
+    "goToLogin": "Zur Anmeldeseite",
+    "close": "Schliessen",
+    "view": "Ansehen",
+    "resetFilters": "Filter zurücksetzen",
+    "applyFilters": "Filter anwenden",
+    "submitRequest": "Anfrage absenden",
+    "remove": "Entfernen",
+    "dismiss": "Verwerfen"
   },
   "navbar": {
-    "toggleNavigation": "Toggle Navigation",
-    "goBackPreviousPage": "Go Back to Previous Page",
-    "searchPlaceholder": "Search...",
-    "viewShoppingCart": "View Shopping Cart",
-    "notifications": "Notifications",
-    "newMessages": "New Messages",
-    "noNewNotifications": "No New Notifications",
-    "viewAll": "View All",
-    "userMenu": "User Menu",
-    "signOut": "Sign Out"
+    "notificationsCount": "Benachrichtigungen: {{count}}",
+    "unreadMessages": "Ungelesene Nachrichten: {{count}}",
+    "searchPlaceholder": "Plattform durchsuchen..."
   },
   "sidebar": {
+    "billingSubscription": "Fakturierung & Abo",
     "dashboard": "Dashboard",
-    "settings": "Settings",
-    "currentPlan": "Current Plan",
-    "manageSubscriptionDesc": "Manage your current plan and billing",
-    "fileGallery": "File Gallery",
-    "messages": "Messages",
-    "discountTerminations": "Discount Terminations",
-    "jobBoard": "Job Board",
-    "analytics": "Analytics",
-    "leads": "Leads",
-    "ordersAppointments": "Orders & Appointments",
-    "organisationProfile": "Organisation Profile",
-    "support": "Support",
-    "myProfile": "My Profile",
-    "applications": "Applications",
-    "homeFindCreche": "Home / Find a Crèche",
-    "myRequests": "My Requests",
-    "supportFAQ": "Support / FAQ",
-    "users": "Users",
-    "allUsers": "All Users",
+    "marketplace": "Marktplatz",
+    "products": "Produkte",
+    "services": "Dienstleistungen",
+    "recruitment": "Rekrutierung",
+    "jobListings": "Stellenangebote",
+    "candidatePool": "Talentpool",
+    "eLearning": "E-Learning",
+    "messages": "Nachrichten",
+    "users": "Benutzer",
+    "allUsers": "Alle Benutzer",
     "admins": "Admins",
-    "foundations": "Foundations",
-    "productSuppliers": "Product Suppliers",
-    "serviceProviders": "Service Providers",
-    "parents": "Parents",
-    "content": "Content",
-    "partners": "Partners",
-    "managePlan": "Manage Plan",
-    "premiumPlan": "Premium Plan",
-    "premiumPlanDesc": "Access to all features",
-    "systemMonitoring": "System Monitoring",
-    "platformSettings": "Platform Settings",
-    "designSystem": "Design System",
-    "parentLeads": "Parent Leads",
-    "products": "Products",
-    "services": "Services"
+    "foundations": "Stiftungen",
+    "productSuppliers": "Produktlieferanten",
+    "serviceProviders": "Dienstleister",
+    "parents": "Eltern",
+    "content": "Inhalt",
+    "hrProcedures": "HR-Verfahren",
+    "statePolicies": "Kantonale Richtlinien",
+    "discountTerminations": "Rabattkündigungen",
+    "systemMonitoring": "Systemüberwachung",
+    "partners": "Partner",
+    "platformSettings": "Plattform-Einstellungen",
+    "designSystem": "Design-System",
+    "settings": "Einstellungen"
   },
   "stockStatus": {
-    "instock": "In Stock",
-    "outofstock": "Out of Stock",
-    "lowstock": "Low Stock",
-    "discontinued": "Discontinued"
+    "instock": "Auf Lager",
+    "outofstock": "Nicht Verfügbar",
+    "lowstock": "Wenig Vorrat",
+    "discontinued": "Eingestellt"
   },
   "common": {
-    "welcome": "Welcome",
-    "loading": "Loading...",
-    "error": "An error occurred",
-    "submit": "Submit",
-    "next": "Next",
-    "back": "Back",
-    "search": "Search",
-    "filter": "Filter",
-    "apply": "Apply",
-    "reset": "Reset",
-    "confirm": "Confirm",
-    "close": "Close",
-    "view": "View",
-    "download": "Download",
-    "upload": "Upload",
-    "continue": "Continue",
-    "send": "Send",
-    "create": "Create",
-    "update": "Update",
-    "register": "Register",
-    "toggleNavigation": "Toggle navigation"
+    "perMonth": "/Monat",
+    "perYear": "/Jahr",
+    "save10Percent": "10% sparen"
   },
   "errors": {
-    "unknown": "An unknown error occurred"
+    "unknown": "Ein unbekannter Fehler ist aufgetreten."
   },
   "notifications": {
-    "successTitle": "Success",
-    "settingsUpdated": "Settings updated successfully"
+    "errorTitle": "Fehler",
+    "successTitle": "Erfolg",
+    "newMessageFrom": "Neue Nachricht von {{sender}}"
   },
-  "hidePassword": "Hide password",
-  "showPassword": "Show password",
+  "hidePassword": "Passwort ausblenden",
+  "showPassword": "Passwort anzeigen",
   "signIn": "Sign In",
   "signOut": "Sign Out",
   "confirmPassword": "Confirm Password",
@@ -154,25 +122,25 @@
   "preferredLocation": "Preferred Location",
   "loginPage": {
     "title": "Welcome to {{appName}}",
-    "subtitle": "Sign in to your account",
-    "emailLabel": "Email Address",
-    "emailPlaceholder": "Enter your email",
-    "passwordLabel": "Password",
-    "passwordPlaceholder": "Enter your password",
-    "forgotPassword": "Forgot your password?",
-    "forgotPasswordTBD": "Forgot password functionality coming soon",
-    "orContinueWith": "Or continue with",
+    "subtitle": "Greifen Sie auf Ihr Dashboard zu",
+    "emailLabel": "E-Mail-Adresse",
+    "emailPlaceholder": "sie@beispiel.com",
+    "passwordLabel": "Passwort",
+    "passwordPlaceholder": "••••••••",
+    "forgotPassword": "Passwort vergessen?",
+    "forgotPasswordTBD": "Die Funktion 'Passwort vergessen' ist noch nicht implementiert.",
+    "orContinueWith": "Oder fortfahren mit",
     "google": "Google",
     "facebook": "Facebook",
-    "noAccount": "Don't have an account?",
-    "viewPlansPrompt": "Want to see our plans?",
-    "viewPlans": "View Plans",
-    "parentLookingForCreche": "Parent looking for a crèche?",
-    "findCrecheHere": "Find your perfect crèche here",
+    "noAccount": "Noch kein Konto?",
+    "viewPlansPrompt": "Interessiert an unseren Funktionen?",
+    "viewPlans": "Abonnements ansehen",
+    "parentLookingForCreche": "Sind Sie ein Elternteil auf Kita-Suche?",
+    "findCrecheHere": "Finden Sie hier eine Kita",
     "socialLoginTBD": "{{provider}} login coming soon!",
-    "alreadyAccount": "Already have an account?",
-    "errorBothFields": "Please fill in both email and password",
-    "loggingIn": "Logging in..."
+    "alreadyAccount": "Haben Sie bereits ein Konto?",
+    "errorBothFields": "Bitte geben Sie E-Mail und Passwort ein.",
+    "loggingIn": "Anmeldung läuft..."
   },
   "signupPage": {
     "form": {
@@ -201,94 +169,94 @@
       "accountCreationFailed": "Failed to create account"
     },
     "errors": {
-      "organisationNameRequired": "Organization name is required",
-      "emailRequired": "Email is required",
-      "emailInvalid": "Please enter a valid email address",
-      "passwordRequired": "Password is required",
-      "passwordTooShort": "Password must be at least 6 characters",
-      "passwordsNoMatch": "Passwords do not match",
-      "phoneRequired": "Phone number is required",
-      "cantonRequired": "Canton is required",
-      "capacityRequired": "Capacity is required",
-      "categoryRequired": "Category is required",
-      "serviceTypeRequired": "Service type is required",
-      "childAgeRequired": "Child age is required",
-      "childStartDateRequired": "Child start date is required",
-      "termsRequired": "You must accept the terms and conditions",
-      "contactPersonRequired": "Contact person is required",
-      "parentNameRequired": "Parent name is required"
+      "organisationNameRequired": "Name der Organisation ist erforderlich.",
+      "emailRequired": "E-Mail ist erforderlich.",
+      "emailInvalid": "Bitte geben Sie eine gültige E-Mail-Adresse ein.",
+      "passwordRequired": "Passwort ist erforderlich.",
+      "passwordTooShort": "Das Passwort muss mindestens 6 Zeichen lang sein.",
+      "passwordsNoMatch": "Die Passwörter stimmen nicht überein.",
+      "phoneRequired": "Telefonnummer ist erforderlich.",
+      "cantonRequired": "Kanton ist erforderlich.",
+      "capacityRequired": "Kapazität muss eine positive Zahl sein.",
+      "categoryRequired": "Produktkategorie ist erforderlich.",
+      "serviceTypeRequired": "Dienstleistungstyp ist erforderlich.",
+      "childAgeRequired": "Das Alter des Kindes ist erforderlich und muss positiv sein.",
+      "childStartDateRequired": "Das gewünschte Startdatum ist erforderlich.",
+      "termsRequired": "Sie müssen den Allgemeinen Geschäftsbedingungen zustimmen.",
+      "contactPersonRequired": "Name der Kontaktperson ist erforderlich.",
+      "parentNameRequired": "Ihr Name ist erforderlich."
     },
-    "progressStep1": "Step 1: Select Role",
-    "progressStep2": "Step 2: Enter Details",
-    "selectRoleTitle": "Select Your Role",
-    "detailsTitle": "Enter Your Details",
-    "submissionSuccessTitle": "Registration Successful!",
-    "submissionSuccessMessage": "Your account has been created successfully. You can now access your dashboard.",
-    "goToDashboardButton": "Go to Dashboard",
-    "termsLabel": "I agree to the terms and conditions",
-    "termsLink": "Terms and Conditions",
-    "creatingAccount": "Creating your account...",
-    "createAccountButton": "Create Account",
+    "progressStep1": "Schritt 1 von 2: Wählen Sie Ihre Rolle",
+    "progressStep2": "Schritt 2 von 2: Kontodetails",
+    "selectRoleTitle": "Wählen Sie Ihre Rolle",
+    "detailsTitle": "Anmeldung als {{role}}",
+    "submissionSuccessTitle": "Registrierung Erfolgreich!",
+    "submissionSuccessMessage": "Ihr Konto wurde erstellt. Sie werden nun zu Ihrem Dashboard weitergeleitet.",
+    "goToDashboardButton": "Zum Dashboard",
+    "termsLabel": "Ich stimme den",
+    "termsLink": "Allgemeinen Geschäftsbedingungen zu",
+    "creatingAccount": "Konto wird erstellt...",
+    "createAccountButton": "Konto erstellen",
     "placeholders": {
       "firstName": "Enter your first name",
       "lastName": "Enter your last name",
-      "email": "Enter your email address",
-      "password": "Enter your password",
-      "confirmPassword": "Confirm your password",
-      "phone": "Enter your phone number",
+      "email": "sie@beispiel.com",
+      "password": "Mind. 6 Zeichen",
+      "confirmPassword": "Passwort erneut eingeben",
+      "phone": "z.B. 079 123 45 67",
       "organization": "Enter your organization name",
-      "select": "Please select...",
-      "organisationName": "Enter your organization name",
-      "contactPerson": "Enter contact person name",
-      "parentName": "Enter your full name",
-      "category": "Enter product category",
-      "serviceType": "Enter service type"
+      "select": "Wählen Sie...",
+      "organisationName": "z.B. Kita Sonnenschein",
+      "contactPerson": "z.B. Erika Mustermann",
+      "parentName": "z.B. Max Mustermann",
+      "category": "z.B. Lernspielzeug, Möbel",
+      "serviceType": "z.B. Reinigung, Workshops, Rechtliches"
     },
     "labels": {
-      "organisationName": "Organization Name",
-      "contactPerson": "Contact Person",
-      "parentName": "Your Name",
-      "email": "Email",
-      "password": "Password",
-      "confirmPassword": "Confirm Password",
-      "phone": "Phone",
-      "canton": "Canton",
-      "capacity": "Capacity",
-      "category": "Product Category",
-      "serviceType": "Service Type",
-      "childAge": "Child's Age",
-      "childStartDate": "Desired Start Date"
+      "organisationName": "Name der Organisation",
+      "contactPerson": "Name der Kontaktperson",
+      "parentName": "Ihr vollständiger Name",
+      "email": "E-Mail-Adresse",
+      "password": "Passwort",
+      "confirmPassword": "Passwort bestätigen",
+      "phone": "Telefonnummer",
+      "canton": "Kanton",
+      "capacity": "Maximale Kinderkapazität",
+      "category": "Hauptproduktkategorie",
+      "serviceType": "Hauptdienstleistungstyp",
+      "childAge": "Alter des Kindes (Jahre)",
+      "childStartDate": "Gewünschtes Startdatum"
     },
     "roles": {
-      "foundation": "Foundation",
-      "supplier": "Product Supplier",
-      "serviceProvider": "Service Provider",
-      "parent": "Parent"
+      "foundation": "Stiftung (Kita)",
+      "supplier": "Produktlieferant",
+      "serviceProvider": "Dienstleister",
+      "parent": "Elternteil"
     }
   },
   "dashboardPage": {
     "welcome": "Welcome back, {{name}}!",
-    "defaultUser": "User",
+    "defaultUser": "Benutzer",
     "overviewSubtitle": "Here's what's happening with {{appName}} today",
-    "activeUsers": "Active Users",
-    "newOrders": "New Orders",
-    "openJobs": "Open Jobs",
-    "pageViews": "Page Views",
-    "recentActivity": "Recent Activity",
-    "quickLinks": "Quick Links",
-    "browseMarketplace": "Browse Marketplace",
-    "postNewJob": "Post New Job",
-    "manageUsers": "Manage Users",
-    "platformSettings": "Platform Settings",
-    "activityLina": "Lina uploaded a new policy document",
-    "activityEcoToys": "EcoToys submitted a new product",
-    "activityJohn": "John applied for the educator position",
-    "activityParent": "A parent submitted a new enquiry",
-    "viewDetailsFor": "View details for",
+    "activeUsers": "Aktive Benutzer",
+    "newOrders": "Neue Bestellungen",
+    "openJobs": "Offene Stellen",
+    "pageViews": "Seitenaufrufe",
+    "recentActivity": "Letzte Aktivitäten",
+    "quickLinks": "Schnellzugriffe",
+    "browseMarketplace": "Marktplatz durchsuchen",
+    "postNewJob": "Neue Stelle ausschreiben",
+    "manageUsers": "Benutzer verwalten",
+    "platformSettings": "Plattform-Einstellungen",
+    "activityLina": "Lina Meier hat eine neue Stelle \"Kinderkrankenschwester\" veröffentlicht",
+    "activityEcoToys": "EcoToys GmbH hat das Produkt \"Holzbausteine\" aktualisiert",
+    "activityJohn": "John Smith hat 3 neue Elternkonten genehmigt",
+    "activityParent": "Elternteil Beispiel hat eine Anfrage für \"Kita Sonnenschein\" eingereicht",
+    "viewDetailsFor": "Details anzeigen für {{name}}",
     "timeAgo": {
       "minutes": "{{count}} minutes ago",
       "hours": "{{count}} hours ago",
-      "yesterday": "Yesterday"
+      "yesterday": "Gestern"
     },
     "upcomingMeetings": "Upcoming Meetings",
     "quickActions": "Quick Actions",
@@ -297,93 +265,80 @@
     "notifications": "Notifications"
   },
   "settingsPage": {
-    "sections": {
-      "accountSecurity": "Account Security",
-      "analyticsPreferences": "Analytics Preferences",
-      "billingSubscription": "Billing & Subscription",
-      "companyProfile": "Company Profile",
-      "contactBooking": "Contact & Booking",
-      "defaults": "Defaults",
-      "notificationPreferences": "Notification Preferences",
-      "privacyData": "Privacy & Data",
-      "promoCodeManager": "Promo Code Manager",
-      "teamPermissions": "Team Permissions"
-    },
-    "forms": {
-      "save": "Save Changes",
-      "cancel": "Cancel",
-      "reset": "Reset"
-    },
-    "validation": {
-      "required": "This field is required",
-      "invalidEmail": "Please enter a valid email address",
-      "passwordTooShort": "Password must be at least 8 characters",
-      "passwordsDoNotMatch": "Passwords do not match"
-    },
-    "success": {
-      "saved": "Settings saved successfully",
-      "updated": "Settings updated successfully"
-    },
-    "error": {
-      "saveFailed": "Failed to save settings",
-      "loadFailed": "Failed to load settings"
-    }
+    "billingSubscription": "Billing & Subscription",
+    "title": "Settings",
+    "accountSecurity": "Account & Security"
   },
   "marketplacePage": {
-    "title": "Marketplace",
+    "emptyStates": {
+      "noServices": "No services available",
+      "noProductSuppliers": "No product suppliers available"
+    },
+    "subtitles": {
+      "productSuppliers": "Product Suppliers",
+      "serviceProviders": "Service Providers"
+    },
     "tabs": {
       "productSuppliers": "Product Suppliers",
       "serviceProviders": "Service Providers"
     },
-    "serviceCard": {
-      "categoryLabel": "Category: {{category}}",
-      "bookAppointment": "Book Appointment",
-      "viewProvider": "View Provider"
+    "buttons": {
+      "partnerOnboarding": "Partner Onboarding"
     },
-    "emptyStates": {
-      "noProductSuppliers": "No product suppliers available",
-      "noServiceProviders": "No service providers available"
+    "infoAlert": "Partner Onboarding TBD",
+    "searchPlaceholder": "Search partners...",
+    "labels": {
+      "category": "Category",
+      "region": "Region",
+      "supplierTags": "Supplier Tags",
+      "sortBy": "Sort by"
+    },
+    "sortOptions": {
+      "nameAsc": "Name (A-Z)",
+      "nameDesc": "Name (Z-A)",
+      "ratingDesc": "Rating (High to Low)"
+    },
+    "ariaLabels": {
+      "gridView": "Switch to grid view",
+      "listView": "Switch to list view"
     }
   },
   "partnerDetailPage": {
-    "title": "Partner Details",
-    "contact": "Contact Partner",
-    "services": "Services"
+    "productOutOfStock": "Product is currently out of stock",
+    "productAddedToOrder": "Product added to order successfully",
+    "addToOrderButton": "Add to Order",
+    "loadingPartnerDetails": "Loading partner details...",
+    "invalidPartnerIdMessage": "Could not find a user associated with this organization to message.",
+    "contactInfoTitle": "Contact Information",
+    "directOrderButton": "Direct Order",
+    "aboutTitle": "About",
+    "ratingsReviewsTitle": "Ratings & Reviews",
+    "ratingText": "Rating",
+    "reviewsPlaceholder": "No reviews yet",
+    "noProductsListed": "No products listed",
+    "requestServiceButton": "Request Service",
+    "noServicesListed": "No services listed",
+    "promoCodeTitle": "Promo Code",
+    "promoCodePlaceholder": "Enter promo code",
+    "applyPromoButton": "Apply",
+    "onlyFoundationsRequestService": "Only foundations can request services",
+    "requestSubmittedAlert": "Service request submitted successfully"
   },
   "adminPlatformSettings": {
-    "title": "Platform Settings",
+    "title": "Plattform-Einstellungen",
     "general": {
-      "title": "General Settings",
-      "nameLabel": "Platform Name",
-      "descriptionLabel": "Platform Description"
+      "title": "Allgemeine Informationen",
+      "nameLabel": "Plattformname",
+      "descriptionLabel": "Metadaten-Beschreibung"
     },
     "branding": {
       "title": "Branding",
-      "logoLabel": "Platform Logo",
-      "faviconLabel": "Favicon"
+      "logoLabel": "Plattform-Logo",
+      "faviconLabel": "Plattform-Favicon"
     }
   },
   "organizationProfileForm": {
-    "title": "Organization Profile",
-    "form": {
-      "name": "Organization Name",
-      "description": "Description",
-      "website": "Website",
-      "phone": "Phone",
-      "email": "Email",
-      "address": "Address"
-    },
-    "validation": {
-      "nameRequired": "Organization name is required",
-      "emailRequired": "Email is required",
-      "invalidEmail": "Please enter a valid email address"
-    },
-    "success": {
-      "saved": "Organization profile saved successfully"
-    },
-    "error": {
-      "saveFailed": "Failed to save organization profile"
-    }
+    "saveSuccess": "Organization profile saved successfully"
   },
   "foundationDashboardPage": {
     "title": "Foundation Dashboard",
@@ -393,30 +348,90 @@
     "quickActions": "Quick Actions"
   },
   "foundationAnalyticsPage": {
-    "title": "Analytics",
-    "overview": "Overview",
-    "reports": "Reports"
+    "mockDataVisualization": "Mock Data Visualization",
+    "spendingByCategory": "Spending by Category",
+    "parentLeadConversion": "Parent Lead Conversion",
+    "staffTrainingCompletion": "Staff Training Completion",
+    "enrollmentTrend": "Enrollment Trend"
   },
   "foundationLeadsPage": {
-    "title": "Parent Leads",
-    "leads": "All Leads",
-    "newLeads": "New Leads",
-    "contactedLeads": "Contacted Leads"
+    "title": "Incoming Parent Leads",
+    "accessDenied": {
+      "title": "Access Denied",
+      "message": "You must be logged in as a Foundation with a valid Organization ID to view this page."
+    },
+    "emptyState": {
+      "title": "No Incoming Leads",
+      "message": "There are currently no new parent enquiries matching your daycare."
+    }
   },
   "foundationOrdersAppointmentsPage": {
-    "title": "Orders & Appointments",
-    "orders": "Orders",
-    "appointments": "Appointments"
+    "productOrdersTitle": "Product Orders",
+    "exportCsvProductAlert": "Product orders CSV export started",
+    "exportCsvButton": "Export CSV",
+    "noProductOrders": "No product orders found",
+    "table": {
+      "refNo": "Ref No",
+      "supplier": "Supplier",
+      "itemsQty": "Items/Qty",
+      "total": "Total",
+      "date": "Date",
+      "status": "Status",
+      "actions": "Actions",
+      "provider": "Provider",
+      "service": "Service"
+    },
+    "cancelOrderAlert": "Order cancelled successfully",
+    "serviceAppointmentsTitle": "Service Appointments",
+    "exportCsvServiceAlert": "Service appointments CSV export started",
+    "noServiceAppointments": "No service appointments found",
+    "unknownProvider": "Unknown Provider",
+    "preferredAbbr": "Pref.",
+    "notApplicable": "N/A",
+    "rescheduleAlert": "Appointment rescheduled successfully",
+    "rescheduleButton": "Reschedule",
+    "productOrdersTab": "Product Orders",
+    "serviceAppointmentsTab": "Service Appointments"
   },
   "foundationOrganisationProfilePage": {
-    "title": "Organization Profile",
-    "profile": "Profile Information",
-    "settings": "Settings"
+    "mock": {
+      "pedagogyStatement": "Our pedagogy is based on the principles of respect, creativity, and individual development. We believe in providing a nurturing environment where children can explore, learn, and grow at their own pace."
+    },
+    "alert": {
+      "infoSaved": "Zusätzliche Profilinformationen gespeichert!"
+    },
+    "sections": {
+      "branding": {
+        "title": "Branding & Präsentation",
+        "logoLabel": "Logo",
+        "coverImageLabel": "Titelbild",
+        "pedagogyStatementLabel": "Pädagogisches Leitbild",
+        "pedagogyStatementPlaceholder": "Beschreiben Sie Ihre pädagogische Philosophie..."
+      },
+      "operations": {
+        "title": "Betriebliche Details",
+        "openingHoursLabel": "Öffnungszeiten",
+        "openingHoursPlaceholder": "z.B. Mo-Fr: 07:30 - 18:30",
+        "contactInfoLabel": "Öffentliche Kontaktinformationen",
+        "contactInfoPlaceholder": "Öffentliche Telefonnummer oder E-Mail für Eltern"
+      },
+      "online": {
+        "title": "Online-Präsenz & Anfragen",
+        "bookingLinkLabel": "Link zur Online-Terminbuchung für Besuche",
+        "bookingLinkPlaceholder": "z.B. https://cal.com/ihre-kita",
+        "socialMediaLinkLabel": "Social Media Link",
+        "socialMediaLinkPlaceholder": "z.B. https://facebook.com/ihre-kita",
+        "acceptingLeadsLabel": "Akzeptiert derzeit neue Elternanfragen"
+      }
+    },
+    "saveButton": "Zusätzliche Infos speichern"
   },
   "foundationSupportPage": {
-    "title": "Support",
-    "help": "Help Center",
-    "tickets": "Support Tickets"
+    "ticketSubmittedAlert": "Support ticket submitted successfully",
+    "ticketForm": {
+      "subjectPlaceholder": "Brief description of your issue",
+      "messagePlaceholder": "Please provide detailed information about your issue"
+    }
   },
   "parentDashboardPage": {
     "title": "Parent Dashboard",
@@ -425,14 +440,43 @@
     "findCreche": "Find a Crèche"
   },
   "parentEnquiriesPage": {
-    "title": "My Enquiries",
-    "enquiries": "All Enquiries",
-    "newEnquiry": "New Enquiry"
+    "accessDenied": {
+      "title": "Access Denied",
+      "message": "You need to be logged in as a parent to view enquiries"
+    },
+    "emptyState": {
+      "title": "No enquiries yet",
+      "message": {
+        "0": "You haven't submitted any enquiries yet.",
+        "1": "Start by filling out the enquiry form to find suitable childcare options."
+      }
+    },
+    "card": {
+      "title": "Enquiry Details",
+      "submitted": "Submitted on {{date}}",
+      "childInfo": "Child Information",
+      "notes": "Additional Notes",
+      "responsesTitle": "Responses",
+      "awaitingMatch": "Awaiting Match",
+      "message": "Your enquiry has been sent to relevant providers",
+      "waitingForMoreResponses": "Waiting for more responses..."
+    }
   },
   "parentSupportPage": {
-    "title": "Support",
-    "help": "Help Center",
-    "faq": "Frequently Asked Questions"
+    "faq": {
+      "matchingProcess": {
+        "q": "How does the matching process work?",
+        "a": "Our algorithm matches your child's needs with available crèches based on location, age, special requirements, and availability."
+      },
+      "responseTime": {
+        "q": "How quickly will I receive responses?",
+        "a": "Most crèches respond within 24-48 hours. You'll be notified immediately when responses arrive."
+      },
+      "dataSecurity": {
+        "q": "Is my personal information secure?",
+        "a": "Yes, we use enterprise-grade encryption and comply with Swiss data protection laws. Your information is never shared without consent."
+      }
+    }
   },
   "educatorDashboardPage": {
     "title": "Educator Dashboard",
@@ -441,44 +485,51 @@
     "jobBoard": "Job Board"
   },
   "educatorApplicationsPage": {
-    "title": "My Applications",
-    "applications": "All Applications",
-    "status": "Application Status"
+    "status": {
+      "new": "New",
+      "viewed": "Viewed",
+      "interview": "Interview",
+      "offer": "Offer",
+      "declined": "Declined"
+    },
+    "table": {
+      "jobTitle": "Job Title",
+      "creche": "Crèche",
+      "status": "Status",
+      "lastUpdated": "Last Updated",
+      "actions": "Actions"
+    },
+    "viewingDetailsFor": "Viewing details for",
+    "emptyState": "No applications found",
+    "footerNote": "Applications are updated in real-time"
   },
   "educatorJobBoardPage": {
-    "title": "Job Board",
-    "jobs": "Available Jobs",
-    "apply": "Apply Now"
+    "postedOn": "Posted on",
+    "searchPlaceholder": "Search jobs...",
+    "noJobsFound": "No jobs found"
   },
   "educatorProfilePage": {
-    "skills": {
-      "title": "Skills",
-      "add": "Add Skill"
-    },
+    "editProfile": "Edit Profile",
     "availability": {
-      "title": "Availability",
-      "schedule": "Schedule"
-    },
-    "documents": {
-      "title": "Documents",
-      "upload": "Upload Document"
-    },
-    "experience": {
-      "title": "Experience",
-      "add": "Add Experience"
+      "days": "Days",
+      "times": "Times",
+      "contract": "Contract",
+      "ageGroups": "Age Groups"
     },
     "education": {
-      "title": "Education",
-      "add": "Add Education"
+      "graduated": "Graduated"
     },
     "certifications": {
-      "title": "Certifications",
-      "add": "Add Certification"
+      "issued": "Issued",
+      "expires": "Expires"
     }
   },
   "educatorSupportPage": {
-    "title": "Support",
-    "help": "Help Center"
+    "ticketSubmittedAlert": "Support ticket submitted successfully",
+    "ticketForm": {
+      "subjectPlaceholder": "Brief description of your issue",
+      "messagePlaceholder": "Please provide detailed information about your issue"
+    }
   },
   "serviceProviderDashboardPage": {
     "title": "Service Provider Dashboard",
@@ -487,23 +538,41 @@
     "requests": "Service Requests"
   },
   "serviceProviderAnalyticsPage": {
-    "title": "Analytics",
-    "overview": "Analytics Overview",
-    "performance": "Performance Metrics"
+    "serviceRequestsPerWeek": "Service Requests Per Week",
+    "topViewedServices": "Top Viewed Services",
+    "requestsByCanton": "Requests by Canton"
   },
   "serviceProviderListingsPage": {
-    "title": "Service Listings",
-    "listings": "All Listings",
-    "addService": "Add New Service"
+    "card": {
+      "category": "Category",
+      "delivery": "Delivery"
+    },
+    "confirmDelete": "Are you sure you want to delete this service?",
+    "addNewServiceButton": "Add New Service",
+    "searchPlaceholder": "Search services...",
+    "emptyState": {
+      "title": "No Services Found",
+      "noMatch": "No services match your search criteria",
+      "noServicesYet": "You haven't created any services yet"
+    }
   },
   "serviceProviderRequestsPage": {
-    "title": "Service Requests",
-    "requests": "All Requests",
-    "pending": "Pending Requests"
+    "filterByStatus": "Nach Status filtern:",
+    "table": {
+      "requestId": "Anfrage-ID",
+      "foundation": "Stiftung",
+      "service": "Dienstleistung",
+      "date": "Datum",
+      "status": "Status"
+    },
+    "emptyState": "Keine Dienstanfragen für den ausgewählten Filter gefunden."
   },
   "serviceProviderSupportPage": {
-    "title": "Support",
-    "help": "Help Center"
+    "ticketSubmittedAlert": "Support ticket submitted successfully",
+    "ticketForm": {
+      "subjectPlaceholder": "Brief description of your issue",
+      "messagePlaceholder": "Please provide detailed information about your issue"
+    }
   },
   "supplierDashboardPage": {
     "title": "Supplier Dashboard",
@@ -512,23 +581,53 @@
     "orders": "Orders"
   },
   "supplierAnalyticsPage": {
-    "title": "Analytics",
-    "overview": "Analytics Overview",
-    "sales": "Sales Metrics"
+    "datePickerLabel": "Datumsbereich auswählen",
+    "exportCsvAlert": "CSV-Bericht wird exportiert... (demnächst verfügbar)",
+    "exportCsvButton": "Als CSV exportieren",
+    "mockChartText": "Simulierte {{type}}-Diagrammdaten",
+    "orderRequestsPerWeek": "Bestellanfragen pro Woche",
+    "topViewedProducts": "Meistgesehene Produkte",
+    "requestsByCanton": "Anfragen nach Kanton",
+    "promoCodePerformance": "Leistung der Gutscheincodes",
+    "table": {
+      "code": "Code",
+      "uses": "Verwendungen",
+      "estRevenueImpact": "Geschätzter Umsatzeinfluss"
+    }
   },
   "supplierProductListingsPage": {
-    "title": "Product Listings",
-    "listings": "All Listings",
-    "addProduct": "Add New Product"
+    "addProductAlert": "Die Funktionalität des Modals/Formulars 'Neues Produkt hinzufügen' wird noch implementiert.",
+    "addProductButton": "Neues Produkt hinzufügen",
+    "searchPlaceholder": "Nach Produktnamen suchen...",
+    "table": {
+      "product": "Produkt",
+      "price": "Preis",
+      "stock": "Lager",
+      "visibility": "Sichtbarkeit",
+      "actions": "Aktionen"
+    },
+    "emptyState": "Keine Produkte gefunden."
   },
   "supplierOrdersPage": {
-    "title": "Orders",
-    "orders": "All Orders",
-    "pending": "Pending Orders"
+    "filterByStatus": "Nach Status filtern",
+    "table": {
+      "orderId": "Bestell-ID",
+      "date": "Datum",
+      "total": "Gesamt",
+      "status": "Status",
+      "foundation": "Stiftung"
+    },
+    "actions": {
+      "ship": "Als versandt markieren"
+    },
+    "emptyState": "Keine Bestellungen für den ausgewählten Filter gefunden."
   },
   "supplierSupportPage": {
-    "title": "Support",
-    "help": "Help Center"
+    "ticketSubmittedAlert": "Support ticket submitted successfully",
+    "ticketForm": {
+      "subjectPlaceholder": "Brief description of your issue",
+      "messagePlaceholder": "Please provide detailed information about your issue"
+    }
   },
   "adminContentManagementDashboardPage": {
     "title": "Content Management",
@@ -537,18 +636,46 @@
     "announcements": "Announcements"
   },
   "adminSystemMonitoringPage": {
-    "title": "System Monitoring",
-    "monitoring": "System Monitoring",
-    "performance": "Performance Metrics",
-    "logs": "System Logs",
     "rawLogConsole": {
-      "emptyLogMessage": "No logs available",
-      "tabs": {
-        "all": "All",
-        "errors": "Errors",
-        "warnings": "Warnings",
-        "info": "Info"
-      }
+      "title": "Roh-Log-Konsole"
+    },
+    "overallStatus": {
+      "title": "Gesamtsystemstatus"
+    },
+    "components": {
+      "api": "Backend-API",
+      "database": "Datenbank",
+      "authService": "Authentifizierungsdienst"
+    },
+    "metadata": {
+      "environment": "Umgebung",
+      "version": "Version",
+      "uptime": "Betriebszeit",
+      "lastCheck": "Letzte Prüfung"
+    },
+    "serverPerformance": {
+      "title": "Serverleistung",
+      "cpuUsage": "CPU-Auslastung",
+      "memoryUsage": "Speichernutzung",
+      "diskUsage": "Festplattennutzung",
+      "uptimeDays": "Betriebszeit (Tage)"
+    },
+    "databasePerformance": {
+      "title": "Datenbankleistung",
+      "activeConnections": "Aktive Verbindungen",
+      "queryTime": "Ø Abfragezeit",
+      "storage": "Speichernutzung",
+      "connectionHealth": "Verbindungszustand"
+    },
+    "appPerformance": {
+      "title": "Anwendungsleistung",
+      "activeUsers": "Aktive Benutzer",
+      "requestsPerMinute": "Anfragen/Min.",
+      "avgResponseTime": "Ø Antwortzeit",
+      "errorRate": "Fehlerrate"
+    },
+    "recentEvents": {
+      "title": "Letzte Systemereignisse"
     }
   },
   "adminDiscountTerminationsPage": {
@@ -557,21 +684,21 @@
     "manage": "Manage Terminations"
   },
   "pricingPage": {
-    "title": "Pricing Plans",
+    "title": "ProCrèche Solutions – Preisführer",
     "plans": "Available Plans",
     "features": "Plan Features",
     "billing": "Billing Information",
-    "monthly": "Monthly",
-    "annual": "Annual",
-    "saveUpTo10": "Save up to 10%",
-    "popular": "Most Popular",
-    "whatYouGet": "What You Get",
-    "selectAndContinue": "Select and Continue",
-    "choosePlan": "Choose Your Plan",
-    "titleSignup": "Sign Up",
-    "subtitleSignup": "Create your account to get started",
-    "subtitle": "Choose the plan that's right for your organization",
-    "suppliersAndProvidersTitle": "For Suppliers & Service Providers"
+    "monthly": "Monatlich",
+    "annual": "Jährlich",
+    "saveUpTo10": "(Bis zu 10% sparen)",
+    "popular": "Am Beliebtesten",
+    "whatYouGet": "Was Sie erhalten",
+    "selectAndContinue": "Auswählen und Fortfahren",
+    "choosePlan": "Plan Wählen",
+    "titleSignup": "Wählen Sie Ihren Plan",
+    "subtitleSignup": "Wählen Sie den Plan, der am besten zu Ihren Bedürfnissen passt",
+    "subtitle": "Wählen Sie den perfekten Plan für Ihre Organisation",
+    "suppliersAndProvidersTitle": "ProCrèche Solutions – Preise für Lieferanten und Dienstleister"
   },
   "recruitmentPage": {
     "title": "Recruitment",
@@ -645,25 +772,23 @@
     }
   },
   "messagesPage": {
-    "selectConversationToView": "Select a conversation to view messages",
-    "conversationFallbackTitle": "Select a conversation",
-    "attachFile": "Attach File",
-    "addEmoji": "Add Emoji",
-    "typeMessagePlaceholder": "Type a message...",
-    "searchPlaceholder": "Search conversations...",
+    "title": "Messages",
+    "newGroupButton": "Neue Gruppe",
+    "noConversationSelectedTitle": "Wählen Sie ein Gespräch",
+    "noConversationSelectedSubtitle": "Wählen Sie aus Ihren bestehenden Gesprächen, um zu chatten.",
+    "noConversationsYet": "Sie haben noch keine Gespräche.",
+    "noConversationsFound": "Keine Gespräche gefunden.",
     "filters": {
-      "all": "All",
-      "unread": "Unread"
-    },
-    "noConversationsFound": "No conversations found",
-    "unknownUser": "Unknown User",
-    "youPrefix": "You:",
-    "noMessagesYet": "No messages yet"
+      "all": "Alle",
+      "unread": "Ungelesen"
+    }
   },
   "notificationsPage": {
-    "title": "Notifications",
-    "notifications": "All Notifications",
-    "unread": "Unread Notifications"
+    "clearAll": "Clear All",
+    "emptyState": {
+      "title": "No notifications",
+      "message": "You're all caught up! New notifications will appear here."
+    }
   },
   "fileGalleryPage": {
     "title": "File Gallery",
@@ -672,8 +797,33 @@
   },
   "eLearningPage": {
     "title": "E-Learning",
-    "courses": "Available Courses",
-    "progress": "Learning Progress"
+    "actions": {
+      "viewCourse": "View Course",
+      "watchVideo": "Watch Video",
+      "downloadPdf": "Download PDF",
+      "openLink": "Open Link"
+    },
+    "viewingAlert": "You are viewing external content",
+    "lessonsCount": "{{count}} lessons",
+    "durationLabel": "Duration",
+    "languageLabel": "Language",
+    "updatedLabel": "Updated",
+    "confirmDelete": "Are you sure you want to delete this item?",
+    "noItemsFound": "No items found",
+    "addNewContentButton": "Add New Content",
+    "searchPlaceholder": "Search content...",
+    "categoryLabel": "Category",
+    "noContentFound": "No content found",
+    "coursesTitle": "Courses",
+    "itemType": {
+      "courses": "Courses",
+      "videos": "Videos",
+      "pdfs": "PDFs",
+      "links": "External Links"
+    },
+    "videosTitle": "Videos",
+    "pdfsTitle": "PDFs",
+    "externalLinksTitle": "External Links"
   },
   "statePoliciesPage": {
     "title": "State Policies",
@@ -682,23 +832,103 @@
   },
   "hrProceduresPage": {
     "title": "HR Procedures",
-    "procedures": "HR Procedures",
-    "guidelines": "Guidelines"
+    "categoryDisplay": {
+      "viewCategoryAria": "View category {{category}}",
+      "documentsCount": "{{count}} documents"
+    },
+    "confirmDeleteDocument": "Are you sure you want to delete this document?",
+    "uploadButton": "Upload Document",
+    "searchPlaceholder": "Search documents...",
+    "categoriesTitle": "Categories",
+    "allDocumentsCategory": "All Documents",
+    "noDocumentsMatchSearch": "No documents match your search",
+    "noDocumentsAvailable": "No documents available",
+    "backToCategoriesButton": "Back to Categories",
+    "documentsInCategoryTitle": "Documents in {{category}}",
+    "allItemsCount": "{{count}} items",
+    "noDocumentsInCategory": "No documents in this category"
   },
   "usersPage": {
-    "title": "User Management",
-    "allUsers": "All Users",
-    "roles": "User Roles"
+    "cannotDeleteOwnAccount": "You cannot delete your own account",
+    "status": {
+      "pending": "Pending"
+    },
+    "userDetailDrawer": {
+      "title": "User Details",
+      "roleLabel": "Role",
+      "statusLabel": "Status",
+      "regionLabel": "Region",
+      "lastLoginLabel": "Last Login",
+      "orgLabel": "Organization",
+      "adminActionsTitle": "Admin Actions",
+      "changeRoleLabel": "Change Role",
+      "updateRoleButton": "Update Role",
+      "suspendUserButton": "Suspend User",
+      "activateUserButton": "Activate User",
+      "cannotModifyOwnAccount": "You cannot modify your own account"
+    },
+    "rolePageTitle": "Role Management",
+    "allUsersTitle": "All Users",
+    "confirmDeleteUser": "Are you sure you want to delete this user?",
+    "userProfileUpdated": "User profile updated successfully",
+    "addNewUserTBD": "Add New User TBD",
+    "addNewUserButton": "Add New User",
+    "searchPlaceholder": "Search users...",
+    "filtersTBD": "Filters TBD",
+    "filtersButton": "Filters",
+    "table": {
+      "nameOrg": "Name / Organization",
+      "role": "Role",
+      "status": "Status",
+      "region": "Region",
+      "lastLogin": "Last Login",
+      "actions": "Actions"
+    },
+    "emptyState": "No users found"
   },
   "partnersPage": {
-    "title": "Partners",
-    "partners": "Partner Directory",
-    "becomePartner": "Become a Partner"
+    "partnerCard": {
+      "logoAlt": "{{partnerName}} logo",
+      "partnerType": "{{type}} Partner",
+      "learnMoreButton": "Mehr erfahren"
+    },
+    "hero": {
+      "title": "Unsere geschätzten Partner",
+      "subtitle": "Wir arbeiten mit führenden Organisationen zusammen, um das frühkindliche Bildungssystem in der Schweiz zu verbessern.",
+      "ctaButton": "Partner werden"
+    },
+    "featured": {
+      "title": "Ausgewählte Partner",
+      "subtitle": "Wir sind stolz darauf, mit Institutionen zusammenzuarbeiten, die unsere Vision für qualitativ hochwertige frühkindliche Bildung teilen."
+    },
+    "joinUs": {
+      "title": "Werden Sie Teil unseres Netzwerks",
+      "subtitle": "Interessiert, Partner von Pro Crèche Solutions zu werden? Wir sind immer auf der Suche nach Organisationen, die unserer Gemeinschaft einen Mehrwert bringen können. Lassen Sie uns in Kontakt treten.",
+      "contactUsAlert": "Die Funktionalität des Kontaktformulars/Modals wird noch implementiert.",
+      "contactUsButton": "Kontaktieren Sie uns",
+      "inquiryFormLink": "oder füllen Sie unser Partnerschaftsanfrageformular aus"
+    }
   },
   "parentLeadFormPage": {
-    "title": "Find a Crèche",
-    "form": "Lead Form",
-    "submit": "Submit Request"
+    "errorAllFields": "Bitte füllen Sie alle Pflichtfelder aus.",
+    "thankYouTitle": "Vielen Dank!",
+    "unauthenticatedSuccessMessage": "Ihre Anfrage wurde erfolgreich übermittelt. Wir haben eine Bestätigungs-E-Mail an {{email}} gesendet. Sie können auch ein Konto erstellen, um Ihre Anfragen zu verfolgen.",
+    "authenticatedSuccessMessage": "Ihre Anfrage wurde erfolgreich übermittelt. Sie können Ihre Anfragen in Ihrem Dashboard einsehen und verwalten.",
+    "subtitle": "Erzählen Sie uns von den Bedürfnissen Ihres Kindes und wir helfen Ihnen, die perfekte Kita zu finden",
+    "labels": {
+      "yourFullName": "Ihr Vollständiger Name",
+      "yourEmail": "Ihre E-Mail",
+      "yourPhone": "Ihre Telefonnummer",
+      "canton": "Kanton",
+      "municipality": "Gemeinde",
+      "childAge": "Alter des Kindes (Jahre)",
+      "desiredStartDate": "Gewünschtes Startdatum",
+      "specialNeeds": "Besondere Bedürfnisse oder Anforderungen"
+    },
+    "sectionTitleChildNeeds": "Bedürfnisse des Kindes",
+    "helpText": {
+      "specialNeeds": "Bitte beschreiben Sie alle besonderen Bedürfnisse, Ernährungsanforderungen oder andere wichtige Informationen über Ihr Kind."
+    }
   },
   "candidateProfilePage": {
     "title": "Candidate Profile",
@@ -707,42 +937,97 @@
   },
   "designSystemPage": {
     "title": "Design System",
-    "components": "UI Components",
-    "guidelines": "Design Guidelines"
+    "description": "A living reference for all UI components and design tokens in the Pro Crèche Solutions application.",
+    "tabs": {
+      "title": "Tabs",
+      "pillsVariant": "Pills Variant (Default)",
+      "lineVariant": "Line Variant",
+      "tab1": "Tab 1",
+      "content1": "This is the content for Tab 1.",
+      "tab2": "Tab 2",
+      "content2": "This is the content for Tab 2.",
+      "tab3": "Tab 3",
+      "content3": "This is a disabled tab."
+    },
+    "typography": {
+      "fontFamily": "Font Family: Nunito, Inter, sans-serif",
+      "heading1": "Heading 1: The quick brown fox",
+      "heading2": "Heading 2: The quick brown fox",
+      "heading3": "Heading 3: The quick brown fox",
+      "heading4": "Heading 4: The quick brown fox",
+      "bodyBase": "Body Text (Base): Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.",
+      "bodySmall": "Body Text (Small): Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi.",
+      "link": "This is a link"
+    },
+    "buttons": {
+      "extraSmall": "Extra Small",
+      "small": "Small",
+      "mediumDefault": "Medium (Default)",
+      "large": "Large",
+      "withIcons": "With Icons",
+      "leftIcon": "Left Icon",
+      "rightIcon": "Right Icon",
+      "smallIcon": "Small Icon",
+      "disabledState": "Disabled State",
+      "primaryDisabled": "Primary Disabled",
+      "secondaryDisabled": "Secondary Disabled",
+      "outlineDisabled": "Outline Disabled"
+    },
+    "cards": {
+      "standardCard": "Standard Card",
+      "standardCardDesc": "This is a standard card component with a soft shadow. It's the base for most content containers.",
+      "hoverEffectCard": "Hover Effect Card",
+      "hoverEffectCardDesc": "This card has a subtle scale and shadow transition on hover, useful for interactive elements."
+    },
+    "formControls": {
+      "title": "Form Controls",
+      "textInput": "Text Input",
+      "selectMenu": "Select Menu",
+      "option1": "Option 1",
+      "option2": "Option 2",
+      "option3": "Option 3",
+      "quantityInput": "Quantity Input",
+      "disabledInput": "Disabled Input"
+    },
+    "View Favorites TBD": "View Favorites TBD",
+    "Could not find a user associated with this organization to message.": "Could not find a user associated with this organization to message.",
+    "User organization details are missing.": "User organization details are missing.",
+    "tailwindcss": "tailwindcss",
+    "sidebar.parentLeads": "Parent Leads",
+    "sidebar.products": "Products",
+    "sidebar.services": "Services",
+    "No recent activity.": "No recent activity.",
+    "loaded": "loaded",
+    "SUPER_ADMIN": "SUPER_ADMIN",
+    "Show": "Show",
+    "Refresh": "Refresh",
+    "keys)": "keys)",
+    "(240)": "(240)",
+    "Branding": "Branding",
+    "Favicon": "Favicon",
+    "Search job offers...": "Search job offers...",
+    "Search partners...": "Search partners...",
+    "Search candidates...": "Search candidates...",
+    "Search content...": "Search content...",
+    "admin@procrechesolutions.com": "admin@procrechesolutions.com",
+    "No documents found in this category for current filters.": "No documents found in this category for current filters.",
+    "No custom alerts created yet.": "No custom alerts created yet."
   },
   "createGroupChatModal": {
     "error": {
-      "minParticipants": "Please select at least 2 participants"
+      "minParticipants": "Bitte wählen Sie mindestens 2 Benutzer aus, um eine Gruppe zu erstellen."
     },
-    "title": "Create Group Chat",
-    "groupNameLabel": "Group Name",
-    "groupNamePlaceholder": "Enter group name...",
-    "selectParticipantsLabel": "Select Participants",
-    "createButton": "Create Group"
+    "title": "Neuen Gruppenchat erstellen",
+    "groupNameLabel": "Gruppenname (Optional)",
+    "groupNamePlaceholder": "z.B. Team-Meeting Vorbereitung",
+    "selectParticipantsLabel": "Teilnehmer auswählen (mind. 2)",
+    "createButton": "Gruppe erstellen"
   },
   "orderRequestDetailModal": {
-    "title": "Order Details",
-    "orderId": "Order ID",
-    "date": "Date",
-    "status": "Status",
-    "total": "Total",
-    "viewDaycareProfile": "View Daycare Profile",
-    "lineItems": "Line Items",
-    "product": "Product",
-    "quantity": "Quantity",
-    "price": "Price",
-    "notes": "Notes"
+    "markAsProcessing": "Mark as Processing"
   },
   "serviceRequestDetailModal": {
-    "title": "Service Request Details",
-    "requestId": "Request ID",
-    "serviceName": "Service Name",
-    "viewDaycareProfile": "View Daycare Profile",
-    "date": "Date",
-    "status": "Status",
-    "preferredDate": "Preferred Date",
-    "noPreferredDate": "No preferred date set",
-    "notes": "Notes"
+    "markAsCompleted": "Mark as Completed"
   },
   "serviceUploadModal": {
     "editTitle": "Edit Service",
@@ -895,61 +1180,46 @@
     "commitToGit": "Commit to Git"
   },
   "supplierCard": {
-    "title": "Supplier",
-    "labels": {
-      "name": "Name",
-      "rating": "Rating",
-      "reviews": "Reviews",
-      "location": "Location",
-      "specialties": "Specialties"
+    "specializesIn": "Specializes in",
+    "viewProfileAndProducts": "View Profile and Products"
+  },
+  "settingsAccountSecurity": {
+    "personalInfo": {
+      "title": "Persönliche Informationen",
+      "subtitle": "Manage your personal details and contact information",
+      "contactNameLabel": "Kontaktname",
+      "orgNameLabel": "Name der Organisation",
+      "emailLabel": "E-Mail-Adresse",
+      "accountTypeLabel": "Kontotyp",
+      "memberSinceLabel": "Mitglied seit",
+      "updateInfoButton": "Informationen aktualisieren"
     },
-    "actions": {
-      "view": "View",
-      "contact": "Contact",
-      "favorite": "Favorite"
+    "changePassword": {
+      "title": "Passwort ändern",
+      "subtitle": "Update your password for better security",
+      "currentPasswordLabel": "Aktuelles Passwort",
+      "newPasswordLabel": "Neues Passwort",
+      "confirmNewPasswordLabel": "Neues Passwort bestätigen",
+      "updatePasswordButton": "Passwort aktualisieren"
     },
-    "rating": {
-      "stars": "{{count}} stars",
-      "noReviews": "No reviews yet"
+    "dangerZone": {
+      "title": "Gefahrenzone",
+      "subtitle": "Irreversible and destructive actions",
+      "deleteAccountTitle": "Dieses Konto löschen",
+      "deleteAccountSubtitle": "Sobald Sie Ihr Konto löschen, gibt es kein Zurück mehr. Bitte seien Sie sich sicher.",
+      "deleteAccountButton": "Konto löschen"
+    },
+    "notifications": {
+      "title": "Notifications",
+      "subtitle": "Manage your notification preferences"
     }
   },
-    "settingsAccountSecurity": {
-      "personalInfo": {
-        "title": "Personal Information",
-        "subtitle": "Manage your personal details and contact information",
-        "contactNameLabel": "Contact Name",
-        "orgNameLabel": "Organization Name",
-        "emailLabel": "Email Address",
-        "accountTypeLabel": "Account Type",
-        "memberSinceLabel": "Member Since",
-        "updateInfoButton": "Update Information"
-      },
-      "changePassword": {
-        "title": "Change Password",
-        "subtitle": "Update your password for better security",
-        "currentPasswordLabel": "Current Password",
-        "newPasswordLabel": "New Password",
-        "confirmNewPasswordLabel": "Confirm New Password",
-        "updatePasswordButton": "Update Password"
-      },
-      "dangerZone": {
-        "title": "Danger Zone",
-        "subtitle": "Irreversible and destructive actions",
-        "deleteAccountTitle": "Delete Account",
-        "deleteAccountSubtitle": "Permanently delete your account and all data",
-        "deleteAccountButton": "Delete Account"
-      },
-      "notifications": {
-        "title": "Notifications",
-        "subtitle": "Manage your notification preferences"
-      }
-    },
   "settingsAnalyticsPreferences": {
     "title": "Analytics Preferences",
     "subtitle": "Configure your analytics and reporting settings"
   },
   "settingsBillingSubscription": {
-    "title": "Billing & Subscription",
+    "title": "Rechnung & Abonnement",
     "subtitle": "Manage your billing and subscription settings"
   },
   "settingsCompanyProfile": {
@@ -969,25 +1239,29 @@
     "subtitle": "Customize how you receive notifications"
   },
   "settingsPrivacyData": {
-    "title": "Privacy & Data",
-    "subtitle": "Manage your privacy settings and data preferences"
+    "confirmGDPRDelete": "Sind Sie sicher? Dies löscht Ihr Konto und alle zugehörigen Daten dauerhaft. Diese Aktion kann nicht rückgängig gemacht werden.",
+    "deletionRequestSubmittedHelpText": "Ihre Anfrage wurde übermittelt. Unser Team wird Sie innerhalb von 30 Tagen kontaktieren."
   },
   "parentDashboard": {
+    "title": "Parent Dashboard",
+    "welcomeMessage": "Welcome to your parent dashboard",
     "enquiry": {
-      "title": "Enquiries",
-      "new": "New Enquiry"
-    },
-    "quickActions": {
-      "title": "Quick Actions",
-      "findCreche": "Find Crèche"
+      "sent": "Enquiries Sent",
+      "responses": "Responses Received",
+      "pending": "Pending Responses",
+      "button": "Send New Enquiry"
     },
     "childProfile": {
-      "title": "Child Profile",
-      "edit": "Edit Profile"
+      "name": "Child's Name",
+      "age": "Age",
+      "location": "Location",
+      "languages": "Languages",
+      "specialNeeds": "Special Needs",
+      "button": "Update Profile"
     },
     "favorites": {
-      "title": "Favorites",
-      "viewAll": "View All"
+      "subtitle": "Your favorite crèches and services",
+      "button": "View Favorites"
     }
   },
   "type": "Type",
@@ -1005,7 +1279,7 @@
     "subtitle": "Manage team member access and permissions"
   },
   "activeClientToggle": {
-    "title": "Active Client",
+    "title": "Beziehungsstatus",
     "labels": {
       "active": "Active",
       "inactive": "Inactive"
@@ -1021,26 +1295,8 @@
     "upgrade": "Upgrade Plan"
   },
   "fileUploadModal": {
-    "title": "Upload File",
-    "labels": {
-      "selectFile": "Select File",
-      "fileType": "File Type",
-      "description": "Description"
-    },
-    "fileUpload": {
-      "dragAndDrop": "Drag and drop files here",
-      "browse": "Browse Files"
-    },
-    "validation": {
-      "fileRequired": "File is required",
-      "invalidFileType": "Invalid file type"
-    },
-    "success": {
-      "uploaded": "File uploaded successfully"
-    },
-    "error": {
-      "uploadFailed": "Upload failed"
-    }
+    "uploading": "Uploading...",
+    "uploadButton": "Upload File"
   },
   "auth": {
     "signIn": "Sign In",
@@ -1153,14 +1409,42 @@
     }
   },
   "serviceProviderDashboard": {
-    "title": "Service Provider Dashboard",
-    "services": "Services",
-    "requests": "Requests"
+    "welcomeMessage": "Welcome to your service provider dashboard",
+    "widgets": {
+      "overview": {
+        "title": "Overview",
+        "activeRequests": "Active Requests",
+        "completedServices": "Completed Services",
+        "upcoming": "Upcoming",
+        "customerRating": "Customer Rating",
+        "button": "View All"
+      },
+      "management": {
+        "title": "Service Management",
+        "listings": "Service Listings",
+        "pending": "Pending Approvals",
+        "categories": "Categories",
+        "button": "Manage Services"
+      },
+      "appointments": {
+        "title": "Appointments",
+        "with": "with",
+        "button": "Schedule New"
+      }
+    }
   },
   "supportPage": {
-    "title": "Support",
-    "faq": "FAQ",
-    "contact": "Contact Us"
+    "faqTitle": "Frequently Asked Questions",
+    "furtherAssistanceTitle": "Need Further Assistance?",
+    "furtherAssistanceText": {
+      "0": "Contact our support team for personalized help",
+      "1": "We're here to assist you with any questions or issues"
+    },
+    "submitTicketTitle": "Submit Support Ticket",
+    "ticketForm": {
+      "subjectLabel": "Subject",
+      "messageLabel": "Message"
+    }
   },
   "T": "T",
   "Title and Message are required.": "Title and Message are required.",
@@ -1168,156 +1452,110 @@
   "Missing keys copied to clipboard!": "Missing keys copied to clipboard!",
   ".": ".",
   "hardcodedText": {},
-    "navbar": {
-      "notificationsCount": "{{count}} Benachrichtigungen",
-      "unreadMessages": "{{count}} ungelesene Nachrichten",
-      "searchPlaceholder": "Suchen..."
-    },
-    "sidebar": {
-      "billingSubscription": "Abrechnung & Abonnement",
-      "dashboard": "Dashboard",
-      "marketplace": "Marktplatz",
-      "products": "Produkte",
-      "services": "Dienstleistungen",
-      "recruitment": "Rekrutierung",
-      "jobListings": "Stellenausschreibungen",
-      "candidatePool": "Kandidatenpool",
-      "eLearning": "E-Learning",
-      "messages": "Nachrichten",
-      "users": "Benutzer",
-      "allUsers": "Alle Benutzer",
-      "admins": "Administratoren",
-      "foundations": "Stiftungen",
-      "productSuppliers": "Produktlieferanten",
-      "serviceProviders": "Dienstleister",
-      "parents": "Eltern",
-      "content": "Inhalt",
-      "hrProcedures": "HR-Verfahren",
-      "statePolicies": "Staatspolitik",
-      "discountTerminations": "Rabattkündigungen",
-      "systemMonitoring": "Systemüberwachung",
-      "partners": "Partner",
-      "platformSettings": "Plattform-Einstellungen",
-      "designSystem": "Design-System",
-      "settings": "Einstellungen"
-    },
   "Quantity must be at least 1.": "Quantity must be at least 1.",
-  "supplierCard": {
-    "specializesIn": "Specializes in",
-    "viewProfileAndProducts": "View Profile and Products"
-  },
   "Cannot post job. Foundation details are missing.": "Cannot post job. Foundation details are missing.",
   "Current user or organization ID is missing.": "Current user or organization ID is missing.",
-  "organizationProfileForm": {
-    "saveSuccess": "Organization profile saved successfully"
-  },
-  "settingsPrivacyData": {
-    "confirmGDPRDelete": "Confirm GDPR Data Deletion",
-    "deletionRequestSubmittedHelpText": "This will permanently delete all your data from our systems"
-  },
-    "settingsPage": {
-      "billingSubscription": "Billing & Subscription",
-      "title": "Settings",
-      "accountSecurity": "Account & Security"
-    },
   "Subscription cancelled (mock action)": "Subscription cancelled (mock action)",
-  "fileUploadModal": {
-    "uploading": "Uploading...",
-    "uploadButton": "Upload File"
-  },
   "renameFileModal": {
     "title": "Rename File",
     "label": "File Name"
   },
   "supplierDashboard": {
+    "title": "Lieferanten-Dashboard",
+    "welcomeMessage": "Willkommen, {{name}}! Hier ist Ihre Lieferantenübersicht.",
+    "noSalesYet": "Noch keine Verkäufe",
+    "widgets": {
+      "sales": {
+        "title": "Verkaufsübersicht",
+        "totalOrders": "Bestellungen Gesamt",
+        "revenueMonth": "Umsatz (dieser Monat)",
+        "topSelling": "Topseller",
+        "fulfillmentRate": "Erfüllungsrate",
+        "button": "Vollständige Analysen anzeigen"
+      },
+      "products": {
+        "title": "Produktmanagement",
+        "active": "Aktive Produkte",
+        "pending": "Warten auf Genehmigung",
+        "lowStock": "Warnungen bei niedrigem Lagerbestand",
+        "button": "Alle Produkte verwalten"
+      },
+      "orders": {
+        "title": "Bestellmanagement",
+        "pending": "Ausstehende Bestellungen",
+        "toFulfill": "Zu erfüllende Bestellungen",
+        "button": "Zur Bestellseite"
+      }
+    },
+    "recentOrdersTitle": "Letzte Bestellungen (die letzten 5)",
+    "noRecentOrders": "Keine aktuellen Bestellungen zum Anzeigen.",
+    "recentOrdersTable": {
+      "id": "ID",
+      "creche": "Kita",
+      "date": "Datum",
+      "total": "Gesamt",
+      "status": "Status"
+    },
     "recentOrdersActions": {
       "decline": "Decline",
       "accept": "Accept"
     }
   },
-  "supplierOrdersPage": {
-    "actions": {
-      "ship": "Ship"
-    },
-    "table": {
-      "foundation": "Foundation"
-    }
-  },
   "You must be logged in as a foundation to submit a request.": "You must be logged in as a foundation to submit a request.",
-  "common": {
-    "perMonth": "/month",
-    "perYear": "/year",
-    "save10Percent": "save 10%"
-  },
   "dashboardDetailPage": {
     "activeUsers": {
-      "recentActivity": "Recent Activity",
-      "totalToday": "Total Today"
+      "recentActivity": "Letzte Aktivität",
+      "totalToday": "Total active users today: {{count}}",
+      "aliceActivity": "Alice Johnson - Logged in 2 hours ago, viewed 5 pages.",
+      "bobActivity": "Bob Williams - Updated profile at 10:30 AM.",
+      "carolActivity": "Carol Davis - Joined yesterday, completed onboarding.",
+      "davidActivity": "David Brown - Viewed marketplace listings."
     },
     "newOrders": {
-      "recentOrders": "Recent Orders",
+      "recentOrders": "Letzte Bestellungen",
       "table": {
-        "orderId": "Order ID",
-        "product": "Product",
-        "amount": "Amount",
+        "orderId": "Bestell-ID",
+        "product": "Produkt",
+        "amount": "Betrag",
         "status": "Status"
       },
       "status": {
-        "paid": "Paid",
-        "pending": "Pending"
+        "paid": "Bezahlt",
+        "pending": "Ausstehend"
       },
-      "totalThisWeek": "Total This Week"
+      "totalThisWeek": "Total orders this week: {{count}}",
+      "order789": "#ORD789",
+      "order790": "#ORD790",
+      "order791": "#ORD791",
+      "ecotoysBlocks": "EcoToys Wooden Blocks",
+      "freshBitesMeal": "FreshBites Meal Plan",
+      "artFunPack": "ArtFun Creative Pack"
     },
     "openJobs": {
-      "currentPositions": "Current Positions",
-      "applications": "Applications",
+      "currentPositions": "Aktuell offene Stellen",
+      "applications": "{{count}} Bewerbungen",
+      "totalOpenPositions": "Offene Stellen gesamt: {{count}}",
+      "leadEducatorGeneva": "Lead Educator - Geneva",
+      "assistantEducatorLausanne": "Assistant Educator - Lausanne",
+      "daycareDirectorZurich": "Daycare Director - Zurich",
       "status": {
-        "open": "Open",
-        "interviewing": "Interviewing"
-      },
-      "totalOpenPositions": "Total Open Positions"
+        "open": "Offen",
+        "interviewing": "Im Gespräch"
+      }
     },
     "pageViews": {
-      "keyMetrics": "Key Metrics",
-      "totalToday": "Total Today",
-      "uniqueVisitors": "Unique Visitors",
-      "mostViewed": "Most Viewed",
-      "avgSession": "Avg Session",
-      "mockChartText": "Mock chart data - replace with real analytics"
+      "keyMetrics": "Wichtige Kennzahlen",
+      "totalToday": "Gesamtaufrufe heute:",
+      "uniqueVisitors": "Einzigartige Besucher:",
+      "mostViewed": "Meistbesuchte Seite:",
+      "dashboardViews": "/dashboard (560 views)",
+      "avgSession": "Ø Sitzungsdauer:",
+      "sessionDuration": "4m 15s",
+      "mockChartText": "Simulierte {{type}}-Diagrammdaten"
     },
-    "defaultTitle": "Dashboard Details",
-    "detailsFor": "Details for",
-    "noSpecificView": "No specific view selected"
-  },
-    "eLearningPage": {
-      "title": "E-Learning",
-      "actions": {
-        "viewCourse": "View Course",
-        "watchVideo": "Watch Video",
-        "downloadPdf": "Download PDF",
-        "openLink": "Open Link"
-      },
-    "viewingAlert": "You are viewing external content",
-    "lessonsCount": "{{count}} lessons",
-    "durationLabel": "Duration",
-    "languageLabel": "Language",
-    "updatedLabel": "Updated",
-    "confirmDelete": "Are you sure you want to delete this item?",
-    "noItemsFound": "No items found",
-    "addNewContentButton": "Add New Content",
-    "searchPlaceholder": "Search content...",
-    "categoryLabel": "Category",
-    "noContentFound": "No content found",
-    "coursesTitle": "Courses",
-    "itemType": {
-      "courses": "Courses",
-      "videos": "Videos",
-      "pdfs": "PDFs",
-      "links": "External Links"
-    },
-    "videosTitle": "Videos",
-    "pdfsTitle": "PDFs",
-    "externalLinksTitle": "External Links"
+    "defaultTitle": "Details",
+    "detailsFor": "Details für: {{pageDisplayTitle}}",
+    "noSpecificView": "Keine spezifische Detailansicht für \"{{pageDisplayTitle}}\" verfügbar."
   },
   "fileGallery": {
     "actions": {
@@ -1346,152 +1584,7 @@
     "editButtonLabel": "Edit",
     "deleteButtonLabel": "Delete"
   },
-    "hrProceduresPage": {
-      "title": "HR Procedures",
-      "categoryDisplay": {
-        "viewCategoryAria": "View category {{category}}",
-        "documentsCount": "{{count}} documents"
-      },
-    "confirmDeleteDocument": "Are you sure you want to delete this document?",
-    "uploadButton": "Upload Document",
-    "searchPlaceholder": "Search documents...",
-    "categoriesTitle": "Categories",
-    "allDocumentsCategory": "All Documents",
-    "noDocumentsMatchSearch": "No documents match your search",
-    "noDocumentsAvailable": "No documents available",
-    "backToCategoriesButton": "Back to Categories",
-    "documentsInCategoryTitle": "Documents in {{category}}",
-    "allItemsCount": "{{count}} items",
-    "noDocumentsInCategory": "No documents in this category"
-  },
-  "partnerDetailPage": {
-    "onlyFoundationsRequestService": "Only foundations can request this service",
-    "requestSubmittedAlert": "Service request submitted successfully"
-  },
-    "marketplacePage": {
-      "emptyStates": {
-        "noServices": "No services available",
-        "noProductSuppliers": "No product suppliers available"
-      },
-      "subtitles": {
-        "productSuppliers": "Product Suppliers",
-        "serviceProviders": "Service Providers"
-      },
-      "tabs": {
-        "productSuppliers": "Product Suppliers",
-        "serviceProviders": "Service Providers"
-      },
-      "buttons": {
-        "partnerOnboarding": "Partner Onboarding"
-      },
-      "infoAlert": "Partner Onboarding TBD",
-      "searchPlaceholder": "Search partners...",
-      "labels": {
-        "category": "Category",
-        "region": "Region",
-        "supplierTags": "Supplier Tags",
-        "sortBy": "Sort by"
-      },
-      "sortOptions": {
-        "nameAsc": "Name (A-Z)",
-        "nameDesc": "Name (Z-A)",
-        "ratingDesc": "Rating (High to Low)"
-      },
-      "ariaLabels": {
-        "gridView": "Switch to grid view",
-        "listView": "Switch to list view"
-      }
-    },
   "Partner Onboarding TBD": "Partner Onboarding TBD",
-  "notifications": {
-    "newMessageFrom": "New message from {{sender}}"
-  },
-    "messagesPage": {
-      "title": "Messages",
-      "newGroupButton": "New Group",
-      "noConversationSelectedTitle": "Select a conversation to start messaging",
-      "noConversationSelectedSubtitle": "Choose a conversation from the list to view messages",
-      "noConversationsYet": "No conversations yet",
-      "noConversationsFound": "No conversations found",
-      "filters": {
-        "all": "All",
-        "unread": "Unread"
-      }
-    },
-  "notificationsPage": {
-    "clearAll": "Clear All",
-    "emptyState": {
-      "title": "No notifications",
-      "message": "You're all caught up! New notifications will appear here."
-    }
-  },
-  "parentEnquiriesPage": {
-    "accessDenied": {
-      "title": "Access Denied",
-      "message": "You need to be logged in as a parent to view enquiries"
-    },
-    "emptyState": {
-      "title": "No enquiries yet",
-      "message": {
-        "0": "You haven't submitted any enquiries yet.",
-        "1": "Start by filling out the enquiry form to find suitable childcare options."
-      }
-    },
-    "card": {
-      "title": "Enquiry Details",
-      "submitted": "Submitted on {{date}}",
-      "childInfo": "Child Information",
-      "notes": "Additional Notes",
-      "responsesTitle": "Responses",
-      "awaitingMatch": "Awaiting Match",
-      "message": "Your enquiry has been sent to relevant providers",
-      "waitingForMoreResponses": "Waiting for more responses..."
-    }
-  },
-  "parentLeadFormPage": {
-    "errorAllFields": "Please fill in all required fields",
-    "thankYouTitle": "Thank You!",
-    "unauthenticatedSuccessMessage": "Your enquiry has been submitted successfully. We'll contact you soon!",
-    "authenticatedSuccessMessage": "Your enquiry has been submitted and saved to your dashboard.",
-    "subtitle": "Tell us about your childcare needs",
-    "labels": {
-      "yourFullName": "Your Full Name",
-      "yourEmail": "Your Email",
-      "yourPhone": "Your Phone",
-      "canton": "Canton",
-      "municipality": "Municipality",
-      "childAge": "Child's Age",
-      "desiredStartDate": "Desired Start Date",
-      "specialNeeds": "Special Needs"
-    },
-    "sectionTitleChildNeeds": "Child's Needs",
-    "helpText": {
-      "specialNeeds": "Please describe any special requirements or needs"
-    }
-  },
-  "partnersPage": {
-    "partnerCard": {
-      "logoAlt": "{{partnerName}} logo",
-      "partnerType": "{{type}} Partner",
-      "learnMoreButton": "Learn More"
-    },
-    "hero": {
-      "title": "Our Partners",
-      "subtitle": "Discover trusted childcare providers and suppliers",
-      "ctaButton": "Become a Partner"
-    },
-    "featured": {
-      "title": "Featured Partners",
-      "subtitle": "Meet our top-rated childcare providers and suppliers"
-    },
-    "joinUs": {
-      "title": "Join Our Network",
-      "subtitle": "Become part of Switzerland's leading childcare platform",
-      "contactUsAlert": "Contact us to learn more about partnership opportunities",
-      "contactUsButton": "Contact Us",
-      "inquiryFormLink": "Partnership Inquiry Form"
-    }
-  },
   "Close Job TBD": "Close Job TBD",
   "Favorite TBD": "Favorite TBD",
   "Adding a new candidate - Functionality TBD.": "Adding a new candidate - Functionality TBD.",
@@ -1503,146 +1596,34 @@
     "notesLabel": "Notes / Specific Requirements (Optional)",
     "submitButton": "Submit Request"
   },
-  "serviceRequestDetailModal": {
-    "markAsCompleted": "Mark as Completed"
-  },
   "Cantonal Policies": "Cantonal Policies",
   "National Regulations": "National Regulations",
   "Compliance Requirements": "Compliance Requirements",
   "Updates & News": "Updates & News",
   "Official Downloads": "Official Downloads",
-  "usersPage": {
-    "cannotDeleteOwnAccount": "You cannot delete your own account",
-    "status": {
-      "pending": "Pending"
-    },
-    "userDetailDrawer": {
-      "title": "User Details",
-      "roleLabel": "Role",
-      "statusLabel": "Status",
-      "regionLabel": "Region",
-      "lastLoginLabel": "Last Login",
-      "orgLabel": "Organization",
-      "adminActionsTitle": "Admin Actions",
-      "changeRoleLabel": "Change Role",
-      "updateRoleButton": "Update Role",
-      "suspendUserButton": "Suspend User",
-      "activateUserButton": "Activate User",
-      "cannotModifyOwnAccount": "You cannot modify your own account"
-    },
-    "rolePageTitle": "Role Management",
-    "allUsersTitle": "All Users",
-    "confirmDeleteUser": "Are you sure you want to delete this user?",
-    "userProfileUpdated": "User profile updated successfully",
-    "addNewUserTBD": "Add New User TBD",
-    "addNewUserButton": "Add New User",
-    "searchPlaceholder": "Search users...",
-    "filtersTBD": "Filters TBD",
-    "filtersButton": "Filters",
-    "table": {
-      "nameOrg": "Name / Organization",
-      "role": "Role",
-      "status": "Status",
-      "region": "Region",
-      "lastLogin": "Last Login",
-      "actions": "Actions"
-    },
-    "emptyState": "No users found"
-  },
-  "adminSystemMonitoringPage": {
-    "rawLogConsole": {
-      "emptyLogMessage": "No logs available",
-      "tabs": {
-        "all": "All",
-        "errors": "Errors",
-        "warnings": "Warnings",
-        "info": "Info"
-      }
-    },
-    "overallStatus": {
-      "title": "Overall System Status"
-    },
-    "components": {
-      "api": "API",
-      "database": "Database",
-      "authService": "Auth Service"
-    },
-    "metadata": {
-      "environment": "Environment",
-      "version": "Version",
-      "uptime": "Uptime",
-      "lastCheck": "Last Check"
-    },
-    "serverPerformance": {
-      "title": "Server Performance",
-      "cpuUsage": "CPU Usage",
-      "memoryUsage": "Memory Usage",
-      "diskUsage": "Disk Usage",
-      "uptimeDays": "Uptime (Days)"
-    },
-    "databasePerformance": {
-      "title": "Database Performance",
-      "activeConnections": "Active Connections",
-      "queryTime": "Query Time",
-      "storage": "Storage",
-      "connectionHealth": "Connection Health"
-    },
-    "appPerformance": {
-      "title": "Application Performance",
-      "activeUsers": "Active Users",
-      "requestsPerMinute": "Requests per Minute",
-      "avgResponseTime": "Average Response Time",
-      "errorRate": "Error Rate"
-    },
-    "recentEvents": {
-      "title": "Recent Events"
-    },
-    "rawLogConsole": {
-      "title": "Raw Log Console"
-    }
-  },
   "discountTerminationsPage": {
     "actions": {
-      "sendNoticesAlert": "Send notices to selected vendors",
-      "markCompleted": "Mark Completed",
-      "sendNotices": "Send Notices"
+      "sendNoticesAlert": "{{count}} Kündigungsmitteilungen gesendet. (Simulierte Aktion)",
+      "markCompleted": "Als erledigt markieren",
+      "sendNotices": "Kündigungsmitteilungen senden ({{count}})"
     },
     "table": {
-      "vendor": "Vendor",
-      "daycare": "Daycare",
-      "activeSince": "Active Since",
-      "reason": "Reason",
-      "actions": "Actions"
+      "vendor": "Anbieter",
+      "daycare": "Kita",
+      "activeSince": "Aktiv seit",
+      "reason": "Grund",
+      "actions": "Aktionen"
     },
     "queue": {
-      "title": "Termination Queue",
-      "description": "Manage discount terminations and send notices",
-      "tableTitle": "Pending Terminations"
+      "title": "Aktion erforderlich: Rabattkündigungen",
+      "description": "Die folgenden Kitas haben die Plattform verlassen. Bitte benachrichtigen Sie die Anbieter, die sie als 'Aktive Kunden' markiert hatten, um Sonderpreise oder Rabatte zu beenden.",
+      "tableTitle": "Kündigungswarteschlange"
     },
     "allActive": {
-      "title": "All Active Discounts",
-      "description": "View and manage all currently active discount agreements",
-      "tableTitle": "Active Discounts"
+      "title": "Alle aktiven Kundenbeziehungen",
+      "description": "Dies ist eine vollständige Liste aller derzeit aktiven Kundenbeziehungen, wie von den Anbietern markiert.",
+      "tableTitle": "Liste der aktiven Kunden"
     }
-  },
-  "educatorApplicationsPage": {
-    "status": {
-      "new": "New",
-      "viewed": "Viewed",
-      "interview": "Interview",
-      "offer": "Offer",
-      "declined": "Declined"
-    },
-    "table": {
-      "jobTitle": "Job Title",
-      "creche": "Crèche",
-      "status": "Status",
-      "lastUpdated": "Last Updated",
-      "actions": "Actions"
-    },
-    "viewingDetailsFor": "Viewing details for",
-    "emptyState": "No applications found",
-    "footerNote": "Applications are updated in real-time"
   },
   "educatorDashboard": {
     "title": "Educator Dashboard",
@@ -1670,367 +1651,24 @@
       "match": "Match"
     }
   },
-  "educatorJobBoardPage": {
-    "postedOn": "Posted on",
-    "searchPlaceholder": "Search jobs...",
-    "noJobsFound": "No jobs found"
-  },
-    "notifications": {
-      "errorTitle": "Error",
-      "successTitle": "Success",
-      "newMessageFrom": "New message from"
-    },
   "Profile changes saved!": "Profile changes saved!",
-  "educatorProfilePage": {
-    "editProfile": "Edit Profile",
-    "availability": {
-      "days": "Days",
-      "times": "Times",
-      "contract": "Contract",
-      "ageGroups": "Age Groups"
-    },
-    "education": {
-      "graduated": "Graduated"
-    },
-    "certifications": {
-      "issued": "Issued",
-      "expires": "Expires"
-    }
-  },
-  "supportPage": {
-    "faqTitle": "Frequently Asked Questions",
-    "furtherAssistanceTitle": "Need Further Assistance?",
-    "furtherAssistanceText": [
-      "Contact our support team for personalized help",
-      "We're here to assist you with any questions or issues"
-    ],
-    "submitTicketTitle": "Submit Support Ticket",
-    "ticketForm": {
-      "subjectLabel": "Subject",
-      "messageLabel": "Message"
-    }
-  },
-  "educatorSupportPage": {
-    "ticketSubmittedAlert": "Support ticket submitted successfully",
-    "ticketForm": {
-      "subjectPlaceholder": "Brief description of your issue",
-      "messagePlaceholder": "Please provide detailed information about your issue"
-    }
-  },
-  "foundationAnalyticsPage": {
-    "mockDataVisualization": "Mock Data Visualization",
-    "spendingByCategory": "Spending by Category",
-    "parentLeadConversion": "Parent Lead Conversion",
-    "staffTrainingCompletion": "Staff Training Completion",
-    "enrollmentTrend": "Enrollment Trend"
-  },
   "foundationDashboard": {
-    "title": "Foundation Dashboard",
-    "welcomeMessage": "Welcome to your foundation dashboard",
+    "title": "Stiftungs-Dashboard",
+    "welcomeMessage": "Willkommen, {{name}}!",
     "quickStats": {
-      "title": "Quick Stats"
+      "title": "Schnellstatistik"
     },
-    "todayAtGlance": "Today at a Glance",
+    "todayAtGlance": "Heutiger Überblick",
     "activity": {
-      "title": "Recent Activity"
+      "title": "Letzte Aktivitäten"
     },
     "quickActions": {
-      "title": "Quick Actions"
+      "title": "Schnellaktionen"
     },
     "quickMessage": {
-      "title": "Quick Message",
-      "placeholder": "Type your message here..."
+      "title": "Schnellnachricht",
+      "placeholder": "Senden Sie eine schnelle Nachricht an das Personal..."
     }
-  },
-  "foundationLeadsPage": {
-    "title": "Incoming Parent Leads",
-    "accessDenied": {
-      "title": "Access Denied",
-      "message": "You must be logged in as a Foundation with a valid Organization ID to view this page."
-    },
-    "emptyState": {
-      "title": "No Incoming Leads",
-      "message": "There are currently no new parent enquiries matching your daycare."
-    }
-  },
-  "foundationOrdersAppointmentsPage": {
-    "productOrdersTitle": "Product Orders",
-    "exportCsvProductAlert": "Product orders CSV export started",
-    "exportCsvButton": "Export CSV",
-    "noProductOrders": "No product orders found",
-    "table": {
-      "refNo": "Ref No",
-      "supplier": "Supplier",
-      "itemsQty": "Items/Qty",
-      "total": "Total",
-      "date": "Date",
-      "status": "Status",
-      "actions": "Actions",
-      "provider": "Provider",
-      "service": "Service"
-    },
-    "cancelOrderAlert": "Order cancelled successfully",
-    "serviceAppointmentsTitle": "Service Appointments",
-    "exportCsvServiceAlert": "Service appointments CSV export started",
-    "noServiceAppointments": "No service appointments found",
-    "unknownProvider": "Unknown Provider",
-    "preferredAbbr": "Pref.",
-    "notApplicable": "N/A",
-    "rescheduleAlert": "Appointment rescheduled successfully",
-    "rescheduleButton": "Reschedule",
-    "productOrdersTab": "Product Orders",
-    "serviceAppointmentsTab": "Service Appointments"
-  },
-  "supplierAnalyticsPage": {
-    "datePickerLabel": "Select Date Range",
-    "exportCsvAlert": "CSV export started",
-    "exportCsvButton": "Export CSV",
-    "mockChartText": "Mock chart visualization",
-    "orderRequestsPerWeek": "Order Requests Per Week",
-    "topViewedProducts": "Top Viewed Products",
-    "requestsByCanton": "Requests by Canton",
-    "promoCodePerformance": "Promo Code Performance",
-    "table": {
-      "code": "Code",
-      "uses": "Uses",
-      "estRevenueImpact": "Est. Revenue Impact"
-    }
-  },
-  "serviceProviderAnalyticsPage": {
-    "serviceRequestsPerWeek": "Service Requests Per Week",
-    "topViewedServices": "Top Viewed Services",
-    "requestsByCanton": "Requests by Canton"
-  },
-  "serviceProviderDashboard": {
-    "welcomeMessage": "Welcome to your service provider dashboard",
-    "widgets": {
-      "overview": {
-        "title": "Overview",
-        "activeRequests": "Active Requests",
-        "completedServices": "Completed Services",
-        "upcoming": "Upcoming",
-        "customerRating": "Customer Rating",
-        "button": "View All"
-      },
-      "management": {
-        "title": "Service Management",
-        "listings": "Service Listings",
-        "pending": "Pending Approvals",
-        "categories": "Categories",
-        "button": "Manage Services"
-      },
-      "appointments": {
-        "title": "Appointments",
-        "with": "with",
-        "button": "Schedule New"
-      }
-    }
-  },
-  "serviceProviderListingsPage": {
-    "card": {
-      "category": "Category",
-      "delivery": "Delivery"
-    },
-    "confirmDelete": "Are you sure you want to delete this service?",
-    "addNewServiceButton": "Add New Service",
-    "searchPlaceholder": "Search services...",
-    "emptyState": {
-      "title": "No Services Found",
-      "noMatch": "No services match your search criteria",
-      "noServicesYet": "You haven't created any services yet"
-    }
-  },
-  "serviceProviderRequestsPage": {
-    "filterByStatus": "Filter by Status",
-    "table": {
-      "requestId": "Request ID",
-      "foundation": "Foundation",
-      "service": "Service",
-      "date": "Date",
-      "status": "Status"
-    },
-    "emptyState": "No service requests found"
-  },
-  "serviceProviderSupportPage": {
-    "ticketSubmittedAlert": "Support ticket submitted successfully",
-    "ticketForm": {
-      "subjectPlaceholder": "Brief description of your issue",
-      "messagePlaceholder": "Please provide detailed information about your issue"
-    }
-  },
-  "supplierDashboard": {
-    "title": "Supplier Dashboard",
-    "welcomeMessage": "Welcome to your supplier dashboard",
-    "noSalesYet": "No sales data available yet",
-    "widgets": {
-      "sales": {
-        "title": "Sales Overview",
-        "totalOrders": "Total Orders",
-        "revenueMonth": "Revenue This Month",
-        "topSelling": "Top Selling",
-        "fulfillmentRate": "Fulfillment Rate",
-        "button": "View Analytics"
-      },
-      "products": {
-        "title": "Product Management",
-        "active": "Active Products",
-        "pending": "Pending Approval",
-        "lowStock": "Low Stock",
-        "button": "Manage Products"
-      },
-      "orders": {
-        "title": "Order Management",
-        "pending": "Pending Orders",
-        "toFulfill": "To Fulfill",
-        "button": "View Orders"
-      }
-    },
-    "recentOrdersTitle": "Recent Orders",
-    "noRecentOrders": "No recent orders",
-    "recentOrdersTable": {
-      "id": "Order ID",
-      "creche": "Crèche",
-      "date": "Date",
-      "total": "Total",
-      "status": "Status"
-    },
-    "recentOrdersActions": {
-      "decline": "Decline",
-      "accept": "Accept"
-    }
-  },
-  "supplierOrdersPage": {
-    "filterByStatus": "Filter by Status",
-    "table": {
-      "orderId": "Order ID",
-      "date": "Date",
-      "total": "Total",
-      "status": "Status",
-      "foundation": "Foundation"
-    },
-    "actions": {
-      "ship": "Ship"
-    },
-    "emptyState": "No orders found"
-  },
-  "supplierProductListingsPage": {
-    "addProductAlert": "Product added successfully",
-    "addProductButton": "Add New Product",
-    "searchPlaceholder": "Search products...",
-    "table": {
-      "product": "Product",
-      "price": "Price",
-      "stock": "Stock",
-      "visibility": "Visibility",
-      "actions": "Actions"
-    },
-    "emptyState": "No products found"
-  },
-  "supplierSupportPage": {
-    "ticketSubmittedAlert": "Support ticket submitted successfully",
-    "ticketForm": {
-      "subjectPlaceholder": "Brief description of your issue",
-      "messagePlaceholder": "Please provide detailed information about your issue"
-    }
-  },
-  "foundationOrganisationProfilePage": {
-    "mock": {
-      "pedagogyStatement": "Our pedagogy is based on the principles of respect, creativity, and individual development. We believe in providing a nurturing environment where children can explore, learn, and grow at their own pace."
-    },
-    "alert": {
-      "infoSaved": "Profile information saved successfully"
-    },
-    "sections": {
-      "branding": {
-        "title": "Branding & Identity",
-        "logoLabel": "Logo",
-        "coverImageLabel": "Cover Image",
-        "pedagogyStatementLabel": "Pedagogy Statement",
-        "pedagogyStatementPlaceholder": "Describe your educational approach and philosophy..."
-      },
-      "operations": {
-        "title": "Operations",
-        "openingHoursLabel": "Opening Hours",
-        "openingHoursPlaceholder": "e.g., Monday-Friday 7:00-18:00",
-        "contactInfoLabel": "Contact Information",
-        "contactInfoPlaceholder": "Phone, email, address..."
-      },
-      "online": {
-        "title": "Online Presence",
-        "bookingLinkLabel": "Booking Link",
-        "bookingLinkPlaceholder": "https://your-booking-system.com",
-        "socialMediaLinkLabel": "Social Media Links",
-        "socialMediaLinkPlaceholder": "Facebook, Instagram, LinkedIn...",
-        "acceptingLeadsLabel": "Accepting New Leads"
-      }
-    },
-    "saveButton": "Save Profile"
-  },
-  "foundationSupportPage": {
-    "ticketSubmittedAlert": "Support ticket submitted successfully",
-    "ticketForm": {
-      "subjectPlaceholder": "Brief description of your issue",
-      "messagePlaceholder": "Please provide detailed information about your issue"
-    }
-  },
-  "parentDashboard": {
-    "title": "Parent Dashboard",
-    "welcomeMessage": "Welcome to your parent dashboard",
-    "enquiry": {
-      "sent": "Enquiries Sent",
-      "responses": "Responses Received",
-      "pending": "Pending Responses",
-      "button": "Send New Enquiry"
-    },
-    "childProfile": {
-      "name": "Child's Name",
-      "age": "Age",
-      "location": "Location",
-      "languages": "Languages",
-      "specialNeeds": "Special Needs",
-      "button": "Update Profile"
-    },
-    "favorites": {
-      "subtitle": "Your favorite crèches and services",
-      "button": "View Favorites"
-    }
-  },
-  "parentSupportPage": {
-    "faq": {
-      "matchingProcess": {
-        "q": "How does the matching process work?",
-        "a": "Our algorithm matches your child's needs with available crèches based on location, age, special requirements, and availability."
-      },
-      "responseTime": {
-        "q": "How quickly will I receive responses?",
-        "a": "Most crèches respond within 24-48 hours. You'll be notified immediately when responses arrive."
-      },
-      "dataSecurity": {
-        "q": "Is my personal information secure?",
-        "a": "Yes, we use enterprise-grade encryption and comply with Swiss data protection laws. Your information is never shared without consent."
-      }
-    }
-  },
-  "partnerDetailPage": {
-    "productOutOfStock": "Product is currently out of stock",
-    "productAddedToOrder": "Product added to order successfully",
-    "addToOrderButton": "Add to Order",
-    "loadingPartnerDetails": "Loading partner details...",
-    "invalidPartnerIdMessage": "Could not find a user associated with this organization to message.",
-    "contactInfoTitle": "Contact Information",
-    "directOrderButton": "Direct Order",
-    "aboutTitle": "About",
-    "ratingsReviewsTitle": "Ratings & Reviews",
-    "ratingText": "Rating",
-    "reviewsPlaceholder": "No reviews yet",
-    "noProductsListed": "No products listed",
-    "requestServiceButton": "Request Service",
-    "noServicesListed": "No services listed",
-    "promoCodeTitle": "Promo Code",
-    "promoCodePlaceholder": "Enter promo code",
-    "applyPromoButton": "Apply",
-    "onlyFoundationsRequestService": "Only foundations can request services",
-    "requestSubmittedAlert": "Service request submitted successfully"
   },
   "userRoles": {
     "Product Supplier": "Product Supplier",
@@ -2045,9 +1683,6 @@
   },
   "addPromoCodeModal": {
     "placeholder": "Add/Edit Promo Code Modal (Placeholder)"
-  },
-  "orderRequestDetailModal": {
-    "markAsProcessing": "Mark as Processing"
   },
   "fileUploadZone": {
     "dragAndDrop": "or drag and drop"
@@ -2064,149 +1699,5 @@
   },
   "notificationContext": {
     "useNotificationsError": "useNotifications must be used within a NotificationProvider"
-  },
-  "loading": {
-    "translations": "Loading translations..."
-  },
-  "dashboardDetailPage": {
-    "activeUsers": {
-      "recentActivity": "Recent Activity",
-      "totalToday": "Total active users today: {{count}}",
-      "aliceActivity": "Alice Johnson - Logged in 2 hours ago, viewed 5 pages.",
-      "bobActivity": "Bob Williams - Updated profile at 10:30 AM.",
-      "carolActivity": "Carol Davis - Joined yesterday, completed onboarding.",
-      "davidActivity": "David Brown - Viewed marketplace listings."
-    },
-    "newOrders": {
-      "recentOrders": "Recent Orders",
-      "table": {
-        "orderId": "Order ID",
-        "product": "Product",
-        "amount": "Amount",
-        "status": "Status"
-      },
-      "status": {
-        "paid": "Paid",
-        "pending": "Pending"
-      },
-      "totalThisWeek": "Total orders this week: {{count}}",
-      "order789": "#ORD789",
-      "order790": "#ORD790", 
-      "order791": "#ORD791",
-      "ecotoysBlocks": "EcoToys Wooden Blocks",
-      "freshBitesMeal": "FreshBites Meal Plan",
-      "artFunPack": "ArtFun Creative Pack"
-    },
-    "openJobs": {
-      "currentPositions": "Current Open Positions",
-      "applications": "Applications",
-      "totalOpenPositions": "Total Open Positions",
-      "leadEducatorGeneva": "Lead Educator - Geneva",
-      "assistantEducatorLausanne": "Assistant Educator - Lausanne",
-      "daycareDirectorZurich": "Daycare Director - Zurich",
-      "status": {
-        "open": "Open",
-        "interviewing": "Interviewing"
-      }
-    },
-    "pageViews": {
-      "keyMetrics": "Key Metrics",
-      "totalToday": "Total page views today",
-      "uniqueVisitors": "Unique visitors",
-      "mostViewed": "Most viewed pages",
-      "dashboardViews": "/dashboard (560 views)",
-      "avgSession": "Average session duration",
-      "sessionDuration": "4m 15s",
-      "mockChartText": "Mock chart visualization"
-    },
-    "defaultTitle": "Dashboard Detail",
-    "detailsFor": "Details for",
-    "noSpecificView": "No specific view selected"
-  },
-  "designSystemPage": {
-    "title": "Design System",
-    "description": "A living reference for all UI components and design tokens in the Pro Crèche Solutions application.",
-    "tabs": {
-      "tab1": "Tab 1",
-      "tab2": "Tab 2",
-      "tab3": "Tab 3",
-      "content1": "This is the content for Tab 1.",
-      "content2": "This is the content for Tab 2.",
-      "content3": "This is a disabled tab."
-    },
-    "typography": {
-      "fontFamily": "Font Family: Nunito, Inter, sans-serif",
-      "heading1": "Heading 1: The quick brown fox",
-      "heading2": "Heading 2: The quick brown fox",
-      "heading3": "Heading 3: The quick brown fox",
-      "heading4": "Heading 4: The quick brown fox",
-      "bodyBase": "Body Text (Base): Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.",
-      "bodySmall": "Body Text (Small): Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi.",
-      "link": "This is a link"
-    },
-    "buttons": {
-      "extraSmall": "Extra Small",
-      "small": "Small",
-      "mediumDefault": "Medium (Default)",
-      "large": "Large",
-      "withIcons": "With Icons",
-      "leftIcon": "Left Icon",
-      "rightIcon": "Right Icon",
-      "smallIcon": "Small Icon",
-      "disabledState": "Disabled State",
-      "primaryDisabled": "Primary Disabled",
-      "secondaryDisabled": "Secondary Disabled",
-      "outlineDisabled": "Outline Disabled"
-    },
-    "cards": {
-      "standardCard": "Standard Card",
-      "standardCardDesc": "This is a standard card component with a soft shadow. It's the base for most content containers.",
-      "hoverEffectCard": "Hover Effect Card",
-      "hoverEffectCardDesc": "This card has a subtle scale and shadow transition on hover, useful for interactive elements."
-    },
-    "formControls": {
-      "title": "Form Controls",
-      "textInput": "Text Input",
-      "selectMenu": "Select Menu",
-      "option1": "Option 1",
-      "option2": "Option 2",
-      "option3": "Option 3",
-      "quantityInput": "Quantity Input",
-      "disabledInput": "Disabled Input"
-    },
-    "tabs": {
-      "title": "Tabs",
-      "pillsVariant": "Pills Variant (Default)",
-      "lineVariant": "Line Variant",
-      "tab1": "Tab 1",
-      "content1": "This is the content for Tab 1.",
-      "tab2": "Tab 2",
-      "content2": "This is the content for Tab 2.",
-      "tab3": "Tab 3",
-      "content3": "This is a disabled tab."
-    },
-  "View Favorites TBD": "View Favorites TBD",
-  "Could not find a user associated with this organization to message.": "Could not find a user associated with this organization to message.",
-  "User organization details are missing.": "User organization details are missing.",
-  "tailwindcss": "tailwindcss",
-  "sidebar.parentLeads": "Parent Leads",
-  "sidebar.products": "Products",
-  "sidebar.services": "Services",
-  "No recent activity.": "No recent activity.",
-  "loaded": "loaded",
-  "SUPER_ADMIN": "SUPER_ADMIN",
-  "Show": "Show",
-  "Refresh": "Refresh",
-  "keys)": "keys)",
-  "(240)": "(240)",
-  "Branding": "Branding",
-  "Favicon": "Favicon",
-  "Search job offers...": "Search job offers...",
-  "Search partners...": "Search partners...",
-  "Search candidates...": "Search candidates...",
-  "Search content...": "Search content...",
-  "admin@procrechesolutions.com": "admin@procrechesolutions.com",
-  "No documents found in this category for current filters.": "No documents found in this category for current filters.",
-  "No custom alerts created yet.": "No custom alerts created yet."
   }
 }

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -1,5 +1,5 @@
 {
-  "appName": "ProCrèche Solutions Suisse",
+  "appName": "Pro Crèche Solutions",
   "languageSwitcher": {
     "enShort": "EN",
     "enLong": "English",
@@ -7,128 +7,96 @@
     "frLong": "Français",
     "deShort": "DE",
     "deLong": "Deutsch",
-    "selectLanguage": "Select Language"
+    "selectLanguage": "Choisir la langue"
   },
-  "loading": "Loading...",
+  "loading": {
+    "translations": "Chargement des traductions..."
+  },
   "buttons": {
-    "save": "Save",
-    "saveChanges": "Save Changes",
-    "cancel": "Cancel",
-    "submit": "Submit",
-    "add": "Add",
-    "edit": "Edit",
-    "delete": "Delete",
-    "viewDetails": "View Details",
-    "goBack": "Go Back",
-    "login": "Log In",
-    "signup": "Sign Up",
-    "applyNow": "Apply Now",
-    "confirmApply": "Confirm Application",
-    "sendMessage": "Send Message",
-    "inviteToApply": "Invite to Apply",
-    "inviteToInterview": "Invite to Interview",
-    "addToFavorites": "Add to Favorites",
-    "favorited": "Favorited",
-    "submitEnquiry": "Submit Enquiry",
-    "viewMyEnquiries": "View My Enquiries",
-    "submitTicket": "Submit Ticket",
-    "goToLogin": "Go to Login",
-    "close": "Close",
-    "view": "View",
-    "resetFilters": "Reset Filters",
-    "applyFilters": "Apply Filters",
-    "submitRequest": "Submit Request",
-    "remove": "Remove",
-    "dismiss": "Dismiss"
+    "save": "Enregistrer",
+    "saveChanges": "Enregistrer les modifications",
+    "cancel": "Annuler",
+    "submit": "Envoyer",
+    "add": "Ajouter",
+    "edit": "Modifier",
+    "delete": "Supprimer",
+    "viewDetails": "Voir les détails",
+    "goBack": "Retour",
+    "login": "Connexion",
+    "signup": "S'inscrire",
+    "applyNow": "Postuler maintenant",
+    "confirmApply": "Confirmer la candidature",
+    "sendMessage": "Envoyer un message",
+    "inviteToApply": "Inviter à postuler",
+    "inviteToInterview": "Inviter à un entretien",
+    "addToFavorites": "Ajouter aux favoris",
+    "favorited": "Favori",
+    "submitEnquiry": "Soumettre la demande",
+    "viewMyEnquiries": "Voir mes demandes",
+    "submitTicket": "Envoyer le ticket",
+    "goToLogin": "Aller à la page de connexion",
+    "close": "Fermer",
+    "view": "Voir",
+    "resetFilters": "Réinitialiser les filtres",
+    "applyFilters": "Appliquer les filtres",
+    "submitRequest": "Envoyer la demande",
+    "remove": "Retirer",
+    "dismiss": "Rejeter"
   },
   "navbar": {
-    "toggleNavigation": "Toggle Navigation",
-    "goBackPreviousPage": "Go Back to Previous Page",
-    "searchPlaceholder": "Search...",
-    "viewShoppingCart": "View Shopping Cart",
-    "notifications": "Notifications",
-    "newMessages": "New Messages",
-    "noNewNotifications": "No New Notifications",
-    "viewAll": "View All",
-    "userMenu": "User Menu",
-    "signOut": "Sign Out"
+    "notificationsCount": "Notifications : {{count}}",
+    "unreadMessages": "Messages non lus : {{count}}",
+    "searchPlaceholder": "Rechercher sur la plateforme..."
   },
   "sidebar": {
-    "dashboard": "Dashboard",
-    "settings": "Settings",
-    "currentPlan": "Current Plan",
-    "manageSubscriptionDesc": "Manage your current plan and billing",
-    "fileGallery": "File Gallery",
+    "billingSubscription": "Facturation et abonnement",
+    "dashboard": "Tableau de bord",
+    "marketplace": "Place de marché",
+    "products": "Produits",
+    "services": "Services",
+    "recruitment": "Recrutement",
+    "jobListings": "Offres d'emploi",
+    "candidatePool": "Réserve de candidats",
+    "eLearning": "Formation en ligne",
     "messages": "Messages",
-    "discountTerminations": "Discount Terminations",
-    "jobBoard": "Job Board",
-    "analytics": "Analytics",
-    "leads": "Leads",
-    "ordersAppointments": "Orders & Appointments",
-    "organisationProfile": "Organisation Profile",
-    "support": "Support",
-    "myProfile": "My Profile",
-    "applications": "Applications",
-    "homeFindCreche": "Home / Find a Crèche",
-    "myRequests": "My Requests",
-    "supportFAQ": "Support / FAQ",
-    "users": "Users",
-    "allUsers": "All Users",
+    "users": "Utilisateurs",
+    "allUsers": "Tous les utilisateurs",
     "admins": "Admins",
-    "foundations": "Foundations",
-    "productSuppliers": "Product Suppliers",
-    "serviceProviders": "Service Providers",
+    "foundations": "Fondations",
+    "productSuppliers": "Fournisseurs",
+    "serviceProviders": "Prestataires",
     "parents": "Parents",
-    "content": "Content",
-    "partners": "Partners",
-    "managePlan": "Manage Plan",
-    "premiumPlan": "Premium Plan",
-    "premiumPlanDesc": "Access to all features",
-    "systemMonitoring": "System Monitoring",
-    "platformSettings": "Platform Settings",
-    "designSystem": "Design System",
-    "parentLeads": "Parent Leads",
-    "products": "Products",
-    "services": "Services"
+    "content": "Contenu",
+    "hrProcedures": "Procédures RH",
+    "statePolicies": "Directives cantonales",
+    "discountTerminations": "Résiliations de Rabais",
+    "systemMonitoring": "Surveillance Système",
+    "partners": "Partenaires",
+    "platformSettings": "Paramètres Plateforme",
+    "designSystem": "Système de Design",
+    "settings": "Paramètres"
   },
   "stockStatus": {
-    "instock": "In Stock",
-    "outofstock": "Out of Stock",
-    "lowstock": "Low Stock",
-    "discontinued": "Discontinued"
+    "instock": "En Stock",
+    "outofstock": "Rupture de Stock",
+    "lowstock": "Stock Faible",
+    "discontinued": "Discontinué"
   },
   "common": {
-    "welcome": "Welcome",
-    "loading": "Loading...",
-    "error": "An error occurred",
-    "submit": "Submit",
-    "next": "Next",
-    "back": "Back",
-    "search": "Search",
-    "filter": "Filter",
-    "apply": "Apply",
-    "reset": "Reset",
-    "confirm": "Confirm",
-    "close": "Close",
-    "view": "View",
-    "download": "Download",
-    "upload": "Upload",
-    "continue": "Continue",
-    "send": "Send",
-    "create": "Create",
-    "update": "Update",
-    "register": "Register",
-    "toggleNavigation": "Toggle navigation"
+    "perMonth": "/mois",
+    "perYear": "/année",
+    "save10Percent": "économiser 10%"
   },
   "errors": {
-    "unknown": "An unknown error occurred"
+    "unknown": "Une erreur inconnue est survenue."
   },
   "notifications": {
-    "successTitle": "Success",
-    "settingsUpdated": "Settings updated successfully"
+    "errorTitle": "Erreur",
+    "successTitle": "Succès",
+    "newMessageFrom": "Nouveau message de {{sender}}"
   },
-  "hidePassword": "Hide password",
-  "showPassword": "Show password",
+  "hidePassword": "Masquer le mot de passe",
+  "showPassword": "Afficher le mot de passe",
   "signIn": "Sign In",
   "signOut": "Sign Out",
   "confirmPassword": "Confirm Password",
@@ -154,25 +122,25 @@
   "preferredLocation": "Preferred Location",
   "loginPage": {
     "title": "Welcome to {{appName}}",
-    "subtitle": "Sign in to your account",
-    "emailLabel": "Email Address",
-    "emailPlaceholder": "Enter your email",
-    "passwordLabel": "Password",
-    "passwordPlaceholder": "Enter your password",
-    "forgotPassword": "Forgot your password?",
-    "forgotPasswordTBD": "Forgot password functionality coming soon",
-    "orContinueWith": "Or continue with",
+    "subtitle": "Accédez à votre tableau de bord",
+    "emailLabel": "Adresse e-mail",
+    "emailPlaceholder": "vous@exemple.com",
+    "passwordLabel": "Mot de passe",
+    "passwordPlaceholder": "••••••••",
+    "forgotPassword": "Mot de passe oublié ?",
+    "forgotPasswordTBD": "La fonctionnalité 'Mot de passe oublié' n'est pas encore implémentée.",
+    "orContinueWith": "Ou continuer avec",
     "google": "Google",
     "facebook": "Facebook",
-    "noAccount": "Don't have an account?",
-    "viewPlansPrompt": "Want to see our plans?",
-    "viewPlans": "View Plans",
-    "parentLookingForCreche": "Parent looking for a crèche?",
-    "findCrecheHere": "Find your perfect crèche here",
+    "noAccount": "Pas encore de compte ?",
+    "viewPlansPrompt": "Intéressé(e) par nos fonctionnalités ?",
+    "viewPlans": "Voir les abonnements",
+    "parentLookingForCreche": "Vous êtes un parent cherchant une crèche ?",
+    "findCrecheHere": "Trouvez une crèche ici",
     "socialLoginTBD": "{{provider}} login coming soon!",
-    "alreadyAccount": "Already have an account?",
-    "errorBothFields": "Please fill in both email and password",
-    "loggingIn": "Logging in..."
+    "alreadyAccount": "Vous avez déjà un compte ?",
+    "errorBothFields": "Veuillez saisir l'e-mail et le mot de passe.",
+    "loggingIn": "Connexion en cours..."
   },
   "signupPage": {
     "form": {
@@ -268,27 +236,27 @@
   },
   "dashboardPage": {
     "welcome": "Welcome back, {{name}}!",
-    "defaultUser": "User",
+    "defaultUser": "Utilisateur",
     "overviewSubtitle": "Here's what's happening with {{appName}} today",
-    "activeUsers": "Active Users",
-    "newOrders": "New Orders",
-    "openJobs": "Open Jobs",
-    "pageViews": "Page Views",
-    "recentActivity": "Recent Activity",
-    "quickLinks": "Quick Links",
-    "browseMarketplace": "Browse Marketplace",
-    "postNewJob": "Post New Job",
-    "manageUsers": "Manage Users",
-    "platformSettings": "Platform Settings",
-    "activityLina": "Lina uploaded a new policy document",
-    "activityEcoToys": "EcoToys submitted a new product",
-    "activityJohn": "John applied for the educator position",
-    "activityParent": "A parent submitted a new enquiry",
-    "viewDetailsFor": "View details for",
+    "activeUsers": "Utilisateurs Actifs",
+    "newOrders": "Nouvelles Commandes",
+    "openJobs": "Postes Ouverts",
+    "pageViews": "Vues de Page",
+    "recentActivity": "Activité Récente",
+    "quickLinks": "Liens Rapides",
+    "browseMarketplace": "Parcourir le Marché",
+    "postNewJob": "Publier une Offre",
+    "manageUsers": "Gérer les Utilisateurs",
+    "platformSettings": "Paramètres Plateforme",
+    "activityLina": "Lina Meier a publié une nouvelle offre \"Infirmière Pédiatrique\"",
+    "activityEcoToys": "EcoToys GmbH a mis à jour le produit \"Blocs en Bois\"",
+    "activityJohn": "John Smith a approuvé 3 nouveaux comptes parents",
+    "activityParent": "Parent Exemple a soumis une demande pour \"Crèche Les Petits Choux\"",
+    "viewDetailsFor": "Voir les détails pour {{name}}",
     "timeAgo": {
       "minutes": "{{count}} minutes ago",
       "hours": "{{count}} hours ago",
-      "yesterday": "Yesterday"
+      "yesterday": "Hier"
     },
     "upcomingMeetings": "Upcoming Meetings",
     "quickActions": "Quick Actions",
@@ -297,93 +265,80 @@
     "notifications": "Notifications"
   },
   "settingsPage": {
-    "sections": {
-      "accountSecurity": "Account Security",
-      "analyticsPreferences": "Analytics Preferences",
-      "billingSubscription": "Billing & Subscription",
-      "companyProfile": "Company Profile",
-      "contactBooking": "Contact & Booking",
-      "defaults": "Defaults",
-      "notificationPreferences": "Notification Preferences",
-      "privacyData": "Privacy & Data",
-      "promoCodeManager": "Promo Code Manager",
-      "teamPermissions": "Team Permissions"
-    },
-    "forms": {
-      "save": "Save Changes",
-      "cancel": "Cancel",
-      "reset": "Reset"
-    },
-    "validation": {
-      "required": "This field is required",
-      "invalidEmail": "Please enter a valid email address",
-      "passwordTooShort": "Password must be at least 8 characters",
-      "passwordsDoNotMatch": "Passwords do not match"
-    },
-    "success": {
-      "saved": "Settings saved successfully",
-      "updated": "Settings updated successfully"
-    },
-    "error": {
-      "saveFailed": "Failed to save settings",
-      "loadFailed": "Failed to load settings"
-    }
+    "billingSubscription": "Billing & Subscription",
+    "title": "Settings",
+    "accountSecurity": "Account & Security"
   },
   "marketplacePage": {
-    "title": "Marketplace",
+    "emptyStates": {
+      "noServices": "No services available",
+      "noProductSuppliers": "No product suppliers available"
+    },
+    "subtitles": {
+      "productSuppliers": "Product Suppliers",
+      "serviceProviders": "Service Providers"
+    },
     "tabs": {
       "productSuppliers": "Product Suppliers",
       "serviceProviders": "Service Providers"
     },
-    "serviceCard": {
-      "categoryLabel": "Category: {{category}}",
-      "bookAppointment": "Book Appointment",
-      "viewProvider": "View Provider"
+    "buttons": {
+      "partnerOnboarding": "Partner Onboarding"
     },
-    "emptyStates": {
-      "noProductSuppliers": "No product suppliers available",
-      "noServiceProviders": "No service providers available"
+    "infoAlert": "Partner Onboarding TBD",
+    "searchPlaceholder": "Search partners...",
+    "labels": {
+      "category": "Category",
+      "region": "Region",
+      "supplierTags": "Supplier Tags",
+      "sortBy": "Sort by"
+    },
+    "sortOptions": {
+      "nameAsc": "Name (A-Z)",
+      "nameDesc": "Name (Z-A)",
+      "ratingDesc": "Rating (High to Low)"
+    },
+    "ariaLabels": {
+      "gridView": "Switch to grid view",
+      "listView": "Switch to list view"
     }
   },
   "partnerDetailPage": {
-    "title": "Partner Details",
-    "contact": "Contact Partner",
-    "services": "Services"
+    "productOutOfStock": "Product is currently out of stock",
+    "productAddedToOrder": "Product added to order successfully",
+    "addToOrderButton": "Add to Order",
+    "loadingPartnerDetails": "Loading partner details...",
+    "invalidPartnerIdMessage": "Could not find a user associated with this organization to message.",
+    "contactInfoTitle": "Contact Information",
+    "directOrderButton": "Direct Order",
+    "aboutTitle": "About",
+    "ratingsReviewsTitle": "Ratings & Reviews",
+    "ratingText": "Rating",
+    "reviewsPlaceholder": "No reviews yet",
+    "noProductsListed": "No products listed",
+    "requestServiceButton": "Request Service",
+    "noServicesListed": "No services listed",
+    "promoCodeTitle": "Promo Code",
+    "promoCodePlaceholder": "Enter promo code",
+    "applyPromoButton": "Apply",
+    "onlyFoundationsRequestService": "Only foundations can request services",
+    "requestSubmittedAlert": "Service request submitted successfully"
   },
   "adminPlatformSettings": {
-    "title": "Platform Settings",
+    "title": "Paramètres de la Plateforme",
     "general": {
-      "title": "General Settings",
-      "nameLabel": "Platform Name",
-      "descriptionLabel": "Platform Description"
+      "title": "Informations Générales",
+      "nameLabel": "Nom de la Plateforme",
+      "descriptionLabel": "Description (Métadonnées)"
     },
     "branding": {
-      "title": "Branding",
-      "logoLabel": "Platform Logo",
-      "faviconLabel": "Favicon"
+      "title": "Image de Marque",
+      "logoLabel": "Logo de la Plateforme",
+      "faviconLabel": "Favicon de la Plateforme"
     }
   },
   "organizationProfileForm": {
-    "title": "Organization Profile",
-    "form": {
-      "name": "Organization Name",
-      "description": "Description",
-      "website": "Website",
-      "phone": "Phone",
-      "email": "Email",
-      "address": "Address"
-    },
-    "validation": {
-      "nameRequired": "Organization name is required",
-      "emailRequired": "Email is required",
-      "invalidEmail": "Please enter a valid email address"
-    },
-    "success": {
-      "saved": "Organization profile saved successfully"
-    },
-    "error": {
-      "saveFailed": "Failed to save organization profile"
-    }
+    "saveSuccess": "Organization profile saved successfully"
   },
   "foundationDashboardPage": {
     "title": "Foundation Dashboard",
@@ -393,30 +348,90 @@
     "quickActions": "Quick Actions"
   },
   "foundationAnalyticsPage": {
-    "title": "Analytics",
-    "overview": "Overview",
-    "reports": "Reports"
+    "mockDataVisualization": "Mock Data Visualization",
+    "spendingByCategory": "Spending by Category",
+    "parentLeadConversion": "Parent Lead Conversion",
+    "staffTrainingCompletion": "Staff Training Completion",
+    "enrollmentTrend": "Enrollment Trend"
   },
   "foundationLeadsPage": {
-    "title": "Parent Leads",
-    "leads": "All Leads",
-    "newLeads": "New Leads",
-    "contactedLeads": "Contacted Leads"
+    "title": "Incoming Parent Leads",
+    "accessDenied": {
+      "title": "Access Denied",
+      "message": "You must be logged in as a Foundation with a valid Organization ID to view this page."
+    },
+    "emptyState": {
+      "title": "No Incoming Leads",
+      "message": "There are currently no new parent enquiries matching your daycare."
+    }
   },
   "foundationOrdersAppointmentsPage": {
-    "title": "Orders & Appointments",
-    "orders": "Orders",
-    "appointments": "Appointments"
+    "productOrdersTitle": "Product Orders",
+    "exportCsvProductAlert": "Product orders CSV export started",
+    "exportCsvButton": "Export CSV",
+    "noProductOrders": "No product orders found",
+    "table": {
+      "refNo": "Ref No",
+      "supplier": "Supplier",
+      "itemsQty": "Items/Qty",
+      "total": "Total",
+      "date": "Date",
+      "status": "Status",
+      "actions": "Actions",
+      "provider": "Provider",
+      "service": "Service"
+    },
+    "cancelOrderAlert": "Order cancelled successfully",
+    "serviceAppointmentsTitle": "Service Appointments",
+    "exportCsvServiceAlert": "Service appointments CSV export started",
+    "noServiceAppointments": "No service appointments found",
+    "unknownProvider": "Unknown Provider",
+    "preferredAbbr": "Pref.",
+    "notApplicable": "N/A",
+    "rescheduleAlert": "Appointment rescheduled successfully",
+    "rescheduleButton": "Reschedule",
+    "productOrdersTab": "Product Orders",
+    "serviceAppointmentsTab": "Service Appointments"
   },
   "foundationOrganisationProfilePage": {
-    "title": "Organization Profile",
-    "profile": "Profile Information",
-    "settings": "Settings"
+    "mock": {
+      "pedagogyStatement": "Our pedagogy is based on the principles of respect, creativity, and individual development. We believe in providing a nurturing environment where children can explore, learn, and grow at their own pace."
+    },
+    "alert": {
+      "infoSaved": "Informations de profil supplémentaires enregistrées!"
+    },
+    "sections": {
+      "branding": {
+        "title": "Image de Marque & Présentation",
+        "logoLabel": "Logo",
+        "coverImageLabel": "Image de Couverture",
+        "pedagogyStatementLabel": "Déclaration Pédagogique",
+        "pedagogyStatementPlaceholder": "Décrivez votre philosophie éducative..."
+      },
+      "operations": {
+        "title": "Détails Opérationnels",
+        "openingHoursLabel": "Heures d'Ouverture",
+        "openingHoursPlaceholder": "ex: Lun-Ven: 07:30 - 18:30",
+        "contactInfoLabel": "Infos de Contact Publiques",
+        "contactInfoPlaceholder": "Téléphone ou email public pour les parents"
+      },
+      "online": {
+        "title": "Présence en Ligne & Demandes",
+        "bookingLinkLabel": "Lien de Réservation de Visite en Ligne",
+        "bookingLinkPlaceholder": "ex: https://cal.com/votre-creche",
+        "socialMediaLinkLabel": "Lien Média Social",
+        "socialMediaLinkPlaceholder": "ex: https://facebook.com/votre-creche",
+        "acceptingLeadsLabel": "Accepte actuellement les nouvelles demandes de parents"
+      }
+    },
+    "saveButton": "Enregistrer les Infos Supplémentaires"
   },
   "foundationSupportPage": {
-    "title": "Support",
-    "help": "Help Center",
-    "tickets": "Support Tickets"
+    "ticketSubmittedAlert": "Support ticket submitted successfully",
+    "ticketForm": {
+      "subjectPlaceholder": "Brief description of your issue",
+      "messagePlaceholder": "Please provide detailed information about your issue"
+    }
   },
   "parentDashboardPage": {
     "title": "Parent Dashboard",
@@ -425,14 +440,43 @@
     "findCreche": "Find a Crèche"
   },
   "parentEnquiriesPage": {
-    "title": "My Enquiries",
-    "enquiries": "All Enquiries",
-    "newEnquiry": "New Enquiry"
+    "accessDenied": {
+      "title": "Access Denied",
+      "message": "You need to be logged in as a parent to view enquiries"
+    },
+    "emptyState": {
+      "title": "No enquiries yet",
+      "message": {
+        "0": "You haven't submitted any enquiries yet.",
+        "1": "Start by filling out the enquiry form to find suitable childcare options."
+      }
+    },
+    "card": {
+      "title": "Enquiry Details",
+      "submitted": "Submitted on {{date}}",
+      "childInfo": "Child Information",
+      "notes": "Additional Notes",
+      "responsesTitle": "Responses",
+      "awaitingMatch": "Awaiting Match",
+      "message": "Your enquiry has been sent to relevant providers",
+      "waitingForMoreResponses": "Waiting for more responses..."
+    }
   },
   "parentSupportPage": {
-    "title": "Support",
-    "help": "Help Center",
-    "faq": "Frequently Asked Questions"
+    "faq": {
+      "matchingProcess": {
+        "q": "How does the matching process work?",
+        "a": "Our algorithm matches your child's needs with available crèches based on location, age, special requirements, and availability."
+      },
+      "responseTime": {
+        "q": "How quickly will I receive responses?",
+        "a": "Most crèches respond within 24-48 hours. You'll be notified immediately when responses arrive."
+      },
+      "dataSecurity": {
+        "q": "Is my personal information secure?",
+        "a": "Yes, we use enterprise-grade encryption and comply with Swiss data protection laws. Your information is never shared without consent."
+      }
+    }
   },
   "educatorDashboardPage": {
     "title": "Educator Dashboard",
@@ -441,44 +485,51 @@
     "jobBoard": "Job Board"
   },
   "educatorApplicationsPage": {
-    "title": "My Applications",
-    "applications": "All Applications",
-    "status": "Application Status"
+    "status": {
+      "new": "New",
+      "viewed": "Viewed",
+      "interview": "Interview",
+      "offer": "Offer",
+      "declined": "Declined"
+    },
+    "table": {
+      "jobTitle": "Job Title",
+      "creche": "Crèche",
+      "status": "Status",
+      "lastUpdated": "Last Updated",
+      "actions": "Actions"
+    },
+    "viewingDetailsFor": "Viewing details for",
+    "emptyState": "No applications found",
+    "footerNote": "Applications are updated in real-time"
   },
   "educatorJobBoardPage": {
-    "title": "Job Board",
-    "jobs": "Available Jobs",
-    "apply": "Apply Now"
+    "postedOn": "Posted on",
+    "searchPlaceholder": "Search jobs...",
+    "noJobsFound": "No jobs found"
   },
   "educatorProfilePage": {
-    "skills": {
-      "title": "Skills",
-      "add": "Add Skill"
-    },
+    "editProfile": "Edit Profile",
     "availability": {
-      "title": "Availability",
-      "schedule": "Schedule"
-    },
-    "documents": {
-      "title": "Documents",
-      "upload": "Upload Document"
-    },
-    "experience": {
-      "title": "Experience",
-      "add": "Add Experience"
+      "days": "Days",
+      "times": "Times",
+      "contract": "Contract",
+      "ageGroups": "Age Groups"
     },
     "education": {
-      "title": "Education",
-      "add": "Add Education"
+      "graduated": "Graduated"
     },
     "certifications": {
-      "title": "Certifications",
-      "add": "Add Certification"
+      "issued": "Issued",
+      "expires": "Expires"
     }
   },
   "educatorSupportPage": {
-    "title": "Support",
-    "help": "Help Center"
+    "ticketSubmittedAlert": "Support ticket submitted successfully",
+    "ticketForm": {
+      "subjectPlaceholder": "Brief description of your issue",
+      "messagePlaceholder": "Please provide detailed information about your issue"
+    }
   },
   "serviceProviderDashboardPage": {
     "title": "Service Provider Dashboard",
@@ -487,23 +538,41 @@
     "requests": "Service Requests"
   },
   "serviceProviderAnalyticsPage": {
-    "title": "Analytics",
-    "overview": "Analytics Overview",
-    "performance": "Performance Metrics"
+    "serviceRequestsPerWeek": "Service Requests Per Week",
+    "topViewedServices": "Top Viewed Services",
+    "requestsByCanton": "Requests by Canton"
   },
   "serviceProviderListingsPage": {
-    "title": "Service Listings",
-    "listings": "All Listings",
-    "addService": "Add New Service"
+    "card": {
+      "category": "Category",
+      "delivery": "Delivery"
+    },
+    "confirmDelete": "Are you sure you want to delete this service?",
+    "addNewServiceButton": "Add New Service",
+    "searchPlaceholder": "Search services...",
+    "emptyState": {
+      "title": "No Services Found",
+      "noMatch": "No services match your search criteria",
+      "noServicesYet": "You haven't created any services yet"
+    }
   },
   "serviceProviderRequestsPage": {
-    "title": "Service Requests",
-    "requests": "All Requests",
-    "pending": "Pending Requests"
+    "filterByStatus": "Filtrer par statut :",
+    "table": {
+      "requestId": "ID Demande",
+      "foundation": "Fondation",
+      "service": "Service",
+      "date": "Date",
+      "status": "Statut"
+    },
+    "emptyState": "Aucune demande de service trouvée pour le filtre sélectionné."
   },
   "serviceProviderSupportPage": {
-    "title": "Support",
-    "help": "Help Center"
+    "ticketSubmittedAlert": "Support ticket submitted successfully",
+    "ticketForm": {
+      "subjectPlaceholder": "Brief description of your issue",
+      "messagePlaceholder": "Please provide detailed information about your issue"
+    }
   },
   "supplierDashboardPage": {
     "title": "Supplier Dashboard",
@@ -512,23 +581,53 @@
     "orders": "Orders"
   },
   "supplierAnalyticsPage": {
-    "title": "Analytics",
-    "overview": "Analytics Overview",
-    "sales": "Sales Metrics"
+    "datePickerLabel": "Sélectionner la plage de dates",
+    "exportCsvAlert": "Exportation du rapport en CSV... (à venir)",
+    "exportCsvButton": "Exporter en CSV",
+    "mockChartText": "Données graphiques fictives de type {{type}}",
+    "orderRequestsPerWeek": "Demandes de commande par semaine",
+    "topViewedProducts": "Produits les plus consultés",
+    "requestsByCanton": "Demandes par canton",
+    "promoCodePerformance": "Performance des codes promo",
+    "table": {
+      "code": "Code",
+      "uses": "Utilisations",
+      "estRevenueImpact": "Impact estimé sur le revenu"
+    }
   },
   "supplierProductListingsPage": {
-    "title": "Product Listings",
-    "listings": "All Listings",
-    "addProduct": "Add New Product"
+    "addProductAlert": "La fonctionnalité du modal/formulaire 'Ajouter un produit' sera implémentée.",
+    "addProductButton": "Ajouter un Nouveau Produit",
+    "searchPlaceholder": "Rechercher par nom de produit...",
+    "table": {
+      "product": "Produit",
+      "price": "Prix",
+      "stock": "Stock",
+      "visibility": "Visibilité",
+      "actions": "Actions"
+    },
+    "emptyState": "Aucun produit trouvé."
   },
   "supplierOrdersPage": {
-    "title": "Orders",
-    "orders": "All Orders",
-    "pending": "Pending Orders"
+    "filterByStatus": "Filtrer par statut",
+    "table": {
+      "orderId": "ID Commande",
+      "date": "Date",
+      "total": "Total",
+      "status": "Statut",
+      "foundation": "Fondation"
+    },
+    "actions": {
+      "ship": "Marquer comme expédié"
+    },
+    "emptyState": "Aucune commande trouvée pour le filtre sélectionné."
   },
   "supplierSupportPage": {
-    "title": "Support",
-    "help": "Help Center"
+    "ticketSubmittedAlert": "Support ticket submitted successfully",
+    "ticketForm": {
+      "subjectPlaceholder": "Brief description of your issue",
+      "messagePlaceholder": "Please provide detailed information about your issue"
+    }
   },
   "adminContentManagementDashboardPage": {
     "title": "Content Management",
@@ -537,18 +636,46 @@
     "announcements": "Announcements"
   },
   "adminSystemMonitoringPage": {
-    "title": "System Monitoring",
-    "monitoring": "System Monitoring",
-    "performance": "Performance Metrics",
-    "logs": "System Logs",
     "rawLogConsole": {
-      "emptyLogMessage": "No logs available",
-      "tabs": {
-        "all": "All",
-        "errors": "Errors",
-        "warnings": "Warnings",
-        "info": "Info"
-      }
+      "title": "Console de Logs Bruts"
+    },
+    "overallStatus": {
+      "title": "État Général du Système"
+    },
+    "components": {
+      "api": "API Backend",
+      "database": "Base de Données",
+      "authService": "Service d'Authentification"
+    },
+    "metadata": {
+      "environment": "Environnement",
+      "version": "Version",
+      "uptime": "Disponibilité",
+      "lastCheck": "Dernier Contrôle"
+    },
+    "serverPerformance": {
+      "title": "Performance du Serveur",
+      "cpuUsage": "Utilisation CPU",
+      "memoryUsage": "Utilisation Mémoire",
+      "diskUsage": "Utilisation Disque",
+      "uptimeDays": "Disponibilité (Jours)"
+    },
+    "databasePerformance": {
+      "title": "Performance de la Base de Données",
+      "activeConnections": "Connexions Actives",
+      "queryTime": "Temps de Requête Moyen",
+      "storage": "Utilisation du Stockage",
+      "connectionHealth": "Santé de la Connexion"
+    },
+    "appPerformance": {
+      "title": "Performance de l'Application",
+      "activeUsers": "Utilisateurs Actifs",
+      "requestsPerMinute": "Requêtes/min",
+      "avgResponseTime": "Temps de Rép. Moyen",
+      "errorRate": "Taux d'Erreur"
+    },
+    "recentEvents": {
+      "title": "Événements Système Récents"
     }
   },
   "adminDiscountTerminationsPage": {
@@ -557,34 +684,34 @@
     "manage": "Manage Terminations"
   },
   "pricingPage": {
-    "title": "Pricing Plans",
+    "title": "ProCrèche Solutions – Guide de Tarification",
     "plans": "Available Plans",
     "features": "Plan Features",
     "billing": "Billing Information",
-    "monthly": "Monthly",
-    "annual": "Annual",
-    "saveUpTo10": "Save up to 10%",
-    "popular": "Most Popular",
-    "whatYouGet": "What You Get",
-    "selectAndContinue": "Select and Continue",
-    "choosePlan": "Choose Your Plan",
-    "titleSignup": "Sign Up",
-    "subtitleSignup": "Create your account to get started",
-    "subtitle": "Choose the plan that's right for your organization",
-    "suppliersAndProvidersTitle": "For Suppliers & Service Providers"
+    "monthly": "Mensuel",
+    "annual": "Annuel",
+    "saveUpTo10": "(Économiser jusqu'à 10%)",
+    "popular": "Plus Populaire",
+    "whatYouGet": "Ce que vous obtenez",
+    "selectAndContinue": "Sélectionner et Continuer",
+    "choosePlan": "Choisir le Plan",
+    "titleSignup": "Choisissez Votre Plan",
+    "subtitleSignup": "Sélectionnez le plan qui correspond le mieux à vos besoins",
+    "subtitle": "Sélectionnez le plan parfait pour votre organisation",
+    "suppliersAndProvidersTitle": "ProCrèche Solutions – Tarification pour Fournisseurs et Prestataires de Services"
   },
   "recruitmentPage": {
     "title": "Recruitment",
     "jobDetailModal": {
-      "title": "Job Details",
+      "title": "Détails de l'offre",
       "apply": "Apply Now",
       "close": "Close",
-      "overviewTitle": "Job Overview",
-      "location": "Location",
-      "contractType": "Contract Type",
-      "startDate": "Start Date",
-      "salary": "Salary",
-      "applyNow": "Apply Now"
+      "overviewTitle": "Aperçu du poste",
+      "location": "Lieu",
+      "contractType": "Type de contrat",
+      "startDate": "Date de début",
+      "salary": "Salaire",
+      "applyNow": "Postuler maintenant"
     },
     "jobPostModal": {
       "title": "Post Job",
@@ -595,8 +722,8 @@
       "location": "Location",
       "contractType": "Contract Type",
       "startDate": "Start Date",
-      "salaryRange": "Salary Range",
-      "salaryRangePlaceholder": "e.g., CHF 4,500 - 5,500",
+      "salaryRange": "Fourchette salariale (Optionnel)",
+      "salaryRangePlaceholder": "ex: CHF 60'000 - 70'000 par an",
       "description": "Job Description",
       "postJob": "Post Job"
     },
@@ -645,25 +772,23 @@
     }
   },
   "messagesPage": {
-    "selectConversationToView": "Select a conversation to view messages",
-    "conversationFallbackTitle": "Select a conversation",
-    "attachFile": "Attach File",
-    "addEmoji": "Add Emoji",
-    "typeMessagePlaceholder": "Type a message...",
-    "searchPlaceholder": "Search conversations...",
+    "title": "Messages",
+    "newGroupButton": "Nouveau Groupe",
+    "noConversationSelectedTitle": "Sélectionnez une conversation",
+    "noConversationSelectedSubtitle": "Choisissez parmi vos conversations existantes pour commencer à discuter.",
+    "noConversationsYet": "Vous n'avez pas encore de conversations.",
+    "noConversationsFound": "Aucune conversation trouvée.",
     "filters": {
-      "all": "All",
-      "unread": "Unread"
-    },
-    "noConversationsFound": "No conversations found",
-    "unknownUser": "Unknown User",
-    "youPrefix": "You:",
-    "noMessagesYet": "No messages yet"
+      "all": "Tous",
+      "unread": "Non lus"
+    }
   },
   "notificationsPage": {
-    "title": "Notifications",
-    "notifications": "All Notifications",
-    "unread": "Unread Notifications"
+    "clearAll": "Clear All",
+    "emptyState": {
+      "title": "No notifications",
+      "message": "You're all caught up! New notifications will appear here."
+    }
   },
   "fileGalleryPage": {
     "title": "File Gallery",
@@ -672,8 +797,33 @@
   },
   "eLearningPage": {
     "title": "E-Learning",
-    "courses": "Available Courses",
-    "progress": "Learning Progress"
+    "actions": {
+      "viewCourse": "View Course",
+      "watchVideo": "Watch Video",
+      "downloadPdf": "Download PDF",
+      "openLink": "Open Link"
+    },
+    "viewingAlert": "You are viewing external content",
+    "lessonsCount": "{{count}} lessons",
+    "durationLabel": "Duration",
+    "languageLabel": "Language",
+    "updatedLabel": "Updated",
+    "confirmDelete": "Are you sure you want to delete this item?",
+    "noItemsFound": "No items found",
+    "addNewContentButton": "Add New Content",
+    "searchPlaceholder": "Search content...",
+    "categoryLabel": "Category",
+    "noContentFound": "No content found",
+    "coursesTitle": "Courses",
+    "itemType": {
+      "courses": "Courses",
+      "videos": "Videos",
+      "pdfs": "PDFs",
+      "links": "External Links"
+    },
+    "videosTitle": "Videos",
+    "pdfsTitle": "PDFs",
+    "externalLinksTitle": "External Links"
   },
   "statePoliciesPage": {
     "title": "State Policies",
@@ -682,23 +832,103 @@
   },
   "hrProceduresPage": {
     "title": "HR Procedures",
-    "procedures": "HR Procedures",
-    "guidelines": "Guidelines"
+    "categoryDisplay": {
+      "viewCategoryAria": "View category {{category}}",
+      "documentsCount": "{{count}} documents"
+    },
+    "confirmDeleteDocument": "Are you sure you want to delete this document?",
+    "uploadButton": "Upload Document",
+    "searchPlaceholder": "Search documents...",
+    "categoriesTitle": "Categories",
+    "allDocumentsCategory": "All Documents",
+    "noDocumentsMatchSearch": "No documents match your search",
+    "noDocumentsAvailable": "No documents available",
+    "backToCategoriesButton": "Back to Categories",
+    "documentsInCategoryTitle": "Documents in {{category}}",
+    "allItemsCount": "{{count}} items",
+    "noDocumentsInCategory": "No documents in this category"
   },
   "usersPage": {
-    "title": "User Management",
-    "allUsers": "All Users",
-    "roles": "User Roles"
+    "cannotDeleteOwnAccount": "You cannot delete your own account",
+    "status": {
+      "pending": "Pending"
+    },
+    "userDetailDrawer": {
+      "title": "User Details",
+      "roleLabel": "Role",
+      "statusLabel": "Status",
+      "regionLabel": "Region",
+      "lastLoginLabel": "Last Login",
+      "orgLabel": "Organization",
+      "adminActionsTitle": "Admin Actions",
+      "changeRoleLabel": "Change Role",
+      "updateRoleButton": "Update Role",
+      "suspendUserButton": "Suspend User",
+      "activateUserButton": "Activate User",
+      "cannotModifyOwnAccount": "You cannot modify your own account"
+    },
+    "rolePageTitle": "Role Management",
+    "allUsersTitle": "All Users",
+    "confirmDeleteUser": "Are you sure you want to delete this user?",
+    "userProfileUpdated": "User profile updated successfully",
+    "addNewUserTBD": "Add New User TBD",
+    "addNewUserButton": "Add New User",
+    "searchPlaceholder": "Search users...",
+    "filtersTBD": "Filters TBD",
+    "filtersButton": "Filters",
+    "table": {
+      "nameOrg": "Name / Organization",
+      "role": "Role",
+      "status": "Status",
+      "region": "Region",
+      "lastLogin": "Last Login",
+      "actions": "Actions"
+    },
+    "emptyState": "No users found"
   },
   "partnersPage": {
-    "title": "Partners",
-    "partners": "Partner Directory",
-    "becomePartner": "Become a Partner"
+    "partnerCard": {
+      "logoAlt": "{{partnerName}} logo",
+      "partnerType": "{{type}} Partner",
+      "learnMoreButton": "En savoir plus"
+    },
+    "hero": {
+      "title": "Nos Précieux Partenaires",
+      "subtitle": "Nous collaborons avec des organisations de premier plan pour améliorer l'écosystème de la petite enfance en Suisse.",
+      "ctaButton": "Devenir Partenaire"
+    },
+    "featured": {
+      "title": "Partenaires en Vedette",
+      "subtitle": "Nous sommes fiers de travailler avec des institutions qui partagent notre vision d'une éducation de la petite enfance de qualité."
+    },
+    "joinUs": {
+      "title": "Rejoignez Notre Réseau",
+      "subtitle": "Intéressé à devenir partenaire de Pro Crèche Solutions ? Nous sommes toujours à la recherche d'organisations qui peuvent apporter de la valeur à notre communauté. Contactons-nous.",
+      "contactUsAlert": "La fonctionnalité du formulaire/modal de contact sera implémentée.",
+      "contactUsButton": "Nous Contacter",
+      "inquiryFormLink": "ou remplissez notre formulaire de partenariat"
+    }
   },
   "parentLeadFormPage": {
-    "title": "Find a Crèche",
-    "form": "Lead Form",
-    "submit": "Submit Request"
+    "errorAllFields": "Veuillez remplir tous les champs obligatoires.",
+    "thankYouTitle": "Merci !",
+    "unauthenticatedSuccessMessage": "Votre demande a été soumise avec succès. Nous avons envoyé un e-mail de confirmation à {{email}}. Vous pouvez également créer un compte pour suivre vos demandes.",
+    "authenticatedSuccessMessage": "Votre demande a été soumise avec succès. Vous pouvez consulter et gérer vos demandes depuis votre tableau de bord.",
+    "subtitle": "Dites-nous quels sont les besoins de votre enfant et nous vous aiderons à trouver la crèche parfaite",
+    "labels": {
+      "yourFullName": "Votre Nom Complet",
+      "yourEmail": "Votre E-mail",
+      "yourPhone": "Votre Numéro de Téléphone",
+      "canton": "Canton",
+      "municipality": "Municipalité",
+      "childAge": "Âge de l'Enfant (Années)",
+      "desiredStartDate": "Date de Début Souhaitée",
+      "specialNeeds": "Besoins Spéciaux ou Exigences"
+    },
+    "sectionTitleChildNeeds": "Besoins de l'Enfant",
+    "helpText": {
+      "specialNeeds": "Veuillez décrire tous besoins spéciaux, exigences alimentaires ou autres informations importantes concernant votre enfant."
+    }
   },
   "candidateProfilePage": {
     "title": "Candidate Profile",
@@ -707,42 +937,97 @@
   },
   "designSystemPage": {
     "title": "Design System",
-    "components": "UI Components",
-    "guidelines": "Design Guidelines"
+    "description": "A living reference for all UI components and design tokens in the Pro Crèche Solutions application.",
+    "tabs": {
+      "title": "Tabs",
+      "pillsVariant": "Pills Variant (Default)",
+      "lineVariant": "Line Variant",
+      "tab1": "Tab 1",
+      "content1": "This is the content for Tab 1.",
+      "tab2": "Tab 2",
+      "content2": "This is the content for Tab 2.",
+      "tab3": "Tab 3",
+      "content3": "This is a disabled tab."
+    },
+    "typography": {
+      "fontFamily": "Font Family: Nunito, Inter, sans-serif",
+      "heading1": "Heading 1: The quick brown fox",
+      "heading2": "Heading 2: The quick brown fox",
+      "heading3": "Heading 3: The quick brown fox",
+      "heading4": "Heading 4: The quick brown fox",
+      "bodyBase": "Body Text (Base): Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.",
+      "bodySmall": "Body Text (Small): Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi.",
+      "link": "This is a link"
+    },
+    "buttons": {
+      "extraSmall": "Extra Small",
+      "small": "Small",
+      "mediumDefault": "Medium (Default)",
+      "large": "Large",
+      "withIcons": "With Icons",
+      "leftIcon": "Left Icon",
+      "rightIcon": "Right Icon",
+      "smallIcon": "Small Icon",
+      "disabledState": "Disabled State",
+      "primaryDisabled": "Primary Disabled",
+      "secondaryDisabled": "Secondary Disabled",
+      "outlineDisabled": "Outline Disabled"
+    },
+    "cards": {
+      "standardCard": "Standard Card",
+      "standardCardDesc": "This is a standard card component with a soft shadow. It's the base for most content containers.",
+      "hoverEffectCard": "Hover Effect Card",
+      "hoverEffectCardDesc": "This card has a subtle scale and shadow transition on hover, useful for interactive elements."
+    },
+    "formControls": {
+      "title": "Form Controls",
+      "textInput": "Text Input",
+      "selectMenu": "Select Menu",
+      "option1": "Option 1",
+      "option2": "Option 2",
+      "option3": "Option 3",
+      "quantityInput": "Quantity Input",
+      "disabledInput": "Disabled Input"
+    },
+    "View Favorites TBD": "View Favorites TBD",
+    "Could not find a user associated with this organization to message.": "Could not find a user associated with this organization to message.",
+    "User organization details are missing.": "User organization details are missing.",
+    "tailwindcss": "tailwindcss",
+    "sidebar.parentLeads": "Parent Leads",
+    "sidebar.products": "Products",
+    "sidebar.services": "Services",
+    "No recent activity.": "No recent activity.",
+    "loaded": "loaded",
+    "SUPER_ADMIN": "SUPER_ADMIN",
+    "Show": "Show",
+    "Refresh": "Refresh",
+    "keys)": "keys)",
+    "(240)": "(240)",
+    "Branding": "Branding",
+    "Favicon": "Favicon",
+    "Search job offers...": "Search job offers...",
+    "Search partners...": "Search partners...",
+    "Search candidates...": "Search candidates...",
+    "Search content...": "Search content...",
+    "admin@procrechesolutions.com": "admin@procrechesolutions.com",
+    "No documents found in this category for current filters.": "No documents found in this category for current filters.",
+    "No custom alerts created yet.": "No custom alerts created yet."
   },
   "createGroupChatModal": {
     "error": {
-      "minParticipants": "Please select at least 2 participants"
+      "minParticipants": "Veuillez sélectionner au moins 2 utilisateurs pour créer un groupe."
     },
-    "title": "Create Group Chat",
-    "groupNameLabel": "Group Name",
-    "groupNamePlaceholder": "Enter group name...",
-    "selectParticipantsLabel": "Select Participants",
-    "createButton": "Create Group"
+    "title": "Créer un nouveau groupe de discussion",
+    "groupNameLabel": "Nom du groupe (Optionnel)",
+    "groupNamePlaceholder": "ex: Préparation réunion d'équipe",
+    "selectParticipantsLabel": "Sélectionner les participants (min. 2)",
+    "createButton": "Créer le groupe"
   },
   "orderRequestDetailModal": {
-    "title": "Order Details",
-    "orderId": "Order ID",
-    "date": "Date",
-    "status": "Status",
-    "total": "Total",
-    "viewDaycareProfile": "View Daycare Profile",
-    "lineItems": "Line Items",
-    "product": "Product",
-    "quantity": "Quantity",
-    "price": "Price",
-    "notes": "Notes"
+    "markAsProcessing": "Mark as Processing"
   },
   "serviceRequestDetailModal": {
-    "title": "Service Request Details",
-    "requestId": "Request ID",
-    "serviceName": "Service Name",
-    "viewDaycareProfile": "View Daycare Profile",
-    "date": "Date",
-    "status": "Status",
-    "preferredDate": "Preferred Date",
-    "noPreferredDate": "No preferred date set",
-    "notes": "Notes"
+    "markAsCompleted": "Mark as Completed"
   },
   "serviceUploadModal": {
     "editTitle": "Edit Service",
@@ -895,61 +1180,46 @@
     "commitToGit": "Commit to Git"
   },
   "supplierCard": {
-    "title": "Supplier",
-    "labels": {
-      "name": "Name",
-      "rating": "Rating",
-      "reviews": "Reviews",
-      "location": "Location",
-      "specialties": "Specialties"
+    "specializesIn": "Specializes in",
+    "viewProfileAndProducts": "View Profile and Products"
+  },
+  "settingsAccountSecurity": {
+    "personalInfo": {
+      "title": "Informations Personnelles",
+      "subtitle": "Manage your personal details and contact information",
+      "contactNameLabel": "Nom du Contact",
+      "orgNameLabel": "Nom de l'Organisation",
+      "emailLabel": "Adresse E-mail",
+      "accountTypeLabel": "Type de Compte",
+      "memberSinceLabel": "Membre Depuis",
+      "updateInfoButton": "Mettre à Jour les Informations"
     },
-    "actions": {
-      "view": "View",
-      "contact": "Contact",
-      "favorite": "Favorite"
+    "changePassword": {
+      "title": "Changer le Mot de Passe",
+      "subtitle": "Update your password for better security",
+      "currentPasswordLabel": "Mot de Passe Actuel",
+      "newPasswordLabel": "Nouveau Mot de Passe",
+      "confirmNewPasswordLabel": "Confirmer le Nouveau Mot de Passe",
+      "updatePasswordButton": "Mettre à Jour le Mot de Passe"
     },
-    "rating": {
-      "stars": "{{count}} stars",
-      "noReviews": "No reviews yet"
+    "dangerZone": {
+      "title": "Zone de Danger",
+      "subtitle": "Irreversible and destructive actions",
+      "deleteAccountTitle": "Supprimer ce compte",
+      "deleteAccountSubtitle": "Une fois que vous supprimez votre compte, il n'y a pas de retour en arrière. Soyez certain.",
+      "deleteAccountButton": "Supprimer le Compte"
+    },
+    "notifications": {
+      "title": "Notifications",
+      "subtitle": "Manage your notification preferences"
     }
   },
-    "settingsAccountSecurity": {
-      "personalInfo": {
-        "title": "Personal Information",
-        "subtitle": "Manage your personal details and contact information",
-        "contactNameLabel": "Contact Name",
-        "orgNameLabel": "Organization Name",
-        "emailLabel": "Email Address",
-        "accountTypeLabel": "Account Type",
-        "memberSinceLabel": "Member Since",
-        "updateInfoButton": "Update Information"
-      },
-      "changePassword": {
-        "title": "Change Password",
-        "subtitle": "Update your password for better security",
-        "currentPasswordLabel": "Current Password",
-        "newPasswordLabel": "New Password",
-        "confirmNewPasswordLabel": "Confirm New Password",
-        "updatePasswordButton": "Update Password"
-      },
-      "dangerZone": {
-        "title": "Danger Zone",
-        "subtitle": "Irreversible and destructive actions",
-        "deleteAccountTitle": "Delete Account",
-        "deleteAccountSubtitle": "Permanently delete your account and all data",
-        "deleteAccountButton": "Delete Account"
-      },
-      "notifications": {
-        "title": "Notifications",
-        "subtitle": "Manage your notification preferences"
-      }
-    },
   "settingsAnalyticsPreferences": {
     "title": "Analytics Preferences",
     "subtitle": "Configure your analytics and reporting settings"
   },
   "settingsBillingSubscription": {
-    "title": "Billing & Subscription",
+    "title": "Facturation & Abonnement",
     "subtitle": "Manage your billing and subscription settings"
   },
   "settingsCompanyProfile": {
@@ -969,25 +1239,29 @@
     "subtitle": "Customize how you receive notifications"
   },
   "settingsPrivacyData": {
-    "title": "Privacy & Data",
-    "subtitle": "Manage your privacy settings and data preferences"
+    "confirmGDPRDelete": "Êtes-vous sûr ? Ceci supprimera définitivement votre compte et toutes les données associées. Cette action est irréversible.",
+    "deletionRequestSubmittedHelpText": "Votre demande a été soumise. Notre équipe vous contactera dans les 30 jours."
   },
   "parentDashboard": {
+    "title": "Parent Dashboard",
+    "welcomeMessage": "Welcome to your parent dashboard",
     "enquiry": {
-      "title": "Enquiries",
-      "new": "New Enquiry"
-    },
-    "quickActions": {
-      "title": "Quick Actions",
-      "findCreche": "Find Crèche"
+      "sent": "Enquiries Sent",
+      "responses": "Responses Received",
+      "pending": "Pending Responses",
+      "button": "Send New Enquiry"
     },
     "childProfile": {
-      "title": "Child Profile",
-      "edit": "Edit Profile"
+      "name": "Child's Name",
+      "age": "Age",
+      "location": "Location",
+      "languages": "Languages",
+      "specialNeeds": "Special Needs",
+      "button": "Update Profile"
     },
     "favorites": {
-      "title": "Favorites",
-      "viewAll": "View All"
+      "subtitle": "Your favorite crèches and services",
+      "button": "View Favorites"
     }
   },
   "type": "Type",
@@ -1005,7 +1279,7 @@
     "subtitle": "Manage team member access and permissions"
   },
   "activeClientToggle": {
-    "title": "Active Client",
+    "title": "Statut de la Relation",
     "labels": {
       "active": "Active",
       "inactive": "Inactive"
@@ -1021,26 +1295,8 @@
     "upgrade": "Upgrade Plan"
   },
   "fileUploadModal": {
-    "title": "Upload File",
-    "labels": {
-      "selectFile": "Select File",
-      "fileType": "File Type",
-      "description": "Description"
-    },
-    "fileUpload": {
-      "dragAndDrop": "Drag and drop files here",
-      "browse": "Browse Files"
-    },
-    "validation": {
-      "fileRequired": "File is required",
-      "invalidFileType": "Invalid file type"
-    },
-    "success": {
-      "uploaded": "File uploaded successfully"
-    },
-    "error": {
-      "uploadFailed": "Upload failed"
-    }
+    "uploading": "Uploading...",
+    "uploadButton": "Upload File"
   },
   "auth": {
     "signIn": "Sign In",
@@ -1153,14 +1409,42 @@
     }
   },
   "serviceProviderDashboard": {
-    "title": "Service Provider Dashboard",
-    "services": "Services",
-    "requests": "Requests"
+    "welcomeMessage": "Welcome to your service provider dashboard",
+    "widgets": {
+      "overview": {
+        "title": "Overview",
+        "activeRequests": "Active Requests",
+        "completedServices": "Completed Services",
+        "upcoming": "Upcoming",
+        "customerRating": "Customer Rating",
+        "button": "View All"
+      },
+      "management": {
+        "title": "Service Management",
+        "listings": "Service Listings",
+        "pending": "Pending Approvals",
+        "categories": "Categories",
+        "button": "Manage Services"
+      },
+      "appointments": {
+        "title": "Appointments",
+        "with": "with",
+        "button": "Schedule New"
+      }
+    }
   },
   "supportPage": {
-    "title": "Support",
-    "faq": "FAQ",
-    "contact": "Contact Us"
+    "faqTitle": "Frequently Asked Questions",
+    "furtherAssistanceTitle": "Need Further Assistance?",
+    "furtherAssistanceText": {
+      "0": "Contact our support team for personalized help",
+      "1": "We're here to assist you with any questions or issues"
+    },
+    "submitTicketTitle": "Submit Support Ticket",
+    "ticketForm": {
+      "subjectLabel": "Subject",
+      "messageLabel": "Message"
+    }
   },
   "T": "T",
   "Title and Message are required.": "Title and Message are required.",
@@ -1168,156 +1452,110 @@
   "Missing keys copied to clipboard!": "Missing keys copied to clipboard!",
   ".": ".",
   "hardcodedText": {},
-    "navbar": {
-      "notificationsCount": "{{count}} notifications",
-      "unreadMessages": "{{count}} messages non lus",
-      "searchPlaceholder": "Rechercher..."
-    },
-    "sidebar": {
-      "billingSubscription": "Facturation et Abonnement",
-      "dashboard": "Tableau de bord",
-      "marketplace": "Marché",
-      "products": "Produits",
-      "services": "Services",
-      "recruitment": "Recrutement",
-      "jobListings": "Offres d'emploi",
-      "candidatePool": "Réserve de candidats",
-      "eLearning": "E-Learning",
-      "messages": "Messages",
-      "users": "Utilisateurs",
-      "allUsers": "Tous les utilisateurs",
-      "admins": "Administrateurs",
-      "foundations": "Fondations",
-      "productSuppliers": "Fournisseurs de produits",
-      "serviceProviders": "Prestataires de services",
-      "parents": "Parents",
-      "content": "Contenu",
-      "hrProcedures": "Procédures RH",
-      "statePolicies": "Politiques d'État",
-      "discountTerminations": "Résiliations de remise",
-      "systemMonitoring": "Surveillance du système",
-      "partners": "Partenaires",
-      "platformSettings": "Paramètres de la plateforme",
-      "designSystem": "Système de design",
-      "settings": "Paramètres"
-    },
   "Quantity must be at least 1.": "Quantity must be at least 1.",
-  "supplierCard": {
-    "specializesIn": "Specializes in",
-    "viewProfileAndProducts": "View Profile and Products"
-  },
   "Cannot post job. Foundation details are missing.": "Cannot post job. Foundation details are missing.",
   "Current user or organization ID is missing.": "Current user or organization ID is missing.",
-  "organizationProfileForm": {
-    "saveSuccess": "Organization profile saved successfully"
-  },
-  "settingsPrivacyData": {
-    "confirmGDPRDelete": "Confirm GDPR Data Deletion",
-    "deletionRequestSubmittedHelpText": "This will permanently delete all your data from our systems"
-  },
-    "settingsPage": {
-      "billingSubscription": "Billing & Subscription",
-      "title": "Settings",
-      "accountSecurity": "Account & Security"
-    },
   "Subscription cancelled (mock action)": "Subscription cancelled (mock action)",
-  "fileUploadModal": {
-    "uploading": "Uploading...",
-    "uploadButton": "Upload File"
-  },
   "renameFileModal": {
     "title": "Rename File",
     "label": "File Name"
   },
   "supplierDashboard": {
+    "title": "Tableau de Bord Fournisseur",
+    "welcomeMessage": "Bienvenue, {{name}} ! Voici votre aperçu fournisseur.",
+    "noSalesYet": "Aucune vente pour le moment",
+    "widgets": {
+      "sales": {
+        "title": "Aperçu des Ventes",
+        "totalOrders": "Commandes Totales",
+        "revenueMonth": "Revenu (ce mois-ci)",
+        "topSelling": "Meilleure Vente",
+        "fulfillmentRate": "Taux de Réalisation",
+        "button": "Voir les Analyses Complètes"
+      },
+      "products": {
+        "title": "Gestion des Produits",
+        "active": "Produits Actifs",
+        "pending": "En Attente d'Approbation",
+        "lowStock": "Alertes de Stock Faible",
+        "button": "Gérer Tous les Produits"
+      },
+      "orders": {
+        "title": "Gestion des Commandes",
+        "pending": "Commandes en Attente",
+        "toFulfill": "Commandes à Préparer",
+        "button": "Aller à la Page des Commandes"
+      }
+    },
+    "recentOrdersTitle": "Commandes Récentes (les 5 dernières)",
+    "noRecentOrders": "Aucune commande récente à afficher.",
+    "recentOrdersTable": {
+      "id": "ID",
+      "creche": "Crèche",
+      "date": "Date",
+      "total": "Total",
+      "status": "Statut"
+    },
     "recentOrdersActions": {
       "decline": "Decline",
       "accept": "Accept"
     }
   },
-  "supplierOrdersPage": {
-    "actions": {
-      "ship": "Ship"
-    },
-    "table": {
-      "foundation": "Foundation"
-    }
-  },
   "You must be logged in as a foundation to submit a request.": "You must be logged in as a foundation to submit a request.",
-  "common": {
-    "perMonth": "/month",
-    "perYear": "/year",
-    "save10Percent": "save 10%"
-  },
   "dashboardDetailPage": {
     "activeUsers": {
-      "recentActivity": "Recent Activity",
-      "totalToday": "Total Today"
+      "recentActivity": "Activité récente",
+      "totalToday": "Total active users today: {{count}}",
+      "aliceActivity": "Alice Johnson - Logged in 2 hours ago, viewed 5 pages.",
+      "bobActivity": "Bob Williams - Updated profile at 10:30 AM.",
+      "carolActivity": "Carol Davis - Joined yesterday, completed onboarding.",
+      "davidActivity": "David Brown - Viewed marketplace listings."
     },
     "newOrders": {
-      "recentOrders": "Recent Orders",
+      "recentOrders": "Commandes récentes",
       "table": {
-        "orderId": "Order ID",
-        "product": "Product",
-        "amount": "Amount",
-        "status": "Status"
+        "orderId": "ID Commande",
+        "product": "Produit",
+        "amount": "Montant",
+        "status": "Statut"
       },
       "status": {
-        "paid": "Paid",
-        "pending": "Pending"
+        "paid": "Payée",
+        "pending": "En attente"
       },
-      "totalThisWeek": "Total This Week"
+      "totalThisWeek": "Total orders this week: {{count}}",
+      "order789": "#ORD789",
+      "order790": "#ORD790",
+      "order791": "#ORD791",
+      "ecotoysBlocks": "EcoToys Wooden Blocks",
+      "freshBitesMeal": "FreshBites Meal Plan",
+      "artFunPack": "ArtFun Creative Pack"
     },
     "openJobs": {
-      "currentPositions": "Current Positions",
-      "applications": "Applications",
+      "currentPositions": "Postes actuellement ouverts",
+      "applications": "{{count}} candidatures",
+      "totalOpenPositions": "Total des postes ouverts : {{count}}",
+      "leadEducatorGeneva": "Lead Educator - Geneva",
+      "assistantEducatorLausanne": "Assistant Educator - Lausanne",
+      "daycareDirectorZurich": "Daycare Director - Zurich",
       "status": {
-        "open": "Open",
-        "interviewing": "Interviewing"
-      },
-      "totalOpenPositions": "Total Open Positions"
+        "open": "Ouvert",
+        "interviewing": "En entretien"
+      }
     },
     "pageViews": {
-      "keyMetrics": "Key Metrics",
-      "totalToday": "Total Today",
-      "uniqueVisitors": "Unique Visitors",
-      "mostViewed": "Most Viewed",
-      "avgSession": "Avg Session",
-      "mockChartText": "Mock chart data - replace with real analytics"
+      "keyMetrics": "Indicateurs clés",
+      "totalToday": "Vues totales aujourd'hui :",
+      "uniqueVisitors": "Visiteurs uniques :",
+      "mostViewed": "Page la plus vue :",
+      "dashboardViews": "/dashboard (560 views)",
+      "avgSession": "Session moyenne :",
+      "sessionDuration": "4m 15s",
+      "mockChartText": "Données graphiques fictives de type {{type}}"
     },
-    "defaultTitle": "Dashboard Details",
-    "detailsFor": "Details for",
-    "noSpecificView": "No specific view selected"
-  },
-    "eLearningPage": {
-      "title": "E-Learning",
-      "actions": {
-        "viewCourse": "View Course",
-        "watchVideo": "Watch Video",
-        "downloadPdf": "Download PDF",
-        "openLink": "Open Link"
-      },
-    "viewingAlert": "You are viewing external content",
-    "lessonsCount": "{{count}} lessons",
-    "durationLabel": "Duration",
-    "languageLabel": "Language",
-    "updatedLabel": "Updated",
-    "confirmDelete": "Are you sure you want to delete this item?",
-    "noItemsFound": "No items found",
-    "addNewContentButton": "Add New Content",
-    "searchPlaceholder": "Search content...",
-    "categoryLabel": "Category",
-    "noContentFound": "No content found",
-    "coursesTitle": "Courses",
-    "itemType": {
-      "courses": "Courses",
-      "videos": "Videos",
-      "pdfs": "PDFs",
-      "links": "External Links"
-    },
-    "videosTitle": "Videos",
-    "pdfsTitle": "PDFs",
-    "externalLinksTitle": "External Links"
+    "defaultTitle": "Détails",
+    "detailsFor": "Détails pour : {{pageDisplayTitle}}",
+    "noSpecificView": "Aucune vue détaillée disponible pour \"{{pageDisplayTitle}}\"."
   },
   "fileGallery": {
     "actions": {
@@ -1346,152 +1584,7 @@
     "editButtonLabel": "Edit",
     "deleteButtonLabel": "Delete"
   },
-    "hrProceduresPage": {
-      "title": "HR Procedures",
-      "categoryDisplay": {
-        "viewCategoryAria": "View category {{category}}",
-        "documentsCount": "{{count}} documents"
-      },
-    "confirmDeleteDocument": "Are you sure you want to delete this document?",
-    "uploadButton": "Upload Document",
-    "searchPlaceholder": "Search documents...",
-    "categoriesTitle": "Categories",
-    "allDocumentsCategory": "All Documents",
-    "noDocumentsMatchSearch": "No documents match your search",
-    "noDocumentsAvailable": "No documents available",
-    "backToCategoriesButton": "Back to Categories",
-    "documentsInCategoryTitle": "Documents in {{category}}",
-    "allItemsCount": "{{count}} items",
-    "noDocumentsInCategory": "No documents in this category"
-  },
-  "partnerDetailPage": {
-    "onlyFoundationsRequestService": "Only foundations can request this service",
-    "requestSubmittedAlert": "Service request submitted successfully"
-  },
-    "marketplacePage": {
-      "emptyStates": {
-        "noServices": "No services available",
-        "noProductSuppliers": "No product suppliers available"
-      },
-      "subtitles": {
-        "productSuppliers": "Product Suppliers",
-        "serviceProviders": "Service Providers"
-      },
-      "tabs": {
-        "productSuppliers": "Product Suppliers",
-        "serviceProviders": "Service Providers"
-      },
-      "buttons": {
-        "partnerOnboarding": "Partner Onboarding"
-      },
-      "infoAlert": "Partner Onboarding TBD",
-      "searchPlaceholder": "Search partners...",
-      "labels": {
-        "category": "Category",
-        "region": "Region",
-        "supplierTags": "Supplier Tags",
-        "sortBy": "Sort by"
-      },
-      "sortOptions": {
-        "nameAsc": "Name (A-Z)",
-        "nameDesc": "Name (Z-A)",
-        "ratingDesc": "Rating (High to Low)"
-      },
-      "ariaLabels": {
-        "gridView": "Switch to grid view",
-        "listView": "Switch to list view"
-      }
-    },
   "Partner Onboarding TBD": "Partner Onboarding TBD",
-  "notifications": {
-    "newMessageFrom": "New message from {{sender}}"
-  },
-    "messagesPage": {
-      "title": "Messages",
-      "newGroupButton": "New Group",
-      "noConversationSelectedTitle": "Select a conversation to start messaging",
-      "noConversationSelectedSubtitle": "Choose a conversation from the list to view messages",
-      "noConversationsYet": "No conversations yet",
-      "noConversationsFound": "No conversations found",
-      "filters": {
-        "all": "All",
-        "unread": "Unread"
-      }
-    },
-  "notificationsPage": {
-    "clearAll": "Clear All",
-    "emptyState": {
-      "title": "No notifications",
-      "message": "You're all caught up! New notifications will appear here."
-    }
-  },
-  "parentEnquiriesPage": {
-    "accessDenied": {
-      "title": "Access Denied",
-      "message": "You need to be logged in as a parent to view enquiries"
-    },
-    "emptyState": {
-      "title": "No enquiries yet",
-      "message": {
-        "0": "You haven't submitted any enquiries yet.",
-        "1": "Start by filling out the enquiry form to find suitable childcare options."
-      }
-    },
-    "card": {
-      "title": "Enquiry Details",
-      "submitted": "Submitted on {{date}}",
-      "childInfo": "Child Information",
-      "notes": "Additional Notes",
-      "responsesTitle": "Responses",
-      "awaitingMatch": "Awaiting Match",
-      "message": "Your enquiry has been sent to relevant providers",
-      "waitingForMoreResponses": "Waiting for more responses..."
-    }
-  },
-  "parentLeadFormPage": {
-    "errorAllFields": "Please fill in all required fields",
-    "thankYouTitle": "Thank You!",
-    "unauthenticatedSuccessMessage": "Your enquiry has been submitted successfully. We'll contact you soon!",
-    "authenticatedSuccessMessage": "Your enquiry has been submitted and saved to your dashboard.",
-    "subtitle": "Tell us about your childcare needs",
-    "labels": {
-      "yourFullName": "Your Full Name",
-      "yourEmail": "Your Email",
-      "yourPhone": "Your Phone",
-      "canton": "Canton",
-      "municipality": "Municipality",
-      "childAge": "Child's Age",
-      "desiredStartDate": "Desired Start Date",
-      "specialNeeds": "Special Needs"
-    },
-    "sectionTitleChildNeeds": "Child's Needs",
-    "helpText": {
-      "specialNeeds": "Please describe any special requirements or needs"
-    }
-  },
-  "partnersPage": {
-    "partnerCard": {
-      "logoAlt": "{{partnerName}} logo",
-      "partnerType": "{{type}} Partner",
-      "learnMoreButton": "Learn More"
-    },
-    "hero": {
-      "title": "Our Partners",
-      "subtitle": "Discover trusted childcare providers and suppliers",
-      "ctaButton": "Become a Partner"
-    },
-    "featured": {
-      "title": "Featured Partners",
-      "subtitle": "Meet our top-rated childcare providers and suppliers"
-    },
-    "joinUs": {
-      "title": "Join Our Network",
-      "subtitle": "Become part of Switzerland's leading childcare platform",
-      "contactUsAlert": "Contact us to learn more about partnership opportunities",
-      "contactUsButton": "Contact Us",
-      "inquiryFormLink": "Partnership Inquiry Form"
-    }
-  },
   "Close Job TBD": "Close Job TBD",
   "Favorite TBD": "Favorite TBD",
   "Adding a new candidate - Functionality TBD.": "Adding a new candidate - Functionality TBD.",
@@ -1503,146 +1596,34 @@
     "notesLabel": "Notes / Specific Requirements (Optional)",
     "submitButton": "Submit Request"
   },
-  "serviceRequestDetailModal": {
-    "markAsCompleted": "Mark as Completed"
-  },
   "Cantonal Policies": "Cantonal Policies",
   "National Regulations": "National Regulations",
   "Compliance Requirements": "Compliance Requirements",
   "Updates & News": "Updates & News",
   "Official Downloads": "Official Downloads",
-  "usersPage": {
-    "cannotDeleteOwnAccount": "You cannot delete your own account",
-    "status": {
-      "pending": "Pending"
-    },
-    "userDetailDrawer": {
-      "title": "User Details",
-      "roleLabel": "Role",
-      "statusLabel": "Status",
-      "regionLabel": "Region",
-      "lastLoginLabel": "Last Login",
-      "orgLabel": "Organization",
-      "adminActionsTitle": "Admin Actions",
-      "changeRoleLabel": "Change Role",
-      "updateRoleButton": "Update Role",
-      "suspendUserButton": "Suspend User",
-      "activateUserButton": "Activate User",
-      "cannotModifyOwnAccount": "You cannot modify your own account"
-    },
-    "rolePageTitle": "Role Management",
-    "allUsersTitle": "All Users",
-    "confirmDeleteUser": "Are you sure you want to delete this user?",
-    "userProfileUpdated": "User profile updated successfully",
-    "addNewUserTBD": "Add New User TBD",
-    "addNewUserButton": "Add New User",
-    "searchPlaceholder": "Search users...",
-    "filtersTBD": "Filters TBD",
-    "filtersButton": "Filters",
-    "table": {
-      "nameOrg": "Name / Organization",
-      "role": "Role",
-      "status": "Status",
-      "region": "Region",
-      "lastLogin": "Last Login",
-      "actions": "Actions"
-    },
-    "emptyState": "No users found"
-  },
-  "adminSystemMonitoringPage": {
-    "rawLogConsole": {
-      "emptyLogMessage": "No logs available",
-      "tabs": {
-        "all": "All",
-        "errors": "Errors",
-        "warnings": "Warnings",
-        "info": "Info"
-      }
-    },
-    "overallStatus": {
-      "title": "Overall System Status"
-    },
-    "components": {
-      "api": "API",
-      "database": "Database",
-      "authService": "Auth Service"
-    },
-    "metadata": {
-      "environment": "Environment",
-      "version": "Version",
-      "uptime": "Uptime",
-      "lastCheck": "Last Check"
-    },
-    "serverPerformance": {
-      "title": "Server Performance",
-      "cpuUsage": "CPU Usage",
-      "memoryUsage": "Memory Usage",
-      "diskUsage": "Disk Usage",
-      "uptimeDays": "Uptime (Days)"
-    },
-    "databasePerformance": {
-      "title": "Database Performance",
-      "activeConnections": "Active Connections",
-      "queryTime": "Query Time",
-      "storage": "Storage",
-      "connectionHealth": "Connection Health"
-    },
-    "appPerformance": {
-      "title": "Application Performance",
-      "activeUsers": "Active Users",
-      "requestsPerMinute": "Requests per Minute",
-      "avgResponseTime": "Average Response Time",
-      "errorRate": "Error Rate"
-    },
-    "recentEvents": {
-      "title": "Recent Events"
-    },
-    "rawLogConsole": {
-      "title": "Raw Log Console"
-    }
-  },
   "discountTerminationsPage": {
     "actions": {
-      "sendNoticesAlert": "Send notices to selected vendors",
-      "markCompleted": "Mark Completed",
-      "sendNotices": "Send Notices"
+      "sendNoticesAlert": "{{count}} avis de résiliation envoyés. (Action simulée)",
+      "markCompleted": "Marquer comme Terminé",
+      "sendNotices": "Envoyer les Avis de Résiliation ({{count}})"
     },
     "table": {
-      "vendor": "Vendor",
-      "daycare": "Daycare",
-      "activeSince": "Active Since",
-      "reason": "Reason",
+      "vendor": "Vendeur",
+      "daycare": "Crèche",
+      "activeSince": "Actif Depuis",
+      "reason": "Raison",
       "actions": "Actions"
     },
     "queue": {
-      "title": "Termination Queue",
-      "description": "Manage discount terminations and send notices",
-      "tableTitle": "Pending Terminations"
+      "title": "Action Requise : Résiliations de Rabais",
+      "description": "Les crèches suivantes ont quitté la plateforme. Veuillez notifier les vendeurs qui les avaient marquées comme 'Clients Actifs' pour mettre fin à toute tarification spéciale ou remise.",
+      "tableTitle": "File d'attente de résiliation"
     },
     "allActive": {
-      "title": "All Active Discounts",
-      "description": "View and manage all currently active discount agreements",
-      "tableTitle": "Active Discounts"
+      "title": "Toutes les Relations Client Actives",
+      "description": "Ceci est une liste complète de toutes les relations client actuellement actives, telles que marquées par les vendeurs.",
+      "tableTitle": "Liste des Clients Actifs"
     }
-  },
-  "educatorApplicationsPage": {
-    "status": {
-      "new": "New",
-      "viewed": "Viewed",
-      "interview": "Interview",
-      "offer": "Offer",
-      "declined": "Declined"
-    },
-    "table": {
-      "jobTitle": "Job Title",
-      "creche": "Crèche",
-      "status": "Status",
-      "lastUpdated": "Last Updated",
-      "actions": "Actions"
-    },
-    "viewingDetailsFor": "Viewing details for",
-    "emptyState": "No applications found",
-    "footerNote": "Applications are updated in real-time"
   },
   "educatorDashboard": {
     "title": "Educator Dashboard",
@@ -1670,367 +1651,24 @@
       "match": "Match"
     }
   },
-  "educatorJobBoardPage": {
-    "postedOn": "Posted on",
-    "searchPlaceholder": "Search jobs...",
-    "noJobsFound": "No jobs found"
-  },
-    "notifications": {
-      "errorTitle": "Error",
-      "successTitle": "Success",
-      "newMessageFrom": "New message from"
-    },
   "Profile changes saved!": "Profile changes saved!",
-  "educatorProfilePage": {
-    "editProfile": "Edit Profile",
-    "availability": {
-      "days": "Days",
-      "times": "Times",
-      "contract": "Contract",
-      "ageGroups": "Age Groups"
-    },
-    "education": {
-      "graduated": "Graduated"
-    },
-    "certifications": {
-      "issued": "Issued",
-      "expires": "Expires"
-    }
-  },
-  "supportPage": {
-    "faqTitle": "Frequently Asked Questions",
-    "furtherAssistanceTitle": "Need Further Assistance?",
-    "furtherAssistanceText": [
-      "Contact our support team for personalized help",
-      "We're here to assist you with any questions or issues"
-    ],
-    "submitTicketTitle": "Submit Support Ticket",
-    "ticketForm": {
-      "subjectLabel": "Subject",
-      "messageLabel": "Message"
-    }
-  },
-  "educatorSupportPage": {
-    "ticketSubmittedAlert": "Support ticket submitted successfully",
-    "ticketForm": {
-      "subjectPlaceholder": "Brief description of your issue",
-      "messagePlaceholder": "Please provide detailed information about your issue"
-    }
-  },
-  "foundationAnalyticsPage": {
-    "mockDataVisualization": "Mock Data Visualization",
-    "spendingByCategory": "Spending by Category",
-    "parentLeadConversion": "Parent Lead Conversion",
-    "staffTrainingCompletion": "Staff Training Completion",
-    "enrollmentTrend": "Enrollment Trend"
-  },
   "foundationDashboard": {
-    "title": "Foundation Dashboard",
-    "welcomeMessage": "Welcome to your foundation dashboard",
+    "title": "Tableau de Bord Fondation",
+    "welcomeMessage": "Bienvenue, {{name}} !",
     "quickStats": {
-      "title": "Quick Stats"
+      "title": "Statistiques Rapides"
     },
-    "todayAtGlance": "Today at a Glance",
+    "todayAtGlance": "Aperçu d'Aujourd'hui",
     "activity": {
-      "title": "Recent Activity"
+      "title": "Activité Récente"
     },
     "quickActions": {
-      "title": "Quick Actions"
+      "title": "Actions Rapides"
     },
     "quickMessage": {
-      "title": "Quick Message",
-      "placeholder": "Type your message here..."
+      "title": "Message Rapide",
+      "placeholder": "Envoyer un message rapide au personnel..."
     }
-  },
-  "foundationLeadsPage": {
-    "title": "Incoming Parent Leads",
-    "accessDenied": {
-      "title": "Access Denied",
-      "message": "You must be logged in as a Foundation with a valid Organization ID to view this page."
-    },
-    "emptyState": {
-      "title": "No Incoming Leads",
-      "message": "There are currently no new parent enquiries matching your daycare."
-    }
-  },
-  "foundationOrdersAppointmentsPage": {
-    "productOrdersTitle": "Product Orders",
-    "exportCsvProductAlert": "Product orders CSV export started",
-    "exportCsvButton": "Export CSV",
-    "noProductOrders": "No product orders found",
-    "table": {
-      "refNo": "Ref No",
-      "supplier": "Supplier",
-      "itemsQty": "Items/Qty",
-      "total": "Total",
-      "date": "Date",
-      "status": "Status",
-      "actions": "Actions",
-      "provider": "Provider",
-      "service": "Service"
-    },
-    "cancelOrderAlert": "Order cancelled successfully",
-    "serviceAppointmentsTitle": "Service Appointments",
-    "exportCsvServiceAlert": "Service appointments CSV export started",
-    "noServiceAppointments": "No service appointments found",
-    "unknownProvider": "Unknown Provider",
-    "preferredAbbr": "Pref.",
-    "notApplicable": "N/A",
-    "rescheduleAlert": "Appointment rescheduled successfully",
-    "rescheduleButton": "Reschedule",
-    "productOrdersTab": "Product Orders",
-    "serviceAppointmentsTab": "Service Appointments"
-  },
-  "supplierAnalyticsPage": {
-    "datePickerLabel": "Select Date Range",
-    "exportCsvAlert": "CSV export started",
-    "exportCsvButton": "Export CSV",
-    "mockChartText": "Mock chart visualization",
-    "orderRequestsPerWeek": "Order Requests Per Week",
-    "topViewedProducts": "Top Viewed Products",
-    "requestsByCanton": "Requests by Canton",
-    "promoCodePerformance": "Promo Code Performance",
-    "table": {
-      "code": "Code",
-      "uses": "Uses",
-      "estRevenueImpact": "Est. Revenue Impact"
-    }
-  },
-  "serviceProviderAnalyticsPage": {
-    "serviceRequestsPerWeek": "Service Requests Per Week",
-    "topViewedServices": "Top Viewed Services",
-    "requestsByCanton": "Requests by Canton"
-  },
-  "serviceProviderDashboard": {
-    "welcomeMessage": "Welcome to your service provider dashboard",
-    "widgets": {
-      "overview": {
-        "title": "Overview",
-        "activeRequests": "Active Requests",
-        "completedServices": "Completed Services",
-        "upcoming": "Upcoming",
-        "customerRating": "Customer Rating",
-        "button": "View All"
-      },
-      "management": {
-        "title": "Service Management",
-        "listings": "Service Listings",
-        "pending": "Pending Approvals",
-        "categories": "Categories",
-        "button": "Manage Services"
-      },
-      "appointments": {
-        "title": "Appointments",
-        "with": "with",
-        "button": "Schedule New"
-      }
-    }
-  },
-  "serviceProviderListingsPage": {
-    "card": {
-      "category": "Category",
-      "delivery": "Delivery"
-    },
-    "confirmDelete": "Are you sure you want to delete this service?",
-    "addNewServiceButton": "Add New Service",
-    "searchPlaceholder": "Search services...",
-    "emptyState": {
-      "title": "No Services Found",
-      "noMatch": "No services match your search criteria",
-      "noServicesYet": "You haven't created any services yet"
-    }
-  },
-  "serviceProviderRequestsPage": {
-    "filterByStatus": "Filter by Status",
-    "table": {
-      "requestId": "Request ID",
-      "foundation": "Foundation",
-      "service": "Service",
-      "date": "Date",
-      "status": "Status"
-    },
-    "emptyState": "No service requests found"
-  },
-  "serviceProviderSupportPage": {
-    "ticketSubmittedAlert": "Support ticket submitted successfully",
-    "ticketForm": {
-      "subjectPlaceholder": "Brief description of your issue",
-      "messagePlaceholder": "Please provide detailed information about your issue"
-    }
-  },
-  "supplierDashboard": {
-    "title": "Supplier Dashboard",
-    "welcomeMessage": "Welcome to your supplier dashboard",
-    "noSalesYet": "No sales data available yet",
-    "widgets": {
-      "sales": {
-        "title": "Sales Overview",
-        "totalOrders": "Total Orders",
-        "revenueMonth": "Revenue This Month",
-        "topSelling": "Top Selling",
-        "fulfillmentRate": "Fulfillment Rate",
-        "button": "View Analytics"
-      },
-      "products": {
-        "title": "Product Management",
-        "active": "Active Products",
-        "pending": "Pending Approval",
-        "lowStock": "Low Stock",
-        "button": "Manage Products"
-      },
-      "orders": {
-        "title": "Order Management",
-        "pending": "Pending Orders",
-        "toFulfill": "To Fulfill",
-        "button": "View Orders"
-      }
-    },
-    "recentOrdersTitle": "Recent Orders",
-    "noRecentOrders": "No recent orders",
-    "recentOrdersTable": {
-      "id": "Order ID",
-      "creche": "Crèche",
-      "date": "Date",
-      "total": "Total",
-      "status": "Status"
-    },
-    "recentOrdersActions": {
-      "decline": "Decline",
-      "accept": "Accept"
-    }
-  },
-  "supplierOrdersPage": {
-    "filterByStatus": "Filter by Status",
-    "table": {
-      "orderId": "Order ID",
-      "date": "Date",
-      "total": "Total",
-      "status": "Status",
-      "foundation": "Foundation"
-    },
-    "actions": {
-      "ship": "Ship"
-    },
-    "emptyState": "No orders found"
-  },
-  "supplierProductListingsPage": {
-    "addProductAlert": "Product added successfully",
-    "addProductButton": "Add New Product",
-    "searchPlaceholder": "Search products...",
-    "table": {
-      "product": "Product",
-      "price": "Price",
-      "stock": "Stock",
-      "visibility": "Visibility",
-      "actions": "Actions"
-    },
-    "emptyState": "No products found"
-  },
-  "supplierSupportPage": {
-    "ticketSubmittedAlert": "Support ticket submitted successfully",
-    "ticketForm": {
-      "subjectPlaceholder": "Brief description of your issue",
-      "messagePlaceholder": "Please provide detailed information about your issue"
-    }
-  },
-  "foundationOrganisationProfilePage": {
-    "mock": {
-      "pedagogyStatement": "Our pedagogy is based on the principles of respect, creativity, and individual development. We believe in providing a nurturing environment where children can explore, learn, and grow at their own pace."
-    },
-    "alert": {
-      "infoSaved": "Profile information saved successfully"
-    },
-    "sections": {
-      "branding": {
-        "title": "Branding & Identity",
-        "logoLabel": "Logo",
-        "coverImageLabel": "Cover Image",
-        "pedagogyStatementLabel": "Pedagogy Statement",
-        "pedagogyStatementPlaceholder": "Describe your educational approach and philosophy..."
-      },
-      "operations": {
-        "title": "Operations",
-        "openingHoursLabel": "Opening Hours",
-        "openingHoursPlaceholder": "e.g., Monday-Friday 7:00-18:00",
-        "contactInfoLabel": "Contact Information",
-        "contactInfoPlaceholder": "Phone, email, address..."
-      },
-      "online": {
-        "title": "Online Presence",
-        "bookingLinkLabel": "Booking Link",
-        "bookingLinkPlaceholder": "https://your-booking-system.com",
-        "socialMediaLinkLabel": "Social Media Links",
-        "socialMediaLinkPlaceholder": "Facebook, Instagram, LinkedIn...",
-        "acceptingLeadsLabel": "Accepting New Leads"
-      }
-    },
-    "saveButton": "Save Profile"
-  },
-  "foundationSupportPage": {
-    "ticketSubmittedAlert": "Support ticket submitted successfully",
-    "ticketForm": {
-      "subjectPlaceholder": "Brief description of your issue",
-      "messagePlaceholder": "Please provide detailed information about your issue"
-    }
-  },
-  "parentDashboard": {
-    "title": "Parent Dashboard",
-    "welcomeMessage": "Welcome to your parent dashboard",
-    "enquiry": {
-      "sent": "Enquiries Sent",
-      "responses": "Responses Received",
-      "pending": "Pending Responses",
-      "button": "Send New Enquiry"
-    },
-    "childProfile": {
-      "name": "Child's Name",
-      "age": "Age",
-      "location": "Location",
-      "languages": "Languages",
-      "specialNeeds": "Special Needs",
-      "button": "Update Profile"
-    },
-    "favorites": {
-      "subtitle": "Your favorite crèches and services",
-      "button": "View Favorites"
-    }
-  },
-  "parentSupportPage": {
-    "faq": {
-      "matchingProcess": {
-        "q": "How does the matching process work?",
-        "a": "Our algorithm matches your child's needs with available crèches based on location, age, special requirements, and availability."
-      },
-      "responseTime": {
-        "q": "How quickly will I receive responses?",
-        "a": "Most crèches respond within 24-48 hours. You'll be notified immediately when responses arrive."
-      },
-      "dataSecurity": {
-        "q": "Is my personal information secure?",
-        "a": "Yes, we use enterprise-grade encryption and comply with Swiss data protection laws. Your information is never shared without consent."
-      }
-    }
-  },
-  "partnerDetailPage": {
-    "productOutOfStock": "Product is currently out of stock",
-    "productAddedToOrder": "Product added to order successfully",
-    "addToOrderButton": "Add to Order",
-    "loadingPartnerDetails": "Loading partner details...",
-    "invalidPartnerIdMessage": "Could not find a user associated with this organization to message.",
-    "contactInfoTitle": "Contact Information",
-    "directOrderButton": "Direct Order",
-    "aboutTitle": "About",
-    "ratingsReviewsTitle": "Ratings & Reviews",
-    "ratingText": "Rating",
-    "reviewsPlaceholder": "No reviews yet",
-    "noProductsListed": "No products listed",
-    "requestServiceButton": "Request Service",
-    "noServicesListed": "No services listed",
-    "promoCodeTitle": "Promo Code",
-    "promoCodePlaceholder": "Enter promo code",
-    "applyPromoButton": "Apply",
-    "onlyFoundationsRequestService": "Only foundations can request services",
-    "requestSubmittedAlert": "Service request submitted successfully"
   },
   "userRoles": {
     "Product Supplier": "Product Supplier",
@@ -2045,9 +1683,6 @@
   },
   "addPromoCodeModal": {
     "placeholder": "Add/Edit Promo Code Modal (Placeholder)"
-  },
-  "orderRequestDetailModal": {
-    "markAsProcessing": "Mark as Processing"
   },
   "fileUploadZone": {
     "dragAndDrop": "or drag and drop"
@@ -2064,149 +1699,5 @@
   },
   "notificationContext": {
     "useNotificationsError": "useNotifications must be used within a NotificationProvider"
-  },
-  "loading": {
-    "translations": "Loading translations..."
-  },
-  "dashboardDetailPage": {
-    "activeUsers": {
-      "recentActivity": "Recent Activity",
-      "totalToday": "Total active users today: {{count}}",
-      "aliceActivity": "Alice Johnson - Logged in 2 hours ago, viewed 5 pages.",
-      "bobActivity": "Bob Williams - Updated profile at 10:30 AM.",
-      "carolActivity": "Carol Davis - Joined yesterday, completed onboarding.",
-      "davidActivity": "David Brown - Viewed marketplace listings."
-    },
-    "newOrders": {
-      "recentOrders": "Recent Orders",
-      "table": {
-        "orderId": "Order ID",
-        "product": "Product",
-        "amount": "Amount",
-        "status": "Status"
-      },
-      "status": {
-        "paid": "Paid",
-        "pending": "Pending"
-      },
-      "totalThisWeek": "Total orders this week: {{count}}",
-      "order789": "#ORD789",
-      "order790": "#ORD790", 
-      "order791": "#ORD791",
-      "ecotoysBlocks": "EcoToys Wooden Blocks",
-      "freshBitesMeal": "FreshBites Meal Plan",
-      "artFunPack": "ArtFun Creative Pack"
-    },
-    "openJobs": {
-      "currentPositions": "Current Open Positions",
-      "applications": "Applications",
-      "totalOpenPositions": "Total Open Positions",
-      "leadEducatorGeneva": "Lead Educator - Geneva",
-      "assistantEducatorLausanne": "Assistant Educator - Lausanne",
-      "daycareDirectorZurich": "Daycare Director - Zurich",
-      "status": {
-        "open": "Open",
-        "interviewing": "Interviewing"
-      }
-    },
-    "pageViews": {
-      "keyMetrics": "Key Metrics",
-      "totalToday": "Total page views today",
-      "uniqueVisitors": "Unique visitors",
-      "mostViewed": "Most viewed pages",
-      "dashboardViews": "/dashboard (560 views)",
-      "avgSession": "Average session duration",
-      "sessionDuration": "4m 15s",
-      "mockChartText": "Mock chart visualization"
-    },
-    "defaultTitle": "Dashboard Detail",
-    "detailsFor": "Details for",
-    "noSpecificView": "No specific view selected"
-  },
-  "designSystemPage": {
-    "title": "Design System",
-    "description": "A living reference for all UI components and design tokens in the Pro Crèche Solutions application.",
-    "tabs": {
-      "tab1": "Tab 1",
-      "tab2": "Tab 2",
-      "tab3": "Tab 3",
-      "content1": "This is the content for Tab 1.",
-      "content2": "This is the content for Tab 2.",
-      "content3": "This is a disabled tab."
-    },
-    "typography": {
-      "fontFamily": "Font Family: Nunito, Inter, sans-serif",
-      "heading1": "Heading 1: The quick brown fox",
-      "heading2": "Heading 2: The quick brown fox",
-      "heading3": "Heading 3: The quick brown fox",
-      "heading4": "Heading 4: The quick brown fox",
-      "bodyBase": "Body Text (Base): Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.",
-      "bodySmall": "Body Text (Small): Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi.",
-      "link": "This is a link"
-    },
-    "buttons": {
-      "extraSmall": "Extra Small",
-      "small": "Small",
-      "mediumDefault": "Medium (Default)",
-      "large": "Large",
-      "withIcons": "With Icons",
-      "leftIcon": "Left Icon",
-      "rightIcon": "Right Icon",
-      "smallIcon": "Small Icon",
-      "disabledState": "Disabled State",
-      "primaryDisabled": "Primary Disabled",
-      "secondaryDisabled": "Secondary Disabled",
-      "outlineDisabled": "Outline Disabled"
-    },
-    "cards": {
-      "standardCard": "Standard Card",
-      "standardCardDesc": "This is a standard card component with a soft shadow. It's the base for most content containers.",
-      "hoverEffectCard": "Hover Effect Card",
-      "hoverEffectCardDesc": "This card has a subtle scale and shadow transition on hover, useful for interactive elements."
-    },
-    "formControls": {
-      "title": "Form Controls",
-      "textInput": "Text Input",
-      "selectMenu": "Select Menu",
-      "option1": "Option 1",
-      "option2": "Option 2",
-      "option3": "Option 3",
-      "quantityInput": "Quantity Input",
-      "disabledInput": "Disabled Input"
-    },
-    "tabs": {
-      "title": "Tabs",
-      "pillsVariant": "Pills Variant (Default)",
-      "lineVariant": "Line Variant",
-      "tab1": "Tab 1",
-      "content1": "This is the content for Tab 1.",
-      "tab2": "Tab 2",
-      "content2": "This is the content for Tab 2.",
-      "tab3": "Tab 3",
-      "content3": "This is a disabled tab."
-    },
-  "View Favorites TBD": "View Favorites TBD",
-  "Could not find a user associated with this organization to message.": "Could not find a user associated with this organization to message.",
-  "User organization details are missing.": "User organization details are missing.",
-  "tailwindcss": "tailwindcss",
-  "sidebar.parentLeads": "Parent Leads",
-  "sidebar.products": "Products",
-  "sidebar.services": "Services",
-  "No recent activity.": "No recent activity.",
-  "loaded": "loaded",
-  "SUPER_ADMIN": "SUPER_ADMIN",
-  "Show": "Show",
-  "Refresh": "Refresh",
-  "keys)": "keys)",
-  "(240)": "(240)",
-  "Branding": "Branding",
-  "Favicon": "Favicon",
-  "Search job offers...": "Search job offers...",
-  "Search partners...": "Search partners...",
-  "Search candidates...": "Search candidates...",
-  "Search content...": "Search content...",
-  "admin@procrechesolutions.com": "admin@procrechesolutions.com",
-  "No documents found in this category for current filters.": "No documents found in this category for current filters.",
-  "No custom alerts created yet.": "No custom alerts created yet."
   }
 }

--- a/scripts/translate-i18n-free.js
+++ b/scripts/translate-i18n-free.js
@@ -16,20 +16,15 @@ const path = require('path');
 
 // Try to use translate-google-api, fallback to manual if not available
 let translate;
+let usingOfflineFallback = false;
+const OFFLINE_TRANSLATIONS_DIR = path.join('translation-files-consolidated');
 
 try {
   translate = require('translate-google-api');
 } catch (error) {
-  console.log('📦 Installing translate-google-api...');
-  const { execSync } = require('child_process');
-  
-  try {
-    execSync('npm install translate-google-api', { stdio: 'inherit' });
-    translate = require('translate-google-api');
-  } catch (installError) {
-    console.error('❌ Failed to install translate-google-api. Please run: npm install translate-google-api');
-    process.exit(1);
-  }
+  console.warn('⚠️  translate-google-api not available. Falling back to offline translations if provided.');
+  usingOfflineFallback = true;
+  translate = async (value, { to }) => ({ value, to });
 }
 
 // Configuration
@@ -51,6 +46,7 @@ class FreeI18nTranslator {
   constructor() {
     this.translatedCount = 0;
     this.totalKeys = 0;
+    this.offlineDictionaries = {};
   }
 
   async loadSourceFile() {
@@ -64,18 +60,31 @@ class FreeI18nTranslator {
     return JSON.parse(content);
   }
 
-  async translateValue(value, targetLanguage) {
+  async translateValue(value, targetLanguage, pathParts = []) {
     if (typeof value === 'string') {
       // Skip if it's just a variable interpolation or HTML
       if (value.includes('{{') || value.includes('<') || value.length < 3) {
         return value;
       }
-      
+
       try {
         console.log(`  Translating: "${value}"`);
+        if (usingOfflineFallback) {
+          const keyPath = pathParts.join('.');
+          const offlineValue = this.offlineDictionaries[targetLanguage]?.get(keyPath);
+
+          if (offlineValue) {
+            this.translatedCount++;
+            return offlineValue;
+          }
+
+          console.warn(`  ⚠️  Offline translation missing for key: ${keyPath}. Keeping original value.`);
+          return value;
+        }
+
         const translated = await translate(value, { to: LANGUAGE_CODES[targetLanguage] });
         this.translatedCount++;
-        
+
         // Handle array responses from Google Translate
         if (Array.isArray(translated)) {
           return translated[0] || value;
@@ -90,7 +99,7 @@ class FreeI18nTranslator {
       // Recursively translate object values
       const result = {};
       for (const [key, val] of Object.entries(value)) {
-        result[key] = await this.translateValue(val, targetLanguage);
+        result[key] = await this.translateValue(val, targetLanguage, [...pathParts, key]);
       }
       return result;
     }
@@ -100,15 +109,50 @@ class FreeI18nTranslator {
 
   async translateObject(obj, targetLanguage) {
     console.log(`\n🌍 Translating to ${targetLanguage.toUpperCase()}...`);
-    
+
     // Count total string values to translate
     this.totalKeys = this.countStringValues(obj);
     this.translatedCount = 0;
-    
+
     const translated = await this.translateValue(obj, targetLanguage);
-    
+
     console.log(`✅ Translated ${this.translatedCount}/${this.totalKeys} values`);
     return translated;
+  }
+
+  prepareOfflineDictionary(sourceObj, targetLanguage) {
+    if (!usingOfflineFallback) {
+      return;
+    }
+
+    const targetFilePath = path.join(process.cwd(), OFFLINE_TRANSLATIONS_DIR, targetLanguage, 'translation.json');
+    if (!fs.existsSync(targetFilePath)) {
+      console.warn(`  ⚠️  Offline translation file not found for ${targetLanguage.toUpperCase()}: ${targetFilePath}`);
+      this.offlineDictionaries[targetLanguage] = new Map();
+      return;
+    }
+
+    const fallbackObj = JSON.parse(fs.readFileSync(targetFilePath, 'utf8'));
+    const map = new Map();
+
+    const walk = (sourceNode, fallbackNode, pathParts = []) => {
+      if (typeof sourceNode === 'string') {
+        if (typeof fallbackNode === 'string') {
+          map.set(pathParts.join('.'), fallbackNode);
+        }
+        return;
+      }
+
+      if (typeof sourceNode === 'object' && sourceNode !== null) {
+        for (const [key, sourceVal] of Object.entries(sourceNode)) {
+          const fallbackVal = fallbackNode && typeof fallbackNode === 'object' ? fallbackNode[key] : undefined;
+          walk(sourceVal, fallbackVal, [...pathParts, key]);
+        }
+      }
+    };
+
+    walk(sourceObj, fallbackObj);
+    this.offlineDictionaries[targetLanguage] = map;
   }
 
   countStringValues(obj) {
@@ -153,14 +197,20 @@ class FreeI18nTranslator {
     const sourceObj = await this.loadSourceFile();
     console.log(`📊 Found ${Object.keys(sourceObj).length} top-level keys\n`);
 
+    if (usingOfflineFallback) {
+      console.log('ℹ️  Using offline fallback translations where available.');
+    }
+
     // Translate to each target language
     for (const targetLanguage of CONFIG.targetLanguages) {
       try {
         console.log(`\n🌍 Processing ${targetLanguage.toUpperCase()}...`);
-        
+
+        this.prepareOfflineDictionary(sourceObj, targetLanguage);
+
         const translatedObj = await this.translateObject(sourceObj, targetLanguage);
         await this.saveTranslation(translatedObj, targetLanguage);
-        
+
         // Add delay between requests to respect rate limits
         if (targetLanguage !== CONFIG.targetLanguages[CONFIG.targetLanguages.length - 1]) {
           console.log(`⏳ Waiting ${CONFIG.delayBetweenRequests}ms before next translation...`);


### PR DESCRIPTION
## Summary
- add an offline fallback path to the translation script so locale regeneration works without downloading packages
- regenerate the French and German locale JSON files using the updated script
- manually polish key strings for a Swiss French and Swiss German tone in the refreshed locale files

## Testing
- pnpm translate
- node - <<'NODE' ... (sample key verification)


------
https://chatgpt.com/codex/tasks/task_e_68e42e46fcc883258622150ccae1132c