### PR TITLE
Add view profile setting for all roles

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -75,6 +75,7 @@ import EducatorSupportPage from './pages/educator/EducatorSupportPage';
 import ParentDashboardPage from './pages/parent/ParentDashboardPage';
 import ParentSupportPage from './pages/parent/ParentSupportPage';
 import PricingPage from './pages/PricingPage';
+import ProfilePage from './pages/ProfilePage';
 
 
 const ProtectedRoute: React.FC<{ children: React.ReactElement; roles: UserRole[] }> = ({ children, roles }): React.ReactElement | null => {
@@ -187,14 +188,24 @@ const ProtectedLayout: React.FC = () => {
         <Route path="/hr-procedures" element={<ProtectedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN]}><HRProceduresPage /></ProtectedRoute>} />
         <Route path="/state-policies" element={<ProtectedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.PRODUCT_SUPPLIER, UserRole.EDUCATOR, UserRole.PARENT]}><StatePoliciesPage /></ProtectedRoute>} />
         <Route path="/e-learning" element={<ProtectedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN]}><ELearningPage /></ProtectedRoute>} />
-        <Route path="/partners" element={<ProtectedRoute roles={[UserRole.ADMIN, UserRole.SUPER_ADMIN]}><PartnersPage /></ProtectedRoute>} />
-        <Route path="/partner/:partnerId" element={ 
-            <ProtectedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER]}>
-              <PartnerDetailPage />
-            </ProtectedRoute>
-          } 
-        />
-        <Route path="/users/*" element={<ProtectedRoute roles={[UserRole.ADMIN, UserRole.SUPER_ADMIN]}><UsersPage /></ProtectedRoute>} />
+          <Route path="/partners" element={<ProtectedRoute roles={[UserRole.ADMIN, UserRole.SUPER_ADMIN]}><PartnersPage /></ProtectedRoute>} />
+          <Route
+            path="/partner/:partnerId"
+            element={
+              <ProtectedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER]}>
+                <PartnerDetailPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/users/*" element={<ProtectedRoute roles={[UserRole.ADMIN, UserRole.SUPER_ADMIN]}><UsersPage /></ProtectedRoute>} />
+          <Route
+            path="/profile"
+            element={
+              <ProtectedRoute roles={[UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.FOUNDATION, UserRole.PARENT, UserRole.EDUCATOR, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER]}>
+                <ProfilePage />
+              </ProtectedRoute>
+            }
+          />
         <Route path="/settings" element={<ProtectedRoute roles={[UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.FOUNDATION, UserRole.PARENT, UserRole.EDUCATOR, UserRole.PRODUCT_SUPPLIER]}><SettingsPage /></ProtectedRoute>} />
         <Route path="/settings/service-provider" element={<ProtectedRoute roles={[UserRole.SERVICE_PROVIDER]}><ServiceProviderSettingsPage /></ProtectedRoute>} />
         

--- a/frontend/i18n.ts
+++ b/frontend/i18n.ts
@@ -16,6 +16,7 @@ import contentEn from '@workspace/translations/locales/en/content.json';
 import messagesEn from '@workspace/translations/locales/en/messages.json';
 import adminEn from '@workspace/translations/locales/en/admin.json';
 import settingsEn from '@workspace/translations/locales/en/settings.json';
+import profileEn from '@workspace/translations/locales/en/profile.json';
 
 import commonFr from '@workspace/translations/locales/fr/common.json';
 import authFr from '@workspace/translations/locales/fr/auth.json';
@@ -30,6 +31,7 @@ import contentFr from '@workspace/translations/locales/fr/content.json';
 import messagesFr from '@workspace/translations/locales/fr/messages.json';
 import adminFr from '@workspace/translations/locales/fr/admin.json';
 import settingsFr from '@workspace/translations/locales/fr/settings.json';
+import profileFr from '@workspace/translations/locales/fr/profile.json';
 
 import commonDe from '@workspace/translations/locales/de/common.json';
 import authDe from '@workspace/translations/locales/de/auth.json';
@@ -44,6 +46,7 @@ import contentDe from '@workspace/translations/locales/de/content.json';
 import messagesDe from '@workspace/translations/locales/de/messages.json';
 import adminDe from '@workspace/translations/locales/de/admin.json';
 import settingsDe from '@workspace/translations/locales/de/settings.json';
+import profileDe from '@workspace/translations/locales/de/profile.json';
 
 i18n
   .use(LanguageDetector)
@@ -52,7 +55,7 @@ i18n
     lng: 'en',
     fallbackLng: ['en'],
     debug: false,
-    ns: ['common', 'auth', 'dashboard', 'pricing', 'signup', 'parentLeadForm', 'marketplace', 'recruitment', 'users', 'content', 'messages', 'admin', 'settings'],
+    ns: ['common', 'auth', 'dashboard', 'pricing', 'signup', 'parentLeadForm', 'marketplace', 'recruitment', 'users', 'content', 'messages', 'admin', 'settings', 'profile'],
     defaultNS: 'common',
     returnEmptyString: false,
     nsSeparator: ':',
@@ -72,6 +75,7 @@ i18n
         messages: messagesEn,
         admin: adminEn,
         settings: settingsEn,
+        profile: profileEn,
       },
       fr: {
         common: commonFr,
@@ -87,6 +91,7 @@ i18n
         messages: messagesFr,
         admin: adminFr,
         settings: settingsFr,
+        profile: profileFr,
       },
       de: {
         common: commonDe,
@@ -102,6 +107,7 @@ i18n
         messages: messagesDe,
         admin: adminDe,
         settings: settingsDe,
+        profile: profileDe,
       },
     },
     interpolation: {

--- a/frontend/pages/ProfilePage.tsx
+++ b/frontend/pages/ProfilePage.tsx
@@ -1,0 +1,204 @@
+import React, { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useAppContext } from '../contexts/AppContext';
+import Card from '../components/ui/Card';
+import Button from '../components/ui/Button';
+import {
+  CalendarDaysIcon,
+  ArrowPathIcon,
+  EnvelopeIcon,
+  UserCircleIcon,
+  BuildingOfficeIcon,
+} from '@heroicons/react/24/outline';
+const ProfilePage: React.FC = () => {
+  const { currentUser } = useAppContext();
+  const { t, i18n } = useTranslation(['profile', 'common']);
+  const navigate = useNavigate();
+
+  const locale = i18n.language || 'en';
+
+  const formatDate = (value?: string | null) => {
+    if (!value) {
+      return '—';
+    }
+
+    try {
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) {
+        return value;
+      }
+      return new Intl.DateTimeFormat(locale, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      }).format(date);
+    } catch {
+      return value;
+    }
+  };
+
+  const roleLabel = useMemo(() => {
+    if (!currentUser) {
+      return '';
+    }
+
+    const roleKey = `common:userRoles.${currentUser.role}`;
+    const friendlyRole = currentUser.role.replace(/_/g, ' ').toLowerCase();
+    return t(roleKey, {
+      defaultValue: friendlyRole
+        .split(' ')
+        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' '),
+    });
+  }, [currentUser, t]);
+
+  if (!currentUser) {
+    return <div className="p-6 text-center text-gray-500">{t('common:loading', 'Loading...')}</div>;
+  }
+
+  const avatarUrl =
+    currentUser.avatarUrl ||
+    `https://ui-avatars.com/api/?name=${encodeURIComponent(currentUser.name || currentUser.email)}&background=48CFAE&color=ffffff&size=128&rounded=true`;
+
+  return (
+    <div className="p-8 space-y-6 bg-page-bg min-h-full">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-swiss-charcoal">{t('profile:title')}</h1>
+          <p className="mt-2 text-sm text-gray-500 max-w-2xl">{t('profile:subtitle')}</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button variant="light" onClick={() => navigate('/settings')}>
+            {t('profile:actions.goToSettings')}
+          </Button>
+        </div>
+      </div>
+
+      <Card className="p-6">
+        <div className="flex flex-col lg:flex-row gap-6">
+          <div className="flex items-start gap-4">
+            <img
+              src={avatarUrl}
+              alt={currentUser.name}
+              className="w-20 h-20 rounded-full border-2 border-swiss-mint/40 object-cover shadow-sm"
+            />
+            <div>
+              <div className="flex items-center gap-2">
+                <UserCircleIcon className="w-5 h-5 text-swiss-mint" />
+                <h2 className="text-2xl font-semibold text-swiss-charcoal">{currentUser.name}</h2>
+              </div>
+              <div className="mt-1 text-sm text-gray-500 flex flex-wrap gap-2">
+                <span className="inline-flex items-center px-2 py-1 rounded-full bg-swiss-mint/10 text-swiss-mint font-medium">
+                  {roleLabel}
+                </span>
+                {currentUser.status && (
+                  <span className="inline-flex items-center px-2 py-1 rounded-full bg-gray-100 text-gray-600 font-medium">
+                    {currentUser.status}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex-1 grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="flex items-start gap-3">
+              <EnvelopeIcon className="w-5 h-5 text-swiss-teal mt-0.5" />
+              <div>
+                <p className="text-xs uppercase tracking-wide text-gray-500">
+                  {t('profile:details.email')}
+                </p>
+                <p className="text-sm text-swiss-charcoal">{currentUser.email}</p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <CalendarDaysIcon className="w-5 h-5 text-swiss-teal mt-0.5" />
+              <div>
+                <p className="text-xs uppercase tracking-wide text-gray-500">
+                  {t('profile:details.memberSince')}
+                </p>
+                <p className="text-sm text-swiss-charcoal">
+                  {formatDate(currentUser.memberSince)}
+                </p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <ArrowPathIcon className="w-5 h-5 text-swiss-teal mt-0.5" />
+              <div>
+                <p className="text-xs uppercase tracking-wide text-gray-500">
+                  {t('profile:details.lastActive')}
+                </p>
+                <p className="text-sm text-swiss-charcoal">
+                  {formatDate(currentUser.lastActiveAt || currentUser.lastLogin)}
+                </p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <UserCircleIcon className="w-5 h-5 text-swiss-teal mt-0.5" />
+              <div>
+                <p className="text-xs uppercase tracking-wide text-gray-500">
+                  {t('profile:details.status')}
+                </p>
+                <p className="text-sm text-swiss-charcoal">
+                  {currentUser.isActive ? t('common:status.active', 'Active') : t('common:status.inactive', 'Inactive')}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Card>
+
+      <Card className="p-6">
+        <div className="flex items-center gap-2 mb-4">
+          <BuildingOfficeIcon className="w-5 h-5 text-swiss-mint" />
+          <h2 className="text-lg font-semibold text-swiss-charcoal">
+            {t('profile:organization.sectionTitle')}
+          </h2>
+        </div>
+
+        {currentUser.orgName || currentUser.plan || currentUser.region || currentUser.orgId ? (
+          <dl className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {currentUser.orgName && (
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-gray-500">
+                  {t('profile:organization.name')}
+                </dt>
+                <dd className="text-sm text-swiss-charcoal mt-1">{currentUser.orgName}</dd>
+              </div>
+            )}
+            {currentUser.region && (
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-gray-500">
+                  {t('profile:organization.region')}
+                </dt>
+                <dd className="text-sm text-swiss-charcoal mt-1">{currentUser.region}</dd>
+              </div>
+            )}
+            {currentUser.plan && (
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-gray-500">
+                  {t('profile:organization.plan')}
+                </dt>
+                <dd className="text-sm text-swiss-charcoal mt-1">{currentUser.plan}</dd>
+              </div>
+            )}
+            {currentUser.orgId && (
+              <div>
+                <dt className="text-xs uppercase tracking-wide text-gray-500">
+                  {t('profile:organization.id')}
+                </dt>
+                <dd className="text-sm text-swiss-charcoal mt-1 font-mono">{currentUser.orgId}</dd>
+              </div>
+            )}
+          </dl>
+        ) : (
+          <p className="text-sm text-gray-500">{t('profile:empty.organization')}</p>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+export default ProfilePage;

--- a/frontend/pages/ServiceProviderSettingsPage.tsx
+++ b/frontend/pages/ServiceProviderSettingsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, Navigate } from 'react-router-dom';
 import { useAppContext } from '../contexts/AppContext';
 import { useNotifications } from '../contexts/NotificationContext';
@@ -10,13 +10,14 @@ import {
 import Button from '../components/ui/Button';
 import Card from '../components/ui/Card';
 import {
-  UsersIcon,
-  LockClosedIcon,
-  BellAlertIcon,
-  WalletIcon,
-  BuildingOfficeIcon,
-  PhoneIcon,
-  AdjustmentsHorizontalIcon,
+    UsersIcon,
+    LockClosedIcon,
+    BellAlertIcon,
+    WalletIcon,
+    BuildingOfficeIcon,
+    PhoneIcon,
+    AdjustmentsHorizontalIcon,
+    EyeIcon,
 } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
 
@@ -243,6 +244,30 @@ const ServiceProviderSettingsPage: React.FC = () => {
     }
   };
 
+  const profilePath = useMemo(() => {
+    if (!currentUser) {
+      return null;
+    }
+
+    if (currentUser.orgId) {
+      return `/partner/${currentUser.orgId}`;
+    }
+
+    return '/profile';
+  }, [currentUser]);
+
+  const handleViewProfile = () => {
+    if (!profilePath) {
+      return;
+    }
+
+    if (isDirty && !window.confirm(t('settings:page.unsavedChangesPrompt'))) {
+      return;
+    }
+
+    navigate(profilePath);
+  };
+
   const scrollToSection = (sectionId: string) => {
     setActiveSectionId(sectionId);
     sectionRefs.current[sectionId]?.scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -263,23 +288,28 @@ const ServiceProviderSettingsPage: React.FC = () => {
   return (
     <div className="flex flex-col h-full bg-page-bg">
       <div className="sticky top-0 z-30 bg-page-bg/80 backdrop-blur-md px-8 py-4 border-b border-gray-200">
-        <div className="flex justify-between items-center">
-          <h1 className="text-2xl font-bold text-swiss-charcoal">{t('settings:page.title')}</h1>
-          <div className="flex space-x-3">
-            <Button variant="light" onClick={handleCancel}>
-              {t('common:buttons.cancel')}
-            </Button>
-            <Button
-              variant="primary"
-              onClick={handleSave}
-              disabled={!isDirty || isSaving}
-              className="bg-swiss-mint hover:bg-opacity-90"
-            >
-              {isSaving ? `${t('common:buttons.saveChanges')}...` : t('common:buttons.saveChanges')}
-            </Button>
+          <div className="flex justify-between items-center">
+            <h1 className="text-2xl font-bold text-swiss-charcoal">{t('settings:page.title')}</h1>
+            <div className="flex items-center space-x-3">
+              {profilePath && (
+                <Button variant="outline" leftIcon={EyeIcon} onClick={handleViewProfile}>
+                  {t('common:buttons.viewProfile')}
+                </Button>
+              )}
+              <Button variant="light" onClick={handleCancel}>
+                {t('common:buttons.cancel')}
+              </Button>
+              <Button
+                variant="primary"
+                onClick={handleSave}
+                disabled={!isDirty || isSaving}
+                className="bg-swiss-mint hover:bg-opacity-90"
+              >
+                {isSaving ? `${t('common:buttons.saveChanges')}...` : t('common:buttons.saveChanges')}
+              </Button>
+            </div>
           </div>
         </div>
-      </div>
 
       <div className="flex flex-1 overflow-hidden">
         <nav className="w-64 bg-white border-r border-gray-200 p-4 space-y-1 overflow-y-auto flex-shrink-0">

--- a/frontend/pages/SettingsPage.tsx
+++ b/frontend/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAppContext } from '../contexts/AppContext';
 import { useNotifications } from '../contexts/NotificationContext';
@@ -8,7 +8,7 @@ import Button from '../components/ui/Button';
 import Card from '../components/ui/Card';
 import {
   UsersIcon, LockClosedIcon, BellAlertIcon, WalletIcon, BuildingOfficeIcon,
-  PhoneIcon, TagIcon, AdjustmentsHorizontalIcon, ChartPieIcon, UserCircleIcon
+  PhoneIcon, TagIcon, AdjustmentsHorizontalIcon, ChartPieIcon, UserCircleIcon, EyeIcon
 } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
 import Tabs from '../components/ui/Tabs';
@@ -392,13 +392,48 @@ const SettingsPage: React.FC = () => {
     </div>
   );
 
+  const profilePath = useMemo(() => {
+    if (!currentUser) {
+      return null;
+    }
+
+    switch (currentUser.role) {
+      case UserRole.FOUNDATION:
+        return '/foundation/organisation-profile';
+      case UserRole.EDUCATOR:
+        return '/educator/profile';
+      case UserRole.PRODUCT_SUPPLIER:
+      case UserRole.SERVICE_PROVIDER:
+        return currentUser.orgId ? `/partner/${currentUser.orgId}` : '/profile';
+      default:
+        return '/profile';
+    }
+  }, [currentUser]);
+
+  const handleViewProfile = () => {
+    if (!profilePath) {
+      return;
+    }
+
+    if (isDirty && !window.confirm(t('settings:page.unsavedChangesPrompt'))) {
+      return;
+    }
+
+    navigate(profilePath);
+  };
+
   return (
     <div className="flex flex-col h-full bg-page-bg">
       <div className="sticky top-0 z-30 bg-page-bg/80 backdrop-blur-md px-8 py-4 border-b border-gray-200">
         <div className="flex justify-between items-center">
           <h1 className="text-2xl font-bold text-swiss-charcoal">{t('settings:page.title')}</h1>
-          {availableSections.length > 1 && (
-            <div className="flex space-x-3">
+          <div className="flex items-center space-x-3">
+            {profilePath && (
+              <Button variant="outline" leftIcon={EyeIcon} onClick={handleViewProfile}>
+                {t('common:buttons.viewProfile')}
+              </Button>
+            )}
+            {availableSections.length > 1 && (
               <Button variant="light" onClick={handleCancel}>
                 {t('common:buttons.cancel')}
               </Button>
@@ -410,8 +445,8 @@ const SettingsPage: React.FC = () => {
               >
                 {isSaving ? `${t('common:buttons.saveChanges')}...` : t('common:buttons.saveChanges')}
               </Button>
-            </div>
-          )}
+            )}
+          </div>
         </div>
       </div>
 

--- a/packages/translations/locales/de/common.json
+++ b/packages/translations/locales/de/common.json
@@ -8,6 +8,7 @@
     "edit": "Bearbeiten",
     "delete": "Löschen",
     "viewDetails": "Details anzeigen",
+    "viewProfile": "Profil anzeigen",
     "goBack": "Zurück",
     "login": "Anmelden",
     "signup": "Registrieren",

--- a/packages/translations/locales/de/profile.json
+++ b/packages/translations/locales/de/profile.json
@@ -1,0 +1,26 @@
+{
+  "title": "Mein Profil",
+  "subtitle": "Überprüfen Sie Ihre Konto- und Organisationsinformationen.",
+  "actions": {
+    "goToSettings": "Profil aktualisieren"
+  },
+  "details": {
+    "sectionTitle": "Kontodaten",
+    "name": "Vollständiger Name",
+    "email": "E-Mail",
+    "role": "Rolle",
+    "status": "Status",
+    "memberSince": "Mitglied seit",
+    "lastActive": "Zuletzt aktiv"
+  },
+  "organization": {
+    "sectionTitle": "Organisation",
+    "name": "Name der Organisation",
+    "region": "Region",
+    "plan": "Tarif",
+    "id": "Organisations-ID"
+  },
+  "empty": {
+    "organization": "Noch keine Organisationsinformationen verfügbar."
+  }
+}

--- a/packages/translations/locales/en/common.json
+++ b/packages/translations/locales/en/common.json
@@ -8,6 +8,7 @@
     "edit": "Edit",
     "delete": "Delete",
     "viewDetails": "View Details",
+    "viewProfile": "View Profile",
     "goBack": "Go Back",
     "login": "Log In",
     "signup": "Sign Up",

--- a/packages/translations/locales/en/profile.json
+++ b/packages/translations/locales/en/profile.json
@@ -1,0 +1,26 @@
+{
+  "title": "My Profile",
+  "subtitle": "Review your account details and organization information.",
+  "actions": {
+    "goToSettings": "Update Profile"
+  },
+  "details": {
+    "sectionTitle": "Account Details",
+    "name": "Full Name",
+    "email": "Email",
+    "role": "Role",
+    "status": "Status",
+    "memberSince": "Member Since",
+    "lastActive": "Last Active"
+  },
+  "organization": {
+    "sectionTitle": "Organization",
+    "name": "Organization Name",
+    "region": "Region",
+    "plan": "Plan",
+    "id": "Organization ID"
+  },
+  "empty": {
+    "organization": "No organization information available yet."
+  }
+}

--- a/packages/translations/locales/fr/common.json
+++ b/packages/translations/locales/fr/common.json
@@ -8,6 +8,7 @@
     "edit": "Modifier",
     "delete": "Supprimer",
     "viewDetails": "Voir les détails",
+    "viewProfile": "Voir le profil",
     "goBack": "Retour",
     "login": "Log In",
     "signup": "S'inscrire",

--- a/packages/translations/locales/fr/profile.json
+++ b/packages/translations/locales/fr/profile.json
@@ -1,0 +1,26 @@
+{
+  "title": "Mon profil",
+  "subtitle": "Consultez les informations de votre compte et de votre organisation.",
+  "actions": {
+    "goToSettings": "Mettre à jour le profil"
+  },
+  "details": {
+    "sectionTitle": "Informations du compte",
+    "name": "Nom complet",
+    "email": "E-mail",
+    "role": "Rôle",
+    "status": "Statut",
+    "memberSince": "Membre depuis",
+    "lastActive": "Dernière activité"
+  },
+  "organization": {
+    "sectionTitle": "Organisation",
+    "name": "Nom de l'organisation",
+    "region": "Région",
+    "plan": "Offre",
+    "id": "ID de l'organisation"
+  },
+  "empty": {
+    "organization": "Aucune information d'organisation pour le moment."
+  }
+}


### PR DESCRIPTION
Add a dedicated profile viewing page accessible to all user roles from their settings.

This PR introduces a `ProfilePage` component and integrates it into the application's routing, allowing all user roles to view their account and organization details. A "View Profile" button has been added to the `SettingsPage` and `ServiceProviderSettingsPage`, with logic to handle unsaved changes and direct users to the appropriate profile path based on their role. Internationalization support for the new profile page and button has also been added.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4ecc83f-ef03-4799-9d12-0112736fbb14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b4ecc83f-ef03-4799-9d12-0112736fbb14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

