### PR TITLE
Debug translation debugger not showing

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -315,7 +315,7 @@ const App: React.FC = () => {
               <Route path="/*" element={<ProtectedLayout />} />
             </Routes>
             {/* Translation Debug Tool - Only visible in development */}
-            {import.meta.env.DEV && <TranslationDebugger />}
+            {(import.meta.env.DEV || import.meta.env.MODE === 'development') && <TranslationDebugger />}
           </NotificationProvider>
         </MessagingProvider>
       </CartProvider>

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -11,7 +11,8 @@
     ],
     "skipLibCheck": true,
     "types": [
-      "node"
+      "node",
+      "vite/client"
     ],
     "moduleResolution": "bundler",
     "isolatedModules": true,

--- a/frontend/vite-env.d.ts
+++ b/frontend/vite-env.d.ts
@@ -1,0 +1,16 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly MODE: string;
+  readonly DEV: boolean;
+  readonly PROD: boolean;
+  readonly SSR: boolean;
+  readonly VITE_CLERK_PUBLISHABLE_KEY: string;
+  readonly VITE_API_URL: string;
+  readonly VITE_NODE_ENV: string;
+  // Add other env variables here as needed
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
Fix the translation debugger not showing by adding Vite type definitions and updating the development mode check.

The translation debugger was not appearing because `import.meta.env.DEV` was not properly recognized due to missing `vite-env.d.ts` and an unconfigured `tsconfig.json`. This PR adds the necessary type definitions and updates the development mode check in `App.tsx` for robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-79c03efa-a383-4bf9-a100-61dd0db095b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-79c03efa-a383-4bf9-a100-61dd0db095b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

