### PR TITLE
Ensure Clerk signups create backend users

### DIFF
--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -1,15 +1,16 @@
 import {
-  Controller,
-  Get,
-  Post,
   Body,
-  Patch,
-  Param,
+  Controller,
   Delete,
-  UseGuards,
-  Query,
+  Get,
+  NotFoundException,
+  Param,
   ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
   Request,
+  UseGuards,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
@@ -50,10 +51,19 @@ export class UsersController {
   @Get('me')
   async getCurrentUser(@Request() request) {
     const user = await this.usersService.findByClerkId(request.user.clerkId);
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
     return {
       success: true,
       data: user,
     };
+  }
+
+  @Post('me/sync')
+  async syncCurrentUser(@Request() request) {
+    const user = await this.usersService.syncCurrentUser(request.user.clerkId);
+    return { success: true, data: user };
   }
 
   @Get(':id')

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -1,8 +1,9 @@
-import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import { Injectable, NotFoundException, ConflictException, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
-import { UserRole } from '@prisma/client';
+import { AppUser, UserRole } from '@prisma/client';
+import { createClerkClient } from '@clerk/clerk-sdk-node';
 
 export interface FindAllUsersParams {
   page: number;
@@ -13,27 +14,20 @@ export interface FindAllUsersParams {
 
 @Injectable()
 export class UsersService {
-  constructor(private prisma: PrismaService) {}
+  private readonly logger = new Logger(UsersService.name);
+  private readonly clerkClient: ReturnType<typeof createClerkClient> | null;
 
-  async create(createUserDto: CreateUserDto) {
-    // Check if user exists
-    const existingUser = await this.prisma.appUser.findUnique({
-      where: { email: createUserDto.email },
-    });
-
-    if (existingUser) {
-      throw new ConflictException('User with this email already exists');
+  constructor(private prisma: PrismaService) {
+    const secret = process.env.CLERK_SECRET_KEY;
+    if (secret) {
+      this.clerkClient = createClerkClient({ secretKey: secret });
+    } else {
+      this.logger.warn('CLERK_SECRET_KEY not configured. Manual Clerk sync is disabled.');
+      this.clerkClient = null;
     }
+  }
 
-    const appUser = await this.prisma.appUser.create({
-      data: {
-        clerkId: createUserDto.clerkId,
-        email: createUserDto.email,
-        role: createUserDto.role as UserRole,
-      },
-    });
-
-    // Return in User format for compatibility
+  private buildUserResponse(appUser: AppUser) {
     return {
       id: appUser.id,
       clerkId: appUser.clerkId,
@@ -55,6 +49,154 @@ export class UsersService {
       updatedAt: appUser.updatedAt,
       organizations: [],
     };
+  }
+
+  private normalizeClerkPayload(clerkData: any) {
+    if (!clerkData || typeof clerkData !== 'object') {
+      throw new Error('Invalid Clerk data payload');
+    }
+
+    const primaryId =
+      clerkData.primary_email_address_id ||
+      clerkData.primaryEmailAddressId ||
+      null;
+
+    const normalizeEmailRecord = (record: any) => {
+      if (!record || typeof record !== 'object') {
+        return null;
+      }
+      const id = record.id ?? null;
+      const email =
+        record.email_address ??
+        record.emailAddress ??
+        record.email ??
+        record.address ??
+        null;
+      const primary =
+        typeof record.primary === 'boolean'
+          ? record.primary
+          : id
+          ? id === primaryId
+          : false;
+      return {
+        id,
+        email_address: email,
+        primary,
+      };
+    };
+
+    let emailAddresses: any[] = [];
+    if (Array.isArray(clerkData.email_addresses)) {
+      emailAddresses = clerkData.email_addresses
+        .map(normalizeEmailRecord)
+        .filter((entry): entry is { id: string | null; email_address: string | null; primary: boolean } => Boolean(entry));
+    } else if (Array.isArray(clerkData.emailAddresses)) {
+      emailAddresses = clerkData.emailAddresses
+        .map(normalizeEmailRecord)
+        .filter((entry): entry is { id: string | null; email_address: string | null; primary: boolean } => Boolean(entry));
+    }
+
+    if (!emailAddresses.length && clerkData.emailAddress) {
+      const email = normalizeEmailRecord({ email_address: clerkData.emailAddress, primary: true });
+      if (email) {
+        emailAddresses = [email];
+      }
+    }
+
+    return {
+      id: clerkData.id,
+      email_addresses: emailAddresses,
+      primary_email_address_id: primaryId,
+      first_name: clerkData.first_name ?? clerkData.firstName ?? '',
+      last_name: clerkData.last_name ?? clerkData.lastName ?? '',
+      created_at: clerkData.created_at ?? clerkData.createdAt ?? new Date().toISOString(),
+      updated_at: clerkData.updated_at ?? clerkData.updatedAt ?? new Date().toISOString(),
+      public_metadata: clerkData.public_metadata ?? clerkData.publicMetadata ?? {},
+      unsafe_metadata: clerkData.unsafe_metadata ?? clerkData.unsafeMetadata ?? {},
+    };
+  }
+
+  private extractPrimaryEmail(
+    emailAddresses: Array<{ id: string | null; email_address: string | null; primary: boolean }>,
+    primaryId?: string | null,
+  ): string | null {
+    if (!Array.isArray(emailAddresses) || emailAddresses.length === 0) {
+      return null;
+    }
+
+    let target = emailAddresses.find(address => address.primary);
+    if (!target && primaryId) {
+      target = emailAddresses.find(address => address.id === primaryId);
+    }
+    if (!target) {
+      target = emailAddresses[0];
+    }
+    return target?.email_address ?? null;
+  }
+
+  private resolveRoleFromMetadata(publicMetadata: Record<string, any>, unsafeMetadata: Record<string, any>): UserRole {
+    const candidates = [
+      publicMetadata?.role,
+      unsafeMetadata?.pendingRole,
+      unsafeMetadata?.role,
+      unsafeMetadata?.signupType,
+    ];
+
+    for (const candidate of candidates) {
+      if (!candidate || typeof candidate !== 'string') {
+        continue;
+      }
+      const normalized = candidate.toUpperCase();
+      switch (normalized) {
+        case 'SUPER_ADMIN':
+          return UserRole.SUPER_ADMIN;
+        case 'ADMIN':
+          return UserRole.ADMIN;
+        case 'FOUNDATION':
+          return UserRole.FOUNDATION;
+        case 'PRODUCT_SUPPLIER':
+        case 'SUPPLIER':
+          return UserRole.PRODUCT_SUPPLIER;
+        case 'SERVICE_PROVIDER':
+          return UserRole.SERVICE_PROVIDER;
+        case 'EDUCATOR':
+          return UserRole.EDUCATOR;
+        case 'PARENT':
+          return UserRole.PARENT;
+        default:
+          break;
+      }
+    }
+
+    return UserRole.PARENT;
+  }
+
+  private ensureClerkClient() {
+    if (!this.clerkClient) {
+      throw new Error('Clerk client is not configured. Set CLERK_SECRET_KEY to enable syncing.');
+    }
+    return this.clerkClient;
+  }
+
+  async create(createUserDto: CreateUserDto) {
+    // Check if user exists
+    const existingUser = await this.prisma.appUser.findUnique({
+      where: { email: createUserDto.email },
+    });
+
+    if (existingUser) {
+      throw new ConflictException('User with this email already exists');
+    }
+
+    const appUser = await this.prisma.appUser.create({
+      data: {
+        clerkId: createUserDto.clerkId,
+        email: createUserDto.email,
+        role: createUserDto.role as UserRole,
+      },
+    });
+
+    return this.buildUserResponse(appUser);
   }
 
   async findAll(params: FindAllUsersParams) {
@@ -87,27 +229,7 @@ export class UsersService {
     ]);
 
     // Convert AppUser to User format for compatibility
-    const users = appUsers.map(appUser => ({
-      id: appUser.id,
-      clerkId: appUser.clerkId,
-      email: appUser.email,
-      firstName: null,
-      lastName: null,
-      role: appUser.role,
-      phoneNumber: null,
-      workExperience: null,
-      education: null,
-      certifications: [],
-      skills: [],
-      availability: null,
-      cvUrl: null,
-      stripeCustomerId: null,
-      lastActiveAt: null,
-      isActive: true,
-      createdAt: appUser.createdAt,
-      updatedAt: appUser.updatedAt,
-      organizations: [],
-    }));
+    const users = appUsers.map(appUser => this.buildUserResponse(appUser));
 
     return {
       data: users,
@@ -149,27 +271,7 @@ export class UsersService {
     }
 
     // User profile doesn't exist yet, return minimal data from AppUser
-    return {
-      id: appUser.id,
-      clerkId: appUser.clerkId,
-      email: appUser.email,
-      firstName: null,
-      lastName: null,
-      role: appUser.role,
-      phoneNumber: null,
-      workExperience: null,
-      education: null,
-      certifications: [],
-      skills: [],
-      availability: null,
-      cvUrl: null,
-      stripeCustomerId: null,
-      lastActiveAt: null,
-      isActive: true,
-      createdAt: appUser.createdAt,
-      updatedAt: appUser.updatedAt,
-      organizations: [],
-    };
+    return this.buildUserResponse(appUser);
   }
 
   async findOne(id: string) {
@@ -181,28 +283,7 @@ export class UsersService {
       throw new NotFoundException('User not found');
     }
 
-    // Return in User format for compatibility
-    return {
-      id: appUser.id,
-      clerkId: appUser.clerkId,
-      email: appUser.email,
-      firstName: null,
-      lastName: null,
-      role: appUser.role,
-      phoneNumber: null,
-      workExperience: null,
-      education: null,
-      certifications: [],
-      skills: [],
-      availability: null,
-      cvUrl: null,
-      stripeCustomerId: null,
-      lastActiveAt: null,
-      isActive: true,
-      createdAt: appUser.createdAt,
-      updatedAt: appUser.updatedAt,
-      organizations: [],
-    };
+    return this.buildUserResponse(appUser);
   }
 
   async findByEmail(email: string) {
@@ -214,28 +295,7 @@ export class UsersService {
       return null;
     }
 
-    // Return in User format for compatibility
-    return {
-      id: appUser.id,
-      clerkId: appUser.clerkId,
-      email: appUser.email,
-      firstName: null,
-      lastName: null,
-      role: appUser.role,
-      phoneNumber: null,
-      workExperience: null,
-      education: null,
-      certifications: [],
-      skills: [],
-      availability: null,
-      cvUrl: null,
-      stripeCustomerId: null,
-      lastActiveAt: null,
-      isActive: true,
-      createdAt: appUser.createdAt,
-      updatedAt: appUser.updatedAt,
-      organizations: [],
-    };
+    return this.buildUserResponse(appUser);
   }
 
   async findByOrganization(orgId: string) {
@@ -379,28 +439,7 @@ export class UsersService {
       },
     });
 
-    // Return in User format for compatibility
-    return {
-      id: updatedAppUser.id,
-      clerkId: updatedAppUser.clerkId,
-      email: updatedAppUser.email,
-      firstName: null,
-      lastName: null,
-      role: updatedAppUser.role,
-      phoneNumber: null,
-      workExperience: null,
-      education: null,
-      certifications: [],
-      skills: [],
-      availability: null,
-      cvUrl: null,
-      stripeCustomerId: null,
-      lastActiveAt: null,
-      isActive: true,
-      createdAt: updatedAppUser.createdAt,
-      updatedAt: updatedAppUser.updatedAt,
-      organizations: [],
-    };
+    return this.buildUserResponse(updatedAppUser);
   }
 
   async assignRole(userId: string, role: UserRole) {
@@ -409,28 +448,7 @@ export class UsersService {
       data: { role },
     });
 
-    // Return in User format for compatibility
-    return {
-      id: updatedAppUser.id,
-      clerkId: updatedAppUser.clerkId,
-      email: updatedAppUser.email,
-      firstName: null,
-      lastName: null,
-      role: updatedAppUser.role,
-      phoneNumber: null,
-      workExperience: null,
-      education: null,
-      certifications: [],
-      skills: [],
-      availability: null,
-      cvUrl: null,
-      stripeCustomerId: null,
-      lastActiveAt: null,
-      isActive: true,
-      createdAt: updatedAppUser.createdAt,
-      updatedAt: updatedAppUser.updatedAt,
-      organizations: [],
-    };
+    return this.buildUserResponse(updatedAppUser);
   }
 
   async removeRole(userId: string, role: UserRole) {
@@ -440,28 +458,7 @@ export class UsersService {
       data: { role: UserRole.PARENT }, // Default role
     });
 
-    // Return in User format for compatibility
-    return {
-      id: updatedAppUser.id,
-      clerkId: updatedAppUser.clerkId,
-      email: updatedAppUser.email,
-      firstName: null,
-      lastName: null,
-      role: updatedAppUser.role,
-      phoneNumber: null,
-      workExperience: null,
-      education: null,
-      certifications: [],
-      skills: [],
-      availability: null,
-      cvUrl: null,
-      stripeCustomerId: null,
-      lastActiveAt: null,
-      isActive: true,
-      createdAt: updatedAppUser.createdAt,
-      updatedAt: updatedAppUser.updatedAt,
-      organizations: [],
-    };
+    return this.buildUserResponse(updatedAppUser);
   }
 
   async remove(id: string) {
@@ -477,116 +474,60 @@ export class UsersService {
       where: { id },
     });
 
-    // Return in User format for compatibility
-    return {
-      id: deletedAppUser.id,
-      clerkId: deletedAppUser.clerkId,
-      email: deletedAppUser.email,
-      firstName: null,
-      lastName: null,
-      role: deletedAppUser.role,
-      phoneNumber: null,
-      workExperience: null,
-      education: null,
-      certifications: [],
-      skills: [],
-      availability: null,
-      cvUrl: null,
-      stripeCustomerId: null,
-      lastActiveAt: null,
-      isActive: true,
-      createdAt: deletedAppUser.createdAt,
-      updatedAt: deletedAppUser.updatedAt,
-      organizations: [],
-    };
+    return this.buildUserResponse(deletedAppUser);
   }
 
   // Sync user with Clerk webhook
-  async syncWithClerk(clerkData: {
-    id: string;
-    email_addresses: any[];
-    first_name: string;
-    last_name: string;
-    created_at: number;
-    updated_at: number;
-  }) {
-    const email = clerkData.email_addresses[0]?.email_address;
-    if (!email) {
-      throw new Error('No email found in Clerk data');
+  async syncWithClerk(clerkPayload: any) {
+    const normalized = this.normalizeClerkPayload(clerkPayload);
+    const email = this.extractPrimaryEmail(normalized.email_addresses, normalized.primary_email_address_id);
+    const role = this.resolveRoleFromMetadata(
+      normalized.public_metadata || {},
+      normalized.unsafe_metadata || {},
+    );
+
+    const createData: any = {
+      clerkId: normalized.id,
+      role,
+    };
+
+    if (email) {
+      createData.email = email;
+    }
+
+    if (normalized.created_at) {
+      createData.createdAt = new Date(normalized.created_at);
     }
 
     try {
-      const existingUser = await this.findByClerkId(clerkData.id);
+      const updatedAppUser = await this.prisma.appUser.upsert({
+        where: { clerkId: normalized.id },
+        update: {
+          role,
+          email: email ?? undefined,
+        },
+        create: createData,
+      });
 
-      if (existingUser) {
-        // Update existing user
-        const updatedAppUser = await this.prisma.appUser.update({
-          where: { clerkId: clerkData.id },
-          data: {
-            email,
-            updatedAt: new Date(clerkData.updated_at),
-          },
-        });
-
-        // Return in User format for compatibility
-        return {
-          id: updatedAppUser.id,
-          clerkId: updatedAppUser.clerkId,
-          email: updatedAppUser.email,
-          firstName: null,
-          lastName: null,
-          role: updatedAppUser.role,
-          phoneNumber: null,
-          workExperience: null,
-          education: null,
-          certifications: [],
-          skills: [],
-          availability: null,
-          cvUrl: null,
-          stripeCustomerId: null,
-          lastActiveAt: null,
-          isActive: true,
-          createdAt: updatedAppUser.createdAt,
-          updatedAt: updatedAppUser.updatedAt,
-          organizations: [],
-        };
-      }
+      return this.buildUserResponse(updatedAppUser);
     } catch (error) {
-      // User not found, create new one
+      this.logger.error(`Failed to sync Clerk user ${normalized.id}: ${error instanceof Error ? error.message : error}`);
+      throw error;
     }
+  }
 
-    // Create new user
-    const newAppUser = await this.prisma.appUser.create({
-      data: {
-        clerkId: clerkData.id,
-        email,
-        role: UserRole.PARENT, // Default role
-        createdAt: new Date(clerkData.created_at),
-        updatedAt: new Date(clerkData.updated_at),
-      },
-    });
+  async syncCurrentUser(clerkId: string) {
+    const client = this.ensureClerkClient();
 
-    // Return in User format for compatibility
-    return {
-      id: newAppUser.id,
-      clerkId: newAppUser.clerkId,
-      email: newAppUser.email,
-      firstName: null,
-      lastName: null,
-      role: newAppUser.role,
-      phoneNumber: null,
-      workExperience: null,
-      education: null,
-      certifications: [],
-      skills: [],
-      availability: null,
-      cvUrl: null,
-      stripeCustomerId: null,
-      lastActiveAt: null,
-      isActive: true,
-      createdAt: newAppUser.createdAt,
-      updatedAt: newAppUser.updatedAt,
-      organizations: [],
-    };
+    try {
+      const clerkUser = await client.users.getUser(clerkId);
+      return this.syncWithClerk(clerkUser);
+    } catch (error: any) {
+      this.logger.error(`Failed to fetch Clerk user ${clerkId} for sync`, error);
+      if (error?.status === 404) {
+        throw new NotFoundException('Clerk user not found');
+      }
+      throw error;
+    }
   }
 }

--- a/api/src/webhooks/webhooks.service.ts
+++ b/api/src/webhooks/webhooks.service.ts
@@ -64,6 +64,9 @@ export class WebhooksService {
         last_name: userData.last_name || '',
         created_at: userData.created_at,
         updated_at: userData.updated_at,
+        primary_email_address_id: userData.primary_email_address_id,
+        public_metadata: userData.public_metadata,
+        unsafe_metadata: userData.unsafe_metadata,
       });
 
       this.logger.log(`User created successfully: ${userData.id}`);
@@ -83,6 +86,9 @@ export class WebhooksService {
         last_name: userData.last_name || '',
         created_at: userData.created_at,
         updated_at: userData.updated_at,
+        primary_email_address_id: userData.primary_email_address_id,
+        public_metadata: userData.public_metadata,
+        unsafe_metadata: userData.unsafe_metadata,
       });
 
       this.logger.log(`User updated successfully: ${userData.id}`);

--- a/frontend/pages/SignupPage.tsx
+++ b/frontend/pages/SignupPage.tsx
@@ -10,12 +10,14 @@ import Captcha from '../components/ui/Captcha';
 import { debugLogger } from '../src/utils/debugLogger';
 import { useDebugLogger } from '../src/hooks/useDebugLogger';
 import { BuildingOffice2Icon, UserIcon, CogIcon, UsersIcon, CheckCircleIcon, EyeIcon, EyeSlashIcon, ArrowLeftIcon, SquaresPlusIcon } from '@heroicons/react/24/outline';
+import { useAuthContext } from '../providers/AuthProvider';
 
 const SignupPage: React.FC = () => {
   const { t } = useTranslation(['signup', 'common']);
   const navigate = useNavigate();
   const { signUp, isLoaded, setActive } = useSignUp();
   const { isSignedIn } = useAuth();
+  const { currentUser, isAuthenticated, refreshCurrentUser } = useAuthContext();
   
   // Enable debug logging for this component
   useDebugLogger();
@@ -49,23 +51,25 @@ const SignupPage: React.FC = () => {
   const [captchaError, setCaptchaError] = useState('');
   const [isVerifying, setIsVerifying] = useState(false);
 
-  // Redirect if user is already logged in
+  // Redirect if the viewer is already authenticated (and not mid-signup)
   useEffect(() => {
-    if (isSignedIn) {
+    if (isAuthenticated && currentUser && currentStep === 1 && !selectedRole) {
+      debugLogger.debug('SIGNUP', 'User already authenticated, redirecting away from signup');
       navigate('/dashboard', { replace: true });
     }
-  }, [isSignedIn, navigate]);
+  }, [isAuthenticated, currentUser, currentStep, selectedRole, navigate]);
 
   // Handle successful verification - redirect if user becomes authenticated
   useEffect(() => {
-    if (isSignedIn && currentStep === 3) {
+    if (isAuthenticated && currentUser && currentStep === 3) {
       debugLogger.info('VERIFICATION', 'User became authenticated after verification, redirecting...');
       // Small delay to ensure the success message is visible
-      setTimeout(() => {
+      const timeoutId = setTimeout(() => {
         navigate('/dashboard', { replace: true });
       }, 2000);
+      return () => clearTimeout(timeoutId);
     }
-  }, [isSignedIn, currentStep, navigate]);
+  }, [isAuthenticated, currentUser, currentStep, navigate]);
 
   // Global error handler to catch unhandled errors
   useEffect(() => {
@@ -256,9 +260,27 @@ const SignupPage: React.FC = () => {
 
       if (result.status === 'complete') {
         try {
+          if (!result.createdSessionId) {
+            debugLogger.error('SIGNUP', 'Signup completed without creating a session');
+            setErrors({ email: 'Account created but session could not be established. Please log in.' });
+            return;
+          }
+
           await setActive({ session: result.createdSessionId });
-          
-          // Redirect based on role
+
+          let profileSynced = true;
+          try {
+            await refreshCurrentUser();
+          } catch (syncError) {
+            profileSynced = false;
+            debugLogger.error('SIGNUP', 'Failed to refresh user profile after signup completion', syncError);
+          }
+
+          if (!profileSynced) {
+            setErrors({ email: 'Account created but we could not load your profile yet. Please log in to continue.' });
+            return;
+          }
+
           if ([SignupRole.FOUNDATION, SignupRole.SUPPLIER, SignupRole.SERVICE_PROVIDER].includes(selectedRole)) {
             navigate('/pricing', { state: { fromSignup: true, role: selectedRole } });
           } else {
@@ -375,10 +397,23 @@ const SignupPage: React.FC = () => {
           try {
             await setActive({ session: result.createdSessionId });
             console.log('🚀 [VERIFICATION DEBUG] Session activated successfully!');
-            
+
+            let profileSynced = true;
+            try {
+              await refreshCurrentUser();
+            } catch (syncError) {
+              profileSynced = false;
+              debugLogger.error('VERIFICATION', 'Failed to refresh user profile after verification', syncError);
+            }
+
+            if (!profileSynced) {
+              setVerificationError('Email verified but we could not load your profile yet. Please try logging in manually.');
+              return;
+            }
+
             // Only show success step after successful session activation
             console.log('🚀 [VERIFICATION DEBUG] Moving to success step...');
-            
+
             // Redirect based on role, similar to direct signup flow
             if ([SignupRole.FOUNDATION, SignupRole.SUPPLIER, SignupRole.SERVICE_PROVIDER].includes(selectedRole)) {
               console.log('🚀 [VERIFICATION DEBUG] Redirecting to pricing for business roles...');

--- a/frontend/providers/AuthProvider.tsx
+++ b/frontend/providers/AuthProvider.tsx
@@ -217,6 +217,90 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
     [getToken, transformBackendUser]
   );
 
+  const triggerBackendUserSync = useCallback(
+    async () => {
+      const token = await getToken();
+
+      if (!token) {
+        throw new ApiError('Authentication token not available', 401, 'auth_token_missing');
+      }
+
+      const apiBaseUrl = apiService.apiBaseUrl;
+      const url = `${apiBaseUrl}${API_ENDPOINTS.users.sync}`;
+
+      console.group('🔄 [BACKEND SYNC] Triggering manual user sync');
+      console.log('📤 Request Details:', { url, method: 'POST' });
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+      }).catch(error => {
+        console.error('❌ Network error during manual sync:', error);
+        console.groupEnd();
+        throw new ApiError('Network error during manual sync', 0, 'network_error');
+      });
+
+      console.log('📥 Sync Response Status:', {
+        status: response.status,
+        statusText: response.statusText,
+        ok: response.ok,
+      });
+
+      if (!response.ok) {
+        const bodyText = await response.text().catch(() => '');
+        console.error('❌ Manual sync failed:', { status: response.status, body: bodyText });
+        console.groupEnd();
+        throw new ApiError(bodyText || 'Failed to sync user with backend', response.status, 'backend_sync_failed');
+      }
+
+      let responseJson: any = null;
+      try {
+        responseJson = await response.json();
+      } catch (parseError) {
+        // Some responses may not include a body; treat as success.
+        console.warn('⚠️ Manual sync response was not JSON. Proceeding anyway.', parseError);
+      }
+
+      if (responseJson?.success) {
+        console.log('✅ Manual sync succeeded:', {
+          userId: responseJson.data?.id,
+          role: responseJson.data?.role,
+        });
+      } else {
+        console.warn('⚠️ Manual sync completed without success flag:', responseJson);
+      }
+
+      console.groupEnd();
+    },
+    [getToken]
+  );
+
+  const syncAndFetchBackendUser = useCallback(async (): Promise<User> => {
+    if (!clerkUserId) {
+      throw new Error('No authenticated user to load');
+    }
+
+    try {
+      return await fetchUserFromBackend(clerkUserId);
+    } catch (error) {
+      const isMissingUser =
+        (error instanceof ApiError && error.status === 404) ||
+        (error instanceof Error && error.message === 'Invalid response format from backend');
+
+      if (!isMissingUser) {
+        throw error;
+      }
+
+      console.warn('⚠️ Backend user missing, attempting manual sync...');
+      await triggerBackendUserSync();
+      return fetchUserFromBackend(clerkUserId);
+    }
+  }, [clerkUserId, fetchUserFromBackend, triggerBackendUserSync]);
+
   useEffect(() => {
     if (!clerkIsLoaded) {
       setIsLoading(true);
@@ -259,7 +343,7 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
       setIsLoading(true);
 
       try {
-        const backendUser = await fetchUserFromBackend(clerkUserId);
+        const backendUser = await syncAndFetchBackendUser();
         if (cancelled) {
           return;
         }
@@ -313,7 +397,7 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
     return () => {
       cancelled = true;
     };
-  }, [clerkIsLoaded, clerkUserId, isSignedIn, fetchUserFromBackend, determineAuthErrorKey]);
+  }, [clerkIsLoaded, clerkUserId, isSignedIn, syncAndFetchBackendUser, determineAuthErrorKey]);
 
   const login = async (email: string, password?: string): Promise<{ success: boolean; message?: string }> => {
     // Clerk handles authentication, this is just for compatibility
@@ -459,7 +543,7 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
       throw new Error('No authenticated user to refresh');
     }
 
-    const backendUser = await fetchUserFromBackend(clerkUserId);
+    const backendUser = await syncAndFetchBackendUser();
     setCurrentUser(backendUser);
     setAuthError(null);
     syncAttemptRef.current = {
@@ -467,7 +551,7 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
       status: 'success',
       lastAttempt: Date.now(),
     };
-  }, [clerkIsLoaded, clerkUserId, fetchUserFromBackend]);
+  }, [clerkIsLoaded, clerkUserId, syncAndFetchBackendUser]);
 
   return (
     <AuthContext.Provider

--- a/frontend/services/api-endpoints.ts
+++ b/frontend/services/api-endpoints.ts
@@ -16,6 +16,7 @@ export const API_ENDPOINTS = {
     me: '/users/me',
     update: '/users/me',
     organization: '/users/organization',
+    sync: '/users/me/sync',
   },
 
   profiles: {


### PR DESCRIPTION
## Summary
- add a manual `/users/me/sync` endpoint and expand `UsersService` to upsert Clerk users with role metadata
- trigger backend sync from the frontend auth provider when `/users/me` returns a 404 so signup completes once Clerk verification succeeds
- forward Clerk metadata through the webhook and expose the new sync route in the frontend API endpoints map

## Testing
- `pnpm --filter copy-of-pro-crèche-solutions-for-merge build` *(fails: missing dependency i18next-browser-languagedetector in vite build)*
- `pnpm --filter api build` *(fails: existing Prisma service typings missing billingTransaction/subscription tables in repository)*

------
https://chatgpt.com/codex/tasks/task_e_690225c8bf548325bfdd4ccdbeb447e3