### PR TITLE
Improve login flow resilience when backend profile load fails

### DIFF
--- a/frontend/pages/LoginPage.tsx
+++ b/frontend/pages/LoginPage.tsx
@@ -51,7 +51,7 @@ const LoginPage: React.FC = () => {
   useEffect(() => {
     if (isSignedIn && !currentUser && !isAuthLoading) {
       if (authError) {
-        setError(authError);
+        setError(t(authError));
       } else {
         setError(t('common:loginPage.backendSyncError'));
       }

--- a/frontend/pages/LoginPage.tsx
+++ b/frontend/pages/LoginPage.tsx
@@ -7,6 +7,8 @@ import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
 import { SquaresPlusIcon, EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
 import LanguageSwitcher from '../components/ui/LanguageSwitcher';
+import { useAppContext } from '../contexts/AppContext';
+import { useAuthContext } from '../providers/AuthProvider';
 
 // Social icons
 const GoogleIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
@@ -30,6 +32,8 @@ const LoginPage: React.FC = () => {
   const navigate = useNavigate();
   const { signIn, isLoaded, setActive } = useSignIn();
   const { isSignedIn } = useAuth();
+  const { currentUser } = useAppContext();
+  const { isLoading: isAuthLoading, authError, clearAuthError } = useAuthContext();
   
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -39,14 +43,25 @@ const LoginPage: React.FC = () => {
 
   // Redirect if user is already logged in
   useEffect(() => {
-    if (isSignedIn) {
+    if (isSignedIn && currentUser) {
       navigate('/dashboard', { replace: true });
     }
-  }, [isSignedIn, navigate]);
+  }, [isSignedIn, currentUser, navigate]);
+
+  useEffect(() => {
+    if (isSignedIn && !currentUser && !isAuthLoading) {
+      if (authError) {
+        setError(authError);
+      } else {
+        setError(t('common:loginPage.backendSyncError'));
+      }
+    }
+  }, [isSignedIn, currentUser, isAuthLoading, authError, t]);
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
+    clearAuthError();
     
     if (!email || !password) {
       setError(t('common:loginPage.errorBothFields'));

--- a/frontend/providers/AuthProvider.tsx
+++ b/frontend/providers/AuthProvider.tsx
@@ -1,13 +1,19 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
-import { useUser, useAuth, ClerkProvider, useClerk } from '@clerk/clerk-react';
+import { useUser, useAuth, ClerkProvider } from '@clerk/clerk-react';
 import { User, UserRole } from '../types';
 import { API_ENDPOINTS } from '../services/api-endpoints';
 import { ApiError } from '../services/api';
 
+const BACKEND_SYNC_ERROR_MESSAGE = "We couldn't load your account details. Please try again.";
+const BACKEND_USER_CREATION_ERROR_MESSAGE = 'Backend user creation failed. Please ensure Clerk webhook is configured.';
+
 interface AuthContextType {
   currentUser: User | null;
+  setCurrentUser: React.Dispatch<React.SetStateAction<User | null>>;
   isLoading: boolean;
   isAuthenticated: boolean;
+  authError: string | null;
+  clearAuthError: () => void;
   login: (email: string, password?: string) => Promise<{ success: boolean; message?: string }>;
   logout: () => Promise<void>;
   signup: (formData: any, role: any) => Promise<{ success: boolean; message?: string; redirectTo?: string }>;
@@ -25,8 +31,9 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
   const { getToken, signOut: clerkSignOut } = useAuth();
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [authError, setAuthError] = useState<string | null>(null);
 
-  const isAuthenticated = !!currentUser && !!clerkUser;
+  const isAuthenticated = !!clerkUser;
 
   // Sync user data when Clerk user changes
   useEffect(() => {
@@ -38,6 +45,7 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
 
       if (!clerkUser) {
         setCurrentUser(null);
+        setAuthError(null);
         setIsLoading(false);
         return;
       }
@@ -45,16 +53,19 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
       try {
         // Sync user with backend API
         await syncUserWithBackend(clerkUser, getToken);
+        setAuthError(null);
       } catch (error) {
         console.error('Failed to sync user with backend:', error);
-        
+
         // Don't create fallback users - show error state
         // Backend connection is required for proper user data
         setCurrentUser(null);
-        
+
+        setAuthError(BACKEND_SYNC_ERROR_MESSAGE);
+
         // Log error for debugging
         console.error('Unable to load user profile. Backend connection required.');
-        
+
         // TODO: Show error notification to user
         // For now, the app will redirect to login via ProtectedRoute
       } finally {
@@ -67,6 +78,7 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
 
   const login = async (email: string, password?: string): Promise<{ success: boolean; message?: string }> => {
     // Clerk handles authentication, this is just for compatibility
+    setAuthError(null);
     return { success: true };
   };
 
@@ -74,7 +86,8 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
     try {
       // Clear local user state first
       setCurrentUser(null);
-      
+      setAuthError(null);
+
       // Properly sign out from Clerk
       await clerkSignOut();
     } catch (error) {
@@ -119,6 +132,7 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
           memberSince: data.data.createdAt,
         };
         setCurrentUser(transformedUser);
+        setAuthError(null);
       }
     } catch (error) {
       console.error('Failed to update user:', error);
@@ -159,11 +173,13 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
           memberSince: data.data.createdAt,
         };
         setCurrentUser(transformedUser);
+        setAuthError(null);
       } else {
         throw new Error('Invalid response format');
       }
     } catch (error) {
       console.error('Sync error:', error);
+      setAuthError(BACKEND_SYNC_ERROR_MESSAGE);
       throw error;
     }
   };
@@ -182,10 +198,11 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
       await syncUserWithBackend(clerkUser, getToken);
     } catch (error) {
       console.error('User still not found after webhook wait. Backend webhook may not be configured.');
-      
+
       // Don't create fallback - require backend connection
       setCurrentUser(null);
-      throw new Error('Backend user creation failed. Please ensure Clerk webhook is configured.');
+      setAuthError(BACKEND_USER_CREATION_ERROR_MESSAGE);
+      throw new Error(BACKEND_USER_CREATION_ERROR_MESSAGE);
     }
   };
 
@@ -193,8 +210,11 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
     <AuthContext.Provider
       value={{
         currentUser,
+        setCurrentUser,
         isLoading,
         isAuthenticated,
+        authError,
+        clearAuthError: () => setAuthError(null),
         login,
         logout,
         signup,

--- a/frontend/providers/AuthProvider.tsx
+++ b/frontend/providers/AuthProvider.tsx
@@ -4,8 +4,8 @@ import { User, UserRole } from '../types';
 import { API_ENDPOINTS } from '../services/api-endpoints';
 import { ApiError } from '../services/api';
 
-const BACKEND_SYNC_ERROR_MESSAGE = "We couldn't load your account details. Please try again.";
-const BACKEND_USER_CREATION_ERROR_MESSAGE = 'Backend user creation failed. Please ensure Clerk webhook is configured.';
+const BACKEND_SYNC_ERROR_KEY = 'common:loginPage.backendSyncError';
+const BACKEND_USER_CREATION_ERROR_KEY = 'common:loginPage.backendUserCreationError';
 
 interface AuthContextType {
   currentUser: User | null;
@@ -62,8 +62,10 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
         setCurrentUser(null);
 
         const errorMessage = error instanceof Error ? error.message : String(error);
-        if (errorMessage !== BACKEND_USER_CREATION_ERROR_MESSAGE) {
-          setAuthError(BACKEND_SYNC_ERROR_MESSAGE);
+        if (errorMessage === BACKEND_USER_CREATION_ERROR_KEY) {
+          setAuthError(BACKEND_USER_CREATION_ERROR_KEY);
+        } else {
+          setAuthError(BACKEND_SYNC_ERROR_KEY);
         }
 
         // Log error for debugging
@@ -182,7 +184,11 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
       }
     } catch (error) {
       console.error('Sync error:', error);
-      setAuthError(BACKEND_SYNC_ERROR_MESSAGE);
+      if (error instanceof Error && error.message === BACKEND_USER_CREATION_ERROR_KEY) {
+        setAuthError(BACKEND_USER_CREATION_ERROR_KEY);
+      } else {
+        setAuthError(BACKEND_SYNC_ERROR_KEY);
+      }
       throw error;
     }
   };
@@ -204,8 +210,8 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
 
       // Don't create fallback - require backend connection
       setCurrentUser(null);
-      setAuthError(BACKEND_USER_CREATION_ERROR_MESSAGE);
-      throw new Error(BACKEND_USER_CREATION_ERROR_MESSAGE);
+      setAuthError(BACKEND_USER_CREATION_ERROR_KEY);
+      throw new Error(BACKEND_USER_CREATION_ERROR_KEY);
     }
   };
 

--- a/frontend/providers/AuthProvider.tsx
+++ b/frontend/providers/AuthProvider.tsx
@@ -61,7 +61,10 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
         // Backend connection is required for proper user data
         setCurrentUser(null);
 
-        setAuthError(BACKEND_SYNC_ERROR_MESSAGE);
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        if (errorMessage !== BACKEND_USER_CREATION_ERROR_MESSAGE) {
+          setAuthError(BACKEND_SYNC_ERROR_MESSAGE);
+        }
 
         // Log error for debugging
         console.error('Unable to load user profile. Backend connection required.');

--- a/packages/translations/locales/de/common.json
+++ b/packages/translations/locales/de/common.json
@@ -587,7 +587,8 @@
     "alreadyAccount": "[DE] Already have an account?",
     "errorBothFields": "[DE] Please fill in both email and password",
     "loggingIn": "[DE] Logging in...",
-    "backendSyncError": "[DE] We couldn't load your account details. Please try again."
+    "backendSyncError": "Wir konnten Ihre Kontodaten nicht laden. Bitte versuchen Sie es erneut.",
+    "backendUserCreationError": "Erstellung des Backend-Benutzers fehlgeschlagen. Bitte stellen Sie sicher, dass der Clerk-Webhook konfiguriert ist."
   },
   "contentUploadModal": {
     "error": {

--- a/packages/translations/locales/de/common.json
+++ b/packages/translations/locales/de/common.json
@@ -586,7 +586,8 @@
     "socialLoginTBD": "[DE] {{provider}} login coming soon!",
     "alreadyAccount": "[DE] Already have an account?",
     "errorBothFields": "[DE] Please fill in both email and password",
-    "loggingIn": "[DE] Logging in..."
+    "loggingIn": "[DE] Logging in...",
+    "backendSyncError": "[DE] We couldn't load your account details. Please try again."
   },
   "contentUploadModal": {
     "error": {

--- a/packages/translations/locales/en/common.json
+++ b/packages/translations/locales/en/common.json
@@ -166,7 +166,8 @@
     "alreadyAccount": "Already have an account?",
     "errorBothFields": "Please fill in both email and password",
     "loggingIn": "Logging in...",
-    "backendSyncError": "We couldn't load your account details. Please try again."
+    "backendSyncError": "We couldn't load your account details. Please try again.",
+    "backendUserCreationError": "Backend user creation failed. Please ensure Clerk webhook is configured."
   },
   "hidePassword": "Hide password",
   "showPassword": "Show password",

--- a/packages/translations/locales/en/common.json
+++ b/packages/translations/locales/en/common.json
@@ -165,7 +165,8 @@
     "socialLoginTBD": "{{provider}} login coming soon!",
     "alreadyAccount": "Already have an account?",
     "errorBothFields": "Please fill in both email and password",
-    "loggingIn": "Logging in..."
+    "loggingIn": "Logging in...",
+    "backendSyncError": "We couldn't load your account details. Please try again."
   },
   "hidePassword": "Hide password",
   "showPassword": "Show password",

--- a/packages/translations/locales/fr/common.json
+++ b/packages/translations/locales/fr/common.json
@@ -267,7 +267,8 @@
     "socialLoginTBD": "[FR] {{provider}} login coming soon!",
     "alreadyAccount": "[FR] Already have an account?",
     "errorBothFields": "[FR] Please fill in both email and password",
-    "loggingIn": "[FR] Logging in..."
+    "loggingIn": "[FR] Logging in...",
+    "backendSyncError": "[FR] We couldn't load your account details. Please try again."
   },
   "settingsPage": {
     "unsavedChangesPrompt": "[FR] You have unsaved changes. Are you sure you want to leave?",

--- a/packages/translations/locales/fr/common.json
+++ b/packages/translations/locales/fr/common.json
@@ -268,7 +268,8 @@
     "alreadyAccount": "[FR] Already have an account?",
     "errorBothFields": "[FR] Please fill in both email and password",
     "loggingIn": "[FR] Logging in...",
-    "backendSyncError": "[FR] We couldn't load your account details. Please try again."
+    "backendSyncError": "Nous n'avons pas pu charger les détails de votre compte. Veuillez réessayer.",
+    "backendUserCreationError": "La création de l'utilisateur sur le backend a échoué. Veuillez vérifier que le webhook Clerk est configuré."
   },
   "settingsPage": {
     "unsavedChangesPrompt": "[FR] You have unsaved changes. Are you sure you want to leave?",


### PR DESCRIPTION
## Summary
- add shared auth context state for backend profile sync errors and expose the setter needed by the app context
- update the login page to wait for a hydrated profile before redirecting and surface backend sync failures to the user
- localize the new backend sync error message across supported languages

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ef6e2422dc8325b5ff677035e3a776