### PR TITLE
Investigate users page loading error

### DIFF
--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -31,7 +31,11 @@ export class UsersService {
         role: createUserDto.role as UserRole,
       },
       include: {
-        organizations: true,
+        organizations: {
+          include: {
+            organization: true,
+          },
+        },
       },
     });
   }
@@ -60,7 +64,11 @@ export class UsersService {
         skip,
         take: limit,
         include: {
-          organizations: true,
+          organizations: {
+            include: {
+              organization: true,
+            },
+          },
         },
         orderBy: {
           createdAt: 'desc',
@@ -84,7 +92,11 @@ export class UsersService {
     return this.prisma.user.findUnique({
       where: { clerkId },
       include: {
-        organizations: true,
+        organizations: {
+          include: {
+            organization: true,
+          },
+        },
       },
     });
   }
@@ -93,7 +105,11 @@ export class UsersService {
     const user = await this.prisma.user.findUnique({
       where: { id },
       include: {
-        organizations: true,
+        organizations: {
+          include: {
+            organization: true,
+          },
+        },
       },
     });
 
@@ -108,7 +124,11 @@ export class UsersService {
     return this.prisma.user.findUnique({
       where: { email },
       include: {
-        organizations: true,
+        organizations: {
+          include: {
+            organization: true,
+          },
+        },
       },
     });
   }
@@ -123,7 +143,11 @@ export class UsersService {
         },
       },
       include: {
-        organizations: true,
+        organizations: {
+          include: {
+            organization: true,
+          },
+        },
       },
     });
   }
@@ -138,7 +162,11 @@ export class UsersService {
       where: { id: user.id },
       data: updateUserDto,
       include: {
-        organizations: true,
+        organizations: {
+          include: {
+            organization: true,
+          },
+        },
       },
     });
   }
@@ -153,7 +181,11 @@ export class UsersService {
       where: { id },
       data: updateUserDto,
       include: {
-        organizations: true,
+        organizations: {
+          include: {
+            organization: true,
+          },
+        },
       },
     });
   }
@@ -211,7 +243,11 @@ export class UsersService {
           updatedAt: new Date(clerkData.updated_at),
         },
         include: {
-          organizations: true,
+          organizations: {
+            include: {
+              organization: true,
+            },
+          },
         },
       });
     } else {
@@ -227,7 +263,11 @@ export class UsersService {
           updatedAt: new Date(clerkData.updated_at),
         },
         include: {
-          organizations: true,
+          organizations: {
+            include: {
+              organization: true,
+            },
+          },
         },
       });
     }


### PR DESCRIPTION
Fixes the users page not loading in the admin dashboard by correcting the Prisma query for user organizations.

The previous Prisma query for `User.organizations` only included the `UserOrganization` join table records (`organizations: true`), but not the actual `Organization` data nested within them. This caused a 500 Internal Server Error when the API tried to serialize the incomplete organization data. The fix updates the include statement to `organizations: { include: { organization: true } }` to correctly fetch the full organization details, aligning with how other services handle this relationship.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d03b4a9-ed2f-4d88-90f9-ce9601040fae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6d03b4a9-ed2f-4d88-90f9-ce9601040fae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

