### PR TITLE
Fix locale path resolution in add-missing-keys scripts

### DIFF
--- a/add-missing-keys-de.js
+++ b/add-missing-keys-de.js
@@ -1,7 +1,10 @@
 const fs = require('fs');
+const path = require('path');
+
+const deTranslationsPath = path.resolve(__dirname, 'frontend/public/locales/de/translation.json');
 
 // Read the current German translation file
-const deTranslations = JSON.parse(fs.readFileSync('/workspace/frontend/public/locales/de/translation.json', 'utf8'));
+const deTranslations = JSON.parse(fs.readFileSync(deTranslationsPath, 'utf8'));
 
 // Add the critical missing keys in German
 const criticalMissingKeys = {
@@ -232,6 +235,6 @@ Object.keys(criticalMissingKeys).forEach(namespace => {
 });
 
 // Write the updated German translation file
-fs.writeFileSync('/workspace/frontend/public/locales/de/translation.json', JSON.stringify(deTranslations, null, 2));
+fs.writeFileSync(deTranslationsPath, JSON.stringify(deTranslations, null, 2));
 
 console.log('✅ Added critical missing translation keys to German locale file');

--- a/add-missing-keys-fr.js
+++ b/add-missing-keys-fr.js
@@ -1,7 +1,10 @@
 const fs = require('fs');
+const path = require('path');
+
+const frTranslationsPath = path.resolve(__dirname, 'frontend/public/locales/fr/translation.json');
 
 // Read the current French translation file
-const frTranslations = JSON.parse(fs.readFileSync('/workspace/frontend/public/locales/fr/translation.json', 'utf8'));
+const frTranslations = JSON.parse(fs.readFileSync(frTranslationsPath, 'utf8'));
 
 // Add the critical missing keys in French
 const criticalMissingKeys = {
@@ -232,6 +235,6 @@ Object.keys(criticalMissingKeys).forEach(namespace => {
 });
 
 // Write the updated French translation file
-fs.writeFileSync('/workspace/frontend/public/locales/fr/translation.json', JSON.stringify(frTranslations, null, 2));
+fs.writeFileSync(frTranslationsPath, JSON.stringify(frTranslations, null, 2));
 
 console.log('✅ Added critical missing translation keys to French locale file');

--- a/add-missing-keys.js
+++ b/add-missing-keys.js
@@ -1,8 +1,10 @@
 const fs = require('fs');
 const path = require('path');
 
+const enTranslationsPath = path.resolve(__dirname, 'frontend/public/locales/en/translation.json');
+
 // Read the current English translation file
-const enTranslations = JSON.parse(fs.readFileSync('/workspace/frontend/public/locales/en/translation.json', 'utf8'));
+const enTranslations = JSON.parse(fs.readFileSync(enTranslationsPath, 'utf8'));
 
 // Function to set a nested key in an object
 function setNestedKey(obj, keyPath, value) {
@@ -249,6 +251,6 @@ Object.keys(criticalMissingKeys).forEach(namespace => {
 });
 
 // Write the updated English translation file
-fs.writeFileSync('/workspace/frontend/public/locales/en/translation.json', JSON.stringify(enTranslations, null, 2));
+fs.writeFileSync(enTranslationsPath, JSON.stringify(enTranslations, null, 2));
 
 console.log('✅ Added critical missing translation keys to English locale file');


### PR DESCRIPTION
## Summary
- update each add-missing-keys helper to resolve translation JSON paths relative to the repository root
- ensure read and write operations reuse the resolved path constants for the English, French, and German locale files

## Testing
- node add-missing-keys-fr.js
- node add-missing-keys-de.js

------
https://chatgpt.com/codex/tasks/task_e_68e42e4fd1f8832584b99f0aa55ecc58