### PR TITLE
Investigate settings page internal server error

### DIFF
--- a/api/src/billing/billing.controller.ts
+++ b/api/src/billing/billing.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Post, Body, UseGuards, Request, Get, Query } from '@nestjs/
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { PrismaService } from '../prisma/prisma.service';
 
+import { ClerkAuthGuard } from '../auth/guards/clerk-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { UserRole } from '@prisma/client';
@@ -10,7 +11,7 @@ import { CreateCheckoutSessionDto } from './dto/create-checkout-session.dto';
 
 @ApiTags('billing')
 @Controller('billing')
-@UseGuards()
+@UseGuards(ClerkAuthGuard, RolesGuard)
 @ApiBearerAuth()
 export class BillingController {
   constructor(

--- a/api/src/dashboard/dashboard.controller.ts
+++ b/api/src/dashboard/dashboard.controller.ts
@@ -2,13 +2,14 @@ import { Controller, Get, UseGuards, Request } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { PrismaService } from '../prisma/prisma.service';
 
+import { ClerkAuthGuard } from '../auth/guards/clerk-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { UserRole } from '@prisma/client';
 
 @ApiTags('dashboard')
 @Controller('dashboard')
-@UseGuards()
+@UseGuards(ClerkAuthGuard, RolesGuard)
 @ApiBearerAuth()
 export class DashboardController {
   constructor(private readonly prisma: PrismaService) {}

--- a/api/src/profiles/profiles.controller.ts
+++ b/api/src/profiles/profiles.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Put, Post, Body, Param, UseGuards, Request } from '@ne
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { PrismaService } from '../prisma/prisma.service';
 
+import { ClerkAuthGuard } from '../auth/guards/clerk-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { UserRole } from '@prisma/client';
@@ -59,7 +60,7 @@ export class CreateOrganizationDto {
 
 @ApiTags('profiles')
 @Controller('profiles')
-@UseGuards()
+@UseGuards(ClerkAuthGuard, RolesGuard)
 @ApiBearerAuth()
 export class ProfileController {
   constructor(private readonly prisma: PrismaService) {}

--- a/api/src/settings/settings.controller.ts
+++ b/api/src/settings/settings.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Patch, Body, UseGuards, Request, UnauthorizedException
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { PrismaService } from '../prisma/prisma.service';
 
+import { ClerkAuthGuard } from '../auth/guards/clerk-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { UserRole } from '@prisma/client';
@@ -15,7 +16,7 @@ import { UpdateNotificationSettingsDto } from './dto/notification-settings.dto';
 
 @ApiTags('settings')
 @Controller('settings')
-@UseGuards()
+@UseGuards(ClerkAuthGuard, RolesGuard)
 @ApiBearerAuth()
 export class SettingsController {
   constructor(private readonly prisma: PrismaService) {}


### PR DESCRIPTION
Add `ClerkAuthGuard` and `RolesGuard` to several controllers to fix 500 errors caused by missing authentication.

The `@UseGuards()` decorator was empty, preventing JWT verification and `request.context.userId` from being set. This led to runtime errors when controller methods attempted to access the undefined `userId`, resulting in 500 Internal Server Errors. This fix ensures proper authentication and context population.

---
<a href="https://cursor.com/background-agent?bcId=bc-240379c7-171d-49f8-a885-ee1990109f58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-240379c7-171d-49f8-a885-ee1990109f58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

