### PR TITLE
Investigate sign out error screen

### DIFF
--- a/frontend/pages/LoginPage.tsx
+++ b/frontend/pages/LoginPage.tsx
@@ -33,7 +33,7 @@ const LoginPage: React.FC = () => {
   const { signIn, isLoaded: isSignInLoaded, setActive } = useSignIn();
   const { isSignedIn, isLoaded: isAuthLoaded } = useAuth();
   const { currentUser } = useAppContext();
-  const { isLoading: isAuthLoading, authError, clearAuthError, logout } = useAuthContext();
+  const { isLoading: isAuthLoading, authError, clearAuthError, logout, isSigningOut: isSigningOutGlobal } = useAuthContext();
   
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -250,8 +250,19 @@ const LoginPage: React.FC = () => {
     );
   }
 
+  // Show loading state during sign-out to prevent flash of error screen
+  // Use global isSigningOut from AuthProvider to catch sign-out from any page
+  if (isSigningOut || isSigningOutGlobal) {
+    return (
+      <div className="min-h-screen bg-page-bg flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-swiss-mint"></div>
+      </div>
+    );
+  }
+
   // SCENARIO B (Edge Case): Signed in to Clerk but backend sync failed
-  if (isSignedIn && !currentUser && !isAuthLoading) {
+  // Don't show this screen during sign-out to prevent flash of error message
+  if (isSignedIn && !currentUser && !isAuthLoading && !isSigningOut && !isSigningOutGlobal) {
     return (
       <div className="min-h-screen bg-page-bg flex flex-col items-center justify-center p-4 sm:p-6 lg:p-8">
         <Card className="w-full max-w-md p-8 shadow-xl">

--- a/frontend/providers/AuthProvider.tsx
+++ b/frontend/providers/AuthProvider.tsx
@@ -38,6 +38,7 @@ interface AuthContextType {
   isLoading: boolean;
   isAuthenticated: boolean;
   authError: string | null;
+  isSigningOut: boolean;
   clearAuthError: () => void;
   login: (email: string, password?: string) => Promise<{ success: boolean; message?: string }>;
   logout: () => Promise<void>;
@@ -59,6 +60,7 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [authError, setAuthError] = useState<string | null>(null);
+  const [isSigningOut, setIsSigningOut] = useState(false);
 
   const syncAttemptRef = useRef<SyncAttemptState>(INITIAL_SYNC_STATE);
   const syncInFlightRef = useRef(false);
@@ -334,6 +336,7 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
 
   const logout = useCallback(async () => {
     try {
+      setIsSigningOut(true);
       // Clear local user state first
       setCurrentUser(null);
       setAuthError(null);
@@ -345,6 +348,8 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
       console.error('Logout error:', error);
       // Still clear local state even if Clerk signOut fails
       setCurrentUser(null);
+    } finally {
+      setIsSigningOut(false);
     }
   }, [clerkSignOut]);
 
@@ -513,6 +518,7 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
         isLoading,
         isAuthenticated,
         authError,
+        isSigningOut,
         clearAuthError: () => setAuthError(null),
         login,
         logout,


### PR DESCRIPTION
Prevent the "We couldn't load your account details" error screen from flashing during sign-out.

During sign-out, `currentUser` was cleared immediately while Clerk's `isSignedIn` could still be `true` briefly, causing the error screen to appear momentarily. This PR introduces a global `isSigningOut` state to manage this transition smoothly, showing a loading spinner instead.

---
<a href="https://cursor.com/background-agent?bcId=bc-57acb274-59af-4d06-bb97-2274d7e1bec5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-57acb274-59af-4d06-bb97-2274d7e1bec5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

