### PR TITLE
Investigate sign in CORS issue

### DIFF
--- a/api/src/common/interceptors/no-cache.interceptor.ts
+++ b/api/src/common/interceptors/no-cache.interceptor.ts
@@ -1,0 +1,29 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class NoCacheInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const http = context.switchToHttp();
+    const request = http.getRequest();
+    const response = http.getResponse();
+
+    if (request?.headers) {
+      delete request.headers['if-none-match'];
+      delete request.headers['if-modified-since'];
+    }
+
+    if (response?.setHeader) {
+      response.setHeader('Cache-Control', 'no-store');
+      response.setHeader('Pragma', 'no-cache');
+      response.setHeader('Expires', '0');
+      response.setHeader('Vary', 'Origin');
+    }
+
+    if (typeof response?.set === 'function') {
+      response.set('etag', false as any);
+    }
+
+    return next.handle();
+  }
+}

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -104,6 +104,19 @@ async function bootstrap() {
     optionsSuccessStatus: 204,
   });
 
+  // Disable ETag generation so dynamic endpoints (like auth) always return 200 responses
+  const httpAdapter = app.getHttpAdapter().getInstance();
+  if (httpAdapter?.set) {
+    httpAdapter.set('etag', false);
+  }
+
+  // Ensure API responses are never cached by intermediaries or browsers
+  app.use((req, res, next) => {
+    res.setHeader('Cache-Control', 'no-store');
+    res.setHeader('Vary', 'Origin');
+    next();
+  });
+
   // CORS debugging middleware (ALWAYS enabled to debug production issues)
   app.use((req, res, next) => {
     const isPreflight = req.method === 'OPTIONS';

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -104,14 +104,12 @@ async function bootstrap() {
     optionsSuccessStatus: 204,
   });
 
-  // Disable ETag generation so dynamic endpoints (like auth) always return 200 responses
-  const httpAdapter = app.getHttpAdapter().getInstance();
-  if (httpAdapter?.set) {
-    httpAdapter.set('etag', false);
-  }
-
-  // Ensure API responses are never cached by intermediaries or browsers
-  app.use((req, res, next) => {
+  // Prevent conditional caching on API routes to avoid 304 responses for identity-dependent endpoints
+  app.use('/api', (req, res, next) => {
+    if (req.headers) {
+      delete req.headers['if-none-match'];
+      delete req.headers['if-modified-since'];
+    }
     res.setHeader('Cache-Control', 'no-store');
     res.setHeader('Vary', 'Origin');
     next();

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Delete,
   UseGuards,
+  UseInterceptors,
   Query,
   ParseUUIDPipe,
   Request,
@@ -21,6 +22,7 @@ import { UserRole } from '@prisma/client';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { Public } from '../auth/decorators/public.decorator';
 import { AllowPending } from '../auth/decorators/allow-pending.decorator';
+import { NoCacheInterceptor } from '../common/interceptors/no-cache.interceptor';
 
 @Controller('users')
 @UseGuards(ClerkAuthGuard, RolesGuard)
@@ -52,6 +54,7 @@ export class UsersController {
   }
 
   @Get('me')
+  @UseInterceptors(NoCacheInterceptor)
   async getCurrentUser(@Request() request) {
     const user = await this.usersService.findByClerkId(request.user.clerkId);
     

--- a/frontend/providers/AuthProvider.tsx
+++ b/frontend/providers/AuthProvider.tsx
@@ -105,20 +105,31 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
       }
 
       const apiBaseUrl = apiService.apiBaseUrl;
-      const url = `${apiBaseUrl}${API_ENDPOINTS.users.me}`;
+      const baseUrl = `${apiBaseUrl}${API_ENDPOINTS.users.me}`;
 
-      let response: Response;
-      const fetchStartTime = performance.now();
-      
-      try {
-        response = await fetch(url, {
+      const doFetch = async (requestUrl: string) =>
+        fetch(requestUrl, {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',
             Accept: 'application/json',
             Authorization: `Bearer ${token}`,
           },
+          cache: 'no-store',
         });
+
+      let response: Response;
+      let url = baseUrl;
+      const fetchStartTime = performance.now();
+      
+      try {
+        response = await doFetch(url);
+
+        if (response.status === 304) {
+          console.warn('Received 304 for /users/me, retrying with cache buster');
+          url = `${baseUrl}?cacheBust=${Date.now()}`;
+          response = await doFetch(url);
+        }
 
       } catch (fetchError) {
         const fetchEndTime = performance.now();


### PR DESCRIPTION
Disable ETag and enforce `no-store` caching on the backend to resolve intermittent login failures caused by 304 Not Modified responses and perceived CORS issues.

The login flow sometimes failed to load user details, displaying a "We couldn't load your account details" message and a CORS error in the console. Investigation revealed the backend was returning a 304 Not Modified status for `/api/users/me` due to ETag caching. The frontend treated this as an error, and Chrome reported a CORS failure when the cached 304 response lacked the expected headers. This change ensures the `/api/users/me` endpoint always returns a full 200 OK response, allowing the frontend to correctly retrieve user data.

---
<a href="https://cursor.com/background-agent?bcId=bc-f8bf0594-ea53-4dc7-80c4-242ad51eb16e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f8bf0594-ea53-4dc7-80c4-242ad51eb16e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

