### PR TITLE
Investigate and identify untranslated frontend strings

### DIFF
--- a/i18n-used-keys.json
+++ b/i18n-used-keys.json
@@ -1,0 +1,10437 @@
+{
+  "timestamp": "2025-11-10T15:12:07.774Z",
+  "totalKeys": 1143,
+  "byNamespace": {
+    "common": 1555,
+    "settings": 38,
+    "parentLeadForm": 10,
+    "auth": 2,
+    "dashboard": 8,
+    "admin": 86,
+    "recruitment": 38
+  },
+  "keys": [
+    {
+      "key": "notifications.successTitle",
+      "file": "SettingsPage.tsx",
+      "line": 103,
+      "context": "addNotification({ title: t('notifications.successTitle'), message: t('notifications.settingsUpdated'), type: 'success' });"
+    },
+    {
+      "key": "notifications.settingsUpdated",
+      "file": "SettingsPage.tsx",
+      "line": 103,
+      "context": "addNotification({ title: t('notifications.successTitle'), message: t('notifications.settingsUpdated'), type: 'success' });"
+    },
+    {
+      "key": "page.unsavedChangesPrompt",
+      "file": "SettingsPage.tsx",
+      "line": 109,
+      "context": "if (window.confirm(t('page.unsavedChangesPrompt'))) {"
+    },
+    {
+      "key": "page.loading",
+      "file": "SettingsPage.tsx",
+      "line": 125,
+      "context": "return <div className=\"p-6 text-center\">{t('page.loading')}</div>;"
+    },
+    {
+      "key": "page.noSectionsAvailable",
+      "file": "SettingsPage.tsx",
+      "line": 184,
+      "context": "<p className=\"text-gray-600\">{t('page.noSectionsAvailable')}</p>"
+    },
+    {
+      "key": "page.title",
+      "file": "SettingsPage.tsx",
+      "line": 195,
+      "context": "<h1 className=\"text-2xl font-bold text-swiss-charcoal\">{t('page.title')}</h1>"
+    },
+    {
+      "key": "buttons.cancel",
+      "file": "SettingsPage.tsx",
+      "line": 200,
+      "context": "{t('buttons.cancel')}"
+    },
+    {
+      "key": "buttons.saveChanges",
+      "file": "SettingsPage.tsx",
+      "line": 203,
+      "context": "{t('buttons.saveChanges')}"
+    },
+    {
+      "key": "roleManagement.cannotDeleteOwnAccount",
+      "file": "pages/UsersPage.tsx",
+      "line": 31,
+      "context": "alert(t('roleManagement.cannotDeleteOwnAccount'));"
+    },
+    {
+      "key": "roleManagement.status.pending",
+      "file": "pages/UsersPage.tsx",
+      "line": 57,
+      "context": "{user.status ? t(`usersPage.status.${user.status.toLowerCase()}`, user.status) : t('roleManagement.status.pending', 'Pending')}"
+    },
+    {
+      "key": "common:buttons.edit",
+      "file": "pages/UsersPage.tsx",
+      "line": 65,
+      "context": "<Button variant=\"ghost\" size=\"xs\" onClick={handleEdit} leftIcon={PencilIcon}>{t('common:buttons.edit')}</Button>"
+    },
+    {
+      "key": "common:buttons.edit",
+      "file": "pages/UsersPage.tsx",
+      "line": 65,
+      "context": "<Button variant=\"ghost\" size=\"xs\" onClick={handleEdit} leftIcon={PencilIcon}>{t('common:buttons.edit')}</Button>"
+    },
+    {
+      "key": "common:buttons.delete",
+      "file": "pages/UsersPage.tsx",
+      "line": 67,
+      "context": "<Button variant=\"ghost\" size=\"xs\" onClick={handleDelete} leftIcon={TrashIcon} className=\"text-red-600 hover:text-red-700\">{t('common:buttons.delete')}</Button>"
+    },
+    {
+      "key": "common:buttons.delete",
+      "file": "pages/UsersPage.tsx",
+      "line": 67,
+      "context": "<Button variant=\"ghost\" size=\"xs\" onClick={handleDelete} leftIcon={TrashIcon} className=\"text-red-600 hover:text-red-700\">{t('common:buttons.delete')}</Button>"
+    },
+    {
+      "key": "common:buttons.view",
+      "file": "pages/UsersPage.tsx",
+      "line": 71,
+      "context": "<Button variant=\"ghost\" size=\"sm\" onClick={(e) => {e.stopPropagation(); onUserSelect(user);}}>{t('common:buttons.view')}</Button>"
+    },
+    {
+      "key": "common:buttons.view",
+      "file": "pages/UsersPage.tsx",
+      "line": 71,
+      "context": "<Button variant=\"ghost\" size=\"sm\" onClick={(e) => {e.stopPropagation(); onUserSelect(user);}}>{t('common:buttons.view')}</Button>"
+    },
+    {
+      "key": "roleManagement.userDetailDrawer.title",
+      "file": "pages/UsersPage.tsx",
+      "line": 117,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal\">{t('roleManagement.userDetailDrawer.title')}</h2>"
+    },
+    {
+      "key": "common:buttons.close",
+      "file": "pages/UsersPage.tsx",
+      "line": 118,
+      "context": "<Button variant=\"ghost\" onClick={onClose}>{t('common:buttons.close')}</Button>"
+    },
+    {
+      "key": "common:buttons.close",
+      "file": "pages/UsersPage.tsx",
+      "line": 118,
+      "context": "<Button variant=\"ghost\" onClick={onClose}>{t('common:buttons.close')}</Button>"
+    },
+    {
+      "key": "roleManagement.userDetailDrawer.roleLabel",
+      "file": "pages/UsersPage.tsx",
+      "line": 126,
+      "context": "<p><strong>{t('roleManagement.userDetailDrawer.roleLabel')}</strong> {t(`userRoles.${user.role}`, user.role)}</p>"
+    },
+    {
+      "key": "roleManagement.userDetailDrawer.statusLabel",
+      "file": "pages/UsersPage.tsx",
+      "line": 127,
+      "context": "<p><strong>{t('roleManagement.userDetailDrawer.statusLabel')}</strong> {user.status ? t(`usersPage.status.${user.status.toLowerCase()}`, user.status) : 'N/A'}</p>"
+    },
+    {
+      "key": "roleManagement.userDetailDrawer.regionLabel",
+      "file": "pages/UsersPage.tsx",
+      "line": 128,
+      "context": "<p><strong>{t('roleManagement.userDetailDrawer.regionLabel')}</strong> {user.region || 'N/A'}</p>"
+    },
+    {
+      "key": "roleManagement.userDetailDrawer.lastLoginLabel",
+      "file": "pages/UsersPage.tsx",
+      "line": 129,
+      "context": "<p><strong>{t('roleManagement.userDetailDrawer.lastLoginLabel')}</strong> {user.lastLogin ? new Date(user.lastLogin).toLocaleString() : 'N/A'}</p>"
+    },
+    {
+      "key": "roleManagement.userDetailDrawer.orgLabel",
+      "file": "pages/UsersPage.tsx",
+      "line": 130,
+      "context": "{user.orgName && <p><strong>{t('roleManagement.userDetailDrawer.orgLabel')}</strong> {user.orgName}</p>}"
+    },
+    {
+      "key": "roleManagement.userDetailDrawer.adminActionsTitle",
+      "file": "pages/UsersPage.tsx",
+      "line": 135,
+      "context": "<h3 className=\"text-md font-semibold mb-2\">{t('roleManagement.userDetailDrawer.adminActionsTitle')}</h3>"
+    },
+    {
+      "key": "roleManagement.userDetailDrawer.changeRoleLabel",
+      "file": "pages/UsersPage.tsx",
+      "line": 139,
+      "context": "<label htmlFor=\"roleSelect\" className=\"block text-xs font-medium text-gray-500 mb-1\">{t('roleManagement.userDetailDrawer.changeRoleLabel')}</label>"
+    },
+    {
+      "key": "roleManagement.userDetailDrawer.updateRoleButton",
+      "file": "pages/UsersPage.tsx",
+      "line": 148,
+      "context": "<Button variant=\"secondary\" className=\"w-full\" onClick={handleRoleUpdate}>{t('roleManagement.userDetailDrawer.updateRoleButton')}</Button>"
+    },
+    {
+      "key": "roleManagement.userDetailDrawer.suspendUserButton",
+      "file": "pages/UsersPage.tsx",
+      "line": 151,
+      "context": "<Button variant=\"danger\" className=\"w-full\" onClick={() => handleStatusUpdate('Inactive')} leftIcon={XCircleIcon}>{t('roleManagement.userDetailDrawer.suspendUserButton')}</Button>"
+    },
+    {
+      "key": "roleManagement.userDetailDrawer.activateUserButton",
+      "file": "pages/UsersPage.tsx",
+      "line": 153,
+      "context": "<Button variant=\"primary\" className=\"w-full\" onClick={() => handleStatusUpdate('Active')} leftIcon={CheckCircleIcon}>{t('roleManagement.userDetailDrawer.activateUserButton')}</Button>"
+    },
+    {
+      "key": "roleManagement.userDetailDrawer.cannotModifyOwnAccount",
+      "file": "pages/UsersPage.tsx",
+      "line": 157,
+      "context": "<p className=\"text-xs text-gray-500 italic\">{t('roleManagement.userDetailDrawer.cannotModifyOwnAccount')}</p>"
+    },
+    {
+      "key": "roleManagement.rolePageTitle",
+      "file": "pages/UsersPage.tsx",
+      "line": 177,
+      "context": "const pageTitle = roleFilter ? t('roleManagement.rolePageTitle', { role: t(`userRoles.${roleFilter}`, roleFilter) }) : t('roleManagement.allUsersTitle');"
+    },
+    {
+      "key": "roleManagement.allUsersTitle",
+      "file": "pages/UsersPage.tsx",
+      "line": 177,
+      "context": "const pageTitle = roleFilter ? t('roleManagement.rolePageTitle', { role: t(`userRoles.${roleFilter}`, roleFilter) }) : t('roleManagement.allUsersTitle');"
+    },
+    {
+      "key": "roleManagement.confirmDeleteUser",
+      "file": "pages/UsersPage.tsx",
+      "line": 197,
+      "context": "if (window.confirm(t('roleManagement.confirmDeleteUser'))) {"
+    },
+    {
+      "key": "roleManagement.userProfileUpdated",
+      "file": "pages/UsersPage.tsx",
+      "line": 208,
+      "context": "alert(t('roleManagement.userProfileUpdated', { name: updatedUser.name }));"
+    },
+    {
+      "key": "roleManagement.addNewUserTBD",
+      "file": "pages/UsersPage.tsx",
+      "line": 216,
+      "context": "<Button variant=\"primary\" leftIcon={PlusIcon} onClick={() => alert(t('roleManagement.addNewUserTBD'))}>{t('roleManagement.addNewUserButton')}</Button>"
+    },
+    {
+      "key": "roleManagement.addNewUserButton",
+      "file": "pages/UsersPage.tsx",
+      "line": 216,
+      "context": "<Button variant=\"primary\" leftIcon={PlusIcon} onClick={() => alert(t('roleManagement.addNewUserTBD'))}>{t('roleManagement.addNewUserButton')}</Button>"
+    },
+    {
+      "key": "roleManagement.searchPlaceholder",
+      "file": "pages/UsersPage.tsx",
+      "line": 225,
+      "context": "placeholder={t('roleManagement.searchPlaceholder')}"
+    },
+    {
+      "key": "roleManagement.filtersTBD",
+      "file": "pages/UsersPage.tsx",
+      "line": 231,
+      "context": "<Button variant=\"outline\" leftIcon={FunnelIcon} onClick={() => alert(t('roleManagement.filtersTBD'))}>{t('roleManagement.filtersButton')}</Button>"
+    },
+    {
+      "key": "roleManagement.filtersButton",
+      "file": "pages/UsersPage.tsx",
+      "line": 231,
+      "context": "<Button variant=\"outline\" leftIcon={FunnelIcon} onClick={() => alert(t('roleManagement.filtersTBD'))}>{t('roleManagement.filtersButton')}</Button>"
+    },
+    {
+      "key": "roleManagement.table.nameOrg",
+      "file": "pages/UsersPage.tsx",
+      "line": 238,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('roleManagement.table.nameOrg')}</th>"
+    },
+    {
+      "key": "roleManagement.table.role",
+      "file": "pages/UsersPage.tsx",
+      "line": 239,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('roleManagement.table.role')}</th>"
+    },
+    {
+      "key": "roleManagement.table.status",
+      "file": "pages/UsersPage.tsx",
+      "line": 240,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('roleManagement.table.status')}</th>"
+    },
+    {
+      "key": "roleManagement.table.region",
+      "file": "pages/UsersPage.tsx",
+      "line": 241,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('roleManagement.table.region')}</th>"
+    },
+    {
+      "key": "roleManagement.table.lastLogin",
+      "file": "pages/UsersPage.tsx",
+      "line": 242,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('roleManagement.table.lastLogin')}</th>"
+    },
+    {
+      "key": "roleManagement.table.actions",
+      "file": "pages/UsersPage.tsx",
+      "line": 243,
+      "context": "<th scope=\"col\" className=\"relative px-6 py-3\"><span className=\"sr-only\">{t('roleManagement.table.actions')}</span></th>"
+    },
+    {
+      "key": "roleManagement.emptyState",
+      "file": "pages/UsersPage.tsx",
+      "line": 259,
+      "context": "{filteredUsers.length === 0 && <p className=\"text-center text-gray-500 py-8\">{t('roleManagement.emptyState')}</p>}"
+    },
+    {
+      "key": "statePoliciesPage.tabs.cantonal",
+      "file": "pages/StatePoliciesPage.tsx",
+      "line": 202,
+      "context": "{ label: t('statePoliciesPage.tabs.cantonal'), content: tabsContent('Cantonal Policies')},"
+    },
+    {
+      "key": "statePoliciesPage.tabs.national",
+      "file": "pages/StatePoliciesPage.tsx",
+      "line": 203,
+      "context": "{ label: t('statePoliciesPage.tabs.national'), content: tabsContent('National Regulations')},"
+    },
+    {
+      "key": "statePoliciesPage.sections.compliance",
+      "file": "pages/StatePoliciesPage.tsx",
+      "line": 204,
+      "context": "{ label: t('statePoliciesPage.sections.compliance'), content: tabsContent('Compliance Requirements')},"
+    },
+    {
+      "key": "statePoliciesPage.sections.updates",
+      "file": "pages/StatePoliciesPage.tsx",
+      "line": 205,
+      "context": "{ label: t('statePoliciesPage.sections.updates'), content: tabsContent('Updates & News')},"
+    },
+    {
+      "key": "statePoliciesPage.sections.downloads",
+      "file": "pages/StatePoliciesPage.tsx",
+      "line": 206,
+      "context": "{ label: t('statePoliciesPage.sections.downloads'), content: tabsContent('Official Downloads')},"
+    },
+    {
+      "key": "goToPricingButton",
+      "file": "pages/SignupPage.tsx",
+      "line": 125,
+      "context": "? t('goToPricingButton', 'Go to Pricing')"
+    },
+    {
+      "key": "goToDashboardButton",
+      "file": "pages/SignupPage.tsx",
+      "line": 126,
+      "context": ": t('goToDashboardButton');"
+    },
+    {
+      "key": "errors.organisationNameRequired",
+      "file": "pages/SignupPage.tsx",
+      "line": 200,
+      "context": "newErrors.organisationName = t('errors.organisationNameRequired');"
+    },
+    {
+      "key": "errors.emailRequired",
+      "file": "pages/SignupPage.tsx",
+      "line": 205,
+      "context": "newErrors.email = t('errors.emailRequired');"
+    },
+    {
+      "key": "errors.emailInvalid",
+      "file": "pages/SignupPage.tsx",
+      "line": 207,
+      "context": "newErrors.email = t('errors.emailInvalid');"
+    },
+    {
+      "key": "errors.passwordRequired",
+      "file": "pages/SignupPage.tsx",
+      "line": 209,
+      "context": "newErrors.password = t('errors.passwordRequired');"
+    },
+    {
+      "key": "errors.passwordTooShort",
+      "file": "pages/SignupPage.tsx",
+      "line": 211,
+      "context": "newErrors.password = t('errors.passwordTooShort');"
+    },
+    {
+      "key": "errors.passwordsNoMatch",
+      "file": "pages/SignupPage.tsx",
+      "line": 213,
+      "context": "newErrors.confirmPassword = t('errors.passwordsNoMatch');"
+    },
+    {
+      "key": "errors.phoneRequired",
+      "file": "pages/SignupPage.tsx",
+      "line": 216,
+      "context": "newErrors.phone = t('errors.phoneRequired');"
+    },
+    {
+      "key": "errors.cantonRequired",
+      "file": "pages/SignupPage.tsx",
+      "line": 219,
+      "context": "newErrors.canton = t('errors.cantonRequired');"
+    },
+    {
+      "key": "errors.capacityRequired",
+      "file": "pages/SignupPage.tsx",
+      "line": 223,
+      "context": "newErrors.capacity = t('errors.capacityRequired');"
+    },
+    {
+      "key": "errors.categoryRequired",
+      "file": "pages/SignupPage.tsx",
+      "line": 225,
+      "context": "newErrors.category = t('errors.categoryRequired');"
+    },
+    {
+      "key": "errors.serviceTypeRequired",
+      "file": "pages/SignupPage.tsx",
+      "line": 227,
+      "context": "newErrors.serviceType = t('errors.serviceTypeRequired');"
+    },
+    {
+      "key": "errors.childAgeRequired",
+      "file": "pages/SignupPage.tsx",
+      "line": 231,
+      "context": "newErrors.childAge = t('errors.childAgeRequired');"
+    },
+    {
+      "key": "errors.childStartDateRequired",
+      "file": "pages/SignupPage.tsx",
+      "line": 233,
+      "context": "newErrors.childStartDate = t('errors.childStartDateRequired');"
+    },
+    {
+      "key": "errors.termsRequired",
+      "file": "pages/SignupPage.tsx",
+      "line": 237,
+      "context": "newErrors.termsAccepted = t('errors.termsRequired');"
+    },
+    {
+      "key": "errors.captchaRequired",
+      "file": "pages/SignupPage.tsx",
+      "line": 241,
+      "context": "setCaptchaError(t('errors.captchaRequired'));"
+    },
+    {
+      "key": "errors.captchaExpired",
+      "file": "pages/SignupPage.tsx",
+      "line": 257,
+      "context": "setCaptchaError(t('errors.captchaExpired'));"
+    },
+    {
+      "key": "errors.captchaError",
+      "file": "pages/SignupPage.tsx",
+      "line": 262,
+      "context": "setCaptchaError(t('errors.captchaError'));"
+    },
+    {
+      "key": "errors.accountExists",
+      "file": "pages/SignupPage.tsx",
+      "line": 330,
+      "context": "errorMessage = t('errors.accountExists', 'An account with this email already exists');"
+    },
+    {
+      "key": "errors.passwordPwned",
+      "file": "pages/SignupPage.tsx",
+      "line": 333,
+      "context": "errorMessage = t('errors.passwordPwned', 'This password has been found in a data breach. Please choose a different password');"
+    },
+    {
+      "key": "errors.passwordWeak",
+      "file": "pages/SignupPage.tsx",
+      "line": 336,
+      "context": "errorMessage = t('errors.passwordWeak', 'Password is not strong enough');"
+    },
+    {
+      "key": "errors.emailInvalid",
+      "file": "pages/SignupPage.tsx",
+      "line": 339,
+      "context": "errorMessage = t('errors.emailInvalid', 'Please enter a valid email address');"
+    },
+    {
+      "key": "placeholders.select",
+      "file": "pages/SignupPage.tsx",
+      "line": 438,
+      "context": "<option value=\"\">{t('placeholders.select')}</option>"
+    },
+    {
+      "key": "common:hidePassword",
+      "file": "pages/SignupPage.tsx",
+      "line": 457,
+      "context": "aria-label={(name === 'password' && showPassword) || (name === 'confirmPassword' && showConfirmPassword) ? t('common:hidePassword') : t('common:showPassword')}"
+    },
+    {
+      "key": "common:showPassword",
+      "file": "pages/SignupPage.tsx",
+      "line": 457,
+      "context": "aria-label={(name === 'password' && showPassword) || (name === 'confirmPassword' && showConfirmPassword) ? t('common:hidePassword') : t('common:showPassword')}"
+    },
+    {
+      "key": "common:hidePassword",
+      "file": "pages/SignupPage.tsx",
+      "line": 457,
+      "context": "aria-label={(name === 'password' && showPassword) || (name === 'confirmPassword' && showConfirmPassword) ? t('common:hidePassword') : t('common:showPassword')}"
+    },
+    {
+      "key": "common:showPassword",
+      "file": "pages/SignupPage.tsx",
+      "line": 457,
+      "context": "aria-label={(name === 'password' && showPassword) || (name === 'confirmPassword' && showConfirmPassword) ? t('common:hidePassword') : t('common:showPassword')}"
+    },
+    {
+      "key": "progress.step1",
+      "file": "pages/SignupPage.tsx",
+      "line": 468,
+      "context": "const progressText = currentStep === 1 ? t('progress.step1') : t('progress.step2');"
+    },
+    {
+      "key": "progress.step2",
+      "file": "pages/SignupPage.tsx",
+      "line": 468,
+      "context": "const progressText = currentStep === 1 ? t('progress.step1') : t('progress.step2');"
+    },
+    {
+      "key": "selectRoleTitle",
+      "file": "pages/SignupPage.tsx",
+      "line": 469,
+      "context": "const formTitle = currentStep === 1 ? t('selectRoleTitle') : t('detailsTitle', { role: selectedRole ? t(rolesConfig.find(rc => rc.role === selectedRole)!.nameKey) : '' });"
+    },
+    {
+      "key": "detailsTitle",
+      "file": "pages/SignupPage.tsx",
+      "line": 469,
+      "context": "const formTitle = currentStep === 1 ? t('selectRoleTitle') : t('detailsTitle', { role: selectedRole ? t(rolesConfig.find(rc => rc.role === selectedRole)!.nameKey) : '' });"
+    },
+    {
+      "key": "submissionSuccessTitle",
+      "file": "pages/SignupPage.tsx",
+      "line": 485,
+      "context": "<h1 className=\"text-2xl font-bold text-swiss-charcoal\">{t('submissionSuccessTitle')}</h1>"
+    },
+    {
+      "key": "submissionSuccessMessage",
+      "file": "pages/SignupPage.tsx",
+      "line": 486,
+      "context": "<p className=\"text-gray-600 mt-2 mb-6\">{t('submissionSuccessMessage')}</p>"
+    },
+    {
+      "key": "common:loginPage.alreadyAccount",
+      "file": "pages/SignupPage.tsx",
+      "line": 497,
+      "context": "{t('common:loginPage.alreadyAccount')}{' '}"
+    },
+    {
+      "key": "common:loginPage.alreadyAccount",
+      "file": "pages/SignupPage.tsx",
+      "line": 497,
+      "context": "{t('common:loginPage.alreadyAccount')}{' '}"
+    },
+    {
+      "key": "common:buttons.login",
+      "file": "pages/SignupPage.tsx",
+      "line": 499,
+      "context": "{t('common:buttons.login')}"
+    },
+    {
+      "key": "common:buttons.login",
+      "file": "pages/SignupPage.tsx",
+      "line": 499,
+      "context": "{t('common:buttons.login')}"
+    },
+    {
+      "key": "termsLabel",
+      "file": "pages/SignupPage.tsx",
+      "line": 566,
+      "context": "{t('termsLabel')}{' '}"
+    },
+    {
+      "key": "termsLink",
+      "file": "pages/SignupPage.tsx",
+      "line": 568,
+      "context": "{t('termsLink')}"
+    },
+    {
+      "key": "buttons.goBack",
+      "file": "pages/SignupPage.tsx",
+      "line": 591,
+      "context": "{t('buttons.goBack')}"
+    },
+    {
+      "key": "creatingAccount",
+      "file": "pages/SignupPage.tsx",
+      "line": 594,
+      "context": "{isLoading ? t('creatingAccount') : t('buttons.createAccount')}"
+    },
+    {
+      "key": "buttons.createAccount",
+      "file": "pages/SignupPage.tsx",
+      "line": 594,
+      "context": "{isLoading ? t('creatingAccount') : t('buttons.createAccount')}"
+    },
+    {
+      "key": "common:verifyEmail",
+      "file": "pages/SignupPage.tsx",
+      "line": 618,
+      "context": "{t('common:verifyEmail', 'Verify Your Email')}"
+    },
+    {
+      "key": "common:verifyEmail",
+      "file": "pages/SignupPage.tsx",
+      "line": 618,
+      "context": "{t('common:verifyEmail', 'Verify Your Email')}"
+    },
+    {
+      "key": "common:verifyEmailMessage",
+      "file": "pages/SignupPage.tsx",
+      "line": 621,
+      "context": "{t('common:verifyEmailMessage', `We've sent a verification code to ${formData.email}. Please enter it below.`)}"
+    },
+    {
+      "key": "common:verifyEmailMessage",
+      "file": "pages/SignupPage.tsx",
+      "line": 621,
+      "context": "{t('common:verifyEmailMessage', `We've sent a verification code to ${formData.email}. Please enter it below.`)}"
+    },
+    {
+      "key": "common:labels.verificationCode",
+      "file": "pages/SignupPage.tsx",
+      "line": 634,
+      "context": "{t('common:labels.verificationCode', 'Verification Code')}"
+    },
+    {
+      "key": "common:labels.verificationCode",
+      "file": "pages/SignupPage.tsx",
+      "line": 634,
+      "context": "{t('common:labels.verificationCode', 'Verification Code')}"
+    },
+    {
+      "key": "common:verifying",
+      "file": "pages/SignupPage.tsx",
+      "line": 659,
+      "context": "{(isLoading || isVerifying) ? t('common:verifying', 'Verifying...') : t('common:buttons.verifyEmail', 'Verify Email')}"
+    },
+    {
+      "key": "common:buttons.verifyEmail",
+      "file": "pages/SignupPage.tsx",
+      "line": 659,
+      "context": "{(isLoading || isVerifying) ? t('common:verifying', 'Verifying...') : t('common:buttons.verifyEmail', 'Verify Email')}"
+    },
+    {
+      "key": "common:verifying",
+      "file": "pages/SignupPage.tsx",
+      "line": 659,
+      "context": "{(isLoading || isVerifying) ? t('common:verifying', 'Verifying...') : t('common:buttons.verifyEmail', 'Verify Email')}"
+    },
+    {
+      "key": "common:buttons.verifyEmail",
+      "file": "pages/SignupPage.tsx",
+      "line": 659,
+      "context": "{(isLoading || isVerifying) ? t('common:verifying', 'Verifying...') : t('common:buttons.verifyEmail', 'Verify Email')}"
+    },
+    {
+      "key": "common:loginPage.alreadyAccount",
+      "file": "pages/SignupPage.tsx",
+      "line": 670,
+      "context": "{t('common:loginPage.alreadyAccount')}{' '}"
+    },
+    {
+      "key": "common:loginPage.alreadyAccount",
+      "file": "pages/SignupPage.tsx",
+      "line": 670,
+      "context": "{t('common:loginPage.alreadyAccount')}{' '}"
+    },
+    {
+      "key": "common:buttons.login",
+      "file": "pages/SignupPage.tsx",
+      "line": 672,
+      "context": "{t('common:buttons.login')}"
+    },
+    {
+      "key": "common:buttons.login",
+      "file": "pages/SignupPage.tsx",
+      "line": 672,
+      "context": "{t('common:buttons.login')}"
+    },
+    {
+      "key": "common:errors.genericErrorTitle",
+      "file": "pages/SettingsPage.tsx",
+      "line": 147,
+      "context": "title: t('common:errors.genericErrorTitle'),"
+    },
+    {
+      "key": "common:errors.genericErrorTitle",
+      "file": "pages/SettingsPage.tsx",
+      "line": 147,
+      "context": "title: t('common:errors.genericErrorTitle'),"
+    },
+    {
+      "key": "common:errors.genericErrorMessage",
+      "file": "pages/SettingsPage.tsx",
+      "line": 148,
+      "context": "message: t('common:errors.genericErrorMessage'),"
+    },
+    {
+      "key": "common:errors.genericErrorMessage",
+      "file": "pages/SettingsPage.tsx",
+      "line": 148,
+      "context": "message: t('common:errors.genericErrorMessage'),"
+    },
+    {
+      "key": "notifications.successTitle",
+      "file": "pages/SettingsPage.tsx",
+      "line": 295,
+      "context": "title: t('notifications.successTitle'),"
+    },
+    {
+      "key": "notifications.settingsUpdated",
+      "file": "pages/SettingsPage.tsx",
+      "line": 296,
+      "context": "message: t('notifications.settingsUpdated'),"
+    },
+    {
+      "key": "common:errors.genericErrorTitle",
+      "file": "pages/SettingsPage.tsx",
+      "line": 302,
+      "context": "title: t('common:errors.genericErrorTitle'),"
+    },
+    {
+      "key": "common:errors.genericErrorTitle",
+      "file": "pages/SettingsPage.tsx",
+      "line": 302,
+      "context": "title: t('common:errors.genericErrorTitle'),"
+    },
+    {
+      "key": "common:errors.genericErrorMessage",
+      "file": "pages/SettingsPage.tsx",
+      "line": 303,
+      "context": "message: t('common:errors.genericErrorMessage'),"
+    },
+    {
+      "key": "common:errors.genericErrorMessage",
+      "file": "pages/SettingsPage.tsx",
+      "line": 303,
+      "context": "message: t('common:errors.genericErrorMessage'),"
+    },
+    {
+      "key": "settings:page.unsavedChangesPrompt",
+      "file": "pages/SettingsPage.tsx",
+      "line": 313,
+      "context": "if (window.confirm(t('settings:page.unsavedChangesPrompt'))) {"
+    },
+    {
+      "key": "settings:page.unsavedChangesPrompt",
+      "file": "pages/SettingsPage.tsx",
+      "line": 313,
+      "context": "if (window.confirm(t('settings:page.unsavedChangesPrompt'))) {"
+    },
+    {
+      "key": "settings:page.loading",
+      "file": "pages/SettingsPage.tsx",
+      "line": 329,
+      "context": "return <div className=\"p-6 text-center\">{t('settings:page.loading')}</div>;"
+    },
+    {
+      "key": "settings:page.loading",
+      "file": "pages/SettingsPage.tsx",
+      "line": 329,
+      "context": "return <div className=\"p-6 text-center\">{t('settings:page.loading')}</div>;"
+    },
+    {
+      "key": "settings:page.noSectionsAvailable",
+      "file": "pages/SettingsPage.tsx",
+      "line": 388,
+      "context": "<p className=\"text-gray-600\">{t('settings:page.noSectionsAvailable')}</p>"
+    },
+    {
+      "key": "settings:page.noSectionsAvailable",
+      "file": "pages/SettingsPage.tsx",
+      "line": 388,
+      "context": "<p className=\"text-gray-600\">{t('settings:page.noSectionsAvailable')}</p>"
+    },
+    {
+      "key": "settings:page.title",
+      "file": "pages/SettingsPage.tsx",
+      "line": 399,
+      "context": "<h1 className=\"text-2xl font-bold text-swiss-charcoal\">{t('settings:page.title')}</h1>"
+    },
+    {
+      "key": "settings:page.title",
+      "file": "pages/SettingsPage.tsx",
+      "line": 399,
+      "context": "<h1 className=\"text-2xl font-bold text-swiss-charcoal\">{t('settings:page.title')}</h1>"
+    },
+    {
+      "key": "common:buttons.cancel",
+      "file": "pages/SettingsPage.tsx",
+      "line": 403,
+      "context": "{t('common:buttons.cancel')}"
+    },
+    {
+      "key": "common:buttons.cancel",
+      "file": "pages/SettingsPage.tsx",
+      "line": 403,
+      "context": "{t('common:buttons.cancel')}"
+    },
+    {
+      "key": "common:buttons.saveChanges",
+      "file": "pages/SettingsPage.tsx",
+      "line": 411,
+      "context": "{isSaving ? `${t('common:buttons.saveChanges')}...` : t('common:buttons.saveChanges')}"
+    },
+    {
+      "key": "common:buttons.saveChanges",
+      "file": "pages/SettingsPage.tsx",
+      "line": 411,
+      "context": "{isSaving ? `${t('common:buttons.saveChanges')}...` : t('common:buttons.saveChanges')}"
+    },
+    {
+      "key": "common:buttons.saveChanges",
+      "file": "pages/SettingsPage.tsx",
+      "line": 411,
+      "context": "{isSaving ? `${t('common:buttons.saveChanges')}...` : t('common:buttons.saveChanges')}"
+    },
+    {
+      "key": "common:buttons.saveChanges",
+      "file": "pages/SettingsPage.tsx",
+      "line": 411,
+      "context": "{isSaving ? `${t('common:buttons.saveChanges')}...` : t('common:buttons.saveChanges')}"
+    },
+    {
+      "key": "common:errors.genericErrorTitle",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 120,
+      "context": "title: t('common:errors.genericErrorTitle'),"
+    },
+    {
+      "key": "common:errors.genericErrorTitle",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 120,
+      "context": "title: t('common:errors.genericErrorTitle'),"
+    },
+    {
+      "key": "common:errors.genericErrorMessage",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 121,
+      "context": "message: t('common:errors.genericErrorMessage'),"
+    },
+    {
+      "key": "common:errors.genericErrorMessage",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 121,
+      "context": "message: t('common:errors.genericErrorMessage'),"
+    },
+    {
+      "key": "notifications.successTitle",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 218,
+      "context": "title: t('notifications.successTitle'),"
+    },
+    {
+      "key": "notifications.settingsUpdated",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 219,
+      "context": "message: t('notifications.settingsUpdated'),"
+    },
+    {
+      "key": "common:errors.genericErrorTitle",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 225,
+      "context": "title: t('common:errors.genericErrorTitle'),"
+    },
+    {
+      "key": "common:errors.genericErrorTitle",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 225,
+      "context": "title: t('common:errors.genericErrorTitle'),"
+    },
+    {
+      "key": "common:errors.genericErrorMessage",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 226,
+      "context": "message: t('common:errors.genericErrorMessage'),"
+    },
+    {
+      "key": "common:errors.genericErrorMessage",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 226,
+      "context": "message: t('common:errors.genericErrorMessage'),"
+    },
+    {
+      "key": "settings:page.unsavedChangesPrompt",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 236,
+      "context": "if (window.confirm(t('settings:page.unsavedChangesPrompt'))) {"
+    },
+    {
+      "key": "settings:page.unsavedChangesPrompt",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 236,
+      "context": "if (window.confirm(t('settings:page.unsavedChangesPrompt'))) {"
+    },
+    {
+      "key": "settings:page.loading",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 252,
+      "context": "return <div className=\"p-6 text-center\">{t('settings:page.loading')}</div>;"
+    },
+    {
+      "key": "settings:page.loading",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 252,
+      "context": "return <div className=\"p-6 text-center\">{t('settings:page.loading')}</div>;"
+    },
+    {
+      "key": "settings:page.loading",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 260,
+      "context": "return <div className=\"p-6 text-center\">{t('settings:page.loading')}</div>;"
+    },
+    {
+      "key": "settings:page.loading",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 260,
+      "context": "return <div className=\"p-6 text-center\">{t('settings:page.loading')}</div>;"
+    },
+    {
+      "key": "settings:page.title",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 267,
+      "context": "<h1 className=\"text-2xl font-bold text-swiss-charcoal\">{t('settings:page.title')}</h1>"
+    },
+    {
+      "key": "settings:page.title",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 267,
+      "context": "<h1 className=\"text-2xl font-bold text-swiss-charcoal\">{t('settings:page.title')}</h1>"
+    },
+    {
+      "key": "common:buttons.cancel",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 270,
+      "context": "{t('common:buttons.cancel')}"
+    },
+    {
+      "key": "common:buttons.cancel",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 270,
+      "context": "{t('common:buttons.cancel')}"
+    },
+    {
+      "key": "common:buttons.saveChanges",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 278,
+      "context": "{isSaving ? `${t('common:buttons.saveChanges')}...` : t('common:buttons.saveChanges')}"
+    },
+    {
+      "key": "common:buttons.saveChanges",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 278,
+      "context": "{isSaving ? `${t('common:buttons.saveChanges')}...` : t('common:buttons.saveChanges')}"
+    },
+    {
+      "key": "common:buttons.saveChanges",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 278,
+      "context": "{isSaving ? `${t('common:buttons.saveChanges')}...` : t('common:buttons.saveChanges')}"
+    },
+    {
+      "key": "common:buttons.saveChanges",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 278,
+      "context": "{isSaving ? `${t('common:buttons.saveChanges')}...` : t('common:buttons.saveChanges')}"
+    },
+    {
+      "key": "settings:page.noSectionsAvailable",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 322,
+      "context": "<p className=\"text-gray-600\">{t('settings:page.noSectionsAvailable')}</p>"
+    },
+    {
+      "key": "settings:page.noSectionsAvailable",
+      "file": "pages/ServiceProviderSettingsPage.tsx",
+      "line": 322,
+      "context": "<p className=\"text-gray-600\">{t('settings:page.noSectionsAvailable')}</p>"
+    },
+    {
+      "key": "recruitmentPage.jobStatus.published",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 29,
+      "context": "return { className: 'bg-green-100 text-green-700', label: t('recruitmentPage.jobStatus.published', 'Published') };"
+    },
+    {
+      "key": "recruitmentPage.jobStatus.draft",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 31,
+      "context": "return { className: 'bg-yellow-100 text-yellow-700', label: t('recruitmentPage.jobStatus.draft', 'Draft') };"
+    },
+    {
+      "key": "recruitmentPage.jobStatus.filled",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 33,
+      "context": "return { className: 'bg-blue-100 text-blue-700', label: t('recruitmentPage.jobStatus.filled', 'Filled') };"
+    },
+    {
+      "key": "recruitmentPage.jobStatus.closed",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 36,
+      "context": "return { className: 'bg-red-100 text-red-700', label: t('recruitmentPage.jobStatus.closed', 'Closed') };"
+    },
+    {
+      "key": "recruitmentPage.contractTypes.fullTime",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 43,
+      "context": "return t('recruitmentPage.contractTypes.fullTime', 'Full-time');"
+    },
+    {
+      "key": "recruitmentPage.contractTypes.partTime",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 45,
+      "context": "return t('recruitmentPage.contractTypes.partTime', 'Part-time');"
+    },
+    {
+      "key": "recruitmentPage.contractTypes.cdi",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 47,
+      "context": "return t('recruitmentPage.contractTypes.cdi', 'CDI');"
+    },
+    {
+      "key": "recruitmentPage.contractTypes.cdd",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 49,
+      "context": "return t('recruitmentPage.contractTypes.cdd', 'CDD');"
+    },
+    {
+      "key": "recruitmentPage.contractTypes.internship",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 52,
+      "context": "return t('recruitmentPage.contractTypes.internship', 'Internship');"
+    },
+    {
+      "key": "recruitmentPage.labels.startDateTbd",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 56,
+      "context": "const formattedStartDate = job.startDate ? new Date(job.startDate).toLocaleDateString() : t('recruitmentPage.labels.startDateTbd', 'To be determined');"
+    },
+    {
+      "key": "recruitmentPage.labels.locationUnknown",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 71,
+      "context": "<p><MapPinIcon className=\"w-4 h-4 inline mr-2 text-gray-400\" />{job.location ?? t('recruitmentPage.labels.locationUnknown', 'Location TBD')}</p>"
+    },
+    {
+      "key": "recruitmentPage.labels.startDate",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 73,
+      "context": "<p><CalendarDaysIcon className=\"w-4 h-4 inline mr-2 text-gray-400\" />{t('recruitmentPage.labels.startDate')}: {formattedStartDate}</p>"
+    },
+    {
+      "key": "recruitmentPage.labels.applications",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 74,
+      "context": "<p><UserGroupIcon className=\"w-4 h-4 inline mr-2 text-gray-400\" />{t('recruitmentPage.labels.applications')}: {job.applicationsCount}</p>"
+    },
+    {
+      "key": "buttons.viewApplicants",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 78,
+      "context": "<Button variant=\"ghost\" size=\"sm\" leftIcon={EyeIcon} onClick={() => onViewApplicants(job)}>{t('buttons.viewApplicants')}</Button>"
+    },
+    {
+      "key": "common:buttons.edit",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 79,
+      "context": "<Button variant=\"ghost\" size=\"sm\" leftIcon={PencilIcon} className=\"text-blue-600 hover:text-blue-700\" onClick={() => onEdit(job)}>{t('common:buttons.edit')}</Button>"
+    },
+    {
+      "key": "common:buttons.edit",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 79,
+      "context": "<Button variant=\"ghost\" size=\"sm\" leftIcon={PencilIcon} className=\"text-blue-600 hover:text-blue-700\" onClick={() => onEdit(job)}>{t('common:buttons.edit')}</Button>"
+    },
+    {
+      "key": "candidateCard.roleUnknown",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 101,
+      "context": "<p className=\"text-sm text-gray-500\">{candidate.currentRoleOrTitle ?? candidate.role ?? t('candidateCard.roleUnknown', 'Role not specified')}</p>"
+    },
+    {
+      "key": "candidateCard.availabilityUnknown",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 109,
+      "context": "<p><CalendarDaysIcon className=\"w-4 h-4 inline mr-2 text-gray-400\" />{candidate.availabilityStatus || candidate.availability || t('candidateCard.availabilityUnknown', 'Availability not provided')}</p>"
+    },
+    {
+      "key": "candidateCard.regionUnknown",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 110,
+      "context": "<p><MapPinIcon className=\"w-4 h-4 inline mr-2 text-gray-400\" />{candidate.location || candidate.preferredRegion || t('candidateCard.regionUnknown', 'Region not specified')}</p>"
+    },
+    {
+      "key": "candidateCard.viewProfile",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 117,
+      "context": "{t('candidateCard.viewProfile')}"
+    },
+    {
+      "key": "errors.loadJobsFailed",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 184,
+      "context": "error instanceof Error ? error.message : t('errors.loadJobsFailed', 'Unable to load job listings'),"
+    },
+    {
+      "key": "errors.loadCandidatesFailed",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 205,
+      "context": "error instanceof Error ? error.message : t('errors.loadCandidatesFailed', 'Unable to load candidates'),"
+    },
+    {
+      "key": "errors.saveJobFailed",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 280,
+      "context": "error instanceof Error ? error.message : t('errors.saveJobFailed', 'Unable to save job listing'),"
+    },
+    {
+      "key": "confirmations.deleteJob",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 286,
+      "context": "if (!window.confirm(t('confirmations.deleteJob', 'Are you sure you want to delete this job listing?'))) {"
+    },
+    {
+      "key": "errors.deleteJobFailed",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 295,
+      "context": "error instanceof Error ? error.message : t('errors.deleteJobFailed', 'Unable to delete job listing'),"
+    },
+    {
+      "key": "errors.loadApplicationsFailed",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 312,
+      "context": "error instanceof Error ? error.message : t('errors.loadApplicationsFailed', 'Unable to load applications'),"
+    },
+    {
+      "key": "jobOffers.searchPlaceholder",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 328,
+      "context": "{t('jobOffers.searchPlaceholder')}"
+    },
+    {
+      "key": "jobOffers.searchPlaceholder",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 333,
+      "context": "placeholder={t('jobOffers.searchPlaceholder')}"
+    },
+    {
+      "key": "buttons.filters",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 341,
+      "context": "{t('buttons.filters')}"
+    },
+    {
+      "key": "buttons.postNewJob",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 350,
+      "context": "{t('buttons.postNewJob')}"
+    },
+    {
+      "key": "jobOffers.filterTitle",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 357,
+      "context": "<h3 className=\"text-lg font-semibold mb-2\">{t('jobOffers.filterTitle')}</h3>"
+    },
+    {
+      "key": "labels.location",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 359,
+      "context": "<input type=\"text\" placeholder={t('labels.location')} className={STANDARD_INPUT_FIELD} aria-label={t('labels.location')} />"
+    },
+    {
+      "key": "labels.location",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 359,
+      "context": "<input type=\"text\" placeholder={t('labels.location')} className={STANDARD_INPUT_FIELD} aria-label={t('labels.location')} />"
+    },
+    {
+      "key": "labels.allContractTypes",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 360,
+      "context": "<select className={STANDARD_INPUT_FIELD} aria-label={t('labels.allContractTypes')}>"
+    },
+    {
+      "key": "labels.allContractTypes",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 361,
+      "context": "<option>{t('labels.allContractTypes')}</option>"
+    },
+    {
+      "key": "labels.allStatuses",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 363,
+      "context": "<select className={STANDARD_INPUT_FIELD} aria-label={t('labels.allStatuses')}>"
+    },
+    {
+      "key": "labels.allStatuses",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 364,
+      "context": "<option>{t('labels.allStatuses')}</option>"
+    },
+    {
+      "key": "buttons.applyFilters",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 368,
+      "context": "{t('buttons.applyFilters')}"
+    },
+    {
+      "key": "common:loading",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 374,
+      "context": "<p className=\"text-center text-gray-500 py-8\">{t('common:loading', 'Loading...')}</p>"
+    },
+    {
+      "key": "common:loading",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 374,
+      "context": "<p className=\"text-center text-gray-500 py-8\">{t('common:loading', 'Loading...')}</p>"
+    },
+    {
+      "key": "common:buttons.delete",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 388,
+      "context": "{t('common:buttons.delete')}"
+    },
+    {
+      "key": "common:buttons.delete",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 388,
+      "context": "{t('common:buttons.delete')}"
+    },
+    {
+      "key": "jobOffers.emptyState",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 395,
+      "context": "<p className=\"text-center text-gray-500 py-8\">{t('jobOffers.emptyState')}</p>"
+    },
+    {
+      "key": "candidatePool.searchPlaceholder",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 406,
+      "context": "{t('candidatePool.searchPlaceholder')}"
+    },
+    {
+      "key": "candidatePool.searchPlaceholder",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 411,
+      "context": "placeholder={t('candidatePool.searchPlaceholder')}"
+    },
+    {
+      "key": "buttons.filters",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 419,
+      "context": "{t('buttons.filters')}"
+    },
+    {
+      "key": "candidatePool.filterTitle",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 425,
+      "context": "<h3 className=\"text-lg font-semibold mb-2\">{t('candidatePool.filterTitle')}</h3>"
+    },
+    {
+      "key": "labels.allRoles",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 427,
+      "context": "<select className={STANDARD_INPUT_FIELD} aria-label={t('labels.allRoles')}>"
+    },
+    {
+      "key": "labels.allRoles",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 428,
+      "context": "<option>{t('labels.allRoles')}</option>"
+    },
+    {
+      "key": "labels.region",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 430,
+      "context": "<input type=\"text\" placeholder={t('labels.region')} className={STANDARD_INPUT_FIELD} aria-label={t('labels.region')} />"
+    },
+    {
+      "key": "labels.region",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 430,
+      "context": "<input type=\"text\" placeholder={t('labels.region')} className={STANDARD_INPUT_FIELD} aria-label={t('labels.region')} />"
+    },
+    {
+      "key": "labels.availabilityDate",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 431,
+      "context": "<input type=\"date\" placeholder={t('labels.availabilityDate')} className={STANDARD_INPUT_FIELD} aria-label={t('labels.availabilityDate')} />"
+    },
+    {
+      "key": "labels.availabilityDate",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 431,
+      "context": "<input type=\"date\" placeholder={t('labels.availabilityDate')} className={STANDARD_INPUT_FIELD} aria-label={t('labels.availabilityDate')} />"
+    },
+    {
+      "key": "labels.allContractTypes",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 432,
+      "context": "<select className={STANDARD_INPUT_FIELD} aria-label={t('labels.allContractTypes')}>"
+    },
+    {
+      "key": "labels.allContractTypes",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 433,
+      "context": "<option>{t('labels.allContractTypes')}</option>"
+    },
+    {
+      "key": "buttons.applyFilters",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 437,
+      "context": "{t('buttons.applyFilters')}"
+    },
+    {
+      "key": "common:loading",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 443,
+      "context": "<p className=\"text-center text-gray-500 py-8\">{t('common:loading', 'Loading...')}</p>"
+    },
+    {
+      "key": "common:loading",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 443,
+      "context": "<p className=\"text-center text-gray-500 py-8\">{t('common:loading', 'Loading...')}</p>"
+    },
+    {
+      "key": "candidatePool.emptyState",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 457,
+      "context": "<p className=\"text-center text-gray-500 py-8\">{t('candidatePool.emptyState')}</p>"
+    },
+    {
+      "key": "tabs.jobOffers",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 463,
+      "context": "{ label: t('tabs.jobOffers'), icon: BriefcaseIcon, content: JobOffersTab },"
+    },
+    {
+      "key": "tabs.candidatePool",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 464,
+      "context": "{ label: t('tabs.candidatePool'), icon: UserGroupIcon, content: CandidateAvailabilityTab },"
+    },
+    {
+      "key": "title",
+      "file": "pages/RecruitmentPage.tsx",
+      "line": 469,
+      "context": "<h1 className=\"text-3xl font-bold text-swiss-charcoal\">{t('title')}</h1>"
+    },
+    {
+      "key": "pricingPage.popular",
+      "file": "pages/PricingPage.tsx",
+      "line": 45,
+      "context": "<span className=\"px-3 py-1 text-xs font-semibold tracking-wide text-white uppercase bg-swiss-mint rounded-full\">{t('pricingPage.popular')}</span>"
+    },
+    {
+      "key": "pricingPage.whatYouGet",
+      "file": "pages/PricingPage.tsx",
+      "line": 58,
+      "context": "<p className=\"font-semibold text-swiss-charcoal mb-3\">{t('pricingPage.whatYouGet')}:</p>"
+    },
+    {
+      "key": "pricingPage.selectAndContinue",
+      "file": "pages/PricingPage.tsx",
+      "line": 70,
+      "context": "{fromSignup ? t('pricingPage.selectAndContinue') : t('pricingPage.choosePlan')}"
+    },
+    {
+      "key": "pricingPage.choosePlan",
+      "file": "pages/PricingPage.tsx",
+      "line": 70,
+      "context": "{fromSignup ? t('pricingPage.selectAndContinue') : t('pricingPage.choosePlan')}"
+    },
+    {
+      "key": "appName",
+      "file": "pages/PricingPage.tsx",
+      "line": 85,
+      "context": "<span className=\"font-bold text-lg hidden sm:block\">{t('appName')}</span>"
+    },
+    {
+      "key": "common:buttons.goBack",
+      "file": "pages/PricingPage.tsx",
+      "line": 88,
+      "context": "{t('common:buttons.goBack')}"
+    },
+    {
+      "key": "common:buttons.goBack",
+      "file": "pages/PricingPage.tsx",
+      "line": 88,
+      "context": "{t('common:buttons.goBack')}"
+    },
+    {
+      "key": "pricingPage.titleSignup",
+      "file": "pages/PricingPage.tsx",
+      "line": 94,
+      "context": "<h1 className=\"text-4xl font-bold text-swiss-charcoal\">{fromSignup ? t('pricingPage.titleSignup') : t('pricingPage.title')}</h1>"
+    },
+    {
+      "key": "pricingPage.title",
+      "file": "pages/PricingPage.tsx",
+      "line": 94,
+      "context": "<h1 className=\"text-4xl font-bold text-swiss-charcoal\">{fromSignup ? t('pricingPage.titleSignup') : t('pricingPage.title')}</h1>"
+    },
+    {
+      "key": "pricingPage.subtitleSignup",
+      "file": "pages/PricingPage.tsx",
+      "line": 95,
+      "context": "<p className=\"mt-3 text-lg text-gray-600\">{fromSignup ? t('pricingPage.subtitleSignup') : t('pricingPage.subtitle')}</p>"
+    },
+    {
+      "key": "pricingPage.subtitle",
+      "file": "pages/PricingPage.tsx",
+      "line": 95,
+      "context": "<p className=\"mt-3 text-lg text-gray-600\">{fromSignup ? t('pricingPage.subtitleSignup') : t('pricingPage.subtitle')}</p>"
+    },
+    {
+      "key": "pricingPage.suppliersAndProvidersTitle",
+      "file": "pages/PricingPage.tsx",
+      "line": 117,
+      "context": "<h2 className=\"text-3xl font-semibold text-center text-swiss-charcoal\">{t('pricingPage.suppliersAndProvidersTitle')}</h2>"
+    },
+    {
+      "key": "partners.partnerCard.logoAlt",
+      "file": "pages/PartnersPage.tsx",
+      "line": 14,
+      "context": "<img src={partner.logoUrl} alt={t('partners.partnerCard.logoAlt', { name: partner.name })} className=\"h-16 mx-auto mb-4 object-contain grayscale hover:grayscale-0 transition-all duration-300\" />"
+    },
+    {
+      "key": "partners.partnerCard.partnerType",
+      "file": "pages/PartnersPage.tsx",
+      "line": 16,
+      "context": "<p className=\"text-sm text-gray-600 mb-1\">{t('partners.partnerCard.partnerType', { type: partner.type })}</p>"
+    },
+    {
+      "key": "partners.partnerCard.learnMoreButton",
+      "file": "pages/PartnersPage.tsx",
+      "line": 20,
+      "context": "{t('partners.partnerCard.learnMoreButton')}"
+    },
+    {
+      "key": "partners.hero.title",
+      "file": "pages/PartnersPage.tsx",
+      "line": 38,
+      "context": "<h1 className=\"text-4xl md:text-5xl font-bold mb-4\">{t('partners.hero.title')}</h1>"
+    },
+    {
+      "key": "partners.hero.subtitle",
+      "file": "pages/PartnersPage.tsx",
+      "line": 40,
+      "context": "{t('partners.hero.subtitle')}"
+    },
+    {
+      "key": "partners.hero.ctaButton",
+      "file": "pages/PartnersPage.tsx",
+      "line": 43,
+      "context": "{t('partners.hero.ctaButton')}"
+    },
+    {
+      "key": "partners.featured.title",
+      "file": "pages/PartnersPage.tsx",
+      "line": 50,
+      "context": "<h2 className=\"text-3xl font-semibold text-swiss-charcoal text-center mb-2\">{t('partners.featured.title')}</h2>"
+    },
+    {
+      "key": "partners.featured.subtitle",
+      "file": "pages/PartnersPage.tsx",
+      "line": 51,
+      "context": "<p className=\"text-center text-gray-600 mb-8\">{t('partners.featured.subtitle')}</p>"
+    },
+    {
+      "key": "partners.joinUs.title",
+      "file": "pages/PartnersPage.tsx",
+      "line": 62,
+      "context": "<h2 className=\"text-3xl font-semibold text-swiss-charcoal mb-4\">{t('partners.joinUs.title')}</h2>"
+    },
+    {
+      "key": "partners.joinUs.subtitle",
+      "file": "pages/PartnersPage.tsx",
+      "line": 64,
+      "context": "{t('partners.joinUs.subtitle')}"
+    },
+    {
+      "key": "partners.joinUs.contactUsAlert",
+      "file": "pages/PartnersPage.tsx",
+      "line": 67,
+      "context": "<Button variant=\"primary\" size=\"lg\" leftIcon={ChatBubbleLeftEllipsisIcon} className=\"bg-swiss-mint hover:bg-opacity-90\" onClick={() => alert(t('partners.joinUs.contactUsAlert'))}>"
+    },
+    {
+      "key": "partners.joinUs.contactUsButton",
+      "file": "pages/PartnersPage.tsx",
+      "line": 68,
+      "context": "{t('partners.joinUs.contactUsButton')}"
+    },
+    {
+      "key": "partners.joinUs.inquiryFormLink",
+      "file": "pages/PartnersPage.tsx",
+      "line": 70,
+      "context": "<a href=\"#/partner-inquiry\" className=\"text-sm text-swiss-teal hover:underline\">{t('partners.joinUs.inquiryFormLink')}</a>"
+    },
+    {
+      "key": "parentLeadForm:messages.error",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 48,
+      "context": "alert(t('parentLeadForm:messages.error', { defaultValue: 'Please fill in all required fields' }));"
+    },
+    {
+      "key": "parentLeadForm:messages.error",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 48,
+      "context": "alert(t('parentLeadForm:messages.error', { defaultValue: 'Please fill in all required fields' }));"
+    },
+    {
+      "key": "parentLeadForm:messages.success",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 75,
+      "context": "<h1 className=\"text-2xl font-bold text-swiss-charcoal mb-4\">{t('parentLeadForm:messages.success')}</h1>"
+    },
+    {
+      "key": "parentLeadForm:messages.success",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 75,
+      "context": "<h1 className=\"text-2xl font-bold text-swiss-charcoal mb-4\">{t('parentLeadForm:messages.success')}</h1>"
+    },
+    {
+      "key": "parentLeadForm:messages.success",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 79,
+      "context": "{t('parentLeadForm:messages.success')}"
+    },
+    {
+      "key": "parentLeadForm:messages.success",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 79,
+      "context": "{t('parentLeadForm:messages.success')}"
+    },
+    {
+      "key": "common:buttons.goToLogin",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 81,
+      "context": "<Button variant=\"primary\" onClick={() => navigate('/login')}>{t('common:buttons.goToLogin')}</Button>"
+    },
+    {
+      "key": "common:buttons.goToLogin",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 81,
+      "context": "<Button variant=\"primary\" onClick={() => navigate('/login')}>{t('common:buttons.goToLogin')}</Button>"
+    },
+    {
+      "key": "parentLeadForm:messages.success",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 86,
+      "context": "{t('parentLeadForm:messages.success')}"
+    },
+    {
+      "key": "parentLeadForm:messages.success",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 86,
+      "context": "{t('parentLeadForm:messages.success')}"
+    },
+    {
+      "key": "parentLeadForm:buttons.viewMyEnquiries",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 88,
+      "context": "<Button variant=\"primary\" onClick={() => navigate('/parent/enquiries')}>{t('parentLeadForm:buttons.viewMyEnquiries')}</Button>"
+    },
+    {
+      "key": "parentLeadForm:buttons.viewMyEnquiries",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 88,
+      "context": "<Button variant=\"primary\" onClick={() => navigate('/parent/enquiries')}>{t('parentLeadForm:buttons.viewMyEnquiries')}</Button>"
+    },
+    {
+      "key": "title",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 100,
+      "context": "<h1 className=\"text-3xl font-bold text-swiss-charcoal\">{APP_NAME} - {t('title')}</h1>"
+    },
+    {
+      "key": "subtitle",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 101,
+      "context": "<p className=\"text-gray-600\">{t('subtitle')}</p>"
+    },
+    {
+      "key": "labels.fullName",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 106,
+      "context": "<label htmlFor=\"contactName\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('labels.fullName')}</label>"
+    },
+    {
+      "key": "placeholders.fullName",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 107,
+      "context": "<input type=\"text\" name=\"contactName\" id=\"contactName\" value={formData.contactName} onChange={handleChange} required className={STANDARD_INPUT_FIELD} placeholder={t('placeholders.fullName')} />"
+    },
+    {
+      "key": "labels.email",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 111,
+      "context": "<label htmlFor=\"contactEmail\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('labels.email')}</label>"
+    },
+    {
+      "key": "placeholders.email",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 112,
+      "context": "<input type=\"email\" name=\"contactEmail\" id=\"contactEmail\" value={formData.contactEmail} onChange={handleChange} required className={STANDARD_INPUT_FIELD} placeholder={t('placeholders.email')} />"
+    },
+    {
+      "key": "labels.phoneNumber",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 115,
+      "context": "<label htmlFor=\"contactPhone\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('labels.phoneNumber')}</label>"
+    },
+    {
+      "key": "placeholders.phoneNumber",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 116,
+      "context": "<input type=\"tel\" name=\"contactPhone\" id=\"contactPhone\" value={formData.contactPhone} onChange={handleChange} className={STANDARD_INPUT_FIELD} placeholder={t('placeholders.phoneNumber')} />"
+    },
+    {
+      "key": "labels.childNeeds",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 121,
+      "context": "<h2 className=\"text-lg font-semibold text-swiss-charcoal\">{t('labels.childNeeds')}</h2>"
+    },
+    {
+      "key": "labels.canton",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 125,
+      "context": "<label htmlFor=\"canton\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('labels.canton')}</label>"
+    },
+    {
+      "key": "placeholders.canton",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 127,
+      "context": "<option value=\"\">{t('placeholders.canton')}</option>"
+    },
+    {
+      "key": "labels.municipality",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 132,
+      "context": "<label htmlFor=\"municipality\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('labels.municipality')}</label>"
+    },
+    {
+      "key": "placeholders.municipality",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 133,
+      "context": "<input type=\"text\" name=\"municipality\" id=\"municipality\" value={formData.municipality} onChange={handleChange} className={STANDARD_INPUT_FIELD} placeholder={t('placeholders.municipality')} />"
+    },
+    {
+      "key": "labels.childAge",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 139,
+      "context": "<label htmlFor=\"childAge\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('labels.childAge')}</label>"
+    },
+    {
+      "key": "placeholders.childAge",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 140,
+      "context": "<input type=\"number\" name=\"childAge\" id=\"childAge\" value={formData.childAge} onChange={handleChange} required min=\"0\" max=\"72\" className={STANDARD_INPUT_FIELD} placeholder={t('placeholders.childAge')} />"
+    },
+    {
+      "key": "labels.startDate",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 143,
+      "context": "<label htmlFor=\"desiredStartDate\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('labels.startDate')}</label>"
+    },
+    {
+      "key": "placeholders.startDate",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 144,
+      "context": "<input type=\"date\" name=\"desiredStartDate\" id=\"desiredStartDate\" value={formData.desiredStartDate} onChange={handleChange} required className={STANDARD_INPUT_FIELD} placeholder={t('placeholders.startDate')} />"
+    },
+    {
+      "key": "labels.specialNeeds",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 149,
+      "context": "<label htmlFor=\"specialNeeds\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('labels.specialNeeds')}</label>"
+    },
+    {
+      "key": "placeholders.specialRequirements",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 150,
+      "context": "<textarea name=\"specialNeeds\" id=\"specialNeeds\" value={formData.specialNeeds} onChange={handleChange} rows={3} className={STANDARD_INPUT_FIELD} placeholder={t('placeholders.specialRequirements')}></textarea>"
+    },
+    {
+      "key": "buttons.submitEnquiry",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 154,
+      "context": "<Button type=\"submit\" variant=\"primary\" size=\"lg\" className=\"w-full\">{t('buttons.submitEnquiry')}</Button>"
+    },
+    {
+      "key": "auth:alreadyHaveAccount",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 159,
+      "context": "{t('auth:alreadyHaveAccount')}{' '}"
+    },
+    {
+      "key": "auth:alreadyHaveAccount",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 159,
+      "context": "{t('auth:alreadyHaveAccount')}{' '}"
+    },
+    {
+      "key": "common:buttons.login",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 160,
+      "context": "<Link to=\"/login\" className=\"text-swiss-mint hover:underline\">{t('common:buttons.login')}</Link>"
+    },
+    {
+      "key": "common:buttons.login",
+      "file": "pages/ParentLeadFormPage.tsx",
+      "line": 160,
+      "context": "<Link to=\"/login\" className=\"text-swiss-mint hover:underline\">{t('common:buttons.login')}</Link>"
+    },
+    {
+      "key": "parentEnquiriesPage.accessDenied.title",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 23,
+      "context": "<h1 className=\"text-2xl font-bold text-swiss-charcoal\">{t('parentEnquiriesPage.accessDenied.title')}</h1>"
+    },
+    {
+      "key": "parentEnquiriesPage.accessDenied.message",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 24,
+      "context": "<p className=\"text-gray-600\">{t('parentEnquiriesPage.accessDenied.message')}</p>"
+    },
+    {
+      "key": "leadCard.status.interested",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 44,
+      "context": "case FoundationLeadResponseStatus.INTERESTED: return { text: t('leadCard.status.interested'), color: \"text-green-600\"};"
+    },
+    {
+      "key": "leadCard.status.notInterested",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 45,
+      "context": "case FoundationLeadResponseStatus.NOT_INTERESTED: return { text: t('leadCard.status.notInterested'), color: \"text-red-600\"};"
+    },
+    {
+      "key": "leadCard.status.needsMoreInfo",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 46,
+      "context": "case FoundationLeadResponseStatus.NEEDS_MORE_INFO: return { text: t('leadCard.status.needsMoreInfo'), color: \"text-orange-600\"};"
+    },
+    {
+      "key": "leadCard.status.enrolled",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 47,
+      "context": "case FoundationLeadResponseStatus.ENROLLED: return { text: t('leadCard.status.enrolled'), color: \"text-purple-600\"};"
+    },
+    {
+      "key": "leadCard.status.notResponded",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 48,
+      "context": "default: return { text: t('leadCard.status.notResponded'), color: \"text-gray-500\"};"
+    },
+    {
+      "key": "parentEnquiriesPage.title",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 67,
+      "context": "{t('parentEnquiriesPage.title')}"
+    },
+    {
+      "key": "parentEnquiriesPage.emptyState.title",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 74,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-2\">{t('parentEnquiriesPage.emptyState.title')}</h2>"
+    },
+    {
+      "key": "parentEnquiriesPage.emptyState.message.0",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 75,
+      "context": "<p className=\"text-gray-500\">{t('parentEnquiriesPage.emptyState.message.0')} <a href=\"/#/parent-lead-form\" className=\"text-swiss-mint hover:underline\">{t('parentEnquiriesPage.emptyState.message.1')}</a></p>"
+    },
+    {
+      "key": "parentEnquiriesPage.emptyState.message.1",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 75,
+      "context": "<p className=\"text-gray-500\">{t('parentEnquiriesPage.emptyState.message.0')} <a href=\"/#/parent-lead-form\" className=\"text-swiss-mint hover:underline\">{t('parentEnquiriesPage.emptyState.message.1')}</a></p>"
+    },
+    {
+      "key": "parentEnquiriesPage.card.title",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 84,
+      "context": "{t('parentEnquiriesPage.card.title', { canton: lead.canton, municipality: lead.municipality ? `- ${lead.municipality}` : ''})}"
+    },
+    {
+      "key": "parentEnquiriesPage.card.submitted",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 86,
+      "context": "<p className=\"text-sm text-gray-500\">{t('parentEnquiriesPage.card.submitted')}: {new Date(lead.submissionDate).toLocaleDateString()}</p>"
+    },
+    {
+      "key": "parentEnquiriesPage.card.childInfo",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 87,
+      "context": "<p className=\"text-sm text-gray-500\">{t('parentEnquiriesPage.card.childInfo', { age: lead.childAge, date: new Date(lead.desiredStartDate).toLocaleDateString()})}</p>"
+    },
+    {
+      "key": "parentEnquiriesPage.card.notes",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 95,
+      "context": "<p className=\"text-sm text-gray-600 mt-2\"><InformationCircleIcon className=\"w-4 h-4 inline mr-1 text-gray-400\" />{t('parentEnquiriesPage.card.notes')}: {lead.specialNeeds}</p>"
+    },
+    {
+      "key": "parentEnquiriesPage.card.responsesTitle",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 99,
+      "context": "<h3 className=\"text-md font-semibold text-swiss-charcoal mb-2\">{t('parentEnquiriesPage.card.responsesTitle')}:</h3>"
+    },
+    {
+      "key": "parentEnquiriesPage.card.awaitingMatch",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 101,
+      "context": "<p className=\"text-sm text-gray-500\">{t('parentEnquiriesPage.card.awaitingMatch')}</p>"
+    },
+    {
+      "key": "parentEnquiriesPage.card.message",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 113,
+      "context": "<p className=\"text-xs text-gray-600 italic flex-grow pr-4\">{t('parentEnquiriesPage.card.message')}: {response.messageToParent}</p>"
+    },
+    {
+      "key": "buttons.sendMessage",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 115,
+      "context": "{t('buttons.sendMessage')}"
+    },
+    {
+      "key": "parentEnquiriesPage.card.waitingForMoreResponses",
+      "file": "pages/ParentEnquiriesPage.tsx",
+      "line": 123,
+      "context": "<p className=\"text-sm text-gray-500 mt-2\">{t('parentEnquiriesPage.card.waitingForMoreResponses')}</p>"
+    },
+    {
+      "key": "notificationsPage.title",
+      "file": "pages/NotificationsPage.tsx",
+      "line": 29,
+      "context": "{t('notificationsPage.title')}"
+    },
+    {
+      "key": "notificationsPage.clearAll",
+      "file": "pages/NotificationsPage.tsx",
+      "line": 39,
+      "context": "{t('notificationsPage.clearAll')}"
+    },
+    {
+      "key": "notificationsPage.emptyState.title",
+      "file": "pages/NotificationsPage.tsx",
+      "line": 48,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal\">{t('notificationsPage.emptyState.title')}</h2>"
+    },
+    {
+      "key": "notificationsPage.emptyState.message",
+      "file": "pages/NotificationsPage.tsx",
+      "line": 49,
+      "context": "<p className=\"text-gray-500 mt-1\">{t('notificationsPage.emptyState.message')}</p>"
+    },
+    {
+      "key": "buttons.dismiss",
+      "file": "pages/NotificationsPage.tsx",
+      "line": 70,
+      "context": "aria-label={t('buttons.dismiss')}"
+    },
+    {
+      "key": "notifications.newMessageFrom",
+      "file": "pages/MessagesPage.tsx",
+      "line": 49,
+      "context": "title: t('notifications.newMessageFrom', { sender: lastMessage.senderName }),"
+    },
+    {
+      "key": "dashboard:sidebar.messages",
+      "file": "pages/MessagesPage.tsx",
+      "line": 65,
+      "context": "{t('dashboard:sidebar.messages')}"
+    },
+    {
+      "key": "dashboard:sidebar.messages",
+      "file": "pages/MessagesPage.tsx",
+      "line": 65,
+      "context": "{t('dashboard:sidebar.messages')}"
+    },
+    {
+      "key": "buttons.newGroup",
+      "file": "pages/MessagesPage.tsx",
+      "line": 68,
+      "context": "{t('buttons.newGroup')}"
+    },
+    {
+      "key": "emptyState.noConversationSelectedTitle",
+      "file": "pages/MessagesPage.tsx",
+      "line": 85,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal\">{t('emptyState.noConversationSelectedTitle')}</h2>"
+    },
+    {
+      "key": "emptyState.noConversationSelectedSubtitle",
+      "file": "pages/MessagesPage.tsx",
+      "line": 86,
+      "context": "<p className=\"text-gray-500\">{t('emptyState.noConversationSelectedSubtitle')}</p>"
+    },
+    {
+      "key": "emptyState.noConversationsYet",
+      "file": "pages/MessagesPage.tsx",
+      "line": 88,
+      "context": "<p className=\"text-sm text-gray-400 mt-2\">{t('emptyState.noConversationsYet')}</p>"
+    },
+    {
+      "key": "serviceCard.categoryLabel",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 32,
+      "context": "<TagIcon className=\"w-3.5 h-3.5 inline mr-1 opacity-70\" /> {t('serviceCard.categoryLabel', { category: service.category })}"
+    },
+    {
+      "key": "serviceCard.bookAppointment",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 39,
+      "context": "<Button variant=\"secondary\" size=\"sm\" className=\"flex-1\" onClick={() => onBookAppointment(service)}>{t('serviceCard.bookAppointment')}</Button>"
+    },
+    {
+      "key": "serviceCard.viewProvider",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 40,
+      "context": "<Button variant=\"outline\" size=\"sm\" leftIcon={EyeIcon} onClick={() => onViewProvider(service.providerId)}>{t('serviceCard.viewProvider')}</Button>"
+    },
+    {
+      "key": "partnerDetailPage.onlyFoundationsRequestService",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 85,
+      "context": "alert(t('partnerDetailPage.onlyFoundationsRequestService'));"
+    },
+    {
+      "key": "partnerDetailPage.requestSubmittedAlert",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 102,
+      "context": "alert(t('partnerDetailPage.requestSubmittedAlert', {serviceName: newRequest.serviceName}));"
+    },
+    {
+      "key": "tabs.productSuppliers",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 107,
+      "context": "? t('tabs.productSuppliers')"
+    },
+    {
+      "key": "tabs.serviceProviders",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 108,
+      "context": ": t('tabs.serviceProviders');"
+    },
+    {
+      "key": "tabs.productSuppliers",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 181,
+      "context": "{ label: t('tabs.productSuppliers'), icon: BuildingStorefrontIcon, content: ("
+    },
+    {
+      "key": "emptyStates.noProductSuppliers",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 188,
+      "context": "{filteredSuppliers.length === 0 && <p className=\"text-center text-gray-500 py-12\">{t('emptyStates.noProductSuppliers')}</p>}"
+    },
+    {
+      "key": "tabs.serviceProviders",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 191,
+      "context": "{ label: t('tabs.serviceProviders'), icon: WrenchScrewdriverIcon, content: ("
+    },
+    {
+      "key": "emptyStates.noServices",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 198,
+      "context": "{filteredServices.length === 0 && <p className=\"text-center text-gray-500 py-12\">{t('emptyStates.noServices')}</p>}"
+    },
+    {
+      "key": "subtitles.productSuppliers",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 211,
+      "context": "<p className=\"text-gray-500 mt-1\">{t('subtitles.productSuppliers')}</p>"
+    },
+    {
+      "key": "subtitles.serviceProviders",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 214,
+      "context": "<p className=\"text-gray-500 mt-1\">{t('subtitles.serviceProviders')}</p>"
+    },
+    {
+      "key": "buttons.partnerOnboarding",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 217,
+      "context": "{currentUser?.role === UserRole.ADMIN && <Button variant=\"secondary\" leftIcon={FunnelIcon} size=\"md\" onClick={() => alert(\"Partner Onboarding TBD\")}>{t('buttons.partnerOnboarding')}</Button>}"
+    },
+    {
+      "key": "infoAlert",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 223,
+      "context": "{t('infoAlert')}"
+    },
+    {
+      "key": "searchPlaceholder",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 230,
+      "context": "<label htmlFor=\"searchMarketplace\" className=\"sr-only\">{t('searchPlaceholder', { activeTabLabel: activeTabLabel.toLowerCase() })}</label>"
+    },
+    {
+      "key": "searchPlaceholder",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 235,
+      "context": "placeholder={t('searchPlaceholder', { activeTabLabel: activeTabLabel.toLowerCase() })}"
+    },
+    {
+      "key": "labels.category",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 242,
+      "context": "<label htmlFor=\"categoryFilterMarketplace\" className=\"block text-xs font-medium text-gray-500 mb-1\">{t('labels.category')}</label>"
+    },
+    {
+      "key": "labels.region",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 253,
+      "context": "<label htmlFor=\"regionFilterMarketplace\" className=\"block text-xs font-medium text-gray-500 mb-1\">{t('labels.region')}</label>"
+    },
+    {
+      "key": "labels.supplierTags",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 266,
+      "context": "<label htmlFor=\"tagFilterMarketplace\" className=\"block text-xs font-medium text-gray-500 mb-1\">{t('labels.supplierTags')}</label>"
+    },
+    {
+      "key": "labels.sortBy",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 277,
+      "context": "<label htmlFor=\"sortOptionMarketplace\" className=\"block text-xs font-medium text-gray-500 mb-1\">{t('labels.sortBy')}</label>"
+    },
+    {
+      "key": "sortOptions.nameAsc",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 284,
+      "context": "<option value=\"name_asc\">{t('sortOptions.nameAsc')}</option>"
+    },
+    {
+      "key": "sortOptions.nameDesc",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 285,
+      "context": "<option value=\"name_desc\">{t('sortOptions.nameDesc')}</option>"
+    },
+    {
+      "key": "sortOptions.ratingDesc",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 286,
+      "context": "<option value=\"rating_desc\">{t('sortOptions.ratingDesc')}</option>"
+    },
+    {
+      "key": "ariaLabels.gridView",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 300,
+      "context": "aria-label={t('ariaLabels.gridView')}"
+    },
+    {
+      "key": "ariaLabels.listView",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 310,
+      "context": "aria-label={t('ariaLabels.listView')}"
+    },
+    {
+      "key": "buttons.resetFilters",
+      "file": "pages/MarketplacePage.tsx",
+      "line": 315,
+      "context": "<Button variant=\"outline\" size=\"sm\" onClick={() => { setSearchTerm(''); setCategoryFilter('All'); setRegionFilter('All'); setTagFilter('All'); setSortOption('name_asc');}}>{t('buttons.resetFilters')}</Button>"
+    },
+    {
+      "key": "common:loginPage.errorBothFields",
+      "file": "pages/LoginPage.tsx",
+      "line": 54,
+      "context": "setError(t('common:loginPage.errorBothFields'));"
+    },
+    {
+      "key": "common:loginPage.errorBothFields",
+      "file": "pages/LoginPage.tsx",
+      "line": 54,
+      "context": "setError(t('common:loginPage.errorBothFields'));"
+    },
+    {
+      "key": "common:loginPage.sessionAlreadyActive",
+      "file": "pages/LoginPage.tsx",
+      "line": 59,
+      "context": "setError(t('common:loginPage.sessionAlreadyActive'));"
+    },
+    {
+      "key": "common:loginPage.sessionAlreadyActive",
+      "file": "pages/LoginPage.tsx",
+      "line": 59,
+      "context": "setError(t('common:loginPage.sessionAlreadyActive'));"
+    },
+    {
+      "key": "common:loginPage.authServiceNotReady",
+      "file": "pages/LoginPage.tsx",
+      "line": 64,
+      "context": "setError(t('common:loginPage.authServiceNotReady'));"
+    },
+    {
+      "key": "common:loginPage.authServiceNotReady",
+      "file": "pages/LoginPage.tsx",
+      "line": 64,
+      "context": "setError(t('common:loginPage.authServiceNotReady'));"
+    },
+    {
+      "key": "common:loginPage.sessionActivationFailed",
+      "file": "pages/LoginPage.tsx",
+      "line": 85,
+      "context": "setError(t('common:loginPage.sessionActivationFailed'));"
+    },
+    {
+      "key": "common:loginPage.sessionActivationFailed",
+      "file": "pages/LoginPage.tsx",
+      "line": 85,
+      "context": "setError(t('common:loginPage.sessionActivationFailed'));"
+    },
+    {
+      "key": "common:loginPage.twoFactorRequired",
+      "file": "pages/LoginPage.tsx",
+      "line": 88,
+      "context": "setError(t('common:loginPage.twoFactorRequired'));"
+    },
+    {
+      "key": "common:loginPage.twoFactorRequired",
+      "file": "pages/LoginPage.tsx",
+      "line": 88,
+      "context": "setError(t('common:loginPage.twoFactorRequired'));"
+    },
+    {
+      "key": "common:loginPage.loginIncomplete",
+      "file": "pages/LoginPage.tsx",
+      "line": 90,
+      "context": "setError(t('common:loginPage.loginIncomplete'));"
+    },
+    {
+      "key": "common:loginPage.loginIncomplete",
+      "file": "pages/LoginPage.tsx",
+      "line": 90,
+      "context": "setError(t('common:loginPage.loginIncomplete'));"
+    },
+    {
+      "key": "common:errors.unknown",
+      "file": "pages/LoginPage.tsx",
+      "line": 95,
+      "context": "let errorMessage = t('common:errors.unknown');"
+    },
+    {
+      "key": "common:errors.unknown",
+      "file": "pages/LoginPage.tsx",
+      "line": 95,
+      "context": "let errorMessage = t('common:errors.unknown');"
+    },
+    {
+      "key": "common:loginPage.incorrectPassword",
+      "file": "pages/LoginPage.tsx",
+      "line": 103,
+      "context": "errorMessage = t('common:loginPage.incorrectPassword', 'Incorrect password. Please try again.');"
+    },
+    {
+      "key": "common:loginPage.incorrectPassword",
+      "file": "pages/LoginPage.tsx",
+      "line": 103,
+      "context": "errorMessage = t('common:loginPage.incorrectPassword', 'Incorrect password. Please try again.');"
+    },
+    {
+      "key": "common:loginPage.accountNotFound",
+      "file": "pages/LoginPage.tsx",
+      "line": 106,
+      "context": "errorMessage = t('common:loginPage.accountNotFound', 'No account found with this email address.');"
+    },
+    {
+      "key": "common:loginPage.accountNotFound",
+      "file": "pages/LoginPage.tsx",
+      "line": 106,
+      "context": "errorMessage = t('common:loginPage.accountNotFound', 'No account found with this email address.');"
+    },
+    {
+      "key": "common:loginPage.invalidEmail",
+      "file": "pages/LoginPage.tsx",
+      "line": 109,
+      "context": "errorMessage = t('common:loginPage.invalidEmail', 'Please enter a valid email address.');"
+    },
+    {
+      "key": "common:loginPage.invalidEmail",
+      "file": "pages/LoginPage.tsx",
+      "line": 109,
+      "context": "errorMessage = t('common:loginPage.invalidEmail', 'Please enter a valid email address.');"
+    },
+    {
+      "key": "common:loginPage.sessionAlreadyActive",
+      "file": "pages/LoginPage.tsx",
+      "line": 112,
+      "context": "errorMessage = t('common:loginPage.sessionAlreadyActive');"
+    },
+    {
+      "key": "common:loginPage.sessionAlreadyActive",
+      "file": "pages/LoginPage.tsx",
+      "line": 112,
+      "context": "errorMessage = t('common:loginPage.sessionAlreadyActive');"
+    },
+    {
+      "key": "common:errors.unknown",
+      "file": "pages/LoginPage.tsx",
+      "line": 115,
+      "context": "errorMessage = clerkError.message || t('common:errors.unknown');"
+    },
+    {
+      "key": "common:errors.unknown",
+      "file": "pages/LoginPage.tsx",
+      "line": 115,
+      "context": "errorMessage = clerkError.message || t('common:errors.unknown');"
+    },
+    {
+      "key": "common:loginPage.sessionAlreadyActive",
+      "file": "pages/LoginPage.tsx",
+      "line": 119,
+      "context": "errorMessage = t('common:loginPage.sessionAlreadyActive');"
+    },
+    {
+      "key": "common:loginPage.sessionAlreadyActive",
+      "file": "pages/LoginPage.tsx",
+      "line": 119,
+      "context": "errorMessage = t('common:loginPage.sessionAlreadyActive');"
+    },
+    {
+      "key": "common:loginPage.sessionAlreadyActive",
+      "file": "pages/LoginPage.tsx",
+      "line": 134,
+      "context": "setError(t('common:loginPage.sessionAlreadyActive'));"
+    },
+    {
+      "key": "common:loginPage.sessionAlreadyActive",
+      "file": "pages/LoginPage.tsx",
+      "line": 134,
+      "context": "setError(t('common:loginPage.sessionAlreadyActive'));"
+    },
+    {
+      "key": "common:loginPage.authServiceNotReady",
+      "file": "pages/LoginPage.tsx",
+      "line": 139,
+      "context": "setError(t('common:loginPage.authServiceNotReady'));"
+    },
+    {
+      "key": "common:loginPage.authServiceNotReady",
+      "file": "pages/LoginPage.tsx",
+      "line": 139,
+      "context": "setError(t('common:loginPage.authServiceNotReady'));"
+    },
+    {
+      "key": "common:loginPage.socialLoginFailed",
+      "file": "pages/LoginPage.tsx",
+      "line": 155,
+      "context": "const errorMessage = error.errors?.[0]?.message || t('common:loginPage.socialLoginFailed');"
+    },
+    {
+      "key": "common:loginPage.socialLoginFailed",
+      "file": "pages/LoginPage.tsx",
+      "line": 155,
+      "context": "const errorMessage = error.errors?.[0]?.message || t('common:loginPage.socialLoginFailed');"
+    },
+    {
+      "key": "common:loginPage.signOutFailed",
+      "file": "pages/LoginPage.tsx",
+      "line": 169,
+      "context": "setError(t('common:loginPage.signOutFailed'));"
+    },
+    {
+      "key": "common:loginPage.signOutFailed",
+      "file": "pages/LoginPage.tsx",
+      "line": 169,
+      "context": "setError(t('common:loginPage.signOutFailed'));"
+    },
+    {
+      "key": "common:loginPage.title",
+      "file": "pages/LoginPage.tsx",
+      "line": 193,
+      "context": "{t('common:loginPage.title', { appName: APP_NAME })}"
+    },
+    {
+      "key": "common:loginPage.title",
+      "file": "pages/LoginPage.tsx",
+      "line": 193,
+      "context": "{t('common:loginPage.title', { appName: APP_NAME })}"
+    },
+    {
+      "key": "common:loginPage.alreadySignedInTitle",
+      "file": "pages/LoginPage.tsx",
+      "line": 202,
+      "context": "{t('common:loginPage.alreadySignedInTitle', 'Active Session Detected')}"
+    },
+    {
+      "key": "common:loginPage.alreadySignedInTitle",
+      "file": "pages/LoginPage.tsx",
+      "line": 202,
+      "context": "{t('common:loginPage.alreadySignedInTitle', 'Active Session Detected')}"
+    },
+    {
+      "key": "common:loginPage.alreadySignedInDescription",
+      "file": "pages/LoginPage.tsx",
+      "line": 209,
+      "context": "{t('common:loginPage.alreadySignedInDescription', 'You are already logged in. Choose an option below to continue.')}"
+    },
+    {
+      "key": "common:loginPage.alreadySignedInDescription",
+      "file": "pages/LoginPage.tsx",
+      "line": 209,
+      "context": "{t('common:loginPage.alreadySignedInDescription', 'You are already logged in. Choose an option below to continue.')}"
+    },
+    {
+      "key": "common:loginPage.goToDashboard",
+      "file": "pages/LoginPage.tsx",
+      "line": 220,
+      "context": "{t('common:loginPage.goToDashboard', 'Go to Dashboard')}"
+    },
+    {
+      "key": "common:loginPage.goToDashboard",
+      "file": "pages/LoginPage.tsx",
+      "line": 220,
+      "context": "{t('common:loginPage.goToDashboard', 'Go to Dashboard')}"
+    },
+    {
+      "key": "common:loginPage.signingOut",
+      "file": "pages/LoginPage.tsx",
+      "line": 230,
+      "context": "? t('common:loginPage.signingOut', 'Signing Out...')"
+    },
+    {
+      "key": "common:loginPage.signingOut",
+      "file": "pages/LoginPage.tsx",
+      "line": 230,
+      "context": "? t('common:loginPage.signingOut', 'Signing Out...')"
+    },
+    {
+      "key": "common:loginPage.signOutButton",
+      "file": "pages/LoginPage.tsx",
+      "line": 231,
+      "context": ": t('common:loginPage.signOutButton', 'Sign Out')}"
+    },
+    {
+      "key": "common:loginPage.signOutButton",
+      "file": "pages/LoginPage.tsx",
+      "line": 231,
+      "context": ": t('common:loginPage.signOutButton', 'Sign Out')}"
+    },
+    {
+      "key": "common:loginPage.noAccount",
+      "file": "pages/LoginPage.tsx",
+      "line": 238,
+      "context": "{t('common:loginPage.noAccount')}{' '}"
+    },
+    {
+      "key": "common:loginPage.noAccount",
+      "file": "pages/LoginPage.tsx",
+      "line": 238,
+      "context": "{t('common:loginPage.noAccount')}{' '}"
+    },
+    {
+      "key": "common:buttons.signup",
+      "file": "pages/LoginPage.tsx",
+      "line": 240,
+      "context": "{t('common:buttons.signup')}"
+    },
+    {
+      "key": "common:buttons.signup",
+      "file": "pages/LoginPage.tsx",
+      "line": 240,
+      "context": "{t('common:buttons.signup')}"
+    },
+    {
+      "key": "common:loginPage.title",
+      "file": "pages/LoginPage.tsx",
+      "line": 272,
+      "context": "{t('common:loginPage.title', { appName: APP_NAME })}"
+    },
+    {
+      "key": "common:loginPage.title",
+      "file": "pages/LoginPage.tsx",
+      "line": 272,
+      "context": "{t('common:loginPage.title', { appName: APP_NAME })}"
+    },
+    {
+      "key": "common:loginPage.backendSyncError",
+      "file": "pages/LoginPage.tsx",
+      "line": 279,
+      "context": "<strong>{t('common:loginPage.backendSyncError', 'Backend Sync Error')}</strong>"
+    },
+    {
+      "key": "common:loginPage.backendSyncError",
+      "file": "pages/LoginPage.tsx",
+      "line": 279,
+      "context": "<strong>{t('common:loginPage.backendSyncError', 'Backend Sync Error')}</strong>"
+    },
+    {
+      "key": "common:loginPage.signingOut",
+      "file": "pages/LoginPage.tsx",
+      "line": 296,
+      "context": "? t('common:loginPage.signingOut', 'Signing Out...')"
+    },
+    {
+      "key": "common:loginPage.signingOut",
+      "file": "pages/LoginPage.tsx",
+      "line": 296,
+      "context": "? t('common:loginPage.signingOut', 'Signing Out...')"
+    },
+    {
+      "key": "common:loginPage.signOutButton",
+      "file": "pages/LoginPage.tsx",
+      "line": 297,
+      "context": ": t('common:loginPage.signOutButton', 'Sign Out')}"
+    },
+    {
+      "key": "common:loginPage.signOutButton",
+      "file": "pages/LoginPage.tsx",
+      "line": 297,
+      "context": ": t('common:loginPage.signOutButton', 'Sign Out')}"
+    },
+    {
+      "key": "common:loginPage.title",
+      "file": "pages/LoginPage.tsx",
+      "line": 317,
+      "context": "{t('common:loginPage.title', { appName: APP_NAME })}"
+    },
+    {
+      "key": "common:loginPage.title",
+      "file": "pages/LoginPage.tsx",
+      "line": 317,
+      "context": "{t('common:loginPage.title', { appName: APP_NAME })}"
+    },
+    {
+      "key": "common:loginPage.subtitle",
+      "file": "pages/LoginPage.tsx",
+      "line": 319,
+      "context": "<p className=\"text-sm text-gray-500\">{t('common:loginPage.subtitle')}</p>"
+    },
+    {
+      "key": "common:loginPage.subtitle",
+      "file": "pages/LoginPage.tsx",
+      "line": 319,
+      "context": "<p className=\"text-sm text-gray-500\">{t('common:loginPage.subtitle')}</p>"
+    },
+    {
+      "key": "common:loginPage.emailLabel",
+      "file": "pages/LoginPage.tsx",
+      "line": 332,
+      "context": "{t('common:loginPage.emailLabel')}"
+    },
+    {
+      "key": "common:loginPage.emailLabel",
+      "file": "pages/LoginPage.tsx",
+      "line": 332,
+      "context": "{t('common:loginPage.emailLabel')}"
+    },
+    {
+      "key": "common:loginPage.emailPlaceholder",
+      "file": "pages/LoginPage.tsx",
+      "line": 341,
+      "context": "placeholder={t('common:loginPage.emailPlaceholder')}"
+    },
+    {
+      "key": "common:loginPage.emailPlaceholder",
+      "file": "pages/LoginPage.tsx",
+      "line": 341,
+      "context": "placeholder={t('common:loginPage.emailPlaceholder')}"
+    },
+    {
+      "key": "common:loginPage.passwordLabel",
+      "file": "pages/LoginPage.tsx",
+      "line": 348,
+      "context": "{t('common:loginPage.passwordLabel')}"
+    },
+    {
+      "key": "common:loginPage.passwordLabel",
+      "file": "pages/LoginPage.tsx",
+      "line": 348,
+      "context": "{t('common:loginPage.passwordLabel')}"
+    },
+    {
+      "key": "common:loginPage.forgotPassword",
+      "file": "pages/LoginPage.tsx",
+      "line": 354,
+      "context": "{t('common:loginPage.forgotPassword')}"
+    },
+    {
+      "key": "common:loginPage.forgotPassword",
+      "file": "pages/LoginPage.tsx",
+      "line": 354,
+      "context": "{t('common:loginPage.forgotPassword')}"
+    },
+    {
+      "key": "common:loginPage.passwordPlaceholder",
+      "file": "pages/LoginPage.tsx",
+      "line": 365,
+      "context": "placeholder={t('common:loginPage.passwordPlaceholder')}"
+    },
+    {
+      "key": "common:loginPage.passwordPlaceholder",
+      "file": "pages/LoginPage.tsx",
+      "line": 365,
+      "context": "placeholder={t('common:loginPage.passwordPlaceholder')}"
+    },
+    {
+      "key": "common:hidePassword",
+      "file": "pages/LoginPage.tsx",
+      "line": 371,
+      "context": "aria-label={showPassword ? t('common:hidePassword') : t('common:showPassword')}"
+    },
+    {
+      "key": "common:showPassword",
+      "file": "pages/LoginPage.tsx",
+      "line": 371,
+      "context": "aria-label={showPassword ? t('common:hidePassword') : t('common:showPassword')}"
+    },
+    {
+      "key": "common:hidePassword",
+      "file": "pages/LoginPage.tsx",
+      "line": 371,
+      "context": "aria-label={showPassword ? t('common:hidePassword') : t('common:showPassword')}"
+    },
+    {
+      "key": "common:showPassword",
+      "file": "pages/LoginPage.tsx",
+      "line": 371,
+      "context": "aria-label={showPassword ? t('common:hidePassword') : t('common:showPassword')}"
+    },
+    {
+      "key": "common:loginPage.loggingIn",
+      "file": "pages/LoginPage.tsx",
+      "line": 379,
+      "context": "{isSubmitting ? t('common:loginPage.loggingIn') : t('common:buttons.login')}"
+    },
+    {
+      "key": "common:buttons.login",
+      "file": "pages/LoginPage.tsx",
+      "line": 379,
+      "context": "{isSubmitting ? t('common:loginPage.loggingIn') : t('common:buttons.login')}"
+    },
+    {
+      "key": "common:loginPage.loggingIn",
+      "file": "pages/LoginPage.tsx",
+      "line": 379,
+      "context": "{isSubmitting ? t('common:loginPage.loggingIn') : t('common:buttons.login')}"
+    },
+    {
+      "key": "common:buttons.login",
+      "file": "pages/LoginPage.tsx",
+      "line": 379,
+      "context": "{isSubmitting ? t('common:loginPage.loggingIn') : t('common:buttons.login')}"
+    },
+    {
+      "key": "common:loginPage.orContinueWith",
+      "file": "pages/LoginPage.tsx",
+      "line": 390,
+      "context": "{t('common:loginPage.orContinueWith')}"
+    },
+    {
+      "key": "common:loginPage.orContinueWith",
+      "file": "pages/LoginPage.tsx",
+      "line": 390,
+      "context": "{t('common:loginPage.orContinueWith')}"
+    },
+    {
+      "key": "common:loginPage.google",
+      "file": "pages/LoginPage.tsx",
+      "line": 402,
+      "context": "<GoogleIcon className=\"w-5 h-5 mr-2\" /> {t('common:loginPage.google')}"
+    },
+    {
+      "key": "common:loginPage.google",
+      "file": "pages/LoginPage.tsx",
+      "line": 402,
+      "context": "<GoogleIcon className=\"w-5 h-5 mr-2\" /> {t('common:loginPage.google')}"
+    },
+    {
+      "key": "common:loginPage.facebook",
+      "file": "pages/LoginPage.tsx",
+      "line": 410,
+      "context": "<FacebookIcon className=\"w-5 h-5 mr-2\" /> {t('common:loginPage.facebook')}"
+    },
+    {
+      "key": "common:loginPage.facebook",
+      "file": "pages/LoginPage.tsx",
+      "line": 410,
+      "context": "<FacebookIcon className=\"w-5 h-5 mr-2\" /> {t('common:loginPage.facebook')}"
+    },
+    {
+      "key": "common:loginPage.noAccount",
+      "file": "pages/LoginPage.tsx",
+      "line": 417,
+      "context": "{t('common:loginPage.noAccount')}{' '}"
+    },
+    {
+      "key": "common:loginPage.noAccount",
+      "file": "pages/LoginPage.tsx",
+      "line": 417,
+      "context": "{t('common:loginPage.noAccount')}{' '}"
+    },
+    {
+      "key": "common:buttons.signup",
+      "file": "pages/LoginPage.tsx",
+      "line": 419,
+      "context": "{t('common:buttons.signup')}"
+    },
+    {
+      "key": "common:buttons.signup",
+      "file": "pages/LoginPage.tsx",
+      "line": 419,
+      "context": "{t('common:buttons.signup')}"
+    },
+    {
+      "key": "common:loginPage.viewPlansPrompt",
+      "file": "pages/LoginPage.tsx",
+      "line": 423,
+      "context": "{t('common:loginPage.viewPlansPrompt')}{' '}"
+    },
+    {
+      "key": "common:loginPage.viewPlansPrompt",
+      "file": "pages/LoginPage.tsx",
+      "line": 423,
+      "context": "{t('common:loginPage.viewPlansPrompt')}{' '}"
+    },
+    {
+      "key": "common:loginPage.viewPlans",
+      "file": "pages/LoginPage.tsx",
+      "line": 425,
+      "context": "{t('common:loginPage.viewPlans')}"
+    },
+    {
+      "key": "common:loginPage.viewPlans",
+      "file": "pages/LoginPage.tsx",
+      "line": 425,
+      "context": "{t('common:loginPage.viewPlans')}"
+    },
+    {
+      "key": "common:loginPage.parentLookingForCreche",
+      "file": "pages/LoginPage.tsx",
+      "line": 430,
+      "context": "{t('common:loginPage.parentLookingForCreche')}"
+    },
+    {
+      "key": "common:loginPage.parentLookingForCreche",
+      "file": "pages/LoginPage.tsx",
+      "line": 430,
+      "context": "{t('common:loginPage.parentLookingForCreche')}"
+    },
+    {
+      "key": "common:loginPage.findCrecheHere",
+      "file": "pages/LoginPage.tsx",
+      "line": 438,
+      "context": "{t('common:loginPage.findCrecheHere')}"
+    },
+    {
+      "key": "common:loginPage.findCrecheHere",
+      "file": "pages/LoginPage.tsx",
+      "line": 438,
+      "context": "{t('common:loginPage.findCrecheHere')}"
+    },
+    {
+      "key": "hrProcedures.documentCard.categoryLabel",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 39,
+      "context": "<p className=\"text-xs text-gray-500\">{t('hrProcedures.documentCard.categoryLabel', { category: doc.category })}</p>"
+    },
+    {
+      "key": "hrProcedures.documentCard.languageLabel",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 40,
+      "context": "{doc.language && <p className=\"text-xs text-gray-500\">{t('hrProcedures.documentCard.languageLabel', { language: doc.language })} {doc.version && t('hrProcedures.documentCard.versionLabel', { version: doc.version })}</p>}"
+    },
+    {
+      "key": "hrProcedures.documentCard.versionLabel",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 40,
+      "context": "{doc.language && <p className=\"text-xs text-gray-500\">{t('hrProcedures.documentCard.languageLabel', { language: doc.language })} {doc.version && t('hrProcedures.documentCard.versionLabel', { version: doc.version })}</p>}"
+    },
+    {
+      "key": "hrProcedures.documentCard.toggleFavoriteLabel",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 43,
+      "context": "<button onClick={() => onToggleFavorite(doc.id)} className=\"text-gray-300 hover:text-yellow-400 focus:outline-none\" aria-label={t('hrProcedures.documentCard.toggleFavoriteLabel')}>"
+    },
+    {
+      "key": "hrProcedures.documentCard.lastUpdatedLabel",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 48,
+      "context": "<CalendarDaysIcon className=\"w-4 h-4 inline mr-1\" /> {t('hrProcedures.documentCard.lastUpdatedLabel', { date: new Date(doc.lastUpdated).toLocaleDateString() })}"
+    },
+    {
+      "key": "hrProcedures.documentCard.downloadingAlert",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 62,
+      "context": "<Button variant=\"primary\" size=\"sm\" leftIcon={ArrowDownTrayIcon} onClick={() => alert(t('hrProcedures.documentCard.downloadingAlert', { title: doc.title }))}>{t('hrProcedures.documentCard.downloadButton')}</Button>"
+    },
+    {
+      "key": "hrProcedures.documentCard.downloadButton",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 62,
+      "context": "<Button variant=\"primary\" size=\"sm\" leftIcon={ArrowDownTrayIcon} onClick={() => alert(t('hrProcedures.documentCard.downloadingAlert', { title: doc.title }))}>{t('hrProcedures.documentCard.downloadButton')}</Button>"
+    },
+    {
+      "key": "hrProcedures.documentCard.previewingAlert",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 63,
+      "context": "<Button variant=\"ghost\" size=\"sm\" leftIcon={EyeIcon} onClick={() => alert(t('hrProcedures.documentCard.previewingAlert', { title: doc.title }))} className=\"p-2\" aria-label={t('hrProcedures.documentCard.previewButtonLabel')} title={t('hrProcedures.documentCard.previewButtonLabel')}></Button>"
+    },
+    {
+      "key": "hrProcedures.documentCard.previewButtonLabel",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 63,
+      "context": "<Button variant=\"ghost\" size=\"sm\" leftIcon={EyeIcon} onClick={() => alert(t('hrProcedures.documentCard.previewingAlert', { title: doc.title }))} className=\"p-2\" aria-label={t('hrProcedures.documentCard.previewButtonLabel')} title={t('hrProcedures.documentCard.previewButtonLabel')}></Button>"
+    },
+    {
+      "key": "hrProcedures.documentCard.previewButtonLabel",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 63,
+      "context": "<Button variant=\"ghost\" size=\"sm\" leftIcon={EyeIcon} onClick={() => alert(t('hrProcedures.documentCard.previewingAlert', { title: doc.title }))} className=\"p-2\" aria-label={t('hrProcedures.documentCard.previewButtonLabel')} title={t('hrProcedures.documentCard.previewButtonLabel')}></Button>"
+    },
+    {
+      "key": "hrProcedures.documentCard.editButtonLabel",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 66,
+      "context": "<Button variant=\"ghost\" size=\"sm\" leftIcon={PencilIcon} onClick={() => onEdit(doc)} className=\"text-blue-600 hover:text-blue-700 p-2\" aria-label={t('hrProcedures.documentCard.editButtonLabel')} title={t('hrProcedures.documentCard.editButtonLabel')}></Button>"
+    },
+    {
+      "key": "hrProcedures.documentCard.editButtonLabel",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 66,
+      "context": "<Button variant=\"ghost\" size=\"sm\" leftIcon={PencilIcon} onClick={() => onEdit(doc)} className=\"text-blue-600 hover:text-blue-700 p-2\" aria-label={t('hrProcedures.documentCard.editButtonLabel')} title={t('hrProcedures.documentCard.editButtonLabel')}></Button>"
+    },
+    {
+      "key": "hrProcedures.documentCard.deleteButtonLabel",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 67,
+      "context": "<Button variant=\"ghost\" size=\"sm\" leftIcon={TrashIcon} onClick={() => onDelete(doc.id)} className=\"text-red-600 hover:text-red-700 p-2\" aria-label={t('hrProcedures.documentCard.deleteButtonLabel')} title={t('hrProcedures.documentCard.deleteButtonLabel')}></Button>"
+    },
+    {
+      "key": "hrProcedures.documentCard.deleteButtonLabel",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 67,
+      "context": "<Button variant=\"ghost\" size=\"sm\" leftIcon={TrashIcon} onClick={() => onDelete(doc.id)} className=\"text-red-600 hover:text-red-700 p-2\" aria-label={t('hrProcedures.documentCard.deleteButtonLabel')} title={t('hrProcedures.documentCard.deleteButtonLabel')}></Button>"
+    },
+    {
+      "key": "hrProcedures.categoryDisplay.viewCategoryAria",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 84,
+      "context": "aria-label={t('hrProcedures.categoryDisplay.viewCategoryAria', { title })}"
+    },
+    {
+      "key": "hrProcedures.categoryDisplay.documentsCount",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 88,
+      "context": "<p className=\"text-sm opacity-80 text-current\">{t('hrProcedures.categoryDisplay.documentsCount', { count })}</p>"
+    },
+    {
+      "key": "hrProcedures.confirmDeleteDocument",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 166,
+      "context": "if (window.confirm(t('hrProcedures.confirmDeleteDocument'))) {"
+    },
+    {
+      "key": "hrProcedures.title",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 177,
+      "context": "<h1 className=\"text-3xl font-bold text-swiss-charcoal mb-4 md:mb-0\">{t('hrProcedures.title')}</h1>"
+    },
+    {
+      "key": "hrProcedures.uploadButton",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 180,
+      "context": "{t('hrProcedures.uploadButton')}"
+    },
+    {
+      "key": "hrProcedures.searchPlaceholder",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 189,
+      "context": "<label htmlFor=\"hrSearch\" className=\"sr-only\">{t('hrProcedures.searchPlaceholder')}</label>"
+    },
+    {
+      "key": "hrProcedures.searchPlaceholder",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 193,
+      "context": "placeholder={t('hrProcedures.searchPlaceholder')}"
+    },
+    {
+      "key": "hrProcedures.categoriesTitle",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 202,
+      "context": "<h2 className=\"text-2xl font-semibold text-swiss-charcoal mt-6 mb-3\">{t('hrProcedures.categoriesTitle')}</h2>"
+    },
+    {
+      "key": "hrProcedures.allDocumentsCategory",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 205,
+      "context": "title={t('hrProcedures.allDocumentsCategory')}"
+    },
+    {
+      "key": "hrProcedures.noDocumentsMatchSearch",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 225,
+      "context": "<p className=\"text-center text-gray-500 py-8 col-span-full\">{t('hrProcedures.noDocumentsMatchSearch')}</p>"
+    },
+    {
+      "key": "hrProcedures.noDocumentsAvailable",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 227,
+      "context": "{totalPublishedDocs === 0 && <p className=\"text-center text-gray-500 py-8 col-span-full\">{t('hrProcedures.noDocumentsAvailable')}</p>}"
+    },
+    {
+      "key": "hrProcedures.backToCategoriesButton",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 233,
+      "context": "{t('hrProcedures.backToCategoriesButton')}"
+    },
+    {
+      "key": "hrProcedures.documentsInCategoryTitle",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 239,
+      "context": "{selectedCategory ? t('hrProcedures.documentsInCategoryTitle', { category: selectedCategory }) : t('hrProcedures.allDocumentsCategory')}"
+    },
+    {
+      "key": "hrProcedures.allDocumentsCategory",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 239,
+      "context": "{selectedCategory ? t('hrProcedures.documentsInCategoryTitle', { category: selectedCategory }) : t('hrProcedures.allDocumentsCategory')}"
+    },
+    {
+      "key": "hrProcedures.allItemsCount",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 240,
+      "context": "<span className=\"text-base font-normal text-gray-500 ml-2\">{t('hrProcedures.allItemsCount', { count: filteredDocs.length })}</span>"
+    },
+    {
+      "key": "hrProcedures.noDocumentsInCategory",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 254,
+      "context": "{filteredDocs.length === 0 && selectedCategory && <p className=\"text-center text-gray-500 py-8\">{t('hrProcedures.noDocumentsInCategory', { category: selectedCategory })}</p>}"
+    },
+    {
+      "key": "hrProcedures.noDocumentsMatchSearch",
+      "file": "pages/HRProceduresPage.tsx",
+      "line": 255,
+      "context": "{filteredDocs.length === 0 && !selectedCategory && totalPublishedDocs > 0 && <p className=\"text-center text-gray-500 py-8\">{t('hrProcedures.noDocumentsMatchSearch')}</p>}"
+    },
+    {
+      "key": "foundationLeadsPage.accessDenied.title",
+      "file": "pages/FoundationLeadsPage.tsx",
+      "line": 17,
+      "context": "<h1 className=\"text-2xl font-bold text-swiss-charcoal\">{t('foundationLeadsPage.accessDenied.title')}</h1>"
+    },
+    {
+      "key": "foundationLeadsPage.accessDenied.message",
+      "file": "pages/FoundationLeadsPage.tsx",
+      "line": 18,
+      "context": "<p className=\"text-gray-600\">{t('foundationLeadsPage.accessDenied.message')}</p>"
+    },
+    {
+      "key": "foundationLeadsPage.title",
+      "file": "pages/FoundationLeadsPage.tsx",
+      "line": 39,
+      "context": "{t('foundationLeadsPage.title')}"
+    },
+    {
+      "key": "foundationLeadsPage.emptyState.title",
+      "file": "pages/FoundationLeadsPage.tsx",
+      "line": 47,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-2\">{t('foundationLeadsPage.emptyState.title')}</h2>"
+    },
+    {
+      "key": "foundationLeadsPage.emptyState.message",
+      "file": "pages/FoundationLeadsPage.tsx",
+      "line": 48,
+      "context": "<p className=\"text-gray-500\">{t('foundationLeadsPage.emptyState.message')}</p>"
+    },
+    {
+      "key": "fileGallery.actions.preview",
+      "file": "pages/FileGalleryPage.tsx",
+      "line": 35,
+      "context": "<Button variant=\"ghost\" size=\"xs\" title={t('fileGallery.actions.preview')} className=\"!p-2\" onClick={() => alert(t('fileGallery.actions.preview') + ' TBD')}><EyeIcon className=\"w-4 h-4\" /></Button>"
+    },
+    {
+      "key": "fileGallery.actions.preview",
+      "file": "pages/FileGalleryPage.tsx",
+      "line": 35,
+      "context": "<Button variant=\"ghost\" size=\"xs\" title={t('fileGallery.actions.preview')} className=\"!p-2\" onClick={() => alert(t('fileGallery.actions.preview') + ' TBD')}><EyeIcon className=\"w-4 h-4\" /></Button>"
+    },
+    {
+      "key": "fileGallery.actions.download",
+      "file": "pages/FileGalleryPage.tsx",
+      "line": 36,
+      "context": "<Button variant=\"ghost\" size=\"xs\" title={t('fileGallery.actions.download')} className=\"!p-2\" onClick={() => alert(t('fileGallery.actions.download') + ' TBD')}><ArrowDownTrayIcon className=\"w-4 h-4\" /></Button>"
+    },
+    {
+      "key": "fileGallery.actions.download",
+      "file": "pages/FileGalleryPage.tsx",
+      "line": 36,
+      "context": "<Button variant=\"ghost\" size=\"xs\" title={t('fileGallery.actions.download')} className=\"!p-2\" onClick={() => alert(t('fileGallery.actions.download') + ' TBD')}><ArrowDownTrayIcon className=\"w-4 h-4\" /></Button>"
+    },
+    {
+      "key": "fileGallery.actions.rename",
+      "file": "pages/FileGalleryPage.tsx",
+      "line": 37,
+      "context": "<Button variant=\"ghost\" size=\"xs\" title={t('fileGallery.actions.rename')} className=\"!p-2\" onClick={() => onRename(file)}><PencilIcon className=\"w-4 h-4\" /></Button>"
+    },
+    {
+      "key": "fileGallery.actions.delete",
+      "file": "pages/FileGalleryPage.tsx",
+      "line": 38,
+      "context": "<Button variant=\"ghost\" size=\"xs\" title={t('fileGallery.actions.delete')} className=\"!p-2 text-swiss-coral\" onClick={() => onDelete(file.id)}><TrashIcon className=\"w-4 h-4\" /></Button>"
+    },
+    {
+      "key": "fileGallery.confirmDelete",
+      "file": "pages/FileGalleryPage.tsx",
+      "line": 52,
+      "context": "if (window.confirm(t('fileGallery.confirmDelete'))) {"
+    },
+    {
+      "key": "sidebar.fileGallery",
+      "file": "pages/FileGalleryPage.tsx",
+      "line": 67,
+      "context": "{t('sidebar.fileGallery')}"
+    },
+    {
+      "key": "fileGallery.uploadButton",
+      "file": "pages/FileGalleryPage.tsx",
+      "line": 70,
+      "context": "{t('fileGallery.uploadButton')}"
+    },
+    {
+      "key": "fileGallery.emptyState.title",
+      "file": "pages/FileGalleryPage.tsx",
+      "line": 77,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-2\">{t('fileGallery.emptyState.title')}</h2>"
+    },
+    {
+      "key": "fileGallery.emptyState.message",
+      "file": "pages/FileGalleryPage.tsx",
+      "line": 78,
+      "context": "<p className=\"text-gray-500\">{t('fileGallery.emptyState.message')}</p>"
+    },
+    {
+      "key": "eLearning.actions.viewCourse",
+      "file": "pages/ELearningPage.tsx",
+      "line": 24,
+      "context": "[ELearningContentType.COURSE]: { icon: AcademicCapIcon, actionText: t('eLearning.actions.viewCourse'), actionIcon: EyeIcon, color: 'text-swiss-mint' },"
+    },
+    {
+      "key": "eLearning.actions.watchVideo",
+      "file": "pages/ELearningPage.tsx",
+      "line": 25,
+      "context": "[ELearningContentType.VIDEO]: { icon: VideoCameraIcon, actionText: t('eLearning.actions.watchVideo'), actionIcon: PlayIcon, color: 'text-swiss-teal' },"
+    },
+    {
+      "key": "eLearning.actions.downloadPdf",
+      "file": "pages/ELearningPage.tsx",
+      "line": 26,
+      "context": "[ELearningContentType.PDF]: { icon: DocumentTextIcon, actionText: t('eLearning.actions.downloadPdf'), actionIcon: ArrowDownTrayIcon, color: 'text-swiss-coral' },"
+    },
+    {
+      "key": "eLearning.actions.openLink",
+      "file": "pages/ELearningPage.tsx",
+      "line": 27,
+      "context": "[ELearningContentType.LINK]: { icon: LinkIcon, actionText: t('eLearning.actions.openLink'), actionIcon: ArrowTopRightOnSquareIcon, color: 'text-purple-600' },"
+    },
+    {
+      "key": "eLearning.viewingAlert",
+      "file": "pages/ELearningPage.tsx",
+      "line": 42,
+      "context": "alert(`${t('eLearning.viewingAlert')} ${item.title}`);"
+    },
+    {
+      "key": "eLearning.lessonsCount",
+      "file": "pages/ELearningPage.tsx",
+      "line": 55,
+      "context": "{item.type === ELearningContentType.COURSE && item.lessons && <p className=\"text-xs text-gray-500\">{t('eLearning.lessonsCount', { count: item.lessons })}</p>}"
+    },
+    {
+      "key": "eLearning.durationLabel",
+      "file": "pages/ELearningPage.tsx",
+      "line": 56,
+      "context": "{(item.type === ELearningContentType.VIDEO || item.type === ELearningContentType.COURSE) && item.duration && <p className=\"text-xs text-gray-500\">{t('eLearning.durationLabel')}: {item.duration}</p>}"
+    },
+    {
+      "key": "eLearning.languageLabel",
+      "file": "pages/ELearningPage.tsx",
+      "line": 57,
+      "context": "{item.language && <p className=\"text-xs text-gray-500\">{t('eLearning.languageLabel')}: {item.language}</p>}"
+    },
+    {
+      "key": "eLearning.updatedLabel",
+      "file": "pages/ELearningPage.tsx",
+      "line": 58,
+      "context": "<p className=\"text-xs text-gray-500 mt-1\">{t('eLearning.updatedLabel')}: {new Date(item.updatedDate).toLocaleDateString()}</p>"
+    },
+    {
+      "key": "common:buttons.edit",
+      "file": "pages/ELearningPage.tsx",
+      "line": 79,
+      "context": "<Button variant=\"ghost\" size=\"xs\" leftIcon={PencilIcon} onClick={() => onEdit(item)} className=\"flex-1 text-blue-600 hover:text-blue-700\">{t('common:buttons.edit')}</Button>"
+    },
+    {
+      "key": "common:buttons.edit",
+      "file": "pages/ELearningPage.tsx",
+      "line": 79,
+      "context": "<Button variant=\"ghost\" size=\"xs\" leftIcon={PencilIcon} onClick={() => onEdit(item)} className=\"flex-1 text-blue-600 hover:text-blue-700\">{t('common:buttons.edit')}</Button>"
+    },
+    {
+      "key": "common:buttons.delete",
+      "file": "pages/ELearningPage.tsx",
+      "line": 80,
+      "context": "<Button variant=\"ghost\" size=\"xs\" leftIcon={TrashIcon} onClick={() => onDelete(item.id)} className=\"flex-1 text-red-600 hover:text-red-700\">{t('common:buttons.delete')}</Button>"
+    },
+    {
+      "key": "common:buttons.delete",
+      "file": "pages/ELearningPage.tsx",
+      "line": 80,
+      "context": "<Button variant=\"ghost\" size=\"xs\" leftIcon={TrashIcon} onClick={() => onDelete(item.id)} className=\"flex-1 text-red-600 hover:text-red-700\">{t('common:buttons.delete')}</Button>"
+    },
+    {
+      "key": "eLearning.confirmDelete",
+      "file": "pages/ELearningPage.tsx",
+      "line": 148,
+      "context": "if (window.confirm(t('eLearning.confirmDelete'))) {"
+    },
+    {
+      "key": "eLearning.noItemsFound",
+      "file": "pages/ELearningPage.tsx",
+      "line": 160,
+      "context": "<p className=\"text-center text-gray-500 py-8\">{t('eLearning.noItemsFound', { itemType: itemTypeName.toLowerCase() })}</p>"
+    },
+    {
+      "key": "eLearning.title",
+      "file": "pages/ELearningPage.tsx",
+      "line": 180,
+      "context": "<h1 className=\"text-3xl font-bold text-swiss-charcoal mb-4 md:mb-0\">{t('eLearning.title')}</h1>"
+    },
+    {
+      "key": "eLearning.addNewContentButton",
+      "file": "pages/ELearningPage.tsx",
+      "line": 183,
+      "context": "{t('eLearning.addNewContentButton')}"
+    },
+    {
+      "key": "eLearning.searchPlaceholder",
+      "file": "pages/ELearningPage.tsx",
+      "line": 192,
+      "context": "<label htmlFor=\"eLearningSearch\" className=\"sr-only\">{t('eLearning.searchPlaceholder')}</label>"
+    },
+    {
+      "key": "eLearning.searchPlaceholder",
+      "file": "pages/ELearningPage.tsx",
+      "line": 196,
+      "context": "placeholder={t('eLearning.searchPlaceholder')}"
+    },
+    {
+      "key": "eLearning.categoryLabel",
+      "file": "pages/ELearningPage.tsx",
+      "line": 203,
+      "context": "<label htmlFor=\"eLearningCategory\" className=\"block text-xs font-medium text-gray-500 mb-1\">{t('eLearning.categoryLabel')}</label>"
+    },
+    {
+      "key": "eLearning.noContentFound",
+      "file": "pages/ELearningPage.tsx",
+      "line": 217,
+      "context": "<p className=\"text-center text-gray-500 py-8 text-lg\">{t('eLearning.noContentFound')}</p>"
+    },
+    {
+      "key": "eLearning.coursesTitle",
+      "file": "pages/ELearningPage.tsx",
+      "line": 220,
+      "context": "{renderSection(t('eLearning.coursesTitle'), courseItems, t('eLearning.itemType.courses'), AcademicCapIcon)}"
+    },
+    {
+      "key": "eLearning.itemType.courses",
+      "file": "pages/ELearningPage.tsx",
+      "line": 220,
+      "context": "{renderSection(t('eLearning.coursesTitle'), courseItems, t('eLearning.itemType.courses'), AcademicCapIcon)}"
+    },
+    {
+      "key": "eLearning.videosTitle",
+      "file": "pages/ELearningPage.tsx",
+      "line": 221,
+      "context": "{renderSection(t('eLearning.videosTitle'), videoItems, t('eLearning.itemType.videos'), VideoCameraIcon)}"
+    },
+    {
+      "key": "eLearning.itemType.videos",
+      "file": "pages/ELearningPage.tsx",
+      "line": 221,
+      "context": "{renderSection(t('eLearning.videosTitle'), videoItems, t('eLearning.itemType.videos'), VideoCameraIcon)}"
+    },
+    {
+      "key": "eLearning.pdfsTitle",
+      "file": "pages/ELearningPage.tsx",
+      "line": 222,
+      "context": "{renderSection(t('eLearning.pdfsTitle'), pdfItems, t('eLearning.itemType.pdfs'), DocumentTextIcon)}"
+    },
+    {
+      "key": "eLearning.itemType.pdfs",
+      "file": "pages/ELearningPage.tsx",
+      "line": 222,
+      "context": "{renderSection(t('eLearning.pdfsTitle'), pdfItems, t('eLearning.itemType.pdfs'), DocumentTextIcon)}"
+    },
+    {
+      "key": "eLearning.externalLinksTitle",
+      "file": "pages/ELearningPage.tsx",
+      "line": 223,
+      "context": "{renderSection(t('eLearning.externalLinksTitle'), linkItems, t('eLearning.itemType.links'), LinkIcon)}"
+    },
+    {
+      "key": "eLearning.itemType.links",
+      "file": "pages/ELearningPage.tsx",
+      "line": 223,
+      "context": "{renderSection(t('eLearning.externalLinksTitle'), linkItems, t('eLearning.itemType.links'), LinkIcon)}"
+    },
+    {
+      "key": "admin:designSystem.tabs.tab1",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 36,
+      "context": "{ label: t('admin:designSystem.tabs.tab1'), content: <p>{t('admin:designSystem.tabs.content1')}</p> },"
+    },
+    {
+      "key": "admin:designSystem.tabs.content1",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 36,
+      "context": "{ label: t('admin:designSystem.tabs.tab1'), content: <p>{t('admin:designSystem.tabs.content1')}</p> },"
+    },
+    {
+      "key": "admin:designSystem.tabs.tab1",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 36,
+      "context": "{ label: t('admin:designSystem.tabs.tab1'), content: <p>{t('admin:designSystem.tabs.content1')}</p> },"
+    },
+    {
+      "key": "admin:designSystem.tabs.content1",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 36,
+      "context": "{ label: t('admin:designSystem.tabs.tab1'), content: <p>{t('admin:designSystem.tabs.content1')}</p> },"
+    },
+    {
+      "key": "admin:designSystem.tabs.tab2",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 37,
+      "context": "{ label: t('admin:designSystem.tabs.tab2'), content: <p>{t('admin:designSystem.tabs.content2')}</p> },"
+    },
+    {
+      "key": "admin:designSystem.tabs.content2",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 37,
+      "context": "{ label: t('admin:designSystem.tabs.tab2'), content: <p>{t('admin:designSystem.tabs.content2')}</p> },"
+    },
+    {
+      "key": "admin:designSystem.tabs.tab2",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 37,
+      "context": "{ label: t('admin:designSystem.tabs.tab2'), content: <p>{t('admin:designSystem.tabs.content2')}</p> },"
+    },
+    {
+      "key": "admin:designSystem.tabs.content2",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 37,
+      "context": "{ label: t('admin:designSystem.tabs.tab2'), content: <p>{t('admin:designSystem.tabs.content2')}</p> },"
+    },
+    {
+      "key": "admin:designSystem.tabs.tab3",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 38,
+      "context": "{ label: t('admin:designSystem.tabs.tab3'), content: <p>{t('admin:designSystem.tabs.content3')}</p>, disabled: true },"
+    },
+    {
+      "key": "admin:designSystem.tabs.content3",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 38,
+      "context": "{ label: t('admin:designSystem.tabs.tab3'), content: <p>{t('admin:designSystem.tabs.content3')}</p>, disabled: true },"
+    },
+    {
+      "key": "admin:designSystem.tabs.tab3",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 38,
+      "context": "{ label: t('admin:designSystem.tabs.tab3'), content: <p>{t('admin:designSystem.tabs.content3')}</p>, disabled: true },"
+    },
+    {
+      "key": "admin:designSystem.tabs.content3",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 38,
+      "context": "{ label: t('admin:designSystem.tabs.tab3'), content: <p>{t('admin:designSystem.tabs.content3')}</p>, disabled: true },"
+    },
+    {
+      "key": "admin:designSystem.title",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 44,
+      "context": "<h1 className=\"text-4xl font-bold text-swiss-charcoal\">{t('admin:designSystem.title')}</h1>"
+    },
+    {
+      "key": "admin:designSystem.title",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 44,
+      "context": "<h1 className=\"text-4xl font-bold text-swiss-charcoal\">{t('admin:designSystem.title')}</h1>"
+    },
+    {
+      "key": "admin:designSystem.description",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 45,
+      "context": "<p className=\"mt-2 text-lg text-gray-600\">{t('admin:designSystem.description')}</p>"
+    },
+    {
+      "key": "admin:designSystem.description",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 45,
+      "context": "<p className=\"mt-2 text-lg text-gray-600\">{t('admin:designSystem.description')}</p>"
+    },
+    {
+      "key": "admin:designSystem.typography.fontFamily",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 64,
+      "context": "<p className=\"text-xs text-gray-500\">{t('admin:designSystem.typography.fontFamily')}</p>"
+    },
+    {
+      "key": "admin:designSystem.typography.fontFamily",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 64,
+      "context": "<p className=\"text-xs text-gray-500\">{t('admin:designSystem.typography.fontFamily')}</p>"
+    },
+    {
+      "key": "admin:designSystem.typography.heading1",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 65,
+      "context": "<h1 className=\"text-4xl font-bold\">{t('admin:designSystem.typography.heading1')}</h1>"
+    },
+    {
+      "key": "admin:designSystem.typography.heading1",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 65,
+      "context": "<h1 className=\"text-4xl font-bold\">{t('admin:designSystem.typography.heading1')}</h1>"
+    },
+    {
+      "key": "admin:designSystem.typography.heading2",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 66,
+      "context": "<h2 className=\"text-3xl font-bold\">{t('admin:designSystem.typography.heading2')}</h2>"
+    },
+    {
+      "key": "admin:designSystem.typography.heading2",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 66,
+      "context": "<h2 className=\"text-3xl font-bold\">{t('admin:designSystem.typography.heading2')}</h2>"
+    },
+    {
+      "key": "admin:designSystem.typography.heading3",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 67,
+      "context": "<h3 className=\"text-2xl font-semibold\">{t('admin:designSystem.typography.heading3')}</h3>"
+    },
+    {
+      "key": "admin:designSystem.typography.heading3",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 67,
+      "context": "<h3 className=\"text-2xl font-semibold\">{t('admin:designSystem.typography.heading3')}</h3>"
+    },
+    {
+      "key": "admin:designSystem.typography.heading4",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 68,
+      "context": "<h4 className=\"text-xl font-semibold\">{t('admin:designSystem.typography.heading4')}</h4>"
+    },
+    {
+      "key": "admin:designSystem.typography.heading4",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 68,
+      "context": "<h4 className=\"text-xl font-semibold\">{t('admin:designSystem.typography.heading4')}</h4>"
+    },
+    {
+      "key": "admin:designSystem.typography.bodyBase",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 69,
+      "context": "<p className=\"text-base\">{t('admin:designSystem.typography.bodyBase')}</p>"
+    },
+    {
+      "key": "admin:designSystem.typography.bodyBase",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 69,
+      "context": "<p className=\"text-base\">{t('admin:designSystem.typography.bodyBase')}</p>"
+    },
+    {
+      "key": "admin:designSystem.typography.bodySmall",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 70,
+      "context": "<p className=\"text-sm\">{t('admin:designSystem.typography.bodySmall')}</p>"
+    },
+    {
+      "key": "admin:designSystem.typography.bodySmall",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 70,
+      "context": "<p className=\"text-sm\">{t('admin:designSystem.typography.bodySmall')}</p>"
+    },
+    {
+      "key": "admin:designSystem.typography.link",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 71,
+      "context": "<a href=\"#\" className=\"text-swiss-mint hover:underline\">{t('admin:designSystem.typography.link')}</a>"
+    },
+    {
+      "key": "admin:designSystem.typography.link",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 71,
+      "context": "<a href=\"#\" className=\"text-swiss-mint hover:underline\">{t('admin:designSystem.typography.link')}</a>"
+    },
+    {
+      "key": "admin:designSystem.buttons.extraSmall",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 93,
+      "context": "<Button variant=\"primary\" size=\"xs\">{t('admin:designSystem.buttons.extraSmall')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.extraSmall",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 93,
+      "context": "<Button variant=\"primary\" size=\"xs\">{t('admin:designSystem.buttons.extraSmall')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.small",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 94,
+      "context": "<Button variant=\"primary\" size=\"sm\">{t('admin:designSystem.buttons.small')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.small",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 94,
+      "context": "<Button variant=\"primary\" size=\"sm\">{t('admin:designSystem.buttons.small')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.mediumDefault",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 95,
+      "context": "<Button variant=\"primary\" size=\"md\">{t('admin:designSystem.buttons.mediumDefault')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.mediumDefault",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 95,
+      "context": "<Button variant=\"primary\" size=\"md\">{t('admin:designSystem.buttons.mediumDefault')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.large",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 96,
+      "context": "<Button variant=\"primary\" size=\"lg\">{t('admin:designSystem.buttons.large')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.large",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 96,
+      "context": "<Button variant=\"primary\" size=\"lg\">{t('admin:designSystem.buttons.large')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.withIcons",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 100,
+      "context": "<h3 className=\"font-medium mb-3\">{t('admin:designSystem.buttons.withIcons')}</h3>"
+    },
+    {
+      "key": "admin:designSystem.buttons.withIcons",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 100,
+      "context": "<h3 className=\"font-medium mb-3\">{t('admin:designSystem.buttons.withIcons')}</h3>"
+    },
+    {
+      "key": "admin:designSystem.buttons.leftIcon",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 102,
+      "context": "<Button variant=\"secondary\" leftIcon={PlusIcon}>{t('admin:designSystem.buttons.leftIcon')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.leftIcon",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 102,
+      "context": "<Button variant=\"secondary\" leftIcon={PlusIcon}>{t('admin:designSystem.buttons.leftIcon')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.rightIcon",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 103,
+      "context": "<Button variant=\"outline\" rightIcon={ArrowRightIcon}>{t('admin:designSystem.buttons.rightIcon')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.rightIcon",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 103,
+      "context": "<Button variant=\"outline\" rightIcon={ArrowRightIcon}>{t('admin:designSystem.buttons.rightIcon')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.smallIcon",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 104,
+      "context": "<Button variant=\"primary\" leftIcon={CheckIcon} size=\"sm\">{t('admin:designSystem.buttons.smallIcon')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.smallIcon",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 104,
+      "context": "<Button variant=\"primary\" leftIcon={CheckIcon} size=\"sm\">{t('admin:designSystem.buttons.smallIcon')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.disabledState",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 109,
+      "context": "<h3 className=\"font-medium mb-3\">{t('admin:designSystem.buttons.disabledState')}</h3>"
+    },
+    {
+      "key": "admin:designSystem.buttons.disabledState",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 109,
+      "context": "<h3 className=\"font-medium mb-3\">{t('admin:designSystem.buttons.disabledState')}</h3>"
+    },
+    {
+      "key": "admin:designSystem.buttons.primaryDisabled",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 111,
+      "context": "<Button variant=\"primary\" disabled>{t('admin:designSystem.buttons.primaryDisabled')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.primaryDisabled",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 111,
+      "context": "<Button variant=\"primary\" disabled>{t('admin:designSystem.buttons.primaryDisabled')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.secondaryDisabled",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 112,
+      "context": "<Button variant=\"secondary\" disabled>{t('admin:designSystem.buttons.secondaryDisabled')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.secondaryDisabled",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 112,
+      "context": "<Button variant=\"secondary\" disabled>{t('admin:designSystem.buttons.secondaryDisabled')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.outlineDisabled",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 113,
+      "context": "<Button variant=\"outline\" disabled>{t('admin:designSystem.buttons.outlineDisabled')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.buttons.outlineDisabled",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 113,
+      "context": "<Button variant=\"outline\" disabled>{t('admin:designSystem.buttons.outlineDisabled')}</Button>"
+    },
+    {
+      "key": "admin:designSystem.cards.standardCard",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 124,
+      "context": "<h3 className=\"font-semibold mb-2\">{t('admin:designSystem.cards.standardCard')}</h3>"
+    },
+    {
+      "key": "admin:designSystem.cards.standardCard",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 124,
+      "context": "<h3 className=\"font-semibold mb-2\">{t('admin:designSystem.cards.standardCard')}</h3>"
+    },
+    {
+      "key": "admin:designSystem.cards.standardCardDesc",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 125,
+      "context": "<p className=\"text-sm text-gray-600\">{t('admin:designSystem.cards.standardCardDesc')}</p>"
+    },
+    {
+      "key": "admin:designSystem.cards.standardCardDesc",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 125,
+      "context": "<p className=\"text-sm text-gray-600\">{t('admin:designSystem.cards.standardCardDesc')}</p>"
+    },
+    {
+      "key": "admin:designSystem.cards.hoverEffectCard",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 128,
+      "context": "<h3 className=\"font-semibold mb-2\">{t('admin:designSystem.cards.hoverEffectCard')}</h3>"
+    },
+    {
+      "key": "admin:designSystem.cards.hoverEffectCard",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 128,
+      "context": "<h3 className=\"font-semibold mb-2\">{t('admin:designSystem.cards.hoverEffectCard')}</h3>"
+    },
+    {
+      "key": "admin:designSystem.cards.hoverEffectCardDesc",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 129,
+      "context": "<p className=\"text-sm text-gray-600\">{t('admin:designSystem.cards.hoverEffectCardDesc')}</p>"
+    },
+    {
+      "key": "admin:designSystem.cards.hoverEffectCardDesc",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 129,
+      "context": "<p className=\"text-sm text-gray-600\">{t('admin:designSystem.cards.hoverEffectCardDesc')}</p>"
+    },
+    {
+      "key": "admin:designSystem.formControls.title",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 136,
+      "context": "<h2 className=\"text-2xl font-semibold mb-4 text-swiss-charcoal\">{t('admin:designSystem.formControls.title')}</h2>"
+    },
+    {
+      "key": "admin:designSystem.formControls.title",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 136,
+      "context": "<h2 className=\"text-2xl font-semibold mb-4 text-swiss-charcoal\">{t('admin:designSystem.formControls.title')}</h2>"
+    },
+    {
+      "key": "admin:designSystem.formControls.textInput",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 140,
+      "context": "<label htmlFor=\"text-input\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('admin:designSystem.formControls.textInput')}</label>"
+    },
+    {
+      "key": "admin:designSystem.formControls.textInput",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 140,
+      "context": "<label htmlFor=\"text-input\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('admin:designSystem.formControls.textInput')}</label>"
+    },
+    {
+      "key": "admin:designSystem.formControls.selectMenu",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 144,
+      "context": "<label htmlFor=\"select-input\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('admin:designSystem.formControls.selectMenu')}</label>"
+    },
+    {
+      "key": "admin:designSystem.formControls.selectMenu",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 144,
+      "context": "<label htmlFor=\"select-input\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('admin:designSystem.formControls.selectMenu')}</label>"
+    },
+    {
+      "key": "admin:designSystem.formControls.option1",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 146,
+      "context": "<option>{t('admin:designSystem.formControls.option1')}</option>"
+    },
+    {
+      "key": "admin:designSystem.formControls.option1",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 146,
+      "context": "<option>{t('admin:designSystem.formControls.option1')}</option>"
+    },
+    {
+      "key": "admin:designSystem.formControls.option2",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 147,
+      "context": "<option>{t('admin:designSystem.formControls.option2')}</option>"
+    },
+    {
+      "key": "admin:designSystem.formControls.option2",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 147,
+      "context": "<option>{t('admin:designSystem.formControls.option2')}</option>"
+    },
+    {
+      "key": "admin:designSystem.formControls.option3",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 148,
+      "context": "<option>{t('admin:designSystem.formControls.option3')}</option>"
+    },
+    {
+      "key": "admin:designSystem.formControls.option3",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 148,
+      "context": "<option>{t('admin:designSystem.formControls.option3')}</option>"
+    },
+    {
+      "key": "admin:designSystem.formControls.quantityInput",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 158,
+      "context": "<label className=\"block text-sm font-medium text-gray-700 mb-1\">{t('admin:designSystem.formControls.quantityInput')}</label>"
+    },
+    {
+      "key": "admin:designSystem.formControls.quantityInput",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 158,
+      "context": "<label className=\"block text-sm font-medium text-gray-700 mb-1\">{t('admin:designSystem.formControls.quantityInput')}</label>"
+    },
+    {
+      "key": "admin:designSystem.formControls.disabledInput",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 162,
+      "context": "<label className=\"block text-sm font-medium text-gray-700 mb-1\">{t('admin:designSystem.formControls.disabledInput')}</label>"
+    },
+    {
+      "key": "admin:designSystem.formControls.disabledInput",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 162,
+      "context": "<label className=\"block text-sm font-medium text-gray-700 mb-1\">{t('admin:designSystem.formControls.disabledInput')}</label>"
+    },
+    {
+      "key": "admin:designSystem.tabs.title",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 171,
+      "context": "<h2 className=\"text-2xl font-semibold mb-4 text-swiss-charcoal\">{t('admin:designSystem.tabs.title')}</h2>"
+    },
+    {
+      "key": "admin:designSystem.tabs.title",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 171,
+      "context": "<h2 className=\"text-2xl font-semibold mb-4 text-swiss-charcoal\">{t('admin:designSystem.tabs.title')}</h2>"
+    },
+    {
+      "key": "admin:designSystem.tabs.pillsVariant",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 174,
+      "context": "<h3 className=\"font-medium mb-3\">{t('admin:designSystem.tabs.pillsVariant')}</h3>"
+    },
+    {
+      "key": "admin:designSystem.tabs.pillsVariant",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 174,
+      "context": "<h3 className=\"font-medium mb-3\">{t('admin:designSystem.tabs.pillsVariant')}</h3>"
+    },
+    {
+      "key": "admin:designSystem.tabs.lineVariant",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 178,
+      "context": "<h3 className=\"font-medium mb-3\">{t('admin:designSystem.tabs.lineVariant')}</h3>"
+    },
+    {
+      "key": "admin:designSystem.tabs.lineVariant",
+      "file": "pages/DesignSystemPage.tsx",
+      "line": 178,
+      "context": "<h3 className=\"font-medium mb-3\">{t('admin:designSystem.tabs.lineVariant')}</h3>"
+    },
+    {
+      "key": "dashboardPage.defaultUser",
+      "file": "pages/DashboardPage.tsx",
+      "line": 14,
+      "context": "const userName = currentUser?.name.split(' ')[0] || t('dashboardPage.defaultUser');"
+    },
+    {
+      "key": "dashboardPage.activeUsers",
+      "file": "pages/DashboardPage.tsx",
+      "line": 17,
+      "context": "{ key: 'activeUsers', name: t('dashboardPage.activeUsers'), value: '1,234', icon: UsersIcon, color: 'text-swiss-mint', bgColor: 'bg-swiss-mint/10', trend: '+5%' },"
+    },
+    {
+      "key": "dashboardPage.newOrders",
+      "file": "pages/DashboardPage.tsx",
+      "line": 18,
+      "context": "{ key: 'newOrders', name: t('dashboardPage.newOrders'), value: '56', icon: ShoppingCartIcon, color: 'text-swiss-sand', bgColor: 'bg-swiss-sand/20', trend: '+12%' },"
+    },
+    {
+      "key": "dashboardPage.openJobs",
+      "file": "pages/DashboardPage.tsx",
+      "line": 19,
+      "context": "{ key: 'openJobs', name: t('dashboardPage.openJobs'), value: '12', icon: BriefcaseIcon, color: 'text-swiss-teal', bgColor: 'bg-swiss-teal/10', trend: '-2%' },"
+    },
+    {
+      "key": "dashboardPage.pageViews",
+      "file": "pages/DashboardPage.tsx",
+      "line": 20,
+      "context": "{ key: 'pageViews', name: t('dashboardPage.pageViews'), value: '25,678', icon: ChartBarIcon, color: 'text-swiss-coral', bgColor: 'bg-swiss-coral/10', trend: '+8%' },"
+    },
+    {
+      "key": "dashboardPage.timeAgo.yesterday",
+      "file": "pages/DashboardPage.tsx",
+      "line": 38,
+      "context": "if (timeUnit === 'yesterday') return t('dashboardPage.timeAgo.yesterday');"
+    },
+    {
+      "key": "dashboardPage.welcome",
+      "file": "pages/DashboardPage.tsx",
+      "line": 47,
+      "context": "{t('dashboardPage.welcome', { name: userName })}"
+    },
+    {
+      "key": "dashboardPage.overviewSubtitle",
+      "file": "pages/DashboardPage.tsx",
+      "line": 49,
+      "context": "<p className=\"text-gray-500 mt-1\">{t('dashboardPage.overviewSubtitle', { appName: APP_NAME })}</p>"
+    },
+    {
+      "key": "dashboardPage.viewDetailsFor",
+      "file": "pages/DashboardPage.tsx",
+      "line": 73,
+      "context": "aria-label={t('dashboardPage.viewDetailsFor', { name: stat.name })}"
+    },
+    {
+      "key": "buttons.viewDetails",
+      "file": "pages/DashboardPage.tsx",
+      "line": 75,
+      "context": "{t('buttons.viewDetails')} &rarr;"
+    },
+    {
+      "key": "dashboardPage.recentActivity",
+      "file": "pages/DashboardPage.tsx",
+      "line": 84,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-5\">{t('dashboardPage.recentActivity')}</h2>"
+    },
+    {
+      "key": "dashboardPage.quickLinks",
+      "file": "pages/DashboardPage.tsx",
+      "line": 101,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-5\">{t('dashboardPage.quickLinks')}</h2>"
+    },
+    {
+      "key": "dashboardDetailPage.activeUsers.recentActivity",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 22,
+      "context": "<p className=\"font-semibold text-lg\">{t('dashboardDetailPage.activeUsers.recentActivity')}</p>"
+    },
+    {
+      "key": "dashboardDetailPage.activeUsers.aliceActivity",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 24,
+      "context": "<li>{t('dashboardDetailPage.activeUsers.aliceActivity')}</li>"
+    },
+    {
+      "key": "dashboardDetailPage.activeUsers.bobActivity",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 25,
+      "context": "<li>{t('dashboardDetailPage.activeUsers.bobActivity')}</li>"
+    },
+    {
+      "key": "dashboardDetailPage.activeUsers.carolActivity",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 26,
+      "context": "<li>{t('dashboardDetailPage.activeUsers.carolActivity')}</li>"
+    },
+    {
+      "key": "dashboardDetailPage.activeUsers.davidActivity",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 27,
+      "context": "<li>{t('dashboardDetailPage.activeUsers.davidActivity')}</li>"
+    },
+    {
+      "key": "dashboardDetailPage.activeUsers.totalToday",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 30,
+      "context": "<p className=\"font-medium text-swiss-mint\">{t('dashboardDetailPage.activeUsers.totalToday', { count: 152 })}</p>"
+    },
+    {
+      "key": "dashboardDetailPage.newOrders.recentOrders",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 40,
+      "context": "<p className=\"font-semibold text-lg\">{t('dashboardDetailPage.newOrders.recentOrders')}</p>"
+    },
+    {
+      "key": "dashboardDetailPage.newOrders.table.orderId",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 44,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('dashboardDetailPage.newOrders.table.orderId')}</th>"
+    },
+    {
+      "key": "dashboardDetailPage.newOrders.table.product",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 45,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('dashboardDetailPage.newOrders.table.product')}</th>"
+    },
+    {
+      "key": "dashboardDetailPage.newOrders.table.amount",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 46,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('dashboardDetailPage.newOrders.table.amount')}</th>"
+    },
+    {
+      "key": "dashboardDetailPage.newOrders.table.status",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 47,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('dashboardDetailPage.newOrders.table.status')}</th>"
+    },
+    {
+      "key": "dashboardDetailPage.newOrders.order789",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 51,
+      "context": "<tr><td className=\"px-4 py-2\">{t('dashboardDetailPage.newOrders.order789')}</td><td className=\"px-4 py-2\">{t('dashboardDetailPage.newOrders.ecotoysBlocks')}</td><td className=\"px-4 py-2\">$49.99</td><td className=\"px-4 py-2\"><span className=\"px-2 py-0.5 bg-green-100 text-green-700 rounded-full text-xs\">{t('dashboardDetailPage.newOrders.status.paid')}</span></td></tr>"
+    },
+    {
+      "key": "dashboardDetailPage.newOrders.ecotoysBlocks",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 51,
+      "context": "<tr><td className=\"px-4 py-2\">{t('dashboardDetailPage.newOrders.order789')}</td><td className=\"px-4 py-2\">{t('dashboardDetailPage.newOrders.ecotoysBlocks')}</td><td className=\"px-4 py-2\">$49.99</td><td className=\"px-4 py-2\"><span className=\"px-2 py-0.5 bg-green-100 text-green-700 rounded-full text-xs\">{t('dashboardDetailPage.newOrders.status.paid')}</span></td></tr>"
+    },
+    {
+      "key": "dashboardDetailPage.newOrders.status.paid",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 51,
+      "context": "<tr><td className=\"px-4 py-2\">{t('dashboardDetailPage.newOrders.order789')}</td><td className=\"px-4 py-2\">{t('dashboardDetailPage.newOrders.ecotoysBlocks')}</td><td className=\"px-4 py-2\">$49.99</td><td className=\"px-4 py-2\"><span className=\"px-2 py-0.5 bg-green-100 text-green-700 rounded-full text-xs\">{t('dashboardDetailPage.newOrders.status.paid')}</span></td></tr>"
+    },
+    {
+      "key": "dashboardDetailPage.newOrders.order790",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 52,
+      "context": "<tr><td className=\"px-4 py-2\">{t('dashboardDetailPage.newOrders.order790')}</td><td className=\"px-4 py-2\">{t('dashboardDetailPage.newOrders.freshBitesMeal')}</td><td className=\"px-4 py-2\">$120.00</td><td className=\"px-4 py-2\"><span className=\"px-2 py-0.5 bg-green-100 text-green-700 rounded-full text-xs\">{t('dashboardDetailPage.newOrders.status.paid')}</span></td></tr>"
+    },
+    {
+      "key": "dashboardDetailPage.newOrders.freshBitesMeal",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 52,
+      "context": "<tr><td className=\"px-4 py-2\">{t('dashboardDetailPage.newOrders.order790')}</td><td className=\"px-4 py-2\">{t('dashboardDetailPage.newOrders.freshBitesMeal')}</td><td className=\"px-4 py-2\">$120.00</td><td className=\"px-4 py-2\"><span className=\"px-2 py-0.5 bg-green-100 text-green-700 rounded-full text-xs\">{t('dashboardDetailPage.newOrders.status.paid')}</span></td></tr>"
+    },
+    {
+      "key": "dashboardDetailPage.newOrders.status.paid",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 52,
+      "context": "<tr><td className=\"px-4 py-2\">{t('dashboardDetailPage.newOrders.order790')}</td><td className=\"px-4 py-2\">{t('dashboardDetailPage.newOrders.freshBitesMeal')}</td><td className=\"px-4 py-2\">$120.00</td><td className=\"px-4 py-2\"><span className=\"px-2 py-0.5 bg-green-100 text-green-700 rounded-full text-xs\">{t('dashboardDetailPage.newOrders.status.paid')}</span></td></tr>"
+    },
+    {
+      "key": "dashboardDetailPage.newOrders.order791",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 53,
+      "context": "<tr><td className=\"px-4 py-2\">{t('dashboardDetailPage.newOrders.order791')}</td><td className=\"px-4 py-2\">{t('dashboardDetailPage.newOrders.artFunPack')}</td><td className=\"px-4 py-2\">$25.50</td><td className=\"px-4 py-2\"><span className=\"px-2 py-0.5 bg-yellow-100 text-yellow-700 rounded-full text-xs\">{t('dashboardDetailPage.newOrders.status.pending')}</span></td></tr>"
+    },
+    {
+      "key": "dashboardDetailPage.newOrders.artFunPack",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 53,
+      "context": "<tr><td className=\"px-4 py-2\">{t('dashboardDetailPage.newOrders.order791')}</td><td className=\"px-4 py-2\">{t('dashboardDetailPage.newOrders.artFunPack')}</td><td className=\"px-4 py-2\">$25.50</td><td className=\"px-4 py-2\"><span className=\"px-2 py-0.5 bg-yellow-100 text-yellow-700 rounded-full text-xs\">{t('dashboardDetailPage.newOrders.status.pending')}</span></td></tr>"
+    },
+    {
+      "key": "dashboardDetailPage.newOrders.status.pending",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 53,
+      "context": "<tr><td className=\"px-4 py-2\">{t('dashboardDetailPage.newOrders.order791')}</td><td className=\"px-4 py-2\">{t('dashboardDetailPage.newOrders.artFunPack')}</td><td className=\"px-4 py-2\">$25.50</td><td className=\"px-4 py-2\"><span className=\"px-2 py-0.5 bg-yellow-100 text-yellow-700 rounded-full text-xs\">{t('dashboardDetailPage.newOrders.status.pending')}</span></td></tr>"
+    },
+    {
+      "key": "dashboardDetailPage.newOrders.totalThisWeek",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 57,
+      "context": "<p className=\"font-medium text-amber-700\">{t('dashboardDetailPage.newOrders.totalThisWeek', { count: 12 })}</p>"
+    },
+    {
+      "key": "dashboardDetailPage.openJobs.currentPositions",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 67,
+      "context": "<p className=\"font-semibold text-lg\">{t('dashboardDetailPage.openJobs.currentPositions')}</p>"
+    },
+    {
+      "key": "dashboardDetailPage.openJobs.leadEducatorGeneva",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 70,
+      "context": "<p className=\"font-medium text-swiss-teal\">{t('dashboardDetailPage.openJobs.leadEducatorGeneva')}</p>"
+    },
+    {
+      "key": "dashboardDetailPage.openJobs.applications",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 71,
+      "context": "<p className=\"text-xs text-gray-500\">{t('dashboardDetailPage.openJobs.applications', { count: 7 })} | {t('dashboardDetailPage.openJobs.status.open')}</p>"
+    },
+    {
+      "key": "dashboardDetailPage.openJobs.status.open",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 71,
+      "context": "<p className=\"text-xs text-gray-500\">{t('dashboardDetailPage.openJobs.applications', { count: 7 })} | {t('dashboardDetailPage.openJobs.status.open')}</p>"
+    },
+    {
+      "key": "dashboardDetailPage.openJobs.assistantEducatorLausanne",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 74,
+      "context": "<p className=\"font-medium text-swiss-teal\">{t('dashboardDetailPage.openJobs.assistantEducatorLausanne')}</p>"
+    },
+    {
+      "key": "dashboardDetailPage.openJobs.applications",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 75,
+      "context": "<p className=\"text-xs text-gray-500\">{t('dashboardDetailPage.openJobs.applications', { count: 3 })} | {t('dashboardDetailPage.openJobs.status.open')}</p>"
+    },
+    {
+      "key": "dashboardDetailPage.openJobs.status.open",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 75,
+      "context": "<p className=\"text-xs text-gray-500\">{t('dashboardDetailPage.openJobs.applications', { count: 3 })} | {t('dashboardDetailPage.openJobs.status.open')}</p>"
+    },
+    {
+      "key": "dashboardDetailPage.openJobs.daycareDirectorZurich",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 78,
+      "context": "<p className=\"font-medium text-swiss-teal\">{t('dashboardDetailPage.openJobs.daycareDirectorZurich')}</p>"
+    },
+    {
+      "key": "dashboardDetailPage.openJobs.applications",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 79,
+      "context": "<p className=\"text-xs text-gray-500\">{t('dashboardDetailPage.openJobs.applications', { count: 1 })} | {t('dashboardDetailPage.openJobs.status.interviewing')}</p>"
+    },
+    {
+      "key": "dashboardDetailPage.openJobs.status.interviewing",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 79,
+      "context": "<p className=\"text-xs text-gray-500\">{t('dashboardDetailPage.openJobs.applications', { count: 1 })} | {t('dashboardDetailPage.openJobs.status.interviewing')}</p>"
+    },
+    {
+      "key": "dashboardDetailPage.openJobs.totalOpenPositions",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 83,
+      "context": "<p className=\"font-medium text-swiss-teal\">{t('dashboardDetailPage.openJobs.totalOpenPositions', { count: 5 })}</p>"
+    },
+    {
+      "key": "dashboardDetailPage.pageViews.keyMetrics",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 93,
+      "context": "<p className=\"font-semibold text-lg\">{t('dashboardDetailPage.pageViews.keyMetrics')}</p>"
+    },
+    {
+      "key": "dashboardDetailPage.pageViews.totalToday",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 95,
+      "context": "<div className=\"p-3 bg-gray-100 rounded\"><strong>{t('dashboardDetailPage.pageViews.totalToday')}</strong> 2,345</div>"
+    },
+    {
+      "key": "dashboardDetailPage.pageViews.uniqueVisitors",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 96,
+      "context": "<div className=\"p-3 bg-gray-100 rounded\"><strong>{t('dashboardDetailPage.pageViews.uniqueVisitors')}</strong> 867</div>"
+    },
+    {
+      "key": "dashboardDetailPage.pageViews.mostViewed",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 97,
+      "context": "<div className=\"p-3 bg-gray-100 rounded\"><strong>{t('dashboardDetailPage.pageViews.mostViewed')}</strong> {t('dashboardDetailPage.pageViews.dashboardViews')}</div>"
+    },
+    {
+      "key": "dashboardDetailPage.pageViews.dashboardViews",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 97,
+      "context": "<div className=\"p-3 bg-gray-100 rounded\"><strong>{t('dashboardDetailPage.pageViews.mostViewed')}</strong> {t('dashboardDetailPage.pageViews.dashboardViews')}</div>"
+    },
+    {
+      "key": "dashboardDetailPage.pageViews.avgSession",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 98,
+      "context": "<div className=\"p-3 bg-gray-100 rounded\"><strong>{t('dashboardDetailPage.pageViews.avgSession')}</strong> {t('dashboardDetailPage.pageViews.sessionDuration')}</div>"
+    },
+    {
+      "key": "dashboardDetailPage.pageViews.sessionDuration",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 98,
+      "context": "<div className=\"p-3 bg-gray-100 rounded\"><strong>{t('dashboardDetailPage.pageViews.avgSession')}</strong> {t('dashboardDetailPage.pageViews.sessionDuration')}</div>"
+    },
+    {
+      "key": "dashboardDetailPage.pageViews.mockChartText",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 101,
+      "context": "{t('dashboardDetailPage.pageViews.mockChartText')}"
+    },
+    {
+      "key": "dashboardDetailPage.defaultTitle",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 119,
+      "context": ": t('dashboardDetailPage.defaultTitle');"
+    },
+    {
+      "key": "buttons.goBack",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 124,
+      "context": "<Button variant=\"ghost\" size=\"sm\" onClick={() => navigate('/dashboard')} aria-label={t('buttons.goBack')}>"
+    },
+    {
+      "key": "dashboardDetailPage.detailsFor",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 127,
+      "context": "<h1 className=\"text-3xl font-bold text-swiss-charcoal\">{t('dashboardDetailPage.detailsFor', { pageDisplayTitle })}</h1>"
+    },
+    {
+      "key": "dashboardDetailPage.detailsFor",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 146,
+      "context": "{t('dashboardDetailPage.detailsFor', { pageDisplayTitle })}"
+    },
+    {
+      "key": "dashboardDetailPage.noSpecificView",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 149,
+      "context": "{t('dashboardDetailPage.noSpecificView', { pageDisplayTitle })}"
+    },
+    {
+      "key": "buttons.goBack",
+      "file": "pages/DashboardDetailPage.tsx",
+      "line": 156,
+      "context": "{t('buttons.goBack')}"
+    },
+    {
+      "key": "common:common.perMonth",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 83,
+      "context": "const priceLabel = t('common:common.perMonth');"
+    },
+    {
+      "key": "common:common.perMonth",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 83,
+      "context": "const priceLabel = t('common:common.perMonth');"
+    },
+    {
+      "key": "common:common.perYear",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 89,
+      "context": "annualPlanText: `CHF ${plan.price.annually} ${t('common:common.perYear')} (${t('common:common.save10Percent')})`,"
+    },
+    {
+      "key": "common:common.save10Percent",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 89,
+      "context": "annualPlanText: `CHF ${plan.price.annually} ${t('common:common.perYear')} (${t('common:common.save10Percent')})`,"
+    },
+    {
+      "key": "common:common.perYear",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 89,
+      "context": "annualPlanText: `CHF ${plan.price.annually} ${t('common:common.perYear')} (${t('common:common.save10Percent')})`,"
+    },
+    {
+      "key": "common:common.save10Percent",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 89,
+      "context": "annualPlanText: `CHF ${plan.price.annually} ${t('common:common.perYear')} (${t('common:common.save10Percent')})`,"
+    },
+    {
+      "key": "common:common.perMonth",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 101,
+      "context": "const priceLabel = t('common:common.perMonth');"
+    },
+    {
+      "key": "common:common.perMonth",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 101,
+      "context": "const priceLabel = t('common:common.perMonth');"
+    },
+    {
+      "key": "common:common.perYear",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 107,
+      "context": "annualPlanText: `CHF ${plan.price.annually} ${t('common:common.perYear')} (${t('common:common.save10Percent')})`,"
+    },
+    {
+      "key": "common:common.save10Percent",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 107,
+      "context": "annualPlanText: `CHF ${plan.price.annually} ${t('common:common.perYear')} (${t('common:common.save10Percent')})`,"
+    },
+    {
+      "key": "common:common.perYear",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 107,
+      "context": "annualPlanText: `CHF ${plan.price.annually} ${t('common:common.perYear')} (${t('common:common.save10Percent')})`,"
+    },
+    {
+      "key": "common:common.save10Percent",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 107,
+      "context": "annualPlanText: `CHF ${plan.price.annually} ${t('common:common.perYear')} (${t('common:common.save10Percent')})`,"
+    },
+    {
+      "key": "common:common.perMonth",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 120,
+      "context": "monthly: `CHF ${monthlyPrice} ${t('common:common.perMonth')}`,"
+    },
+    {
+      "key": "common:common.perMonth",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 120,
+      "context": "monthly: `CHF ${monthlyPrice} ${t('common:common.perMonth')}`,"
+    },
+    {
+      "key": "common:common.perYear",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 121,
+      "context": "annual: `CHF ${annualPrice} ${t('common:common.perYear')} (${t('common:common.save10Percent')})`"
+    },
+    {
+      "key": "common:common.save10Percent",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 121,
+      "context": "annual: `CHF ${annualPrice} ${t('common:common.perYear')} (${t('common:common.save10Percent')})`"
+    },
+    {
+      "key": "common:common.perYear",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 121,
+      "context": "annual: `CHF ${annualPrice} ${t('common:common.perYear')} (${t('common:common.save10Percent')})`"
+    },
+    {
+      "key": "common:common.save10Percent",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 121,
+      "context": "annual: `CHF ${annualPrice} ${t('common:common.perYear')} (${t('common:common.save10Percent')})`"
+    },
+    {
+      "key": "common:common.perMonth",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 126,
+      "context": "perMonth: t('common:common.perMonth'),"
+    },
+    {
+      "key": "common:common.perMonth",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 126,
+      "context": "perMonth: t('common:common.perMonth'),"
+    },
+    {
+      "key": "common:common.perYear",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 127,
+      "context": "perYear: t('common:common.perYear'),"
+    },
+    {
+      "key": "common:common.perYear",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 127,
+      "context": "perYear: t('common:common.perYear'),"
+    },
+    {
+      "key": "common:common.save10Percent",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 128,
+      "context": "save10Percent: t('common:common.save10Percent')"
+    },
+    {
+      "key": "common:common.save10Percent",
+      "file": "hooks/usePricingTranslations.ts",
+      "line": 128,
+      "context": "save10Percent: t('common:common.save10Percent')"
+    },
+    {
+      "key": "notificationContext.useNotificationsError",
+      "file": "contexts/NotificationContext.tsx",
+      "line": 48,
+      "context": "throw new Error(t('notificationContext.useNotificationsError'));"
+    },
+    {
+      "key": "messagingContext.userNotLoggedIn",
+      "file": "contexts/MessagingContext.tsx",
+      "line": 171,
+      "context": "if (!currentUser) throw new Error(t(\"messagingContext.userNotLoggedIn\"));"
+    },
+    {
+      "key": "messagingContext.userNotLoggedIn",
+      "file": "contexts/MessagingContext.tsx",
+      "line": 181,
+      "context": "if (!currentUser) throw new Error(t(\"messagingContext.userNotLoggedIn\"));"
+    },
+    {
+      "key": "messagingContext.useMessagingError",
+      "file": "contexts/MessagingContext.tsx",
+      "line": 248,
+      "context": "throw new Error(t('messagingContext.useMessagingError'));"
+    },
+    {
+      "key": "cartContext.useCartError",
+      "file": "contexts/CartContext.tsx",
+      "line": 136,
+      "context": "throw new Error(t('cartContext.useCartError'));"
+    },
+    {
+      "key": "appName",
+      "file": "contexts/AppContext.tsx",
+      "line": 114,
+      "context": "document.title = i18n.t('appName');"
+    },
+    {
+      "key": "appName",
+      "file": "contexts/AppContext.tsx",
+      "line": 120,
+      "context": "document.title = i18n.t('appName');"
+    },
+    {
+      "key": "appName",
+      "file": "contexts/AppContext.tsx",
+      "line": 124,
+      "context": "document.title = i18n.t('appName');"
+    },
+    {
+      "key": "appContext.useAppContextError",
+      "file": "contexts/AppContext.tsx",
+      "line": 318,
+      "context": "throw new Error(t('appContext.useAppContextError'));"
+    },
+    {
+      "key": "supplierSupportPage.ticketSubmittedAlert",
+      "file": "pages/supplier/SupplierSupportPage.tsx",
+      "line": 46,
+      "context": "alert(t('supplierSupportPage.ticketSubmittedAlert'));"
+    },
+    {
+      "key": "sidebar.support",
+      "file": "pages/supplier/SupplierSupportPage.tsx",
+      "line": 55,
+      "context": "{t('sidebar.support')}"
+    },
+    {
+      "key": "supportPage.faqTitle",
+      "file": "pages/supplier/SupplierSupportPage.tsx",
+      "line": 61,
+      "context": "{t('supportPage.faqTitle')}"
+    },
+    {
+      "key": "supportPage.furtherAssistanceTitle",
+      "file": "pages/supplier/SupplierSupportPage.tsx",
+      "line": 65,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-2\">{t('supportPage.furtherAssistanceTitle')}</h2>"
+    },
+    {
+      "key": "supportPage.furtherAssistanceText.0",
+      "file": "pages/supplier/SupplierSupportPage.tsx",
+      "line": 66,
+      "context": "<p className=\"text-gray-600 text-sm\">{t('supportPage.furtherAssistanceText.0')} <a href=\"mailto:support@procrechesolutions.com\" className=\"text-swiss-mint hover:underline\">{t('supportPage.furtherAssistanceText.1')}</a>.</p>"
+    },
+    {
+      "key": "supportPage.furtherAssistanceText.1",
+      "file": "pages/supplier/SupplierSupportPage.tsx",
+      "line": 66,
+      "context": "<p className=\"text-gray-600 text-sm\">{t('supportPage.furtherAssistanceText.0')} <a href=\"mailto:support@procrechesolutions.com\" className=\"text-swiss-mint hover:underline\">{t('supportPage.furtherAssistanceText.1')}</a>.</p>"
+    },
+    {
+      "key": "supportPage.submitTicketTitle",
+      "file": "pages/supplier/SupplierSupportPage.tsx",
+      "line": 71,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-4\">{t('supportPage.submitTicketTitle')}</h2>"
+    },
+    {
+      "key": "supportPage.ticketForm.subjectLabel",
+      "file": "pages/supplier/SupplierSupportPage.tsx",
+      "line": 74,
+      "context": "<label htmlFor=\"ticketSubject\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('supportPage.ticketForm.subjectLabel')}</label>"
+    },
+    {
+      "key": "supplierSupportPage.ticketForm.subjectPlaceholder",
+      "file": "pages/supplier/SupplierSupportPage.tsx",
+      "line": 82,
+      "context": "placeholder={t('supplierSupportPage.ticketForm.subjectPlaceholder')}"
+    },
+    {
+      "key": "supportPage.ticketForm.messageLabel",
+      "file": "pages/supplier/SupplierSupportPage.tsx",
+      "line": 86,
+      "context": "<label htmlFor=\"ticketMessage\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('supportPage.ticketForm.messageLabel')}</label>"
+    },
+    {
+      "key": "supplierSupportPage.ticketForm.messagePlaceholder",
+      "file": "pages/supplier/SupplierSupportPage.tsx",
+      "line": 94,
+      "context": "placeholder={t('supplierSupportPage.ticketForm.messagePlaceholder')}"
+    },
+    {
+      "key": "common:buttons.submitTicket",
+      "file": "pages/supplier/SupplierSupportPage.tsx",
+      "line": 98,
+      "context": "<Button type=\"submit\" variant=\"primary\">{t('common:buttons.submitTicket')}</Button>"
+    },
+    {
+      "key": "common:buttons.submitTicket",
+      "file": "pages/supplier/SupplierSupportPage.tsx",
+      "line": 98,
+      "context": "<Button type=\"submit\" variant=\"primary\">{t('common:buttons.submitTicket')}</Button>"
+    },
+    {
+      "key": "supplierProductListingsPage.title",
+      "file": "pages/supplier/SupplierProductListingsPage.tsx",
+      "line": 52,
+      "context": "<h1 className=\"text-3xl font-bold text-swiss-charcoal\">{t('supplierProductListingsPage.title')}</h1>"
+    },
+    {
+      "key": "supplierProductListingsPage.addProductAlert",
+      "file": "pages/supplier/SupplierProductListingsPage.tsx",
+      "line": 53,
+      "context": "<Button variant=\"primary\" leftIcon={PlusCircleIcon} onClick={() => alert(t('supplierProductListingsPage.addProductAlert'))}>"
+    },
+    {
+      "key": "supplierProductListingsPage.addProductButton",
+      "file": "pages/supplier/SupplierProductListingsPage.tsx",
+      "line": 54,
+      "context": "{t('supplierProductListingsPage.addProductButton')}"
+    },
+    {
+      "key": "supplierProductListingsPage.searchPlaceholder",
+      "file": "pages/supplier/SupplierProductListingsPage.tsx",
+      "line": 62,
+      "context": "placeholder={t('supplierProductListingsPage.searchPlaceholder')}"
+    },
+    {
+      "key": "supplierProductListingsPage.table.product",
+      "file": "pages/supplier/SupplierProductListingsPage.tsx",
+      "line": 74,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('supplierProductListingsPage.table.product')}</th>"
+    },
+    {
+      "key": "supplierProductListingsPage.table.price",
+      "file": "pages/supplier/SupplierProductListingsPage.tsx",
+      "line": 75,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('supplierProductListingsPage.table.price')}</th>"
+    },
+    {
+      "key": "supplierProductListingsPage.table.stock",
+      "file": "pages/supplier/SupplierProductListingsPage.tsx",
+      "line": 76,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('supplierProductListingsPage.table.stock')}</th>"
+    },
+    {
+      "key": "supplierProductListingsPage.table.visibility",
+      "file": "pages/supplier/SupplierProductListingsPage.tsx",
+      "line": 77,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('supplierProductListingsPage.table.visibility')}</th>"
+    },
+    {
+      "key": "supplierProductListingsPage.table.actions",
+      "file": "pages/supplier/SupplierProductListingsPage.tsx",
+      "line": 78,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('supplierProductListingsPage.table.actions')}</th>"
+    },
+    {
+      "key": "supplierProductListingsPage.emptyState",
+      "file": "pages/supplier/SupplierProductListingsPage.tsx",
+      "line": 114,
+      "context": "{myProducts.length === 0 && <p className=\"text-center text-gray-500 py-8\">{t('supplierProductListingsPage.emptyState')}</p>}"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.unknownProvider",
+      "file": "pages/supplier/SupplierOrdersPage.tsx",
+      "line": 30,
+      "context": "return org ? org.name : t('foundationOrdersAppointmentsPage.unknownProvider');"
+    },
+    {
+      "key": "supplierOrdersPage.title",
+      "file": "pages/supplier/SupplierOrdersPage.tsx",
+      "line": 58,
+      "context": "<h1 className=\"text-3xl font-bold text-swiss-charcoal\">{t('supplierOrdersPage.title')}</h1>"
+    },
+    {
+      "key": "supplierOrdersPage.filterByStatus",
+      "file": "pages/supplier/SupplierOrdersPage.tsx",
+      "line": 61,
+      "context": "<span className=\"text-sm font-medium mr-2\">{t('supplierOrdersPage.filterByStatus')}:</span>"
+    },
+    {
+      "key": "filters.all",
+      "file": "pages/supplier/SupplierOrdersPage.tsx",
+      "line": 69,
+      "context": "{status === 'All' ? t('filters.all') : t(`orderStatus.${status.toLowerCase().replace(/\\s/g, '')}` as const, status)}"
+    },
+    {
+      "key": "supplierOrdersPage.table.orderId",
+      "file": "pages/supplier/SupplierOrdersPage.tsx",
+      "line": 79,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('supplierOrdersPage.table.orderId')}</th>"
+    },
+    {
+      "key": "supplierOrdersPage.table.foundation",
+      "file": "pages/supplier/SupplierOrdersPage.tsx",
+      "line": 80,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('supplierOrdersPage.table.foundation')}</th>"
+    },
+    {
+      "key": "supplierOrdersPage.table.date",
+      "file": "pages/supplier/SupplierOrdersPage.tsx",
+      "line": 81,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('supplierOrdersPage.table.date')}</th>"
+    },
+    {
+      "key": "supplierOrdersPage.table.total",
+      "file": "pages/supplier/SupplierOrdersPage.tsx",
+      "line": 82,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('supplierOrdersPage.table.total')}</th>"
+    },
+    {
+      "key": "supplierOrdersPage.table.status",
+      "file": "pages/supplier/SupplierOrdersPage.tsx",
+      "line": 83,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('supplierOrdersPage.table.status')}</th>"
+    },
+    {
+      "key": "supplierOrdersPage.emptyState",
+      "file": "pages/supplier/SupplierOrdersPage.tsx",
+      "line": 102,
+      "context": "{filteredOrders.length === 0 && <p className=\"text-center text-gray-500 py-8\">{t('supplierOrdersPage.emptyState')}</p>}"
+    },
+    {
+      "key": "supplierDashboard.noSalesYet",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 29,
+      "context": "if (myOrders.length === 0) return t('supplierDashboard.noSalesYet', 'No sales yet');"
+    },
+    {
+      "key": "supplierDashboard.noSalesYet",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 36,
+      "context": "if (productQuantities.size === 0) return t('supplierDashboard.noSalesYet', 'No sales yet');"
+    },
+    {
+      "key": "supplierDashboard.title",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 86,
+      "context": "{t('supplierDashboard.title')}"
+    },
+    {
+      "key": "supplierDashboard.welcomeMessage",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 88,
+      "context": "<p className=\"text-gray-500 mt-1\">{t('supplierDashboard.welcomeMessage', { name: currentUser?.name?.split(' ')[0] })}</p>"
+    },
+    {
+      "key": "supplierDashboard.widgets.sales.title",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 94,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-4\">{t('supplierDashboard.widgets.sales.title')}</h2>"
+    },
+    {
+      "key": "supplierDashboard.widgets.sales.totalOrders",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 97,
+      "context": "<span className=\"text-gray-600\">{t('supplierDashboard.widgets.sales.totalOrders')}</span>"
+    },
+    {
+      "key": "supplierDashboard.widgets.sales.revenueMonth",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 101,
+      "context": "<span className=\"text-gray-600\">{t('supplierDashboard.widgets.sales.revenueMonth')}</span>"
+    },
+    {
+      "key": "supplierDashboard.widgets.sales.topSelling",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 105,
+      "context": "<span className=\"text-gray-600\">{t('supplierDashboard.widgets.sales.topSelling')}</span>"
+    },
+    {
+      "key": "supplierDashboard.widgets.sales.fulfillmentRate",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 109,
+      "context": "<span className=\"text-gray-600\">{t('supplierDashboard.widgets.sales.fulfillmentRate')}</span>"
+    },
+    {
+      "key": "supplierDashboard.widgets.sales.button",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 113,
+      "context": "<Button variant=\"secondary\" size=\"sm\" className=\"w-full mt-5\" onClick={() => navigate('/supplier/analytics')}>{t('supplierDashboard.widgets.sales.button')}</Button>"
+    },
+    {
+      "key": "supplierDashboard.widgets.products.title",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 118,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-4\">{t('supplierDashboard.widgets.products.title')}</h2>"
+    },
+    {
+      "key": "supplierDashboard.widgets.products.active",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 121,
+      "context": "<span className=\"text-gray-600\">{t('supplierDashboard.widgets.products.active')}</span>"
+    },
+    {
+      "key": "supplierDashboard.widgets.products.pending",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 125,
+      "context": "<span className=\"text-gray-600\">{t('supplierDashboard.widgets.products.pending')}</span>"
+    },
+    {
+      "key": "supplierDashboard.widgets.products.lowStock",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 130,
+      "context": "<p className=\"text-sm font-medium text-gray-600 flex items-center\"><ExclamationTriangleIcon className=\"w-4 h-4 mr-1 text-red-500\"/>{t('supplierDashboard.widgets.products.lowStock')}</p>"
+    },
+    {
+      "key": "supplierDashboard.widgets.products.button",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 138,
+      "context": "{t('supplierDashboard.widgets.products.button')}"
+    },
+    {
+      "key": "supplierDashboard.widgets.orders.title",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 144,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-4\">{t('supplierDashboard.widgets.orders.title')}</h2>"
+    },
+    {
+      "key": "supplierDashboard.widgets.orders.pending",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 147,
+      "context": "<span className=\"text-gray-600\">{t('supplierDashboard.widgets.orders.pending')}</span>"
+    },
+    {
+      "key": "supplierDashboard.widgets.orders.toFulfill",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 152,
+      "context": "<p className=\"text-sm font-medium text-gray-600\">{t('supplierDashboard.widgets.orders.toFulfill')}</p>"
+    },
+    {
+      "key": "supplierDashboard.widgets.orders.button",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 160,
+      "context": "{t('supplierDashboard.widgets.orders.button')}"
+    },
+    {
+      "key": "supplierDashboard.recentOrdersTitle",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 167,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-4\">{t('supplierDashboard.recentOrdersTitle')}</h2>"
+    },
+    {
+      "key": "supplierDashboard.noRecentOrders",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 169,
+      "context": "<p className=\"text-gray-500 text-center py-4\">{t('supplierDashboard.noRecentOrders')}</p>"
+    },
+    {
+      "key": "supplierDashboard.recentOrdersTable.id",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 175,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('supplierDashboard.recentOrdersTable.id')}</th>"
+    },
+    {
+      "key": "supplierDashboard.recentOrdersTable.creche",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 176,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('supplierDashboard.recentOrdersTable.creche')}</th>"
+    },
+    {
+      "key": "supplierDashboard.recentOrdersTable.date",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 177,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('supplierDashboard.recentOrdersTable.date')}</th>"
+    },
+    {
+      "key": "supplierDashboard.recentOrdersTable.total",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 178,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('supplierDashboard.recentOrdersTable.total')}</th>"
+    },
+    {
+      "key": "supplierDashboard.recentOrdersTable.status",
+      "file": "pages/supplier/SupplierDashboardPage.tsx",
+      "line": 179,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('supplierDashboard.recentOrdersTable.status')}</th>"
+    },
+    {
+      "key": "supplierAnalyticsPage.mockChartText",
+      "file": "pages/supplier/SupplierAnalyticsPage.tsx",
+      "line": 20,
+      "context": "<p className=\"text-xs text-gray-400\">{t('supplierAnalyticsPage.mockChartText', { type })}</p>"
+    },
+    {
+      "key": "sidebar.analytics",
+      "file": "pages/supplier/SupplierAnalyticsPage.tsx",
+      "line": 33,
+      "context": "<h1 className=\"text-3xl font-bold text-swiss-charcoal mb-4 md:mb-0\">{t('sidebar.analytics')}</h1>"
+    },
+    {
+      "key": "supplierAnalyticsPage.datePickerLabel",
+      "file": "pages/supplier/SupplierAnalyticsPage.tsx",
+      "line": 35,
+      "context": "<input type=\"date\" className={`${STANDARD_INPUT_FIELD} w-auto`} defaultValue={new Date().toISOString().split('T')[0]} aria-label={t('supplierAnalyticsPage.datePickerLabel')}/>"
+    },
+    {
+      "key": "supplierAnalyticsPage.exportCsvAlert",
+      "file": "pages/supplier/SupplierAnalyticsPage.tsx",
+      "line": 36,
+      "context": "<Button variant=\"outline\" size=\"md\" leftIcon={ArrowDownTrayIcon} onClick={() => alert(t('supplierAnalyticsPage.exportCsvAlert'))}>"
+    },
+    {
+      "key": "supplierAnalyticsPage.exportCsvButton",
+      "file": "pages/supplier/SupplierAnalyticsPage.tsx",
+      "line": 37,
+      "context": "{t('supplierAnalyticsPage.exportCsvButton')}"
+    },
+    {
+      "key": "supplierAnalyticsPage.orderRequestsPerWeek",
+      "file": "pages/supplier/SupplierAnalyticsPage.tsx",
+      "line": 44,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-3\">{t('supplierAnalyticsPage.orderRequestsPerWeek')}</h2>"
+    },
+    {
+      "key": "supplierAnalyticsPage.topViewedProducts",
+      "file": "pages/supplier/SupplierAnalyticsPage.tsx",
+      "line": 48,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-3\">{t('supplierAnalyticsPage.topViewedProducts')}</h2>"
+    },
+    {
+      "key": "supplierAnalyticsPage.requestsByCanton",
+      "file": "pages/supplier/SupplierAnalyticsPage.tsx",
+      "line": 55,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-3\">{t('supplierAnalyticsPage.requestsByCanton')}</h2>"
+    },
+    {
+      "key": "supplierAnalyticsPage.promoCodePerformance",
+      "file": "pages/supplier/SupplierAnalyticsPage.tsx",
+      "line": 61,
+      "context": "{t('supplierAnalyticsPage.promoCodePerformance')}"
+    },
+    {
+      "key": "supplierAnalyticsPage.table.code",
+      "file": "pages/supplier/SupplierAnalyticsPage.tsx",
+      "line": 67,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('supplierAnalyticsPage.table.code')}</th>"
+    },
+    {
+      "key": "supplierAnalyticsPage.table.uses",
+      "file": "pages/supplier/SupplierAnalyticsPage.tsx",
+      "line": 68,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('supplierAnalyticsPage.table.uses')}</th>"
+    },
+    {
+      "key": "supplierAnalyticsPage.table.estRevenueImpact",
+      "file": "pages/supplier/SupplierAnalyticsPage.tsx",
+      "line": 69,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('supplierAnalyticsPage.table.estRevenueImpact')}</th>"
+    },
+    {
+      "key": "serviceProviderSupportPage.ticketSubmittedAlert",
+      "file": "pages/service-provider/ServiceProviderSupportPage.tsx",
+      "line": 46,
+      "context": "alert(t('serviceProviderSupportPage.ticketSubmittedAlert'));"
+    },
+    {
+      "key": "sidebar.support",
+      "file": "pages/service-provider/ServiceProviderSupportPage.tsx",
+      "line": 55,
+      "context": "{t('sidebar.support')}"
+    },
+    {
+      "key": "supportPage.faqTitle",
+      "file": "pages/service-provider/ServiceProviderSupportPage.tsx",
+      "line": 61,
+      "context": "{t('supportPage.faqTitle')}"
+    },
+    {
+      "key": "supportPage.furtherAssistanceTitle",
+      "file": "pages/service-provider/ServiceProviderSupportPage.tsx",
+      "line": 65,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-2\">{t('supportPage.furtherAssistanceTitle')}</h2>"
+    },
+    {
+      "key": "supportPage.furtherAssistanceText.0",
+      "file": "pages/service-provider/ServiceProviderSupportPage.tsx",
+      "line": 66,
+      "context": "<p className=\"text-gray-600 text-sm\">{t('supportPage.furtherAssistanceText.0')} <a href=\"mailto:support@procrechesolutions.com\" className=\"text-swiss-mint hover:underline\">{t('supportPage.furtherAssistanceText.1')}</a>.</p>"
+    },
+    {
+      "key": "supportPage.furtherAssistanceText.1",
+      "file": "pages/service-provider/ServiceProviderSupportPage.tsx",
+      "line": 66,
+      "context": "<p className=\"text-gray-600 text-sm\">{t('supportPage.furtherAssistanceText.0')} <a href=\"mailto:support@procrechesolutions.com\" className=\"text-swiss-mint hover:underline\">{t('supportPage.furtherAssistanceText.1')}</a>.</p>"
+    },
+    {
+      "key": "supportPage.submitTicketTitle",
+      "file": "pages/service-provider/ServiceProviderSupportPage.tsx",
+      "line": 71,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-4\">{t('supportPage.submitTicketTitle')}</h2>"
+    },
+    {
+      "key": "supportPage.ticketForm.subjectLabel",
+      "file": "pages/service-provider/ServiceProviderSupportPage.tsx",
+      "line": 74,
+      "context": "<label htmlFor=\"ticketSubjectSp\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('supportPage.ticketForm.subjectLabel')}</label>"
+    },
+    {
+      "key": "serviceProviderSupportPage.ticketForm.subjectPlaceholder",
+      "file": "pages/service-provider/ServiceProviderSupportPage.tsx",
+      "line": 82,
+      "context": "placeholder={t('serviceProviderSupportPage.ticketForm.subjectPlaceholder')}"
+    },
+    {
+      "key": "supportPage.ticketForm.messageLabel",
+      "file": "pages/service-provider/ServiceProviderSupportPage.tsx",
+      "line": 86,
+      "context": "<label htmlFor=\"ticketMessageSp\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('supportPage.ticketForm.messageLabel')}</label>"
+    },
+    {
+      "key": "serviceProviderSupportPage.ticketForm.messagePlaceholder",
+      "file": "pages/service-provider/ServiceProviderSupportPage.tsx",
+      "line": 94,
+      "context": "placeholder={t('serviceProviderSupportPage.ticketForm.messagePlaceholder')}"
+    },
+    {
+      "key": "common:buttons.submitTicket",
+      "file": "pages/service-provider/ServiceProviderSupportPage.tsx",
+      "line": 98,
+      "context": "<Button type=\"submit\" variant=\"primary\">{t('common:buttons.submitTicket')}</Button>"
+    },
+    {
+      "key": "common:buttons.submitTicket",
+      "file": "pages/service-provider/ServiceProviderSupportPage.tsx",
+      "line": 98,
+      "context": "<Button type=\"submit\" variant=\"primary\">{t('common:buttons.submitTicket')}</Button>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.unknownProvider",
+      "file": "pages/service-provider/ServiceProviderRequestsPage.tsx",
+      "line": 30,
+      "context": "return MOCK_ORGANIZATIONS.find(o => o.id === orgId)?.name || t('foundationOrdersAppointmentsPage.unknownProvider');"
+    },
+    {
+      "key": "serviceProviderRequestsPage.title",
+      "file": "pages/service-provider/ServiceProviderRequestsPage.tsx",
+      "line": 58,
+      "context": "<h1 className=\"text-3xl font-bold text-swiss-charcoal\">{t('serviceProviderRequestsPage.title')}</h1>"
+    },
+    {
+      "key": "serviceProviderRequestsPage.filterByStatus",
+      "file": "pages/service-provider/ServiceProviderRequestsPage.tsx",
+      "line": 61,
+      "context": "<span className=\"text-sm font-medium mr-2\">{t('serviceProviderRequestsPage.filterByStatus')}:</span>"
+    },
+    {
+      "key": "filters.all",
+      "file": "pages/service-provider/ServiceProviderRequestsPage.tsx",
+      "line": 69,
+      "context": "{status === 'All' ? t('filters.all') : t(`serviceStatus.${status.toLowerCase().replace(/\\s/g, '')}` as const, status)}"
+    },
+    {
+      "key": "serviceProviderRequestsPage.table.requestId",
+      "file": "pages/service-provider/ServiceProviderRequestsPage.tsx",
+      "line": 79,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('serviceProviderRequestsPage.table.requestId')}</th>"
+    },
+    {
+      "key": "serviceProviderRequestsPage.table.foundation",
+      "file": "pages/service-provider/ServiceProviderRequestsPage.tsx",
+      "line": 80,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('serviceProviderRequestsPage.table.foundation')}</th>"
+    },
+    {
+      "key": "serviceProviderRequestsPage.table.service",
+      "file": "pages/service-provider/ServiceProviderRequestsPage.tsx",
+      "line": 81,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('serviceProviderRequestsPage.table.service')}</th>"
+    },
+    {
+      "key": "serviceProviderRequestsPage.table.date",
+      "file": "pages/service-provider/ServiceProviderRequestsPage.tsx",
+      "line": 82,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('serviceProviderRequestsPage.table.date')}</th>"
+    },
+    {
+      "key": "serviceProviderRequestsPage.table.status",
+      "file": "pages/service-provider/ServiceProviderRequestsPage.tsx",
+      "line": 83,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('serviceProviderRequestsPage.table.status')}</th>"
+    },
+    {
+      "key": "serviceProviderRequestsPage.emptyState",
+      "file": "pages/service-provider/ServiceProviderRequestsPage.tsx",
+      "line": 105,
+      "context": "{t('serviceProviderRequestsPage.emptyState')}"
+    },
+    {
+      "key": "serviceProviderListingsPage.card.category",
+      "file": "pages/service-provider/ServiceProviderListingsPage.tsx",
+      "line": 27,
+      "context": "<TagIcon className=\"w-3.5 h-3.5 inline mr-1 opacity-70\" /> {t('serviceProviderListingsPage.card.category')}: {service.category} | <WrenchScrewdriverIcon className=\"w-3.5 h-3.5 inline mr-1 opacity-70\" /> {t('serviceProviderListingsPage.card.delivery')}: {service.deliveryType || 'N/A'}"
+    },
+    {
+      "key": "serviceProviderListingsPage.card.delivery",
+      "file": "pages/service-provider/ServiceProviderListingsPage.tsx",
+      "line": 27,
+      "context": "<TagIcon className=\"w-3.5 h-3.5 inline mr-1 opacity-70\" /> {t('serviceProviderListingsPage.card.category')}: {service.category} | <WrenchScrewdriverIcon className=\"w-3.5 h-3.5 inline mr-1 opacity-70\" /> {t('serviceProviderListingsPage.card.delivery')}: {service.deliveryType || 'N/A'}"
+    },
+    {
+      "key": "common:buttons.edit",
+      "file": "pages/service-provider/ServiceProviderListingsPage.tsx",
+      "line": 32,
+      "context": "<Button variant=\"outline\" size=\"sm\" leftIcon={PencilSquareIcon} onClick={() => onEdit(service)} className=\"flex-1\">{t('common:buttons.edit')}</Button>"
+    },
+    {
+      "key": "common:buttons.edit",
+      "file": "pages/service-provider/ServiceProviderListingsPage.tsx",
+      "line": 32,
+      "context": "<Button variant=\"outline\" size=\"sm\" leftIcon={PencilSquareIcon} onClick={() => onEdit(service)} className=\"flex-1\">{t('common:buttons.edit')}</Button>"
+    },
+    {
+      "key": "common:buttons.delete",
+      "file": "pages/service-provider/ServiceProviderListingsPage.tsx",
+      "line": 33,
+      "context": "<Button variant=\"danger\" size=\"sm\" leftIcon={TrashIcon} onClick={() => onDelete(service.id)} className=\"flex-1\">{t('common:buttons.delete')}</Button>"
+    },
+    {
+      "key": "common:buttons.delete",
+      "file": "pages/service-provider/ServiceProviderListingsPage.tsx",
+      "line": 33,
+      "context": "<Button variant=\"danger\" size=\"sm\" leftIcon={TrashIcon} onClick={() => onDelete(service.id)} className=\"flex-1\">{t('common:buttons.delete')}</Button>"
+    },
+    {
+      "key": "serviceProviderListingsPage.confirmDelete",
+      "file": "pages/service-provider/ServiceProviderListingsPage.tsx",
+      "line": 108,
+      "context": "if (window.confirm(t('serviceProviderListingsPage.confirmDelete'))) {"
+    },
+    {
+      "key": "serviceProviderListingsPage.title",
+      "file": "pages/service-provider/ServiceProviderListingsPage.tsx",
+      "line": 123,
+      "context": "<h1 className=\"text-3xl font-bold text-swiss-charcoal mb-4 md:mb-0\">{t('serviceProviderListingsPage.title')}</h1>"
+    },
+    {
+      "key": "serviceProviderListingsPage.addNewServiceButton",
+      "file": "pages/service-provider/ServiceProviderListingsPage.tsx",
+      "line": 125,
+      "context": "{t('serviceProviderListingsPage.addNewServiceButton')}"
+    },
+    {
+      "key": "serviceProviderListingsPage.searchPlaceholder",
+      "file": "pages/service-provider/ServiceProviderListingsPage.tsx",
+      "line": 133,
+      "context": "placeholder={t('serviceProviderListingsPage.searchPlaceholder')}"
+    },
+    {
+      "key": "serviceProviderListingsPage.emptyState.title",
+      "file": "pages/service-provider/ServiceProviderListingsPage.tsx",
+      "line": 151,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-2\">{t('serviceProviderListingsPage.emptyState.title')}</h2>"
+    },
+    {
+      "key": "serviceProviderListingsPage.emptyState.noMatch",
+      "file": "pages/service-provider/ServiceProviderListingsPage.tsx",
+      "line": 153,
+      "context": "{serviceListings.length > 0 ? t('serviceProviderListingsPage.emptyState.noMatch') : t('serviceProviderListingsPage.emptyState.noServicesYet')}"
+    },
+    {
+      "key": "serviceProviderListingsPage.emptyState.noServicesYet",
+      "file": "pages/service-provider/ServiceProviderListingsPage.tsx",
+      "line": 153,
+      "context": "{serviceListings.length > 0 ? t('serviceProviderListingsPage.emptyState.noMatch') : t('serviceProviderListingsPage.emptyState.noServicesYet')}"
+    },
+    {
+      "key": "serviceProviderDashboard.title",
+      "file": "pages/service-provider/ServiceProviderDashboardPage.tsx",
+      "line": 39,
+      "context": "{t('serviceProviderDashboard.title')}"
+    },
+    {
+      "key": "serviceProviderDashboard.welcomeMessage",
+      "file": "pages/service-provider/ServiceProviderDashboardPage.tsx",
+      "line": 41,
+      "context": "<p className=\"text-gray-500 mt-1\">{t('serviceProviderDashboard.welcomeMessage', { name: currentUser?.name?.split(' ')[0] })}</p>"
+    },
+    {
+      "key": "serviceProviderDashboard.widgets.overview.title",
+      "file": "pages/service-provider/ServiceProviderDashboardPage.tsx",
+      "line": 47,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-4\">{t('serviceProviderDashboard.widgets.overview.title')}</h2>"
+    },
+    {
+      "key": "serviceProviderDashboard.widgets.overview.activeRequests",
+      "file": "pages/service-provider/ServiceProviderDashboardPage.tsx",
+      "line": 50,
+      "context": "<span className=\"text-gray-600\">{t('serviceProviderDashboard.widgets.overview.activeRequests')}</span>"
+    },
+    {
+      "key": "serviceProviderDashboard.widgets.overview.completedServices",
+      "file": "pages/service-provider/ServiceProviderDashboardPage.tsx",
+      "line": 54,
+      "context": "<span className=\"text-gray-600\">{t('serviceProviderDashboard.widgets.overview.completedServices')}</span>"
+    },
+    {
+      "key": "serviceProviderDashboard.widgets.overview.upcoming",
+      "file": "pages/service-provider/ServiceProviderDashboardPage.tsx",
+      "line": 58,
+      "context": "<span className=\"text-gray-600\">{t('serviceProviderDashboard.widgets.overview.upcoming')}</span>"
+    },
+    {
+      "key": "serviceProviderDashboard.widgets.overview.customerRating",
+      "file": "pages/service-provider/ServiceProviderDashboardPage.tsx",
+      "line": 62,
+      "context": "<span className=\"text-gray-600\">{t('serviceProviderDashboard.widgets.overview.customerRating')}</span>"
+    },
+    {
+      "key": "serviceProviderDashboard.widgets.overview.button",
+      "file": "pages/service-provider/ServiceProviderDashboardPage.tsx",
+      "line": 70,
+      "context": "{t('serviceProviderDashboard.widgets.overview.button')}"
+    },
+    {
+      "key": "serviceProviderDashboard.widgets.management.title",
+      "file": "pages/service-provider/ServiceProviderDashboardPage.tsx",
+      "line": 76,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-4\">{t('serviceProviderDashboard.widgets.management.title')}</h2>"
+    },
+    {
+      "key": "serviceProviderDashboard.widgets.management.listings",
+      "file": "pages/service-provider/ServiceProviderDashboardPage.tsx",
+      "line": 79,
+      "context": "<span className=\"text-gray-600\">{t('serviceProviderDashboard.widgets.management.listings')}</span>"
+    },
+    {
+      "key": "serviceProviderDashboard.widgets.management.pending",
+      "file": "pages/service-provider/ServiceProviderDashboardPage.tsx",
+      "line": 83,
+      "context": "<span className=\"text-gray-600\">{t('serviceProviderDashboard.widgets.management.pending')}</span>"
+    },
+    {
+      "key": "serviceProviderDashboard.widgets.management.categories",
+      "file": "pages/service-provider/ServiceProviderDashboardPage.tsx",
+      "line": 87,
+      "context": "<p className=\"text-sm font-medium text-gray-600\">{t('serviceProviderDashboard.widgets.management.categories')}</p>"
+    },
+    {
+      "key": "serviceProviderDashboard.widgets.management.button",
+      "file": "pages/service-provider/ServiceProviderDashboardPage.tsx",
+      "line": 96,
+      "context": "{t('serviceProviderDashboard.widgets.management.button')}"
+    },
+    {
+      "key": "serviceProviderDashboard.widgets.appointments.title",
+      "file": "pages/service-provider/ServiceProviderDashboardPage.tsx",
+      "line": 104,
+      "context": "{t('serviceProviderDashboard.widgets.appointments.title')}"
+    },
+    {
+      "key": "serviceProviderDashboard.widgets.appointments.with",
+      "file": "pages/service-provider/ServiceProviderDashboardPage.tsx",
+      "line": 110,
+      "context": "<p className=\"text-sm text-gray-600\">{t('serviceProviderDashboard.widgets.appointments.with', { foundation: appt.foundation })}</p>"
+    },
+    {
+      "key": "serviceProviderDashboard.widgets.appointments.button",
+      "file": "pages/service-provider/ServiceProviderDashboardPage.tsx",
+      "line": 115,
+      "context": "{t('serviceProviderDashboard.widgets.appointments.button')}"
+    },
+    {
+      "key": "supplierAnalyticsPage.mockChartText",
+      "file": "pages/service-provider/ServiceProviderAnalyticsPage.tsx",
+      "line": 20,
+      "context": "<p className=\"text-xs text-gray-400\">{t('supplierAnalyticsPage.mockChartText', { type })}</p>"
+    },
+    {
+      "key": "serviceProviderAnalyticsPage.title",
+      "file": "pages/service-provider/ServiceProviderAnalyticsPage.tsx",
+      "line": 32,
+      "context": "<h1 className=\"text-3xl font-bold text-swiss-charcoal mb-4 md:mb-0\">{t('serviceProviderAnalyticsPage.title')}</h1>"
+    },
+    {
+      "key": "supplierAnalyticsPage.datePickerLabel",
+      "file": "pages/service-provider/ServiceProviderAnalyticsPage.tsx",
+      "line": 34,
+      "context": "<input type=\"date\" className={`${STANDARD_INPUT_FIELD} w-auto`} defaultValue={new Date().toISOString().split('T')[0]} aria-label={t('supplierAnalyticsPage.datePickerLabel')} />"
+    },
+    {
+      "key": "supplierAnalyticsPage.exportCsvAlert",
+      "file": "pages/service-provider/ServiceProviderAnalyticsPage.tsx",
+      "line": 35,
+      "context": "<Button variant=\"outline\" size=\"md\" leftIcon={ArrowDownTrayIcon} onClick={() => alert(t('supplierAnalyticsPage.exportCsvAlert'))}>"
+    },
+    {
+      "key": "supplierAnalyticsPage.exportCsvButton",
+      "file": "pages/service-provider/ServiceProviderAnalyticsPage.tsx",
+      "line": 36,
+      "context": "{t('supplierAnalyticsPage.exportCsvButton')}"
+    },
+    {
+      "key": "serviceProviderAnalyticsPage.serviceRequestsPerWeek",
+      "file": "pages/service-provider/ServiceProviderAnalyticsPage.tsx",
+      "line": 43,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-3\">{t('serviceProviderAnalyticsPage.serviceRequestsPerWeek')}</h2>"
+    },
+    {
+      "key": "serviceProviderAnalyticsPage.topViewedServices",
+      "file": "pages/service-provider/ServiceProviderAnalyticsPage.tsx",
+      "line": 47,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-3\">{t('serviceProviderAnalyticsPage.topViewedServices')}</h2>"
+    },
+    {
+      "key": "serviceProviderAnalyticsPage.requestsByCanton",
+      "file": "pages/service-provider/ServiceProviderAnalyticsPage.tsx",
+      "line": 54,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-3\">{t('serviceProviderAnalyticsPage.requestsByCanton')}</h2>"
+    },
+    {
+      "key": "supplierAnalyticsPage.promoCodePerformance",
+      "file": "pages/service-provider/ServiceProviderAnalyticsPage.tsx",
+      "line": 60,
+      "context": "{t('supplierAnalyticsPage.promoCodePerformance')}"
+    },
+    {
+      "key": "supplierAnalyticsPage.table.code",
+      "file": "pages/service-provider/ServiceProviderAnalyticsPage.tsx",
+      "line": 66,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('supplierAnalyticsPage.table.code')}</th>"
+    },
+    {
+      "key": "supplierAnalyticsPage.table.uses",
+      "file": "pages/service-provider/ServiceProviderAnalyticsPage.tsx",
+      "line": 67,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('supplierAnalyticsPage.table.uses')}</th>"
+    },
+    {
+      "key": "supplierAnalyticsPage.table.estRevenueImpact",
+      "file": "pages/service-provider/ServiceProviderAnalyticsPage.tsx",
+      "line": 68,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('supplierAnalyticsPage.table.estRevenueImpact')}</th>"
+    },
+    {
+      "key": "partnerDetailPage.productOutOfStock",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 40,
+      "context": "alert(t('partnerDetailPage.productOutOfStock', {productName: product.title}));"
+    },
+    {
+      "key": "partnerDetailPage.productAddedToOrder",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 46,
+      "context": "alert(t('partnerDetailPage.productAddedToOrder', {quantity, productName: product.title}));"
+    },
+    {
+      "key": "partnerDetailPage.addToOrderButton",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 77,
+      "context": "{t('partnerDetailPage.addToOrderButton')}"
+    },
+    {
+      "key": "partnerDetailPage.onlyFoundationsRequestService",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 143,
+      "context": "alert(t('partnerDetailPage.onlyFoundationsRequestService'));"
+    },
+    {
+      "key": "partnerDetailPage.requestSubmittedAlert",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 165,
+      "context": "alert(t('partnerDetailPage.requestSubmittedAlert', {serviceName: newRequest.serviceName}));"
+    },
+    {
+      "key": "partnerDetailPage.loadingPartnerDetails",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 172,
+      "context": "<p className=\"mt-4 text-gray-600\">{t('partnerDetailPage.loadingPartnerDetails')}</p>"
+    },
+    {
+      "key": "partnerDetailPage.invalidPartnerIdMessage",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 173,
+      "context": "<p className=\"text-sm text-gray-400\">{t('partnerDetailPage.invalidPartnerIdMessage')}</p>"
+    },
+    {
+      "key": "buttons.goBack",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 181,
+      "context": "{t('buttons.goBack')}"
+    },
+    {
+      "key": "userRoles.Product Supplier",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 194,
+      "context": "<p className=\"text-gray-500\">{partner.type === 'supplier' ? t('userRoles.Product Supplier') : t('userRoles.Service Provider')}</p>"
+    },
+    {
+      "key": "userRoles.Service Provider",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 194,
+      "context": "<p className=\"text-gray-500\">{partner.type === 'supplier' ? t('userRoles.Product Supplier') : t('userRoles.Service Provider')}</p>"
+    },
+    {
+      "key": "buttons.sendMessage",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 204,
+      "context": "{t('buttons.sendMessage')}"
+    },
+    {
+      "key": "partnerDetailPage.contactInfoTitle",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 217,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-3\">{t('partnerDetailPage.contactInfoTitle')}</h2>"
+    },
+    {
+      "key": "partnerDetailPage.directOrderButton",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 231,
+      "context": "{t('partnerDetailPage.directOrderButton')}"
+    },
+    {
+      "key": "partnerDetailPage.aboutTitle",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 237,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-3\">{t('partnerDetailPage.aboutTitle', { partnerName: partner.name })}</h2>"
+    },
+    {
+      "key": "partnerDetailPage.ratingsReviewsTitle",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 242,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-3\">{t('partnerDetailPage.ratingsReviewsTitle')}</h2>"
+    },
+    {
+      "key": "partnerDetailPage.ratingText",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 245,
+      "context": "{partner.rating && <span className=\"ml-2 text-sm text-gray-600\">{t('partnerDetailPage.ratingText', { rating: partner.rating.toFixed(1)})}</span>}"
+    },
+    {
+      "key": "partnerDetailPage.reviewsPlaceholder",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 247,
+      "context": "<p className=\"text-sm text-gray-500\">{t('partnerDetailPage.reviewsPlaceholder')}</p>"
+    },
+    {
+      "key": "sidebar.products",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 255,
+      "context": "{partner.type === 'supplier' ? t('sidebar.products') : t('sidebar.services')}"
+    },
+    {
+      "key": "sidebar.services",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 255,
+      "context": "{partner.type === 'supplier' ? t('sidebar.products') : t('sidebar.services')}"
+    },
+    {
+      "key": "partnerDetailPage.noProductsListed",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 270,
+      "context": ") : <p className=\"text-gray-500\">{t('partnerDetailPage.noProductsListed')}</p>"
+    },
+    {
+      "key": "partnerDetailPage.requestServiceButton",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 287,
+      "context": "{t('partnerDetailPage.requestServiceButton')}"
+    },
+    {
+      "key": "partnerDetailPage.noServicesListed",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 293,
+      "context": ") : <p className=\"text-gray-500\">{t('partnerDetailPage.noServicesListed')}</p>"
+    },
+    {
+      "key": "partnerDetailPage.promoCodeTitle",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 298,
+      "context": "<h3 className=\"text-md font-semibold text-swiss-charcoal mb-2\">{t('partnerDetailPage.promoCodeTitle')}</h3>"
+    },
+    {
+      "key": "partnerDetailPage.promoCodePlaceholder",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 300,
+      "context": "<input type=\"text\" placeholder={t('partnerDetailPage.promoCodePlaceholder')} className={`${STANDARD_INPUT_FIELD} flex-grow`} />"
+    },
+    {
+      "key": "partnerDetailPage.applyPromoButton",
+      "file": "pages/partner/PartnerDetailPage.tsx",
+      "line": 301,
+      "context": "<Button variant=\"outline\" size=\"md\">{t('partnerDetailPage.applyPromoButton')}</Button>"
+    },
+    {
+      "key": "sidebar.supportFAQ",
+      "file": "pages/parent/ParentSupportPage.tsx",
+      "line": 15,
+      "context": "{t('sidebar.supportFAQ')}"
+    },
+    {
+      "key": "supportPage.faqTitle",
+      "file": "pages/parent/ParentSupportPage.tsx",
+      "line": 19,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-4\">{t('supportPage.faqTitle')}</h2>"
+    },
+    {
+      "key": "parentSupportPage.faq.matchingProcess.q",
+      "file": "pages/parent/ParentSupportPage.tsx",
+      "line": 22,
+      "context": "<h3 className=\"font-medium text-gray-800\">{t('parentSupportPage.faq.matchingProcess.q')}</h3>"
+    },
+    {
+      "key": "parentSupportPage.faq.matchingProcess.a",
+      "file": "pages/parent/ParentSupportPage.tsx",
+      "line": 23,
+      "context": "<p className=\"text-gray-600 text-sm\">{t('parentSupportPage.faq.matchingProcess.a')}</p>"
+    },
+    {
+      "key": "parentSupportPage.faq.responseTime.q",
+      "file": "pages/parent/ParentSupportPage.tsx",
+      "line": 26,
+      "context": "<h3 className=\"font-medium text-gray-800\">{t('parentSupportPage.faq.responseTime.q')}</h3>"
+    },
+    {
+      "key": "parentSupportPage.faq.responseTime.a",
+      "file": "pages/parent/ParentSupportPage.tsx",
+      "line": 27,
+      "context": "<p className=\"text-gray-600 text-sm\">{t('parentSupportPage.faq.responseTime.a')}</p>"
+    },
+    {
+      "key": "parentSupportPage.faq.dataSecurity.q",
+      "file": "pages/parent/ParentSupportPage.tsx",
+      "line": 30,
+      "context": "<h3 className=\"font-medium text-gray-800\">{t('parentSupportPage.faq.dataSecurity.q')}</h3>"
+    },
+    {
+      "key": "parentSupportPage.faq.dataSecurity.a",
+      "file": "pages/parent/ParentSupportPage.tsx",
+      "line": 31,
+      "context": "<p className=\"text-gray-600 text-sm\">{t('parentSupportPage.faq.dataSecurity.a')}</p>"
+    },
+    {
+      "key": "supportPage.furtherAssistanceTitle",
+      "file": "pages/parent/ParentSupportPage.tsx",
+      "line": 36,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-2\">{t('supportPage.furtherAssistanceTitle')}</h2>"
+    },
+    {
+      "key": "supportPage.furtherAssistanceText.0",
+      "file": "pages/parent/ParentSupportPage.tsx",
+      "line": 37,
+      "context": "<p className=\"text-gray-600 text-sm\">{t('supportPage.furtherAssistanceText.0')} <a href=\"mailto:support@procrechesolutions.com\" className=\"text-swiss-mint hover:underline\">{t('supportPage.furtherAssistanceText.1')}</a>.</p>"
+    },
+    {
+      "key": "supportPage.furtherAssistanceText.1",
+      "file": "pages/parent/ParentSupportPage.tsx",
+      "line": 37,
+      "context": "<p className=\"text-gray-600 text-sm\">{t('supportPage.furtherAssistanceText.0')} <a href=\"mailto:support@procrechesolutions.com\" className=\"text-swiss-mint hover:underline\">{t('supportPage.furtherAssistanceText.1')}</a>.</p>"
+    },
+    {
+      "key": "parentEnquiriesPage.accessDenied.title",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 17,
+      "context": "<h1 className=\"text-2xl font-bold text-swiss-charcoal\">{t('parentEnquiriesPage.accessDenied.title')}</h1>"
+    },
+    {
+      "key": "parentEnquiriesPage.accessDenied.message",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 18,
+      "context": "<p className=\"text-gray-600\">{t('parentEnquiriesPage.accessDenied.message')}</p>"
+    },
+    {
+      "key": "leadCard.status.interested",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 38,
+      "context": "case FoundationLeadResponseStatus.INTERESTED: return { text: t('leadCard.status.interested'), color: \"text-green-600\"};"
+    },
+    {
+      "key": "leadCard.status.notInterested",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 39,
+      "context": "case FoundationLeadResponseStatus.NOT_INTERESTED: return { text: t('leadCard.status.notInterested'), color: \"text-red-600\"};"
+    },
+    {
+      "key": "leadCard.status.needsMoreInfo",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 40,
+      "context": "case FoundationLeadResponseStatus.NEEDS_MORE_INFO: return { text: t('leadCard.status.needsMoreInfo'), color: \"text-orange-600\"};"
+    },
+    {
+      "key": "leadCard.status.enrolled",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 41,
+      "context": "case FoundationLeadResponseStatus.ENROLLED: return { text: t('leadCard.status.enrolled'), color: \"text-purple-600\"};"
+    },
+    {
+      "key": "leadCard.status.notResponded",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 42,
+      "context": "default: return { text: t('leadCard.status.notResponded'), color: \"text-gray-500\"};"
+    },
+    {
+      "key": "parentEnquiriesPage.title",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 51,
+      "context": "{t('parentEnquiriesPage.title')}"
+    },
+    {
+      "key": "parentEnquiriesPage.emptyState.title",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 58,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-2\">{t('parentEnquiriesPage.emptyState.title')}</h2>"
+    },
+    {
+      "key": "parentEnquiriesPage.emptyState.message.0",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 59,
+      "context": "<p className=\"text-gray-500\">{t('parentEnquiriesPage.emptyState.message.0')} <a href=\"/#/parent-lead-form\" className=\"text-swiss-mint hover:underline\">{t('parentEnquiriesPage.emptyState.message.1')}</a></p>"
+    },
+    {
+      "key": "parentEnquiriesPage.emptyState.message.1",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 59,
+      "context": "<p className=\"text-gray-500\">{t('parentEnquiriesPage.emptyState.message.0')} <a href=\"/#/parent-lead-form\" className=\"text-swiss-mint hover:underline\">{t('parentEnquiriesPage.emptyState.message.1')}</a></p>"
+    },
+    {
+      "key": "parentEnquiriesPage.card.title",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 68,
+      "context": "{t('parentEnquiriesPage.card.title', { canton: lead.canton, municipality: lead.municipality ? `- ${lead.municipality}` : ''})}"
+    },
+    {
+      "key": "parentEnquiriesPage.card.submitted",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 70,
+      "context": "<p className=\"text-sm text-gray-500\">{t('parentEnquiriesPage.card.submitted')}: {new Date(lead.submissionDate).toLocaleDateString()}</p>"
+    },
+    {
+      "key": "parentEnquiriesPage.card.childInfo",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 71,
+      "context": "<p className=\"text-sm text-gray-500\">{t('parentEnquiriesPage.card.childInfo', { age: lead.childAge, date: new Date(lead.desiredStartDate).toLocaleDateString()})}</p>"
+    },
+    {
+      "key": "parentEnquiriesPage.card.notes",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 79,
+      "context": "<p className=\"text-sm text-gray-600 mt-2\"><InformationCircleIcon className=\"w-4 h-4 inline mr-1 text-gray-400\" />{t('parentEnquiriesPage.card.notes')}: {lead.specialNeeds}</p>"
+    },
+    {
+      "key": "parentEnquiriesPage.card.responsesTitle",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 83,
+      "context": "<h3 className=\"text-md font-semibold text-swiss-charcoal mb-2\">{t('parentEnquiriesPage.card.responsesTitle')}:</h3>"
+    },
+    {
+      "key": "parentEnquiriesPage.card.awaitingMatch",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 85,
+      "context": "<p className=\"text-sm text-gray-500\">{t('parentEnquiriesPage.card.awaitingMatch')}</p>"
+    },
+    {
+      "key": "parentEnquiriesPage.card.message",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 95,
+      "context": "{response.messageToParent && <p className=\"text-xs text-gray-600 mt-1 italic\">{t('parentEnquiriesPage.card.message')}: {response.messageToParent}</p>}"
+    },
+    {
+      "key": "parentEnquiriesPage.card.waitingForMoreResponses",
+      "file": "pages/parent/ParentEnquiriesPage.tsx",
+      "line": 100,
+      "context": "<p className=\"text-sm text-gray-500 mt-2\">{t('parentEnquiriesPage.card.waitingForMoreResponses')}</p>"
+    },
+    {
+      "key": "parentDashboard.title",
+      "file": "pages/parent/ParentDashboardPage.tsx",
+      "line": 33,
+      "context": "{t('parentDashboard.title')}"
+    },
+    {
+      "key": "parentDashboard.welcomeMessage",
+      "file": "pages/parent/ParentDashboardPage.tsx",
+      "line": 35,
+      "context": "<p className=\"text-gray-500 mt-1\">{t('parentDashboard.welcomeMessage', { name: currentUser?.name?.split(' ')[0] })}</p>"
+    },
+    {
+      "key": "parentDashboard.enquiry.title",
+      "file": "pages/parent/ParentDashboardPage.tsx",
+      "line": 42,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-4\">{t('parentDashboard.enquiry.title')}</h2>"
+    },
+    {
+      "key": "parentDashboard.enquiry.sent",
+      "file": "pages/parent/ParentDashboardPage.tsx",
+      "line": 46,
+      "context": "<p className=\"text-sm text-gray-600\">{t('parentDashboard.enquiry.sent')}</p>"
+    },
+    {
+      "key": "parentDashboard.enquiry.responses",
+      "file": "pages/parent/ParentDashboardPage.tsx",
+      "line": 50,
+      "context": "<p className=\"text-sm text-gray-600\">{t('parentDashboard.enquiry.responses')}</p>"
+    },
+    {
+      "key": "parentDashboard.enquiry.pending",
+      "file": "pages/parent/ParentDashboardPage.tsx",
+      "line": 54,
+      "context": "<p className=\"text-sm text-gray-600\">{t('parentDashboard.enquiry.pending')}</p>"
+    },
+    {
+      "key": "parentDashboard.enquiry.button",
+      "file": "pages/parent/ParentDashboardPage.tsx",
+      "line": 59,
+      "context": "{t('parentDashboard.enquiry.button')}"
+    },
+    {
+      "key": "parentDashboard.quickActions.title",
+      "file": "pages/parent/ParentDashboardPage.tsx",
+      "line": 64,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-4\">{t('parentDashboard.quickActions.title')}</h2>"
+    },
+    {
+      "key": "parentDashboard.childProfile.title",
+      "file": "pages/parent/ParentDashboardPage.tsx",
+      "line": 78,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-4\">{t('parentDashboard.childProfile.title')}</h2>"
+    },
+    {
+      "key": "parentDashboard.childProfile.name",
+      "file": "pages/parent/ParentDashboardPage.tsx",
+      "line": 80,
+      "context": "<p><strong>{t('parentDashboard.childProfile.name')}:</strong> Child's Name (from Profile)</p>"
+    },
+    {
+      "key": "parentDashboard.childProfile.age",
+      "file": "pages/parent/ParentDashboardPage.tsx",
+      "line": 81,
+      "context": "<p><strong>{t('parentDashboard.childProfile.age')}:</strong> 3 years</p>"
+    },
+    {
+      "key": "parentDashboard.childProfile.location",
+      "file": "pages/parent/ParentDashboardPage.tsx",
+      "line": 82,
+      "context": "<p><strong>{t('parentDashboard.childProfile.location')}:</strong> Geneva</p>"
+    },
+    {
+      "key": "parentDashboard.childProfile.languages",
+      "file": "pages/parent/ParentDashboardPage.tsx",
+      "line": 83,
+      "context": "<p><strong>{t('parentDashboard.childProfile.languages')}:</strong> French, English</p>"
+    },
+    {
+      "key": "parentDashboard.childProfile.specialNeeds",
+      "file": "pages/parent/ParentDashboardPage.tsx",
+      "line": 84,
+      "context": "<p><strong>{t('parentDashboard.childProfile.specialNeeds')}:</strong> None specified</p>"
+    },
+    {
+      "key": "parentDashboard.childProfile.button",
+      "file": "pages/parent/ParentDashboardPage.tsx",
+      "line": 86,
+      "context": "<Button variant=\"outline\" size=\"sm\" className=\"w-full mt-4\" onClick={() => navigate('/settings')}>{t('parentDashboard.childProfile.button')}</Button>"
+    },
+    {
+      "key": "parentDashboard.favorites.title",
+      "file": "pages/parent/ParentDashboardPage.tsx",
+      "line": 90,
+      "context": "<h2 className=\"text-xl font-semibold text-amber-800 mb-2\">{t('parentDashboard.favorites.title')}</h2>"
+    },
+    {
+      "key": "parentDashboard.favorites.subtitle",
+      "file": "pages/parent/ParentDashboardPage.tsx",
+      "line": 91,
+      "context": "<p className=\"text-sm text-amber-800 mb-4\">{t('parentDashboard.favorites.subtitle')}</p>"
+    },
+    {
+      "key": "parentDashboard.favorites.button",
+      "file": "pages/parent/ParentDashboardPage.tsx",
+      "line": 92,
+      "context": "<Button variant=\"secondary\" className=\"bg-amber-600 hover:bg-amber-700 text-white\" onClick={() => alert('View Favorites TBD')}>{t('parentDashboard.favorites.button')}</Button>"
+    },
+    {
+      "key": "educatorSupportPage.ticketSubmittedAlert",
+      "file": "pages/educator/EducatorSupportPage.tsx",
+      "line": 46,
+      "context": "alert(t('educatorSupportPage.ticketSubmittedAlert'));"
+    },
+    {
+      "key": "sidebar.support",
+      "file": "pages/educator/EducatorSupportPage.tsx",
+      "line": 55,
+      "context": "{t('sidebar.support')}"
+    },
+    {
+      "key": "supportPage.faqTitle",
+      "file": "pages/educator/EducatorSupportPage.tsx",
+      "line": 61,
+      "context": "{t('supportPage.faqTitle')}"
+    },
+    {
+      "key": "supportPage.furtherAssistanceTitle",
+      "file": "pages/educator/EducatorSupportPage.tsx",
+      "line": 65,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-2\">{t('supportPage.furtherAssistanceTitle')}</h2>"
+    },
+    {
+      "key": "supportPage.furtherAssistanceText.0",
+      "file": "pages/educator/EducatorSupportPage.tsx",
+      "line": 66,
+      "context": "<p className=\"text-gray-600 text-sm\">{t('supportPage.furtherAssistanceText.0')} <a href=\"mailto:support@procrechesolutions.com\" className=\"text-swiss-mint hover:underline\">{t('supportPage.furtherAssistanceText.1')}</a>.</p>"
+    },
+    {
+      "key": "supportPage.furtherAssistanceText.1",
+      "file": "pages/educator/EducatorSupportPage.tsx",
+      "line": 66,
+      "context": "<p className=\"text-gray-600 text-sm\">{t('supportPage.furtherAssistanceText.0')} <a href=\"mailto:support@procrechesolutions.com\" className=\"text-swiss-mint hover:underline\">{t('supportPage.furtherAssistanceText.1')}</a>.</p>"
+    },
+    {
+      "key": "supportPage.submitTicketTitle",
+      "file": "pages/educator/EducatorSupportPage.tsx",
+      "line": 71,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-4\">{t('supportPage.submitTicketTitle')}</h2>"
+    },
+    {
+      "key": "supportPage.ticketForm.subjectLabel",
+      "file": "pages/educator/EducatorSupportPage.tsx",
+      "line": 74,
+      "context": "<label htmlFor=\"ticketSubjectEducator\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('supportPage.ticketForm.subjectLabel')}</label>"
+    },
+    {
+      "key": "educatorSupportPage.ticketForm.subjectPlaceholder",
+      "file": "pages/educator/EducatorSupportPage.tsx",
+      "line": 82,
+      "context": "placeholder={t('educatorSupportPage.ticketForm.subjectPlaceholder')}"
+    },
+    {
+      "key": "supportPage.ticketForm.messageLabel",
+      "file": "pages/educator/EducatorSupportPage.tsx",
+      "line": 86,
+      "context": "<label htmlFor=\"ticketMessageEducator\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('supportPage.ticketForm.messageLabel')}</label>"
+    },
+    {
+      "key": "educatorSupportPage.ticketForm.messagePlaceholder",
+      "file": "pages/educator/EducatorSupportPage.tsx",
+      "line": 94,
+      "context": "placeholder={t('educatorSupportPage.ticketForm.messagePlaceholder')}"
+    },
+    {
+      "key": "common:buttons.submitTicket",
+      "file": "pages/educator/EducatorSupportPage.tsx",
+      "line": 98,
+      "context": "<Button type=\"submit\" variant=\"primary\">{t('common:buttons.submitTicket')}</Button>"
+    },
+    {
+      "key": "common:buttons.submitTicket",
+      "file": "pages/educator/EducatorSupportPage.tsx",
+      "line": 98,
+      "context": "<Button type=\"submit\" variant=\"primary\">{t('common:buttons.submitTicket')}</Button>"
+    },
+    {
+      "key": "common:buttons.cancel",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 26,
+      "context": "{isEditing ? t('common:buttons.cancel') : t('common:buttons.edit')}"
+    },
+    {
+      "key": "common:buttons.edit",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 26,
+      "context": "{isEditing ? t('common:buttons.cancel') : t('common:buttons.edit')}"
+    },
+    {
+      "key": "common:buttons.cancel",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 26,
+      "context": "{isEditing ? t('common:buttons.cancel') : t('common:buttons.edit')}"
+    },
+    {
+      "key": "common:buttons.edit",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 26,
+      "context": "{isEditing ? t('common:buttons.cancel') : t('common:buttons.edit')}"
+    },
+    {
+      "key": "educatorProfilePage.loadError",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 65,
+      "context": "setError(err instanceof Error ? err.message : t('educatorProfilePage.loadError', 'Unable to load profile.'));"
+    },
+    {
+      "key": "educatorProfilePage.saveSuccess",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 80,
+      "context": "alert(t('educatorProfilePage.saveSuccess', 'Profile changes saved!'));"
+    },
+    {
+      "key": "common:loading",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 85,
+      "context": "return <p className=\"text-center text-gray-500\">{t('common:loading', 'Loading...')}</p>;"
+    },
+    {
+      "key": "common:loading",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 85,
+      "context": "return <p className=\"text-center text-gray-500\">{t('common:loading', 'Loading...')}</p>;"
+    },
+    {
+      "key": "educatorProfilePage.loadError",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 91,
+      "context": "<p className=\"text-red-600\">{error || t('educatorProfilePage.loadError', 'Unable to load profile.')}</p>"
+    },
+    {
+      "key": "common:buttons.retry",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 92,
+      "context": "<Button variant=\"primary\" onClick={fetchProfile}>{t('common:buttons.retry', 'Retry')}</Button>"
+    },
+    {
+      "key": "common:buttons.retry",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 92,
+      "context": "<Button variant=\"primary\" onClick={fetchProfile}>{t('common:buttons.retry', 'Retry')}</Button>"
+    },
+    {
+      "key": "sidebar.myProfile",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 102,
+      "context": "{t('sidebar.myProfile')}"
+    },
+    {
+      "key": "common:buttons.cancel",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 105,
+      "context": "{isEditing && <Button variant=\"light\" onClick={() => setIsEditing(false)}>{t('common:buttons.cancel')}</Button>}"
+    },
+    {
+      "key": "common:buttons.cancel",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 105,
+      "context": "{isEditing && <Button variant=\"light\" onClick={() => setIsEditing(false)}>{t('common:buttons.cancel')}</Button>}"
+    },
+    {
+      "key": "common:buttons.saveChanges",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 107,
+      "context": "{isEditing ? t('common:buttons.saveChanges') : t('educatorProfilePage.editProfile')}"
+    },
+    {
+      "key": "educatorProfilePage.editProfile",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 107,
+      "context": "{isEditing ? t('common:buttons.saveChanges') : t('educatorProfilePage.editProfile')}"
+    },
+    {
+      "key": "common:buttons.saveChanges",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 107,
+      "context": "{isEditing ? t('common:buttons.saveChanges') : t('educatorProfilePage.editProfile')}"
+    },
+    {
+      "key": "educatorProfilePage.roleUnknown",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 122,
+      "context": "<p className=\"text-md text-swiss-teal\">{profile.currentRoleOrTitle ?? t('educatorProfilePage.roleUnknown', 'Role not specified')}</p>"
+    },
+    {
+      "key": "educatorProfilePage.locationUnknown",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 123,
+      "context": "<p className=\"text-sm text-gray-500\">{profile.location ?? t('educatorProfilePage.locationUnknown', 'Location not provided')}</p>"
+    },
+    {
+      "key": "educatorProfilePage.skills.empty",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 134,
+      "context": ": <span className=\"text-xs text-gray-500\">{t('educatorProfilePage.skills.empty', 'No skills listed yet.')}</span>}"
+    },
+    {
+      "key": "educatorProfilePage.availability.days",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 139,
+      "context": "<p><strong>{t('educatorProfilePage.availability.days')}:</strong> {profile.availabilityPreferences?.days?.join(', ') ?? t('educatorProfilePage.notProvided', 'Not provided')}</p>"
+    },
+    {
+      "key": "educatorProfilePage.notProvided",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 139,
+      "context": "<p><strong>{t('educatorProfilePage.availability.days')}:</strong> {profile.availabilityPreferences?.days?.join(', ') ?? t('educatorProfilePage.notProvided', 'Not provided')}</p>"
+    },
+    {
+      "key": "educatorProfilePage.availability.times",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 140,
+      "context": "<p><strong>{t('educatorProfilePage.availability.times')}:</strong> {profile.availabilityPreferences?.times ?? t('educatorProfilePage.notProvided', 'Not provided')}</p>"
+    },
+    {
+      "key": "educatorProfilePage.notProvided",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 140,
+      "context": "<p><strong>{t('educatorProfilePage.availability.times')}:</strong> {profile.availabilityPreferences?.times ?? t('educatorProfilePage.notProvided', 'Not provided')}</p>"
+    },
+    {
+      "key": "educatorProfilePage.availability.contract",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 141,
+      "context": "<p><strong>{t('educatorProfilePage.availability.contract')}:</strong> {profile.availabilityPreferences?.contractType ?? t('educatorProfilePage.notProvided', 'Not provided')}</p>"
+    },
+    {
+      "key": "educatorProfilePage.notProvided",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 141,
+      "context": "<p><strong>{t('educatorProfilePage.availability.contract')}:</strong> {profile.availabilityPreferences?.contractType ?? t('educatorProfilePage.notProvided', 'Not provided')}</p>"
+    },
+    {
+      "key": "educatorProfilePage.availability.ageGroups",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 142,
+      "context": "<p><strong>{t('educatorProfilePage.availability.ageGroups')}:</strong> {profile.availabilityPreferences?.preferredAgeGroups?.join(', ') ?? t('educatorProfilePage.notProvided', 'Not provided')}</p>"
+    },
+    {
+      "key": "educatorProfilePage.notProvided",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 142,
+      "context": "<p><strong>{t('educatorProfilePage.availability.ageGroups')}:</strong> {profile.availabilityPreferences?.preferredAgeGroups?.join(', ') ?? t('educatorProfilePage.notProvided', 'Not provided')}</p>"
+    },
+    {
+      "key": "educatorProfilePage.documents.empty",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 158,
+      "context": "<li className=\"text-xs text-gray-500\">{t('educatorProfilePage.documents.empty', 'No documents uploaded yet.')}</li>"
+    },
+    {
+      "key": "educatorProfilePage.bio.empty",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 170,
+      "context": "{profile.shortBio ?? t('educatorProfilePage.bio.empty', 'No bio information yet.')}"
+    },
+    {
+      "key": "educatorProfilePage.experience.empty",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 185,
+      "context": ")) : <p className=\"text-sm text-gray-500\">{t('educatorProfilePage.experience.empty', 'No experience added yet.')}</p>}"
+    },
+    {
+      "key": "educatorProfilePage.education.graduated",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 194,
+      "context": "<p className=\"text-xs text-gray-500\">{t('educatorProfilePage.education.graduated')}: {edu.graduationYear}</p>"
+    },
+    {
+      "key": "educatorProfilePage.education.empty",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 196,
+      "context": ")) : <p className=\"text-sm text-gray-500\">{t('educatorProfilePage.education.empty', 'No education added yet.')}</p>}"
+    },
+    {
+      "key": "educatorProfilePage.certifications.issued",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 207,
+      "context": "{t('educatorProfilePage.certifications.issued')}: {cert.issueDate}"
+    },
+    {
+      "key": "educatorProfilePage.certifications.expires",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 208,
+      "context": "{cert.expiryDate && ` - ${t('educatorProfilePage.certifications.expires')}: ${cert.expiryDate}`}"
+    },
+    {
+      "key": "educatorProfilePage.certifications.empty",
+      "file": "pages/educator/EducatorProfilePage.tsx",
+      "line": 213,
+      "context": "<p className=\"text-sm text-gray-500\">{t('educatorProfilePage.certifications.empty', 'No certifications added yet.')}</p>"
+    },
+    {
+      "key": "recruitment:contractTypes.fullTime",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 25,
+      "context": "return { className: 'bg-green-100 text-green-700', label: t('recruitment:contractTypes.fullTime', 'Full-time') };"
+    },
+    {
+      "key": "recruitment:contractTypes.fullTime",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 25,
+      "context": "return { className: 'bg-green-100 text-green-700', label: t('recruitment:contractTypes.fullTime', 'Full-time') };"
+    },
+    {
+      "key": "recruitment:contractTypes.partTime",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 27,
+      "context": "return { className: 'bg-teal-100 text-teal-700', label: t('recruitment:contractTypes.partTime', 'Part-time') };"
+    },
+    {
+      "key": "recruitment:contractTypes.partTime",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 27,
+      "context": "return { className: 'bg-teal-100 text-teal-700', label: t('recruitment:contractTypes.partTime', 'Part-time') };"
+    },
+    {
+      "key": "recruitment:contractTypes.cdi",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 29,
+      "context": "return { className: 'bg-blue-100 text-blue-700', label: t('recruitment:contractTypes.cdi', 'CDI') };"
+    },
+    {
+      "key": "recruitment:contractTypes.cdi",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 29,
+      "context": "return { className: 'bg-blue-100 text-blue-700', label: t('recruitment:contractTypes.cdi', 'CDI') };"
+    },
+    {
+      "key": "recruitment:contractTypes.cdd",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 31,
+      "context": "return { className: 'bg-yellow-100 text-yellow-700', label: t('recruitment:contractTypes.cdd', 'CDD') };"
+    },
+    {
+      "key": "recruitment:contractTypes.cdd",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 31,
+      "context": "return { className: 'bg-yellow-100 text-yellow-700', label: t('recruitment:contractTypes.cdd', 'CDD') };"
+    },
+    {
+      "key": "recruitment:contractTypes.internship",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 34,
+      "context": "return { className: 'bg-purple-100 text-purple-700', label: t('recruitment:contractTypes.internship', 'Internship') };"
+    },
+    {
+      "key": "recruitment:contractTypes.internship",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 34,
+      "context": "return { className: 'bg-purple-100 text-purple-700', label: t('recruitment:contractTypes.internship', 'Internship') };"
+    },
+    {
+      "key": "dashboard:educatorJobBoardPage.unknownFoundation",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 52,
+      "context": "alt={job.foundationName ?? t('dashboard:educatorJobBoardPage.unknownFoundation', 'Unknown foundation')}"
+    },
+    {
+      "key": "dashboard:educatorJobBoardPage.unknownFoundation",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 52,
+      "context": "alt={job.foundationName ?? t('dashboard:educatorJobBoardPage.unknownFoundation', 'Unknown foundation')}"
+    },
+    {
+      "key": "dashboard:educatorJobBoardPage.unknownFoundation",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 55,
+      "context": "{job.foundationName ?? t('dashboard:educatorJobBoardPage.unknownFoundation', 'Unknown foundation')}"
+    },
+    {
+      "key": "dashboard:educatorJobBoardPage.unknownFoundation",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 55,
+      "context": "{job.foundationName ?? t('dashboard:educatorJobBoardPage.unknownFoundation', 'Unknown foundation')}"
+    },
+    {
+      "key": "recruitment:recruitmentPage.labels.locationUnknown",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 58,
+      "context": "<p><MapPinIcon className=\"w-4 h-4 inline mr-1.5 text-gray-400\" />{job.location ?? t('recruitment:recruitmentPage.labels.locationUnknown', 'Location TBD')}</p>"
+    },
+    {
+      "key": "recruitment:recruitmentPage.labels.locationUnknown",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 58,
+      "context": "<p><MapPinIcon className=\"w-4 h-4 inline mr-1.5 text-gray-400\" />{job.location ?? t('recruitment:recruitmentPage.labels.locationUnknown', 'Location TBD')}</p>"
+    },
+    {
+      "key": "educatorJobBoardPage.postedOn",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 59,
+      "context": "<p><CalendarDaysIcon className=\"w-4 h-4 inline mr-1.5 text-gray-400\" />{t('educatorJobBoardPage.postedOn', { date: new Date(postedDate).toLocaleDateString() })}</p>"
+    },
+    {
+      "key": "common:buttons.viewDetails",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 65,
+      "context": "{t('common:buttons.viewDetails')}"
+    },
+    {
+      "key": "common:buttons.viewDetails",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 65,
+      "context": "{t('common:buttons.viewDetails')}"
+    },
+    {
+      "key": "educatorJobBoardPage.errors.loadJobs",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 100,
+      "context": "setError(err instanceof Error ? err.message : t('educatorJobBoardPage.errors.loadJobs', 'Unable to load job listings.'));"
+    },
+    {
+      "key": "notifications.successTitle",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 131,
+      "context": "title: result.success ? t('notifications.successTitle') : t('notifications.errorTitle'),"
+    },
+    {
+      "key": "notifications.errorTitle",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 131,
+      "context": "title: result.success ? t('notifications.successTitle') : t('notifications.errorTitle'),"
+    },
+    {
+      "key": "educatorJobBoardPage.title",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 144,
+      "context": "<h1 className=\"text-3xl font-bold text-swiss-charcoal mb-4 md:mb-0\">{t('educatorJobBoardPage.title')}</h1>"
+    },
+    {
+      "key": "educatorJobBoardPage.searchPlaceholder",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 149,
+      "context": "placeholder={t('educatorJobBoardPage.searchPlaceholder')}"
+    },
+    {
+      "key": "labels.region",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 161,
+      "context": "{t('labels.region')}"
+    },
+    {
+      "key": "labels.allContractTypes",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 173,
+      "context": "{t('labels.allContractTypes')}"
+    },
+    {
+      "key": "recruitment:contractTypes.cdi",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 180,
+      "context": "return t('recruitment:contractTypes.cdi', 'CDI');"
+    },
+    {
+      "key": "recruitment:contractTypes.cdi",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 180,
+      "context": "return t('recruitment:contractTypes.cdi', 'CDI');"
+    },
+    {
+      "key": "recruitment:contractTypes.cdd",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 182,
+      "context": "return t('recruitment:contractTypes.cdd', 'CDD');"
+    },
+    {
+      "key": "recruitment:contractTypes.cdd",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 182,
+      "context": "return t('recruitment:contractTypes.cdd', 'CDD');"
+    },
+    {
+      "key": "recruitment:contractTypes.internship",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 184,
+      "context": "return t('recruitment:contractTypes.internship', 'Internship');"
+    },
+    {
+      "key": "recruitment:contractTypes.internship",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 184,
+      "context": "return t('recruitment:contractTypes.internship', 'Internship');"
+    },
+    {
+      "key": "recruitment:contractTypes.partTime",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 186,
+      "context": "return t('recruitment:contractTypes.partTime', 'Part-time');"
+    },
+    {
+      "key": "recruitment:contractTypes.partTime",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 186,
+      "context": "return t('recruitment:contractTypes.partTime', 'Part-time');"
+    },
+    {
+      "key": "recruitment:contractTypes.fullTime",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 188,
+      "context": "return t('recruitment:contractTypes.fullTime', 'Full-time');"
+    },
+    {
+      "key": "recruitment:contractTypes.fullTime",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 188,
+      "context": "return t('recruitment:contractTypes.fullTime', 'Full-time');"
+    },
+    {
+      "key": "labels.allContractTypes",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 190,
+      "context": "return t('labels.allContractTypes');"
+    },
+    {
+      "key": "common:loading",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 205,
+      "context": "{loading && <p className=\"text-center text-gray-500 py-8\">{t('common:loading', 'Loading...')}</p>}"
+    },
+    {
+      "key": "common:loading",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 205,
+      "context": "{loading && <p className=\"text-center text-gray-500 py-8\">{t('common:loading', 'Loading...')}</p>}"
+    },
+    {
+      "key": "educatorJobBoardPage.noJobsFound",
+      "file": "pages/educator/EducatorJobBoardPage.tsx",
+      "line": 207,
+      "context": "<p className=\"text-center text-gray-500 py-8\">{t('educatorJobBoardPage.noJobsFound')}</p>"
+    },
+    {
+      "key": "educatorDashboard.title",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 35,
+      "context": "{t('educatorDashboard.title')}"
+    },
+    {
+      "key": "educatorDashboard.welcome",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 37,
+      "context": "<p className=\"text-gray-500 mt-1\">{t('educatorDashboard.welcome', { name: currentUser?.name?.split(' ')[0] })}</p>"
+    },
+    {
+      "key": "educatorDashboard.profileCompletion.title",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 43,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal\">{t('educatorDashboard.profileCompletion.title')}</h2>"
+    },
+    {
+      "key": "educatorDashboard.profileCompletion.subtitle",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 44,
+      "context": "<p className=\"text-sm text-gray-500\">{t('educatorDashboard.profileCompletion.subtitle')}</p>"
+    },
+    {
+      "key": "educatorDashboard.profileCompletion.button",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 51,
+      "context": "<Button variant=\"outline\" size=\"sm\" onClick={() => navigate('/educator/profile')}>{t('educatorDashboard.profileCompletion.button')}</Button>"
+    },
+    {
+      "key": "educatorDashboard.applicationStatus.title",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 60,
+      "context": "<h2 className=\"text-lg font-semibold text-swiss-charcoal mb-4\">{t('educatorDashboard.applicationStatus.title')}</h2>"
+    },
+    {
+      "key": "educatorDashboard.applicationStatus.submitted",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 63,
+      "context": "<span className=\"text-gray-600\">{t('educatorDashboard.applicationStatus.submitted')}</span>"
+    },
+    {
+      "key": "educatorDashboard.applicationStatus.viewed",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 67,
+      "context": "<span className=\"text-gray-600\">{t('educatorDashboard.applicationStatus.viewed')}</span>"
+    },
+    {
+      "key": "educatorDashboard.applicationStatus.interviews",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 71,
+      "context": "<span className=\"text-gray-600\">{t('educatorDashboard.applicationStatus.interviews')}</span>"
+    },
+    {
+      "key": "educatorDashboard.applicationStatus.offers",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 75,
+      "context": "<span className=\"text-gray-600\">{t('educatorDashboard.applicationStatus.offers')}</span>"
+    },
+    {
+      "key": "educatorDashboard.applicationStatus.button",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 80,
+      "context": "{t('educatorDashboard.applicationStatus.button')}"
+    },
+    {
+      "key": "educatorDashboard.skills.title",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 84,
+      "context": "<h2 className=\"text-lg font-semibold text-swiss-charcoal mb-2 flex items-center\"><AcademicCapIcon className=\"w-5 h-5 mr-2 text-swiss-coral\"/>{t('educatorDashboard.skills.title')}</h2>"
+    },
+    {
+      "key": "educatorDashboard.skills.subtitle",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 85,
+      "context": "<p className=\"text-sm text-gray-500 mb-3\">{t('educatorDashboard.skills.subtitle')}</p>"
+    },
+    {
+      "key": "educatorDashboard.skills.button",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 86,
+      "context": "<Button variant=\"outline\" size=\"sm\" className=\"w-full\">{t('educatorDashboard.skills.button')}</Button>"
+    },
+    {
+      "key": "educatorDashboard.recommendations.title",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 93,
+      "context": "<h2 className=\"text-lg font-semibold text-swiss-charcoal mb-4\">{t('educatorDashboard.recommendations.title')}</h2>"
+    },
+    {
+      "key": "educatorDashboard.recommendations.match",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 105,
+      "context": "<p className=\"text-sm font-bold text-swiss-mint\">{job.match}% {t('educatorDashboard.recommendations.match')}</p>"
+    },
+    {
+      "key": "common:buttons.applyNow",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 106,
+      "context": "<Button variant=\"ghost\" size=\"xs\" onClick={() => alert(`${t('common:buttons.applyNow')} TBD`)}>{t('common:buttons.applyNow')} <ArrowUpRightIcon className=\"w-3 h-3 ml-1\"/></Button>"
+    },
+    {
+      "key": "common:buttons.applyNow",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 106,
+      "context": "<Button variant=\"ghost\" size=\"xs\" onClick={() => alert(`${t('common:buttons.applyNow')} TBD`)}>{t('common:buttons.applyNow')} <ArrowUpRightIcon className=\"w-3 h-3 ml-1\"/></Button>"
+    },
+    {
+      "key": "common:buttons.applyNow",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 106,
+      "context": "<Button variant=\"ghost\" size=\"xs\" onClick={() => alert(`${t('common:buttons.applyNow')} TBD`)}>{t('common:buttons.applyNow')} <ArrowUpRightIcon className=\"w-3 h-3 ml-1\"/></Button>"
+    },
+    {
+      "key": "common:buttons.applyNow",
+      "file": "pages/educator/EducatorDashboardPage.tsx",
+      "line": 106,
+      "context": "<Button variant=\"ghost\" size=\"xs\" onClick={() => alert(`${t('common:buttons.applyNow')} TBD`)}>{t('common:buttons.applyNow')} <ArrowUpRightIcon className=\"w-3 h-3 ml-1\"/></Button>"
+    },
+    {
+      "key": "educatorApplicationsPage.status.pending",
+      "file": "pages/educator/EducatorApplicationsPage.tsx",
+      "line": 15,
+      "context": "case ApplicationStatus.PENDING: return { className: 'bg-swiss-sand/30 text-amber-800', label: t('educatorApplicationsPage.status.pending') };"
+    },
+    {
+      "key": "educatorApplicationsPage.status.reviewed",
+      "file": "pages/educator/EducatorApplicationsPage.tsx",
+      "line": 16,
+      "context": "case ApplicationStatus.REVIEWED: return { className: 'bg-blue-100 text-blue-800', label: t('educatorApplicationsPage.status.reviewed') };"
+    },
+    {
+      "key": "educatorApplicationsPage.status.accepted",
+      "file": "pages/educator/EducatorApplicationsPage.tsx",
+      "line": 17,
+      "context": "case ApplicationStatus.ACCEPTED: return { className: 'bg-swiss-mint text-white', label: t('educatorApplicationsPage.status.accepted') };"
+    },
+    {
+      "key": "educatorApplicationsPage.status.rejected",
+      "file": "pages/educator/EducatorApplicationsPage.tsx",
+      "line": 18,
+      "context": "case ApplicationStatus.REJECTED: return { className: 'bg-swiss-coral/20 text-swiss-coral', label: t('educatorApplicationsPage.status.rejected') };"
+    },
+    {
+      "key": "educatorApplicationsPage.title",
+      "file": "pages/educator/EducatorApplicationsPage.tsx",
+      "line": 27,
+      "context": "{t('educatorApplicationsPage.title')}"
+    },
+    {
+      "key": "educatorApplicationsPage.table.jobTitle",
+      "file": "pages/educator/EducatorApplicationsPage.tsx",
+      "line": 34,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('educatorApplicationsPage.table.jobTitle')}</th>"
+    },
+    {
+      "key": "educatorApplicationsPage.table.creche",
+      "file": "pages/educator/EducatorApplicationsPage.tsx",
+      "line": 35,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('educatorApplicationsPage.table.creche')}</th>"
+    },
+    {
+      "key": "educatorApplicationsPage.table.status",
+      "file": "pages/educator/EducatorApplicationsPage.tsx",
+      "line": 36,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('educatorApplicationsPage.table.status')}</th>"
+    },
+    {
+      "key": "educatorApplicationsPage.table.lastUpdated",
+      "file": "pages/educator/EducatorApplicationsPage.tsx",
+      "line": 37,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('educatorApplicationsPage.table.lastUpdated')}</th>"
+    },
+    {
+      "key": "educatorApplicationsPage.table.actions",
+      "file": "pages/educator/EducatorApplicationsPage.tsx",
+      "line": 38,
+      "context": "<th scope=\"col\" className=\"px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('educatorApplicationsPage.table.actions')}</th>"
+    },
+    {
+      "key": "educatorApplicationsPage.unknownFoundation",
+      "file": "pages/educator/EducatorApplicationsPage.tsx",
+      "line": 47,
+      "context": "<td className=\"px-6 py-4 whitespace-nowrap text-gray-500\">{app.foundationName ?? t('educatorApplicationsPage.unknownFoundation', 'N/A')}</td>"
+    },
+    {
+      "key": "educatorApplicationsPage.viewingDetailsFor",
+      "file": "pages/educator/EducatorApplicationsPage.tsx",
+      "line": 55,
+      "context": "<Button variant=\"ghost\" size=\"sm\" leftIcon={EyeIcon} onClick={() => alert(`${t('educatorApplicationsPage.viewingDetailsFor')} ${app.jobTitle}`)}>"
+    },
+    {
+      "key": "common:buttons.viewDetails",
+      "file": "pages/educator/EducatorApplicationsPage.tsx",
+      "line": 56,
+      "context": "{t('common:buttons.viewDetails')}"
+    },
+    {
+      "key": "common:buttons.viewDetails",
+      "file": "pages/educator/EducatorApplicationsPage.tsx",
+      "line": 56,
+      "context": "{t('common:buttons.viewDetails')}"
+    },
+    {
+      "key": "educatorApplicationsPage.emptyState",
+      "file": "pages/educator/EducatorApplicationsPage.tsx",
+      "line": 65,
+      "context": "{applications.length === 0 && <p className=\"text-center text-gray-500 py-8\">{t('educatorApplicationsPage.emptyState')}</p>}"
+    },
+    {
+      "key": "educatorApplicationsPage.footerNote",
+      "file": "pages/educator/EducatorApplicationsPage.tsx",
+      "line": 67,
+      "context": "<p className=\"text-xs text-gray-500 text-center\">{t('educatorApplicationsPage.footerNote')}</p>"
+    },
+    {
+      "key": "foundationSupportPage.ticketSubmittedAlert",
+      "file": "pages/foundation/FoundationSupportPage.tsx",
+      "line": 46,
+      "context": "alert(t('foundationSupportPage.ticketSubmittedAlert'));"
+    },
+    {
+      "key": "sidebar.support",
+      "file": "pages/foundation/FoundationSupportPage.tsx",
+      "line": 55,
+      "context": "{t('sidebar.support')}"
+    },
+    {
+      "key": "supportPage.faqTitle",
+      "file": "pages/foundation/FoundationSupportPage.tsx",
+      "line": 61,
+      "context": "{t('supportPage.faqTitle')}"
+    },
+    {
+      "key": "supportPage.furtherAssistanceTitle",
+      "file": "pages/foundation/FoundationSupportPage.tsx",
+      "line": 65,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-2\">{t('supportPage.furtherAssistanceTitle')}</h2>"
+    },
+    {
+      "key": "supportPage.furtherAssistanceText.0",
+      "file": "pages/foundation/FoundationSupportPage.tsx",
+      "line": 66,
+      "context": "<p className=\"text-gray-600 text-sm\">{t('supportPage.furtherAssistanceText.0')} <a href=\"mailto:support@procrechesolutions.com\" className=\"text-swiss-mint hover:underline\">{t('supportPage.furtherAssistanceText.1')}</a>.</p>"
+    },
+    {
+      "key": "supportPage.furtherAssistanceText.1",
+      "file": "pages/foundation/FoundationSupportPage.tsx",
+      "line": 66,
+      "context": "<p className=\"text-gray-600 text-sm\">{t('supportPage.furtherAssistanceText.0')} <a href=\"mailto:support@procrechesolutions.com\" className=\"text-swiss-mint hover:underline\">{t('supportPage.furtherAssistanceText.1')}</a>.</p>"
+    },
+    {
+      "key": "supportPage.submitTicketTitle",
+      "file": "pages/foundation/FoundationSupportPage.tsx",
+      "line": 71,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-4\">{t('supportPage.submitTicketTitle')}</h2>"
+    },
+    {
+      "key": "supportPage.ticketForm.subjectLabel",
+      "file": "pages/foundation/FoundationSupportPage.tsx",
+      "line": 74,
+      "context": "<label htmlFor=\"ticketSubjectFoundation\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('supportPage.ticketForm.subjectLabel')}</label>"
+    },
+    {
+      "key": "foundationSupportPage.ticketForm.subjectPlaceholder",
+      "file": "pages/foundation/FoundationSupportPage.tsx",
+      "line": 82,
+      "context": "placeholder={t('foundationSupportPage.ticketForm.subjectPlaceholder')}"
+    },
+    {
+      "key": "supportPage.ticketForm.messageLabel",
+      "file": "pages/foundation/FoundationSupportPage.tsx",
+      "line": 86,
+      "context": "<label htmlFor=\"ticketMessageFoundation\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('supportPage.ticketForm.messageLabel')}</label>"
+    },
+    {
+      "key": "foundationSupportPage.ticketForm.messagePlaceholder",
+      "file": "pages/foundation/FoundationSupportPage.tsx",
+      "line": 94,
+      "context": "placeholder={t('foundationSupportPage.ticketForm.messagePlaceholder')}"
+    },
+    {
+      "key": "common:buttons.submitTicket",
+      "file": "pages/foundation/FoundationSupportPage.tsx",
+      "line": 98,
+      "context": "<Button type=\"submit\" variant=\"primary\">{t('common:buttons.submitTicket')}</Button>"
+    },
+    {
+      "key": "common:buttons.submitTicket",
+      "file": "pages/foundation/FoundationSupportPage.tsx",
+      "line": 98,
+      "context": "<Button type=\"submit\" variant=\"primary\">{t('common:buttons.submitTicket')}</Button>"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.mock.pedagogyStatement",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 16,
+      "context": "pedagogyStatement: t('foundationOrganisationProfilePage.mock.pedagogyStatement'),"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.alert.infoSaved",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 35,
+      "context": "alert(t('foundationOrganisationProfilePage.alert.infoSaved'));"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.title",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 43,
+      "context": "{t('foundationOrganisationProfilePage.title')}"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.sections.branding.title",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 54,
+      "context": "{t('foundationOrganisationProfilePage.sections.branding.title')}"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.sections.branding.logoLabel",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 58,
+      "context": "<label htmlFor=\"orgLogoUpload\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('foundationOrganisationProfilePage.sections.branding.logoLabel')}</label>"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.sections.branding.coverImageLabel",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 62,
+      "context": "<label htmlFor=\"orgCoverImageUpload\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('foundationOrganisationProfilePage.sections.branding.coverImageLabel')}</label>"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.sections.branding.pedagogyStatementLabel",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 66,
+      "context": "<label htmlFor=\"pedagogyStatement\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('foundationOrganisationProfilePage.sections.branding.pedagogyStatementLabel')}</label>"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.sections.branding.pedagogyStatementPlaceholder",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 67,
+      "context": "<textarea name=\"pedagogyStatement\" id=\"pedagogyStatement\" value={additionalProfile.pedagogyStatement} onChange={handleChange} rows={4} className={STANDARD_INPUT_FIELD} placeholder={t('foundationOrganisationProfilePage.sections.branding.pedagogyStatementPlaceholder')}/>"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.sections.operations.title",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 73,
+      "context": "{t('foundationOrganisationProfilePage.sections.operations.title')}"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.sections.operations.openingHoursLabel",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 77,
+      "context": "<label htmlFor=\"orgOpeningHours\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('foundationOrganisationProfilePage.sections.operations.openingHoursLabel')}</label>"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.sections.operations.openingHoursPlaceholder",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 78,
+      "context": "<input type=\"text\" name=\"openingHours\" id=\"orgOpeningHours\" value={additionalProfile.openingHours} onChange={handleChange} className={STANDARD_INPUT_FIELD} placeholder={t('foundationOrganisationProfilePage.sections.operations.openingHoursPlaceholder')}/>"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.sections.operations.contactInfoLabel",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 81,
+      "context": "<label htmlFor=\"contactInfo\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('foundationOrganisationProfilePage.sections.operations.contactInfoLabel')}</label>"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.sections.operations.contactInfoPlaceholder",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 82,
+      "context": "<input type=\"text\" name=\"contactInfo\" id=\"contactInfo\" className={STANDARD_INPUT_FIELD} placeholder={t('foundationOrganisationProfilePage.sections.operations.contactInfoPlaceholder')}/>"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.sections.online.title",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 88,
+      "context": "{t('foundationOrganisationProfilePage.sections.online.title')}"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.sections.online.bookingLinkLabel",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 92,
+      "context": "<label htmlFor=\"calComLink\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('foundationOrganisationProfilePage.sections.online.bookingLinkLabel')}</label>"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.sections.online.bookingLinkPlaceholder",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 93,
+      "context": "<input type=\"url\" name=\"calComLink\" id=\"calComLink\" value={additionalProfile.calComLink} onChange={handleChange} className={STANDARD_INPUT_FIELD} placeholder={t('foundationOrganisationProfilePage.sections.online.bookingLinkPlaceholder')}/>"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.sections.online.socialMediaLinkLabel",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 96,
+      "context": "<label htmlFor=\"socialMediaLink\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('foundationOrganisationProfilePage.sections.online.socialMediaLinkLabel')}</label>"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.sections.online.socialMediaLinkPlaceholder",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 97,
+      "context": "<input type=\"url\" name=\"socialMediaLink\" id=\"socialMediaLink\" value={additionalProfile.socialMediaLink} onChange={handleChange} className={STANDARD_INPUT_FIELD} placeholder={t('foundationOrganisationProfilePage.sections.online.socialMediaLinkPlaceholder')}/>"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.sections.online.acceptingLeadsLabel",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 101,
+      "context": "<label htmlFor=\"acceptingLeads\" className=\"ml-2 block text-sm font-medium text-gray-700\">{t('foundationOrganisationProfilePage.sections.online.acceptingLeadsLabel')}</label>"
+    },
+    {
+      "key": "foundationOrganisationProfilePage.saveButton",
+      "file": "pages/foundation/FoundationOrganisationProfilePage.tsx",
+      "line": 106,
+      "context": "<Button type=\"submit\" variant=\"primary\">{t('foundationOrganisationProfilePage.saveButton')}</Button>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.productOrdersTitle",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 76,
+      "context": "<h3 className=\"text-lg font-semibold text-swiss-charcoal\">{t('foundationOrdersAppointmentsPage.productOrdersTitle')}</h3>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.exportCsvProductAlert",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 77,
+      "context": "<Button variant=\"outline\" size=\"sm\" onClick={() => alert(t('foundationOrdersAppointmentsPage.exportCsvProductAlert'))}>{t('foundationOrdersAppointmentsPage.exportCsvButton')}</Button>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.exportCsvButton",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 77,
+      "context": "<Button variant=\"outline\" size=\"sm\" onClick={() => alert(t('foundationOrdersAppointmentsPage.exportCsvProductAlert'))}>{t('foundationOrdersAppointmentsPage.exportCsvButton')}</Button>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.noProductOrders",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 82,
+      "context": "{t('foundationOrdersAppointmentsPage.noProductOrders')}"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.table.refNo",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 89,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('foundationOrdersAppointmentsPage.table.refNo')}</th>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.table.supplier",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 90,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('foundationOrdersAppointmentsPage.table.supplier')}</th>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.table.itemsQty",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 91,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('foundationOrdersAppointmentsPage.table.itemsQty')}</th>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.table.total",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 92,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('foundationOrdersAppointmentsPage.table.total')}</th>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.table.date",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 93,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('foundationOrdersAppointmentsPage.table.date')}</th>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.table.status",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 94,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('foundationOrdersAppointmentsPage.table.status')}</th>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.table.actions",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 95,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('foundationOrdersAppointmentsPage.table.actions')}</th>"
+    },
+    {
+      "key": "common:buttons.sendMessage",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 121,
+      "context": "<Button variant=\"ghost\" size=\"xs\" onClick={() => handleSendMessageToPartner(order.supplierId, order.supplierName, UserRole.PRODUCT_SUPPLIER)}>{t('common:buttons.sendMessage')}</Button>"
+    },
+    {
+      "key": "common:buttons.sendMessage",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 121,
+      "context": "<Button variant=\"ghost\" size=\"xs\" onClick={() => handleSendMessageToPartner(order.supplierId, order.supplierName, UserRole.PRODUCT_SUPPLIER)}>{t('common:buttons.sendMessage')}</Button>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.cancelOrderAlert",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 123,
+      "context": "<Button variant=\"ghost\" size=\"xs\" className=\"text-red-600 hover:text-red-700 ml-1\" onClick={() => alert(t('foundationOrdersAppointmentsPage.cancelOrderAlert', { orderId: order.id }))}>{t('common:buttons.cancel')}</Button>"
+    },
+    {
+      "key": "common:buttons.cancel",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 123,
+      "context": "<Button variant=\"ghost\" size=\"xs\" className=\"text-red-600 hover:text-red-700 ml-1\" onClick={() => alert(t('foundationOrdersAppointmentsPage.cancelOrderAlert', { orderId: order.id }))}>{t('common:buttons.cancel')}</Button>"
+    },
+    {
+      "key": "common:buttons.cancel",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 123,
+      "context": "<Button variant=\"ghost\" size=\"xs\" className=\"text-red-600 hover:text-red-700 ml-1\" onClick={() => alert(t('foundationOrdersAppointmentsPage.cancelOrderAlert', { orderId: order.id }))}>{t('common:buttons.cancel')}</Button>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.serviceAppointmentsTitle",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 139,
+      "context": "<h3 className=\"text-lg font-semibold text-swiss-charcoal\">{t('foundationOrdersAppointmentsPage.serviceAppointmentsTitle')}</h3>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.exportCsvServiceAlert",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 140,
+      "context": "<Button variant=\"outline\" size=\"sm\" onClick={() => alert(t('foundationOrdersAppointmentsPage.exportCsvServiceAlert'))}>{t('foundationOrdersAppointmentsPage.exportCsvButton')}</Button>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.exportCsvButton",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 140,
+      "context": "<Button variant=\"outline\" size=\"sm\" onClick={() => alert(t('foundationOrdersAppointmentsPage.exportCsvServiceAlert'))}>{t('foundationOrdersAppointmentsPage.exportCsvButton')}</Button>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.noServiceAppointments",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 145,
+      "context": "{t('foundationOrdersAppointmentsPage.noServiceAppointments')}"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.table.refNo",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 152,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('foundationOrdersAppointmentsPage.table.refNo')}</th>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.table.provider",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 153,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('foundationOrdersAppointmentsPage.table.provider')}</th>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.table.service",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 154,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('foundationOrdersAppointmentsPage.table.service')}</th>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.table.date",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 155,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('foundationOrdersAppointmentsPage.table.date')}</th>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.table.status",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 156,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('foundationOrdersAppointmentsPage.table.status')}</th>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.table.actions",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 157,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('foundationOrdersAppointmentsPage.table.actions')}</th>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.unknownProvider",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 169,
+      "context": "{provider?.name || t('foundationOrdersAppointmentsPage.unknownProvider')}"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.preferredAbbr",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 174,
+      "context": "{req.appointmentDate ? new Date(req.appointmentDate).toLocaleDateString() : (req.preferredDate ? `${new Date(req.preferredDate).toLocaleDateString()} (${t('foundationOrdersAppointmentsPage.preferredAbbr')})` : t('foundationOrdersAppointmentsPage.notApplicable'))}"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.notApplicable",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 174,
+      "context": "{req.appointmentDate ? new Date(req.appointmentDate).toLocaleDateString() : (req.preferredDate ? `${new Date(req.preferredDate).toLocaleDateString()} (${t('foundationOrdersAppointmentsPage.preferredAbbr')})` : t('foundationOrdersAppointmentsPage.notApplicable'))}"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.unknownProvider",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 182,
+      "context": "<Button variant=\"ghost\" size=\"xs\" onClick={() => handleSendMessageToPartner(req.providerId, provider?.name || t('foundationOrdersAppointmentsPage.unknownProvider'), UserRole.SERVICE_PROVIDER)}>{t('common:buttons.sendMessage')}</Button>"
+    },
+    {
+      "key": "common:buttons.sendMessage",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 182,
+      "context": "<Button variant=\"ghost\" size=\"xs\" onClick={() => handleSendMessageToPartner(req.providerId, provider?.name || t('foundationOrdersAppointmentsPage.unknownProvider'), UserRole.SERVICE_PROVIDER)}>{t('common:buttons.sendMessage')}</Button>"
+    },
+    {
+      "key": "common:buttons.sendMessage",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 182,
+      "context": "<Button variant=\"ghost\" size=\"xs\" onClick={() => handleSendMessageToPartner(req.providerId, provider?.name || t('foundationOrdersAppointmentsPage.unknownProvider'), UserRole.SERVICE_PROVIDER)}>{t('common:buttons.sendMessage')}</Button>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.rescheduleAlert",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 184,
+      "context": "<Button variant=\"ghost\" size=\"xs\" className=\"text-orange-600 hover:text-orange-700 ml-1\" onClick={() => alert(t('foundationOrdersAppointmentsPage.rescheduleAlert', { requestId: req.id }))}>{t('foundationOrdersAppointmentsPage.rescheduleButton')}</Button>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.rescheduleButton",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 184,
+      "context": "<Button variant=\"ghost\" size=\"xs\" className=\"text-orange-600 hover:text-orange-700 ml-1\" onClick={() => alert(t('foundationOrdersAppointmentsPage.rescheduleAlert', { requestId: req.id }))}>{t('foundationOrdersAppointmentsPage.rescheduleButton')}</Button>"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.productOrdersTab",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 198,
+      "context": "{ label: t('foundationOrdersAppointmentsPage.productOrdersTab'), icon: ShoppingCartIcon, content: <ProductOrdersView /> },"
+    },
+    {
+      "key": "foundationOrdersAppointmentsPage.serviceAppointmentsTab",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 199,
+      "context": "{ label: t('foundationOrdersAppointmentsPage.serviceAppointmentsTab'), icon: CalendarDaysIcon, content: <ServiceAppointmentsView /> },"
+    },
+    {
+      "key": "sidebar.ordersAppointments",
+      "file": "pages/foundation/FoundationOrdersAppointmentsPage.tsx",
+      "line": 204,
+      "context": "<h1 className=\"text-3xl font-bold text-swiss-charcoal\">{t('sidebar.ordersAppointments')}</h1>"
+    },
+    {
+      "key": "foundationLeadsPage.accessDenied.title",
+      "file": "pages/foundation/FoundationLeadsPage.tsx",
+      "line": 18,
+      "context": "<h1 className=\"text-2xl font-bold text-swiss-charcoal\">{t('foundationLeadsPage.accessDenied.title')}</h1>"
+    },
+    {
+      "key": "foundationLeadsPage.accessDenied.message",
+      "file": "pages/foundation/FoundationLeadsPage.tsx",
+      "line": 19,
+      "context": "<p className=\"text-gray-600\">{t('foundationLeadsPage.accessDenied.message')}</p>"
+    },
+    {
+      "key": "sidebar.parentLeads",
+      "file": "pages/foundation/FoundationLeadsPage.tsx",
+      "line": 25,
+      "context": "return <FeatureLock featureName={t('sidebar.parentLeads')} requiredPlan=\"Pro\" />;"
+    },
+    {
+      "key": "foundationLeadsPage.title",
+      "file": "pages/foundation/FoundationLeadsPage.tsx",
+      "line": 44,
+      "context": "{t('foundationLeadsPage.title')}"
+    },
+    {
+      "key": "foundationLeadsPage.emptyState.title",
+      "file": "pages/foundation/FoundationLeadsPage.tsx",
+      "line": 52,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-2\">{t('foundationLeadsPage.emptyState.title')}</h2>"
+    },
+    {
+      "key": "foundationLeadsPage.emptyState.message",
+      "file": "pages/foundation/FoundationLeadsPage.tsx",
+      "line": 53,
+      "context": "<p className=\"text-gray-500\">{t('foundationLeadsPage.emptyState.message')}</p>"
+    },
+    {
+      "key": "dashboardPage.timeAgo.minutes",
+      "file": "pages/foundation/FoundationDashboardPage.tsx",
+      "line": 37,
+      "context": "{ id: 1, icon: InboxArrowDownIcon, textKey: 'foundationDashboard.activity.parentInquiry', details: 'S. Dubois for a 2-year-old', time: t('dashboardPage.timeAgo.minutes', { count: 15 }), color: 'text-swiss-mint' },"
+    },
+    {
+      "key": "dashboardPage.timeAgo.hours",
+      "file": "pages/foundation/FoundationDashboardPage.tsx",
+      "line": 38,
+      "context": "{ id: 2, icon: BriefcaseIcon, textKey: 'foundationDashboard.activity.jobApplication', details: 'J. Miller for Lead Educator', time: t('dashboardPage.timeAgo.hours', { count: 1 }), color: 'text-swiss-teal' },"
+    },
+    {
+      "key": "dashboardPage.timeAgo.hours",
+      "file": "pages/foundation/FoundationDashboardPage.tsx",
+      "line": 39,
+      "context": "{ id: 3, icon: BanknotesIcon, textKey: 'foundationDashboard.activity.orderConfirmation', details: '#ORD123 from EcoToys', time: t('dashboardPage.timeAgo.hours', { count: 3 }), color: 'text-swiss-sand' },"
+    },
+    {
+      "key": "dashboardPage.timeAgo.hours",
+      "file": "pages/foundation/FoundationDashboardPage.tsx",
+      "line": 40,
+      "context": "{ id: 4, icon: DocumentTextIcon, textKey: 'foundationDashboard.activity.serviceUpdate', details: 'ProClean confirmed cleaning for Friday', time: t('dashboardPage.timeAgo.hours', { count: 5 }), color: 'text-swiss-coral' },"
+    },
+    {
+      "key": "dashboardPage.timeAgo.yesterday",
+      "file": "pages/foundation/FoundationDashboardPage.tsx",
+      "line": 41,
+      "context": "{ id: 5, icon: ChatBubbleLeftEllipsisIcon, textKey: 'foundationDashboard.activity.newMessage', details: 'From candidate T. Fischer', time: t('dashboardPage.timeAgo.yesterday'), color: 'text-gray-500' },"
+    },
+    {
+      "key": "foundationDashboard.title",
+      "file": "pages/foundation/FoundationDashboardPage.tsx",
+      "line": 61,
+      "context": "{t('foundationDashboard.title')}"
+    },
+    {
+      "key": "foundationDashboard.welcomeMessage",
+      "file": "pages/foundation/FoundationDashboardPage.tsx",
+      "line": 63,
+      "context": "<p className=\"text-gray-500 mt-1\">{t('foundationDashboard.welcomeMessage', { name: currentUser?.name?.split(' ')[0] })}</p>"
+    },
+    {
+      "key": "foundationDashboard.quickStats.title",
+      "file": "pages/foundation/FoundationDashboardPage.tsx",
+      "line": 70,
+      "context": "<h2 className=\"text-lg font-semibold text-swiss-charcoal mb-3\">{t('foundationDashboard.quickStats.title')}</h2>"
+    },
+    {
+      "key": "foundationDashboard.todayAtGlance",
+      "file": "pages/foundation/FoundationDashboardPage.tsx",
+      "line": 88,
+      "context": "<h2 className=\"text-lg font-semibold text-swiss-charcoal\">{t('foundationDashboard.todayAtGlance')}</h2>"
+    },
+    {
+      "key": "foundationDashboard.activity.title",
+      "file": "pages/foundation/FoundationDashboardPage.tsx",
+      "line": 108,
+      "context": "<h2 className=\"text-lg font-semibold text-swiss-charcoal mb-4\">{t('foundationDashboard.activity.title')}</h2>"
+    },
+    {
+      "key": "common:buttons.view",
+      "file": "pages/foundation/FoundationDashboardPage.tsx",
+      "line": 121,
+      "context": "<Button variant=\"ghost\" size=\"xs\">{t('common:buttons.view')}</Button>"
+    },
+    {
+      "key": "common:buttons.view",
+      "file": "pages/foundation/FoundationDashboardPage.tsx",
+      "line": 121,
+      "context": "<Button variant=\"ghost\" size=\"xs\">{t('common:buttons.view')}</Button>"
+    },
+    {
+      "key": "foundationDashboard.quickActions.title",
+      "file": "pages/foundation/FoundationDashboardPage.tsx",
+      "line": 131,
+      "context": "<h2 className=\"text-lg font-semibold text-swiss-charcoal mb-3\">{t('foundationDashboard.quickActions.title')}</h2>"
+    },
+    {
+      "key": "foundationDashboard.quickMessage.title",
+      "file": "pages/foundation/FoundationDashboardPage.tsx",
+      "line": 141,
+      "context": "<h2 className=\"text-lg font-semibold mb-2\">{t('foundationDashboard.quickMessage.title')}</h2>"
+    },
+    {
+      "key": "foundationDashboard.quickMessage.placeholder",
+      "file": "pages/foundation/FoundationDashboardPage.tsx",
+      "line": 142,
+      "context": "<textarea placeholder={t('foundationDashboard.quickMessage.placeholder')} rows={3} className=\"w-full p-2 rounded-md text-sm text-swiss-charcoal placeholder-gray-500 border-gray-300 focus:ring-swiss-mint focus:border-swiss-mint\"></textarea>"
+    },
+    {
+      "key": "common:buttons.sendMessage",
+      "file": "pages/foundation/FoundationDashboardPage.tsx",
+      "line": 143,
+      "context": "<Button variant=\"secondary\" size=\"sm\" className=\"w-full mt-2 !bg-white !text-swiss-teal\">{t('common:buttons.sendMessage')}</Button>"
+    },
+    {
+      "key": "common:buttons.sendMessage",
+      "file": "pages/foundation/FoundationDashboardPage.tsx",
+      "line": 143,
+      "context": "<Button variant=\"secondary\" size=\"sm\" className=\"w-full mt-2 !bg-white !text-swiss-teal\">{t('common:buttons.sendMessage')}</Button>"
+    },
+    {
+      "key": "foundationAnalyticsPage.mockDataVisualization",
+      "file": "pages/foundation/FoundationAnalyticsPage.tsx",
+      "line": 18,
+      "context": "<p className=\"text-xs text-gray-400\">{t('foundationAnalyticsPage.mockDataVisualization')}</p>"
+    },
+    {
+      "key": "foundationAnalyticsPage.title",
+      "file": "pages/foundation/FoundationAnalyticsPage.tsx",
+      "line": 25,
+      "context": "<h1 className=\"text-3xl font-bold text-swiss-charcoal mb-4 md:mb-0\">{t('foundationAnalyticsPage.title')}</h1>"
+    },
+    {
+      "key": "supplierAnalyticsPage.datePickerLabel",
+      "file": "pages/foundation/FoundationAnalyticsPage.tsx",
+      "line": 27,
+      "context": "<input type=\"date\" className={`${STANDARD_INPUT_FIELD} w-auto`} defaultValue={new Date().toISOString().split('T')[0]} aria-label={t('supplierAnalyticsPage.datePickerLabel')}/>"
+    },
+    {
+      "key": "supplierAnalyticsPage.exportCsvAlert",
+      "file": "pages/foundation/FoundationAnalyticsPage.tsx",
+      "line": 28,
+      "context": "<Button variant=\"outline\" size=\"md\" leftIcon={ArrowDownTrayIcon} onClick={() => alert(t('supplierAnalyticsPage.exportCsvAlert'))}>"
+    },
+    {
+      "key": "supplierAnalyticsPage.exportCsvButton",
+      "file": "pages/foundation/FoundationAnalyticsPage.tsx",
+      "line": 29,
+      "context": "{t('supplierAnalyticsPage.exportCsvButton')}"
+    },
+    {
+      "key": "foundationAnalyticsPage.spendingByCategory",
+      "file": "pages/foundation/FoundationAnalyticsPage.tsx",
+      "line": 36,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-3\">{t('foundationAnalyticsPage.spendingByCategory')}</h2>"
+    },
+    {
+      "key": "foundationAnalyticsPage.parentLeadConversion",
+      "file": "pages/foundation/FoundationAnalyticsPage.tsx",
+      "line": 40,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-3\">{t('foundationAnalyticsPage.parentLeadConversion')}</h2>"
+    },
+    {
+      "key": "foundationAnalyticsPage.staffTrainingCompletion",
+      "file": "pages/foundation/FoundationAnalyticsPage.tsx",
+      "line": 44,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-3\">{t('foundationAnalyticsPage.staffTrainingCompletion')}</h2>"
+    },
+    {
+      "key": "foundationAnalyticsPage.enrollmentTrend",
+      "file": "pages/foundation/FoundationAnalyticsPage.tsx",
+      "line": 50,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-3\">{t('foundationAnalyticsPage.enrollmentTrend')}</h2>"
+    },
+    {
+      "key": "discountTerminations.actions.sendNoticesAlert",
+      "file": "pages/admin/DiscountTerminationsPage.tsx",
+      "line": 28,
+      "context": "alert(t('discountTerminations.actions.sendNoticesAlert', { count: terminationQueue.length }));"
+    },
+    {
+      "key": "discountTerminations.table.vendor",
+      "file": "pages/admin/DiscountTerminationsPage.tsx",
+      "line": 56,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('discountTerminations.table.vendor')}</th>"
+    },
+    {
+      "key": "discountTerminations.table.daycare",
+      "file": "pages/admin/DiscountTerminationsPage.tsx",
+      "line": 57,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('discountTerminations.table.daycare')}</th>"
+    },
+    {
+      "key": "discountTerminations.table.activeSince",
+      "file": "pages/admin/DiscountTerminationsPage.tsx",
+      "line": 58,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('discountTerminations.table.activeSince')}</th>"
+    },
+    {
+      "key": "discountTerminations.table.reason",
+      "file": "pages/admin/DiscountTerminationsPage.tsx",
+      "line": 59,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('discountTerminations.table.reason')}</th>"
+    },
+    {
+      "key": "discountTerminations.table.actions",
+      "file": "pages/admin/DiscountTerminationsPage.tsx",
+      "line": 60,
+      "context": "<th className=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase\">{t('discountTerminations.table.actions')}</th>"
+    },
+    {
+      "key": "discountTerminations.actions.markCompleted",
+      "file": "pages/admin/DiscountTerminationsPage.tsx",
+      "line": 72,
+      "context": "<Button variant=\"secondary\" size=\"xs\" onClick={() => handleMarkCompleted(vc.id)}>{t('discountTerminations.actions.markCompleted')}</Button>"
+    },
+    {
+      "key": "common:buttons.viewDetails",
+      "file": "pages/admin/DiscountTerminationsPage.tsx",
+      "line": 74,
+      "context": "<Button variant=\"outline\" size=\"xs\">{t('common:buttons.viewDetails')}</Button>"
+    },
+    {
+      "key": "common:buttons.viewDetails",
+      "file": "pages/admin/DiscountTerminationsPage.tsx",
+      "line": 74,
+      "context": "<Button variant=\"outline\" size=\"xs\">{t('common:buttons.viewDetails')}</Button>"
+    },
+    {
+      "key": "dashboard:sidebar.discountTerminations",
+      "file": "pages/admin/DiscountTerminationsPage.tsx",
+      "line": 90,
+      "context": "{t('dashboard:sidebar.discountTerminations')}"
+    },
+    {
+      "key": "dashboard:sidebar.discountTerminations",
+      "file": "pages/admin/DiscountTerminationsPage.tsx",
+      "line": 90,
+      "context": "{t('dashboard:sidebar.discountTerminations')}"
+    },
+    {
+      "key": "discountTerminations.queue.title",
+      "file": "pages/admin/DiscountTerminationsPage.tsx",
+      "line": 99,
+      "context": "{t('discountTerminations.queue.title')}"
+    },
+    {
+      "key": "discountTerminations.queue.description",
+      "file": "pages/admin/DiscountTerminationsPage.tsx",
+      "line": 101,
+      "context": "<p className=\"text-sm text-gray-700\">{t('discountTerminations.queue.description')}</p>"
+    },
+    {
+      "key": "discountTerminations.actions.sendNotices",
+      "file": "pages/admin/DiscountTerminationsPage.tsx",
+      "line": 105,
+      "context": "{t('discountTerminations.actions.sendNotices', { count: terminationQueue.length })}"
+    },
+    {
+      "key": "discountTerminations.queue.tableTitle",
+      "file": "pages/admin/DiscountTerminationsPage.tsx",
+      "line": 110,
+      "context": "{renderTable(terminationQueue, t('discountTerminations.queue.tableTitle'), 'discountTerminations.queue.empty')}"
+    },
+    {
+      "key": "discountTerminations.allActive.title",
+      "file": "pages/admin/DiscountTerminationsPage.tsx",
+      "line": 118,
+      "context": "{t('discountTerminations.allActive.title')}"
+    },
+    {
+      "key": "discountTerminations.allActive.description",
+      "file": "pages/admin/DiscountTerminationsPage.tsx",
+      "line": 120,
+      "context": "<p className=\"text-sm text-gray-600 mb-4\">{t('discountTerminations.allActive.description')}</p>"
+    },
+    {
+      "key": "discountTerminations.allActive.tableTitle",
+      "file": "pages/admin/DiscountTerminationsPage.tsx",
+      "line": 121,
+      "context": "{renderTable(allActiveClients, t('discountTerminations.allActive.tableTitle'), 'discountTerminations.allActive.empty')}"
+    },
+    {
+      "key": "adminSystemMonitoringPage.rawLogConsole.emptyLogMessage",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 54,
+      "context": "return <p className=\"text-center text-gray-400 py-8\">{t('adminSystemMonitoringPage.rawLogConsole.emptyLogMessage')}</p>;"
+    },
+    {
+      "key": "adminSystemMonitoringPage.rawLogConsole.tabs.all",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 73,
+      "context": "{ label: t('adminSystemMonitoringPage.rawLogConsole.tabs.all'), content: <LogList logs={MOCK_LOG_ENTRIES} /> },"
+    },
+    {
+      "key": "adminSystemMonitoringPage.rawLogConsole.tabs.errors",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 74,
+      "context": "{ label: t('adminSystemMonitoringPage.rawLogConsole.tabs.errors'), content: <LogList logs={MOCK_LOG_ENTRIES.filter(l => l.level === 'ERROR')} /> },"
+    },
+    {
+      "key": "adminSystemMonitoringPage.rawLogConsole.tabs.warnings",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 75,
+      "context": "{ label: t('adminSystemMonitoringPage.rawLogConsole.tabs.warnings'), content: <LogList logs={MOCK_LOG_ENTRIES.filter(l => l.level === 'WARN')} /> },"
+    },
+    {
+      "key": "adminSystemMonitoringPage.rawLogConsole.tabs.info",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 76,
+      "context": "{ label: t('adminSystemMonitoringPage.rawLogConsole.tabs.info'), content: <LogList logs={MOCK_LOG_ENTRIES.filter(l => l.level === 'INFO')} /> },"
+    },
+    {
+      "key": "adminSystemMonitoringPage.title",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 83,
+      "context": "{t('adminSystemMonitoringPage.title')}"
+    },
+    {
+      "key": "adminSystemMonitoringPage.overallStatus.title",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 95,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal\">{t('adminSystemMonitoringPage.overallStatus.title')}</h2>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.components.api",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 102,
+      "context": "<div className=\"flex items-center\"><span className={`h-2.5 w-2.5 rounded-full mr-2 ${getStatusIndicator(data.systemStatus.components.api)}`}></span> {t('adminSystemMonitoringPage.components.api')}</div>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.components.database",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 103,
+      "context": "<div className=\"flex items-center\"><span className={`h-2.5 w-2.5 rounded-full mr-2 ${getStatusIndicator(data.systemStatus.components.database)}`}></span> {t('adminSystemMonitoringPage.components.database')}</div>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.components.authService",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 104,
+      "context": "<div className=\"flex items-center\"><span className={`h-2.5 w-2.5 rounded-full mr-2 ${getStatusIndicator(data.systemStatus.components.authService)}`}></span> {t('adminSystemMonitoringPage.components.authService')}</div>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.metadata.environment",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 111,
+      "context": "<Card className=\"p-4\"><p className=\"text-xs text-gray-500\">{t('adminSystemMonitoringPage.metadata.environment')}</p><p className=\"font-semibold text-lg\">{data.metadata.environment}</p></Card>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.metadata.version",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 112,
+      "context": "<Card className=\"p-4\"><p className=\"text-xs text-gray-500\">{t('adminSystemMonitoringPage.metadata.version')}</p><p className=\"font-semibold text-lg\">{data.metadata.version}</p></Card>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.metadata.uptime",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 113,
+      "context": "<Card className=\"p-4\"><p className=\"text-xs text-gray-500\">{t('adminSystemMonitoringPage.metadata.uptime')}</p><p className=\"font-semibold text-lg\">{Math.floor(data.metadata.uptimeMinutes / (60*24))} days</p></Card>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.metadata.lastCheck",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 114,
+      "context": "<Card className=\"p-4\"><p className=\"text-xs text-gray-500\">{t('adminSystemMonitoringPage.metadata.lastCheck')}</p><p className=\"font-semibold text-lg\">{new Date(data.metadata.lastHealthCheck).toLocaleTimeString()}</p></Card>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.serverPerformance.title",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 121,
+      "context": "<h3 className=\"text-lg font-semibold text-swiss-charcoal mb-4 flex items-center\"><CpuChipIcon className=\"w-6 h-6 mr-2 text-swiss-teal\"/>{t('adminSystemMonitoringPage.serverPerformance.title')}</h3>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.serverPerformance.cpuUsage",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 124,
+      "context": "<div className=\"flex justify-between text-sm mb-1\"><p>{t('adminSystemMonitoringPage.serverPerformance.cpuUsage')}</p><p className=\"font-medium\">{data.serverPerformance.cpuUsage.toFixed(1)}%</p></div>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.serverPerformance.memoryUsage",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 128,
+      "context": "<div className=\"flex justify-between text-sm mb-1\"><p>{t('adminSystemMonitoringPage.serverPerformance.memoryUsage')}</p><p className=\"font-medium\">{data.serverPerformance.memoryUsage.toFixed(1)}%</p></div>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.serverPerformance.diskUsage",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 132,
+      "context": "<div className=\"flex justify-between text-sm mb-1\"><p>{t('adminSystemMonitoringPage.serverPerformance.diskUsage')}</p><p className=\"font-medium\">{data.serverPerformance.diskUsage.toFixed(1)}%</p></div>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.serverPerformance.uptimeDays",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 136,
+      "context": "<p className=\"text-sm text-gray-500\">{t('adminSystemMonitoringPage.serverPerformance.uptimeDays')}</p>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.databasePerformance.title",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 144,
+      "context": "<h3 className=\"text-lg font-semibold text-swiss-charcoal mb-4 flex items-center\"><CircleStackIcon className=\"w-6 h-6 mr-2 text-swiss-teal\"/>{t('adminSystemMonitoringPage.databasePerformance.title')}</h3>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.databasePerformance.activeConnections",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 147,
+      "context": "<div className=\"flex justify-between text-sm mb-1\"><p>{t('adminSystemMonitoringPage.databasePerformance.activeConnections')}</p><p className=\"font-medium\">{data.databasePerformance.activeConnections} / {data.databasePerformance.maxConnections}</p></div>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.databasePerformance.queryTime",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 150,
+      "context": "<div className=\"flex justify-between text-sm items-center\"><p>{t('adminSystemMonitoringPage.databasePerformance.queryTime')}</p><p className=\"font-medium text-lg\">{data.databasePerformance.avgQueryTimeMs}ms</p></div>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.databasePerformance.storage",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 152,
+      "context": "<div className=\"flex justify-between text-sm mb-1\"><p>{t('adminSystemMonitoringPage.databasePerformance.storage')}</p><p className=\"font-medium\">{data.databasePerformance.storageUsedGb.toFixed(1)} / {data.databasePerformance.storageTotalGb} GB</p></div>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.databasePerformance.connectionHealth",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 156,
+      "context": "<p className=\"text-sm text-gray-500\">{t('adminSystemMonitoringPage.databasePerformance.connectionHealth')}</p>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.appPerformance.title",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 166,
+      "context": "<h3 className=\"text-lg font-semibold text-swiss-charcoal mb-4 flex items-center\"><CogIcon className=\"w-6 h-6 mr-2 text-swiss-teal\"/>{t('adminSystemMonitoringPage.appPerformance.title')}</h3>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.appPerformance.activeUsers",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 168,
+      "context": "<div className=\"p-2 rounded-lg bg-gray-50\"><p className=\"text-xs text-gray-500\">{t('adminSystemMonitoringPage.appPerformance.activeUsers')}</p><p className=\"text-2xl font-bold\">{data.appPerformance.activeUsers}</p></div>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.appPerformance.requestsPerMinute",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 169,
+      "context": "<div className=\"p-2 rounded-lg bg-gray-50\"><p className=\"text-xs text-gray-500\">{t('adminSystemMonitoringPage.appPerformance.requestsPerMinute')}</p><p className=\"text-2xl font-bold\">{data.appPerformance.requestsPerMinute}</p></div>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.appPerformance.avgResponseTime",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 170,
+      "context": "<div className=\"p-2 rounded-lg bg-gray-50\"><p className=\"text-xs text-gray-500\">{t('adminSystemMonitoringPage.appPerformance.avgResponseTime')}</p><p className=\"text-2xl font-bold\">{data.appPerformance.avgResponseTimeMs}ms</p></div>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.appPerformance.errorRate",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 171,
+      "context": "<div className=\"p-2 rounded-lg bg-gray-50\"><p className=\"text-xs text-gray-500\">{t('adminSystemMonitoringPage.appPerformance.errorRate')}</p><p className=\"text-2xl font-bold\">{data.appPerformance.errorRate}%</p></div>"
+    },
+    {
+      "key": "adminSystemMonitoringPage.recentEvents.title",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 180,
+      "context": "{t('adminSystemMonitoringPage.recentEvents.title')}"
+    },
+    {
+      "key": "adminSystemMonitoringPage.rawLogConsole.title",
+      "file": "pages/admin/AdminSystemMonitoringPage.tsx",
+      "line": 220,
+      "context": "{t('adminSystemMonitoringPage.rawLogConsole.title')}"
+    },
+    {
+      "key": "platformSettings.title",
+      "file": "pages/admin/AdminPlatformSettingsPage.tsx",
+      "line": 32,
+      "context": "{t('platformSettings.title')}"
+    },
+    {
+      "key": "organizationProfileForm.saveSuccess",
+      "file": "pages/admin/AdminPlatformSettingsPage.tsx",
+      "line": 39,
+      "context": "{t('organizationProfileForm.saveSuccess')}"
+    },
+    {
+      "key": "platformSettings.general.title",
+      "file": "pages/admin/AdminPlatformSettingsPage.tsx",
+      "line": 45,
+      "context": "{t('platformSettings.general.title')}"
+    },
+    {
+      "key": "platformSettings.general.nameLabel",
+      "file": "pages/admin/AdminPlatformSettingsPage.tsx",
+      "line": 49,
+      "context": "<label htmlFor=\"platformName\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('platformSettings.general.nameLabel')}</label>"
+    },
+    {
+      "key": "platformSettings.general.descriptionLabel",
+      "file": "pages/admin/AdminPlatformSettingsPage.tsx",
+      "line": 60,
+      "context": "<label htmlFor=\"metadataDescription\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('platformSettings.general.descriptionLabel')}</label>"
+    },
+    {
+      "key": "platformSettings.branding.title",
+      "file": "pages/admin/AdminPlatformSettingsPage.tsx",
+      "line": 74,
+      "context": "{t('platformSettings.branding.title')}"
+    },
+    {
+      "key": "platformSettings.branding.logoLabel",
+      "file": "pages/admin/AdminPlatformSettingsPage.tsx",
+      "line": 78,
+      "context": "<label htmlFor=\"logoUrl\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('platformSettings.branding.logoLabel')}</label>"
+    },
+    {
+      "key": "platformSettings.branding.faviconLabel",
+      "file": "pages/admin/AdminPlatformSettingsPage.tsx",
+      "line": 82,
+      "context": "<label htmlFor=\"faviconUrl\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('platformSettings.branding.faviconLabel')}</label>"
+    },
+    {
+      "key": "common:buttons.saveChanges",
+      "file": "pages/admin/AdminPlatformSettingsPage.tsx",
+      "line": 88,
+      "context": "<Button type=\"submit\" variant=\"primary\">{t('common:buttons.saveChanges')}</Button>"
+    },
+    {
+      "key": "common:buttons.saveChanges",
+      "file": "pages/admin/AdminPlatformSettingsPage.tsx",
+      "line": 88,
+      "context": "<Button type=\"submit\" variant=\"primary\">{t('common:buttons.saveChanges')}</Button>"
+    },
+    {
+      "key": "pricingPage.monthly",
+      "file": "components/ui/PricingToggle.tsx",
+      "line": 24,
+      "context": "{t('pricingPage.monthly')}"
+    },
+    {
+      "key": "pricingPage.annual",
+      "file": "components/ui/PricingToggle.tsx",
+      "line": 34,
+      "context": "{t('pricingPage.annual')}"
+    },
+    {
+      "key": "pricingPage.saveUpTo10",
+      "file": "components/ui/PricingToggle.tsx",
+      "line": 39,
+      "context": "{t('pricingPage.saveUpTo10')}"
+    },
+    {
+      "key": "languageSwitcher.selectLanguage",
+      "file": "components/ui/LanguageSwitcher.tsx",
+      "line": 60,
+      "context": "aria-label={t('languageSwitcher.selectLanguage', { currentLanguage: getName(currentLanguageDetails) })}"
+    },
+    {
+      "key": "fileUploadZone.dragAndDrop",
+      "file": "components/ui/FileUploadZone.tsx",
+      "line": 121,
+      "context": "<p className=\"pl-1 text-gray-500\">{t(\"fileUploadZone.dragAndDrop\")}</p>"
+    },
+    {
+      "key": "supplierDashboard.recentOrdersActions.decline",
+      "file": "components/supplier/OrderRequestDetailModal.tsx",
+      "line": 34,
+      "context": "<Button variant=\"danger\" onClick={() => onUpdateStatus(order.id, OrderRequestStatus.DECLINED)}>{t('supplierDashboard.recentOrdersActions.decline')}</Button>"
+    },
+    {
+      "key": "supplierDashboard.recentOrdersActions.accept",
+      "file": "components/supplier/OrderRequestDetailModal.tsx",
+      "line": 35,
+      "context": "<Button variant=\"primary\" onClick={() => onUpdateStatus(order.id, OrderRequestStatus.ACCEPTED)}>{t('supplierDashboard.recentOrdersActions.accept')}</Button>"
+    },
+    {
+      "key": "orderRequestDetailModal.markAsProcessing",
+      "file": "components/supplier/OrderRequestDetailModal.tsx",
+      "line": 39,
+      "context": "return <Button variant=\"secondary\" onClick={() => onUpdateStatus(order.id, OrderRequestStatus.PROCESSING)}>{t(\"orderRequestDetailModal.markAsProcessing\")}</Button>;"
+    },
+    {
+      "key": "supplierOrdersPage.actions.ship",
+      "file": "components/supplier/OrderRequestDetailModal.tsx",
+      "line": 41,
+      "context": "return <Button variant=\"secondary\" onClick={() => onUpdateStatus(order.id, OrderRequestStatus.SHIPPED)}>{t('supplierOrdersPage.actions.ship')}</Button>;"
+    },
+    {
+      "key": "orderRequestDetailModal.title",
+      "file": "components/supplier/OrderRequestDetailModal.tsx",
+      "line": 51,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal\">{t('orderRequestDetailModal.title')}</h2>"
+    },
+    {
+      "key": "orderRequestDetailModal.orderId",
+      "file": "components/supplier/OrderRequestDetailModal.tsx",
+      "line": 56,
+      "context": "<div className=\"p-3 bg-gray-50 rounded-md\"><span className=\"block text-xs text-gray-500\">{t('orderRequestDetailModal.orderId')}</span><span className=\"font-semibold\">{order.id}</span></div>"
+    },
+    {
+      "key": "orderRequestDetailModal.date",
+      "file": "components/supplier/OrderRequestDetailModal.tsx",
+      "line": 57,
+      "context": "<div className=\"p-3 bg-gray-50 rounded-md\"><span className=\"block text-xs text-gray-500\">{t('orderRequestDetailModal.date')}</span><span className=\"font-semibold\">{new Date(order.requestDate).toLocaleDateString()}</span></div>"
+    },
+    {
+      "key": "orderRequestDetailModal.status",
+      "file": "components/supplier/OrderRequestDetailModal.tsx",
+      "line": 58,
+      "context": "<div className=\"p-3 bg-gray-50 rounded-md\"><span className=\"block text-xs text-gray-500\">{t('orderRequestDetailModal.status')}</span><span className=\"font-semibold\">{t(`orderStatus.${order.status.toLowerCase().replace(/\\s/g, '')}` as const, order.status)}</span></div>"
+    },
+    {
+      "key": "orderRequestDetailModal.total",
+      "file": "components/supplier/OrderRequestDetailModal.tsx",
+      "line": 59,
+      "context": "<div className=\"p-3 bg-gray-50 rounded-md\"><span className=\"block text-xs text-gray-500\">{t('orderRequestDetailModal.total')}</span><span className=\"font-semibold\">CHF {order.totalAmount.toFixed(2)}</span></div>"
+    },
+    {
+      "key": "supplierOrdersPage.table.foundation",
+      "file": "components/supplier/OrderRequestDetailModal.tsx",
+      "line": 63,
+      "context": "<h3 className=\"font-semibold mb-2\">{t('supplierOrdersPage.table.foundation')}</h3>"
+    },
+    {
+      "key": "orderRequestDetailModal.viewDaycareProfile",
+      "file": "components/supplier/OrderRequestDetailModal.tsx",
+      "line": 71,
+      "context": "{t('orderRequestDetailModal.viewDaycareProfile')}"
+    },
+    {
+      "key": "orderRequestDetailModal.lineItems",
+      "file": "components/supplier/OrderRequestDetailModal.tsx",
+      "line": 76,
+      "context": "<h3 className=\"font-semibold mb-2\">{t('orderRequestDetailModal.lineItems')}</h3>"
+    },
+    {
+      "key": "orderRequestDetailModal.product",
+      "file": "components/supplier/OrderRequestDetailModal.tsx",
+      "line": 81,
+      "context": "<th className=\"px-4 py-2 text-left font-medium text-gray-600\">{t('orderRequestDetailModal.product')}</th>"
+    },
+    {
+      "key": "orderRequestDetailModal.quantity",
+      "file": "components/supplier/OrderRequestDetailModal.tsx",
+      "line": 82,
+      "context": "<th className=\"px-4 py-2 text-center font-medium text-gray-600\">{t('orderRequestDetailModal.quantity')}</th>"
+    },
+    {
+      "key": "orderRequestDetailModal.price",
+      "file": "components/supplier/OrderRequestDetailModal.tsx",
+      "line": 83,
+      "context": "<th className=\"px-4 py-2 text-right font-medium text-gray-600\">{t('orderRequestDetailModal.price')}</th>"
+    },
+    {
+      "key": "orderRequestDetailModal.notes",
+      "file": "components/supplier/OrderRequestDetailModal.tsx",
+      "line": 103,
+      "context": "<h3 className=\"font-semibold mb-1\">{t('orderRequestDetailModal.notes')}</h3>"
+    },
+    {
+      "key": "buttons.close",
+      "file": "components/supplier/OrderRequestDetailModal.tsx",
+      "line": 109,
+      "context": "<Button type=\"button\" variant=\"light\" onClick={onClose}>{t('buttons.close')}</Button>"
+    },
+    {
+      "key": "renameFileModal.title",
+      "file": "components/shared/RenameFileModal.tsx",
+      "line": 40,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal\">{t('renameFileModal.title')}</h2>"
+    },
+    {
+      "key": "renameFileModal.label",
+      "file": "components/shared/RenameFileModal.tsx",
+      "line": 44,
+      "context": "<label htmlFor=\"fileName\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('renameFileModal.label')}</label>"
+    },
+    {
+      "key": "buttons.cancel",
+      "file": "components/shared/RenameFileModal.tsx",
+      "line": 56,
+      "context": "<Button type=\"button\" variant=\"light\" onClick={onClose}>{t('buttons.cancel')}</Button>"
+    },
+    {
+      "key": "buttons.save",
+      "file": "components/shared/RenameFileModal.tsx",
+      "line": 57,
+      "context": "<Button type=\"submit\" variant=\"primary\">{t('buttons.save')}</Button>"
+    },
+    {
+      "key": "fileUploadModal.title",
+      "file": "components/shared/FileUploadModal.tsx",
+      "line": 57,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal\">{t('fileUploadModal.title')}</h2>"
+    },
+    {
+      "key": "fileUploadModal.uploadFile",
+      "file": "components/shared/FileUploadModal.tsx",
+      "line": 70,
+      "context": "<span>{t('fileUploadModal.uploadFile')}</span>"
+    },
+    {
+      "key": "fileUploadModal.dragAndDrop",
+      "file": "components/shared/FileUploadModal.tsx",
+      "line": 73,
+      "context": "<p className=\"pl-1\">{t('fileUploadModal.dragAndDrop')}</p>"
+    },
+    {
+      "key": "fileUploadModal.fileTypes",
+      "file": "components/shared/FileUploadModal.tsx",
+      "line": 75,
+      "context": "<p className=\"text-xs text-gray-500\">{t('fileUploadModal.fileTypes')}</p>"
+    },
+    {
+      "key": "fileUploadModal.filesToUpload",
+      "file": "components/shared/FileUploadModal.tsx",
+      "line": 80,
+      "context": "<h3 className=\"text-sm font-medium text-gray-700\">{t('fileUploadModal.filesToUpload')}</h3>"
+    },
+    {
+      "key": "buttons.cancel",
+      "file": "components/shared/FileUploadModal.tsx",
+      "line": 95,
+      "context": "<Button variant=\"light\" onClick={onClose} disabled={isUploading}>{t('buttons.cancel')}</Button>"
+    },
+    {
+      "key": "fileUploadModal.uploading",
+      "file": "components/shared/FileUploadModal.tsx",
+      "line": 97,
+      "context": "{isUploading ? t('fileUploadModal.uploading') : t('fileUploadModal.uploadButton', { count: filesToUpload.length })}"
+    },
+    {
+      "key": "fileUploadModal.uploadButton",
+      "file": "components/shared/FileUploadModal.tsx",
+      "line": 97,
+      "context": "{isUploading ? t('fileUploadModal.uploading') : t('fileUploadModal.uploadButton', { count: filesToUpload.length })}"
+    },
+    {
+      "key": "featureLock.title",
+      "file": "components/shared/FeatureLock.tsx",
+      "line": 21,
+      "context": "<h2 className=\"text-2xl font-bold text-swiss-charcoal mb-2\">{t('featureLock.title', { featureName })}</h2>"
+    },
+    {
+      "key": "featureLock.message",
+      "file": "components/shared/FeatureLock.tsx",
+      "line": 22,
+      "context": "<p className=\"text-gray-600 mb-6\">{t('featureLock.message', { requiredPlan })}</p>"
+    },
+    {
+      "key": "featureLock.upgradeButton",
+      "file": "components/shared/FeatureLock.tsx",
+      "line": 24,
+      "context": "{t('featureLock.upgradeButton')}"
+    },
+    {
+      "key": "errorBoundary.somethingWentWrong",
+      "file": "components/shared/ErrorBoundary.tsx",
+      "line": 55,
+      "context": "{t(\"errorBoundary.somethingWentWrong\")}"
+    },
+    {
+      "key": "errorBoundary.sorryMessage",
+      "file": "components/shared/ErrorBoundary.tsx",
+      "line": 58,
+      "context": "{t(\"errorBoundary.sorryMessage\")}"
+    },
+    {
+      "key": "errorBoundary.errorDetails",
+      "file": "components/shared/ErrorBoundary.tsx",
+      "line": 63,
+      "context": "{t(\"errorBoundary.errorDetails\")}"
+    },
+    {
+      "key": "errorBoundary.tryAgain",
+      "file": "components/shared/ErrorBoundary.tsx",
+      "line": 77,
+      "context": "{t(\"errorBoundary.tryAgain\")}"
+    },
+    {
+      "key": "errorBoundary.reloadPage",
+      "file": "components/shared/ErrorBoundary.tsx",
+      "line": 84,
+      "context": "{t(\"errorBoundary.reloadPage\")}"
+    },
+    {
+      "key": "activeClientToggle.confirmSave",
+      "file": "components/shared/ActiveClientToggle.tsx",
+      "line": 35,
+      "context": "if (window.confirm(t('activeClientToggle.confirmSave'))) {"
+    },
+    {
+      "key": "activeClientToggle.saveSuccess.title",
+      "file": "components/shared/ActiveClientToggle.tsx",
+      "line": 38,
+      "context": "title: t('activeClientToggle.saveSuccess.title'),"
+    },
+    {
+      "key": "activeClientToggle.saveSuccess.message",
+      "file": "components/shared/ActiveClientToggle.tsx",
+      "line": 39,
+      "context": "message: t('activeClientToggle.saveSuccess.message'),"
+    },
+    {
+      "key": "activeClientToggle.title",
+      "file": "components/shared/ActiveClientToggle.tsx",
+      "line": 49,
+      "context": "<h3 className=\"text-lg font-semibold text-amber-900 mb-2\">{t('activeClientToggle.title')}</h3>"
+    },
+    {
+      "key": "activeClientToggle.label",
+      "file": "components/shared/ActiveClientToggle.tsx",
+      "line": 51,
+      "context": "<label htmlFor=\"activeClientToggle\" className=\"font-medium text-amber-800\">{t('activeClientToggle.label')}</label>"
+    },
+    {
+      "key": "activeClientToggle.reasonLabel",
+      "file": "components/shared/ActiveClientToggle.tsx",
+      "line": 64,
+      "context": "<label htmlFor=\"clientReason\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('activeClientToggle.reasonLabel')}</label>"
+    },
+    {
+      "key": "placeholders.select",
+      "file": "components/shared/ActiveClientToggle.tsx",
+      "line": 66,
+      "context": "<option value=\"\">{t('placeholders.select')}</option>"
+    },
+    {
+      "key": "activeClientToggle.noteLabel",
+      "file": "components/shared/ActiveClientToggle.tsx",
+      "line": 73,
+      "context": "<label htmlFor=\"clientNote\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('activeClientToggle.noteLabel')}</label>"
+    },
+    {
+      "key": "activeClientToggle.notePlaceholder",
+      "file": "components/shared/ActiveClientToggle.tsx",
+      "line": 81,
+      "context": "placeholder={t('activeClientToggle.notePlaceholder')}"
+    },
+    {
+      "key": "activeClientToggle.subtext",
+      "file": "components/shared/ActiveClientToggle.tsx",
+      "line": 85,
+      "context": "<p className=\"text-xs text-gray-600 mt-2\">{t('activeClientToggle.subtext')}</p>"
+    },
+    {
+      "key": "buttons.saveChanges",
+      "file": "components/shared/ActiveClientToggle.tsx",
+      "line": 87,
+      "context": "{t('buttons.saveChanges')}"
+    },
+    {
+      "key": "common:errors.genericErrorTitle",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 80,
+      "context": "title: t('common:errors.genericErrorTitle'),"
+    },
+    {
+      "key": "common:errors.genericErrorTitle",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 80,
+      "context": "title: t('common:errors.genericErrorTitle'),"
+    },
+    {
+      "key": "common:errors.genericErrorMessage",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 81,
+      "context": "message: t('common:errors.genericErrorMessage'),"
+    },
+    {
+      "key": "common:errors.genericErrorMessage",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 81,
+      "context": "message: t('common:errors.genericErrorMessage'),"
+    },
+    {
+      "key": "notifications.successTitle",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 157,
+      "context": "title: t('notifications.successTitle'),"
+    },
+    {
+      "key": "notifications.settingsUpdated",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 158,
+      "context": "message: t('notifications.settingsUpdated'),"
+    },
+    {
+      "key": "common:errors.genericErrorTitle",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 164,
+      "context": "title: t('common:errors.genericErrorTitle'),"
+    },
+    {
+      "key": "common:errors.genericErrorTitle",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 164,
+      "context": "title: t('common:errors.genericErrorTitle'),"
+    },
+    {
+      "key": "common:errors.genericErrorMessage",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 165,
+      "context": "message: t('common:errors.genericErrorMessage'),"
+    },
+    {
+      "key": "common:errors.genericErrorMessage",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 165,
+      "context": "message: t('common:errors.genericErrorMessage'),"
+    },
+    {
+      "key": "organizationProfileForm.accessDenied",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 174,
+      "context": "return <p>{t('organizationProfileForm.accessDenied')}</p>;"
+    },
+    {
+      "key": "common:loading",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 180,
+      "context": "<p>{t('common:loading')}</p>"
+    },
+    {
+      "key": "common:loading",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 180,
+      "context": "<p>{t('common:loading')}</p>"
+    },
+    {
+      "key": "organizationProfileForm.title",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 187,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal mb-1\">{t('organizationProfileForm.title')}</h2>"
+    },
+    {
+      "key": "organizationProfileForm.subtitle",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 188,
+      "context": "<p className=\"text-sm text-gray-500 mb-6\">{t('organizationProfileForm.subtitle')}</p>"
+    },
+    {
+      "key": "organizationProfileForm.saveSuccess",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 192,
+      "context": "{t('organizationProfileForm.saveSuccess')}"
+    },
+    {
+      "key": "organizationProfileForm.labels.capacity",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 199,
+      "context": "{t('organizationProfileForm.labels.capacity')}"
+    },
+    {
+      "key": "organizationProfileForm.labels.pedagogy",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 214,
+      "context": "{t('organizationProfileForm.labels.pedagogy')}"
+    },
+    {
+      "key": "organizationProfileForm.placeholders.pedagogy",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 223,
+      "context": "placeholder={t('organizationProfileForm.placeholders.pedagogy')}"
+    },
+    {
+      "key": "organizationProfileForm.helpText.commaSeparated",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 225,
+      "context": "<p className=\"text-xs text-gray-500 mt-1\">{t('organizationProfileForm.helpText.commaSeparated')}</p>"
+    },
+    {
+      "key": "organizationProfileForm.labels.languages",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 230,
+      "context": "{t('organizationProfileForm.labels.languages')}"
+    },
+    {
+      "key": "organizationProfileForm.placeholders.languages",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 239,
+      "context": "placeholder={t('organizationProfileForm.placeholders.languages')}"
+    },
+    {
+      "key": "organizationProfileForm.helpText.commaSeparated",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 241,
+      "context": "<p className=\"text-xs text-gray-500 mt-1\">{t('organizationProfileForm.helpText.commaSeparated')}</p>"
+    },
+    {
+      "key": "common:buttons.saveChanges",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 246,
+      "context": "{isSaving ? `${t('common:buttons.saveChanges')}...` : t('organizationProfileForm.saveButton')}"
+    },
+    {
+      "key": "organizationProfileForm.saveButton",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 246,
+      "context": "{isSaving ? `${t('common:buttons.saveChanges')}...` : t('organizationProfileForm.saveButton')}"
+    },
+    {
+      "key": "common:buttons.saveChanges",
+      "file": "components/settings/OrganizationProfileForm.tsx",
+      "line": 246,
+      "context": "{isSaving ? `${t('common:buttons.saveChanges')}...` : t('organizationProfileForm.saveButton')}"
+    },
+    {
+      "key": "addPromoCodeModal.placeholder",
+      "file": "components/settings/AddPromoCodeModal.tsx",
+      "line": 12,
+      "context": "<p>{t(\"addPromoCodeModal.placeholder\")}</p>"
+    },
+    {
+      "key": "serviceUploadModal.editTitle",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 84,
+      "context": "{existingService ? t('serviceUploadModal.editTitle') : t('serviceUploadModal.addTitle')}"
+    },
+    {
+      "key": "serviceUploadModal.addTitle",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 84,
+      "context": "{existingService ? t('serviceUploadModal.editTitle') : t('serviceUploadModal.addTitle')}"
+    },
+    {
+      "key": "buttons.close",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 86,
+      "context": "<button onClick={onClose} className=\"p-1 rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors\" aria-label={t('buttons.close')}>"
+    },
+    {
+      "key": "serviceUploadModal.labels.title",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 94,
+      "context": "<label htmlFor=\"title\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('serviceUploadModal.labels.title')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "serviceUploadModal.labels.description",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 99,
+      "context": "<label htmlFor=\"description\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('serviceUploadModal.labels.description')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "serviceUploadModal.labels.category",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 106,
+      "context": "<label htmlFor=\"category\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('serviceUploadModal.labels.category')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "serviceUploadModal.labels.deliveryType",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 112,
+      "context": "<label htmlFor=\"deliveryType\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('serviceUploadModal.labels.deliveryType')}</label>"
+    },
+    {
+      "key": "serviceUploadModal.labels.availability",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 120,
+      "context": "<label htmlFor=\"availability\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('serviceUploadModal.labels.availability')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "serviceUploadModal.placeholders.availability",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 121,
+      "context": "<input type=\"text\" name=\"availability\" id=\"availability\" value={formData.availability} onChange={handleInputChange} required className={STANDARD_INPUT_FIELD} placeholder={t('serviceUploadModal.placeholders.availability')} />"
+    },
+    {
+      "key": "serviceUploadModal.labels.priceInfo",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 125,
+      "context": "<label htmlFor=\"priceInfo\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('serviceUploadModal.labels.priceInfo')}</label>"
+    },
+    {
+      "key": "serviceUploadModal.placeholders.priceInfo",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 126,
+      "context": "<input type=\"text\" name=\"priceInfo\" id=\"priceInfo\" value={formData.priceInfo} onChange={handleInputChange} className={STANDARD_INPUT_FIELD} placeholder={t('serviceUploadModal.placeholders.priceInfo')} />"
+    },
+    {
+      "key": "serviceUploadModal.labels.tags",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 130,
+      "context": "<label htmlFor=\"tags\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('serviceUploadModal.labels.tags')}</label>"
+    },
+    {
+      "key": "serviceUploadModal.placeholders.tags",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 131,
+      "context": "<input type=\"text\" name=\"tags\" id=\"tags\" value={(formData.tags || []).join(', ')} onChange={handleInputChange} className={STANDARD_INPUT_FIELD} placeholder={t('serviceUploadModal.placeholders.tags')} />"
+    },
+    {
+      "key": "serviceUploadModal.labels.image",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 135,
+      "context": "<label className=\"block text-sm font-medium text-gray-700 mb-1\">{t('serviceUploadModal.labels.image')}</label>"
+    },
+    {
+      "key": "contentUploadModal.fileUpload.browse",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 141,
+      "context": "<span>{t('contentUploadModal.fileUpload.browse')}</span>"
+    },
+    {
+      "key": "contentUploadModal.fileUpload.dragAndDrop",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 144,
+      "context": "<p className=\"pl-1 text-gray-500\">{t('contentUploadModal.fileUpload.dragAndDrop')}</p>"
+    },
+    {
+      "key": "serviceUploadModal.imageHelpText",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 146,
+      "context": "<p className=\"text-xs text-gray-500\">{t('serviceUploadModal.imageHelpText')}</p>"
+    },
+    {
+      "key": "contentUploadModal.fileUpload.selected",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 149,
+      "context": "{file && <p className=\"mt-2 text-sm text-gray-500\"><PaperClipIcon className=\"w-4 h-4 inline mr-1\"/> {t('contentUploadModal.fileUpload.selected', { fileName: file.name })}</p>}"
+    },
+    {
+      "key": "serviceUploadModal.currentImage",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 150,
+      "context": "{formData.imageUrl && !file && <p className=\"mt-2 text-sm text-gray-500\">{t('serviceUploadModal.currentImage')}: <a href={formData.imageUrl} target=\"_blank\" rel=\"noopener noreferrer\" className=\"text-swiss-mint hover:underline\">{t('buttons.view')}</a></p>}"
+    },
+    {
+      "key": "buttons.view",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 150,
+      "context": "{formData.imageUrl && !file && <p className=\"mt-2 text-sm text-gray-500\">{t('serviceUploadModal.currentImage')}: <a href={formData.imageUrl} target=\"_blank\" rel=\"noopener noreferrer\" className=\"text-swiss-mint hover:underline\">{t('buttons.view')}</a></p>}"
+    },
+    {
+      "key": "buttons.cancel",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 154,
+      "context": "<Button type=\"button\" variant=\"light\" onClick={onClose}>{t('buttons.cancel')}</Button>"
+    },
+    {
+      "key": "buttons.saveChanges",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 156,
+      "context": "{existingService ? t('buttons.saveChanges') : t('buttons.add')}"
+    },
+    {
+      "key": "buttons.add",
+      "file": "components/service-provider/ServiceUploadModal.tsx",
+      "line": 156,
+      "context": "{existingService ? t('buttons.saveChanges') : t('buttons.add')}"
+    },
+    {
+      "key": "serviceRequestDetailModal.markAsCompleted",
+      "file": "components/service-provider/ServiceRequestDetailModal.tsx",
+      "line": 41,
+      "context": "return <Button variant=\"primary\" onClick={() => onUpdateStatus(request.id, ServiceRequestStatus.COMPLETED)}>{t(\"serviceRequestDetailModal.markAsCompleted\")}</Button>;"
+    },
+    {
+      "key": "serviceRequestDetailModal.title",
+      "file": "components/service-provider/ServiceRequestDetailModal.tsx",
+      "line": 51,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal\">{t('serviceRequestDetailModal.title')}</h2>"
+    },
+    {
+      "key": "serviceRequestDetailModal.requestId",
+      "file": "components/service-provider/ServiceRequestDetailModal.tsx",
+      "line": 56,
+      "context": "<span className=\"block text-xs text-gray-500\">{t('serviceRequestDetailModal.requestId')}</span>"
+    },
+    {
+      "key": "serviceRequestDetailModal.serviceName",
+      "file": "components/service-provider/ServiceRequestDetailModal.tsx",
+      "line": 60,
+      "context": "<span className=\"block text-xs text-gray-500\">{t('serviceRequestDetailModal.serviceName')}</span>"
+    },
+    {
+      "key": "serviceRequestDetailModal.viewDaycareProfile",
+      "file": "components/service-provider/ServiceRequestDetailModal.tsx",
+      "line": 71,
+      "context": "{t('serviceRequestDetailModal.viewDaycareProfile')}"
+    },
+    {
+      "key": "serviceRequestDetailModal.date",
+      "file": "components/service-provider/ServiceRequestDetailModal.tsx",
+      "line": 76,
+      "context": "<div className=\"p-3 bg-gray-50 rounded-md\"><span className=\"block text-xs text-gray-500\">{t('serviceRequestDetailModal.date')}</span><span className=\"font-semibold\">{new Date(request.requestDate).toLocaleDateString()}</span></div>"
+    },
+    {
+      "key": "serviceRequestDetailModal.status",
+      "file": "components/service-provider/ServiceRequestDetailModal.tsx",
+      "line": 77,
+      "context": "<div className=\"p-3 bg-gray-50 rounded-md\"><span className=\"block text-xs text-gray-500\">{t('serviceRequestDetailModal.status')}</span><span className=\"font-semibold\">{t(`serviceStatus.${request.status.toLowerCase().replace(/\\s/g, '')}` as const, request.status)}</span></div>"
+    },
+    {
+      "key": "serviceRequestDetailModal.preferredDate",
+      "file": "components/service-provider/ServiceRequestDetailModal.tsx",
+      "line": 81,
+      "context": "<span className=\"block text-xs text-gray-500\">{t('serviceRequestDetailModal.preferredDate')}</span>"
+    },
+    {
+      "key": "serviceRequestDetailModal.noPreferredDate",
+      "file": "components/service-provider/ServiceRequestDetailModal.tsx",
+      "line": 82,
+      "context": "<span className=\"font-semibold\">{request.preferredDate ? new Date(request.preferredDate).toLocaleDateString() : t('serviceRequestDetailModal.noPreferredDate')}</span>"
+    },
+    {
+      "key": "serviceRequestDetailModal.notes",
+      "file": "components/service-provider/ServiceRequestDetailModal.tsx",
+      "line": 87,
+      "context": "<h3 className=\"font-semibold text-sm mb-1\">{t('serviceRequestDetailModal.notes')}</h3>"
+    },
+    {
+      "key": "buttons.close",
+      "file": "components/service-provider/ServiceRequestDetailModal.tsx",
+      "line": 93,
+      "context": "<Button type=\"button\" variant=\"light\" onClick={onClose}>{t('buttons.close')}</Button>"
+    },
+    {
+      "key": "recruitmentPage.viewApplicantsModal.loading",
+      "file": "components/recruitment/ViewApplicantsModal.tsx",
+      "line": 45,
+      "context": "return <p className=\"text-gray-500 text-center py-8\">{t('recruitmentPage.viewApplicantsModal.loading', 'Loading applications...')}</p>;"
+    },
+    {
+      "key": "recruitmentPage.viewApplicantsModal.noApplicants",
+      "file": "components/recruitment/ViewApplicantsModal.tsx",
+      "line": 53,
+      "context": "return <p className=\"text-gray-500 text-center py-8\">{t('recruitmentPage.viewApplicantsModal.noApplicants')}</p>;"
+    },
+    {
+      "key": "recruitmentPage.viewApplicantsModal.unknownCandidate",
+      "file": "components/recruitment/ViewApplicantsModal.tsx",
+      "line": 63,
+      "context": "<p className=\"font-medium text-swiss-charcoal\">{application.candidateName ?? t('recruitmentPage.viewApplicantsModal.unknownCandidate', 'Candidate')}</p>"
+    },
+    {
+      "key": "recruitmentPage.viewApplicantsModal.appliedOn",
+      "file": "components/recruitment/ViewApplicantsModal.tsx",
+      "line": 65,
+      "context": "{t('recruitmentPage.viewApplicantsModal.appliedOn', {"
+    },
+    {
+      "key": "buttons.sendMessage",
+      "file": "components/recruitment/ViewApplicantsModal.tsx",
+      "line": 73,
+      "context": "{t('buttons.sendMessage')}"
+    },
+    {
+      "key": "candidateCard.viewProfile",
+      "file": "components/recruitment/ViewApplicantsModal.tsx",
+      "line": 76,
+      "context": "{t('candidateCard.viewProfile')}"
+    },
+    {
+      "key": "recruitmentPage.viewApplicantsModal.title",
+      "file": "components/recruitment/ViewApplicantsModal.tsx",
+      "line": 90,
+      "context": "{t('recruitmentPage.viewApplicantsModal.title', { jobTitle: job.title })}"
+    },
+    {
+      "key": "buttons.close",
+      "file": "components/recruitment/ViewApplicantsModal.tsx",
+      "line": 92,
+      "context": "<button onClick={onClose} className=\"p-1 rounded-full text-gray-400 hover:text-gray-600\" aria-label={t('buttons.close')}>"
+    },
+    {
+      "key": "buttons.close",
+      "file": "components/recruitment/ViewApplicantsModal.tsx",
+      "line": 103,
+      "context": "{t('buttons.close')}"
+    },
+    {
+      "key": "recruitmentPage.jobPostModal.editTitle",
+      "file": "components/recruitment/JobPostModal.tsx",
+      "line": 136,
+      "context": "{existingJob ? t('recruitmentPage.jobPostModal.editTitle') : t('recruitmentPage.jobPostModal.addTitle')}"
+    },
+    {
+      "key": "recruitmentPage.jobPostModal.addTitle",
+      "file": "components/recruitment/JobPostModal.tsx",
+      "line": 136,
+      "context": "{existingJob ? t('recruitmentPage.jobPostModal.editTitle') : t('recruitmentPage.jobPostModal.addTitle')}"
+    },
+    {
+      "key": "buttons.close",
+      "file": "components/recruitment/JobPostModal.tsx",
+      "line": 138,
+      "context": "<button onClick={onClose} className=\"p-1 rounded-full text-gray-400 hover:text-gray-600\" aria-label={t('buttons.close')}>"
+    },
+    {
+      "key": "recruitmentPage.jobPostModal.jobTitle",
+      "file": "components/recruitment/JobPostModal.tsx",
+      "line": 147,
+      "context": "<label htmlFor=\"title\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('recruitmentPage.jobPostModal.jobTitle')} *</label>"
+    },
+    {
+      "key": "recruitmentPage.jobPostModal.location",
+      "file": "components/recruitment/JobPostModal.tsx",
+      "line": 151,
+      "context": "<label htmlFor=\"location\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('recruitmentPage.jobPostModal.location')} *</label>"
+    },
+    {
+      "key": "recruitmentPage.jobPostModal.contractType",
+      "file": "components/recruitment/JobPostModal.tsx",
+      "line": 155,
+      "context": "<label htmlFor=\"contractType\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('recruitmentPage.jobPostModal.contractType')} *</label>"
+    },
+    {
+      "key": "recruitmentPage.contractTypes.fullTime",
+      "file": "components/recruitment/JobPostModal.tsx",
+      "line": 157,
+      "context": "<option value=\"FULL_TIME\">{t('recruitmentPage.contractTypes.fullTime', 'Full-time')}</option>"
+    },
+    {
+      "key": "recruitmentPage.contractTypes.partTime",
+      "file": "components/recruitment/JobPostModal.tsx",
+      "line": 158,
+      "context": "<option value=\"PART_TIME\">{t('recruitmentPage.contractTypes.partTime', 'Part-time')}</option>"
+    },
+    {
+      "key": "recruitmentPage.contractTypes.cdi",
+      "file": "components/recruitment/JobPostModal.tsx",
+      "line": 159,
+      "context": "<option value=\"CDI\">{t('recruitmentPage.contractTypes.cdi', 'CDI')}</option>"
+    },
+    {
+      "key": "recruitmentPage.contractTypes.cdd",
+      "file": "components/recruitment/JobPostModal.tsx",
+      "line": 160,
+      "context": "<option value=\"CDD\">{t('recruitmentPage.contractTypes.cdd', 'CDD')}</option>"
+    },
+    {
+      "key": "recruitmentPage.contractTypes.internship",
+      "file": "components/recruitment/JobPostModal.tsx",
+      "line": 161,
+      "context": "<option value=\"INTERNSHIP\">{t('recruitmentPage.contractTypes.internship', 'Internship')}</option>"
+    },
+    {
+      "key": "recruitmentPage.jobPostModal.startDate",
+      "file": "components/recruitment/JobPostModal.tsx",
+      "line": 165,
+      "context": "<label htmlFor=\"startDate\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('recruitmentPage.jobPostModal.startDate')} *</label>"
+    },
+    {
+      "key": "recruitmentPage.jobPostModal.salaryRange",
+      "file": "components/recruitment/JobPostModal.tsx",
+      "line": 170,
+      "context": "<label htmlFor=\"salaryRange\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('recruitmentPage.jobPostModal.salaryRange')}</label>"
+    },
+    {
+      "key": "recruitmentPage.jobPostModal.salaryRangePlaceholder",
+      "file": "components/recruitment/JobPostModal.tsx",
+      "line": 171,
+      "context": "<input type=\"text\" name=\"salaryRange\" id=\"salaryRange\" value={formData.salaryRange || ''} onChange={handleChange} className={STANDARD_INPUT_FIELD} placeholder={t('recruitmentPage.jobPostModal.salaryRangePlaceholder')}/>"
+    },
+    {
+      "key": "recruitmentPage.jobPostModal.description",
+      "file": "components/recruitment/JobPostModal.tsx",
+      "line": 174,
+      "context": "<label htmlFor=\"description\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('recruitmentPage.jobPostModal.description')} *</label>"
+    },
+    {
+      "key": "buttons.cancel",
+      "file": "components/recruitment/JobPostModal.tsx",
+      "line": 185,
+      "context": "<Button type=\"button\" variant=\"light\" onClick={onClose}>{t('buttons.cancel')}</Button>"
+    },
+    {
+      "key": "buttons.saveChanges",
+      "file": "components/recruitment/JobPostModal.tsx",
+      "line": 186,
+      "context": "<Button type=\"submit\" variant=\"primary\">{existingJob ? t('buttons.saveChanges') : t('recruitmentPage.jobPostModal.postJob')}</Button>"
+    },
+    {
+      "key": "recruitmentPage.jobPostModal.postJob",
+      "file": "components/recruitment/JobPostModal.tsx",
+      "line": 186,
+      "context": "<Button type=\"submit\" variant=\"primary\">{existingJob ? t('buttons.saveChanges') : t('recruitmentPage.jobPostModal.postJob')}</Button>"
+    },
+    {
+      "key": "recruitment:contractTypes.fullTime",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 35,
+      "context": "return t('recruitment:contractTypes.fullTime', 'Full-time');"
+    },
+    {
+      "key": "recruitment:contractTypes.fullTime",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 35,
+      "context": "return t('recruitment:contractTypes.fullTime', 'Full-time');"
+    },
+    {
+      "key": "recruitment:contractTypes.partTime",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 37,
+      "context": "return t('recruitment:contractTypes.partTime', 'Part-time');"
+    },
+    {
+      "key": "recruitment:contractTypes.partTime",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 37,
+      "context": "return t('recruitment:contractTypes.partTime', 'Part-time');"
+    },
+    {
+      "key": "recruitment:contractTypes.cdi",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 39,
+      "context": "return t('recruitment:contractTypes.cdi', 'CDI');"
+    },
+    {
+      "key": "recruitment:contractTypes.cdi",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 39,
+      "context": "return t('recruitment:contractTypes.cdi', 'CDI');"
+    },
+    {
+      "key": "recruitment:contractTypes.cdd",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 41,
+      "context": "return t('recruitment:contractTypes.cdd', 'CDD');"
+    },
+    {
+      "key": "recruitment:contractTypes.cdd",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 41,
+      "context": "return t('recruitment:contractTypes.cdd', 'CDD');"
+    },
+    {
+      "key": "recruitment:contractTypes.internship",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 44,
+      "context": "return t('recruitment:contractTypes.internship', 'Internship');"
+    },
+    {
+      "key": "recruitment:contractTypes.internship",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 44,
+      "context": "return t('recruitment:contractTypes.internship', 'Internship');"
+    },
+    {
+      "key": "recruitment:labels.startDateTbd",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 48,
+      "context": "const formattedStartDate = job.startDate ? new Date(job.startDate).toLocaleDateString() : t('recruitment:labels.startDateTbd', 'To be determined');"
+    },
+    {
+      "key": "recruitment:labels.startDateTbd",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 48,
+      "context": "const formattedStartDate = job.startDate ? new Date(job.startDate).toLocaleDateString() : t('recruitment:labels.startDateTbd', 'To be determined');"
+    },
+    {
+      "key": "buttons.close",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 68,
+      "context": "<button onClick={onClose} className=\"p-1 rounded-full text-gray-400 hover:text-gray-600\" aria-label={t('buttons.close')}>"
+    },
+    {
+      "key": "recruitment:jobDetailModal.noDescription",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 81,
+      "context": "{job.description ?? t('recruitment:jobDetailModal.noDescription', 'No description provided.')}"
+    },
+    {
+      "key": "recruitment:jobDetailModal.noDescription",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 81,
+      "context": "{job.description ?? t('recruitment:jobDetailModal.noDescription', 'No description provided.')}"
+    },
+    {
+      "key": "recruitmentPage.jobDetailModal.overviewTitle",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 121,
+      "context": "<h3 className=\"text-xl font-semibold text-swiss-charcoal mb-4\">{t('recruitmentPage.jobDetailModal.overviewTitle')}</h3>"
+    },
+    {
+      "key": "recruitmentPage.jobDetailModal.location",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 126,
+      "context": "<p className=\"font-medium text-gray-500\">{t('recruitmentPage.jobDetailModal.location')}</p>"
+    },
+    {
+      "key": "recruitment:labels.locationUnknown",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 127,
+      "context": "<p className=\"text-gray-800 font-semibold\">{job.location ?? t('recruitment:labels.locationUnknown', 'Location TBD')}</p>"
+    },
+    {
+      "key": "recruitment:labels.locationUnknown",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 127,
+      "context": "<p className=\"text-gray-800 font-semibold\">{job.location ?? t('recruitment:labels.locationUnknown', 'Location TBD')}</p>"
+    },
+    {
+      "key": "recruitmentPage.jobDetailModal.contractType",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 133,
+      "context": "<p className=\"font-medium text-gray-500\">{t('recruitmentPage.jobDetailModal.contractType')}</p>"
+    },
+    {
+      "key": "recruitmentPage.jobDetailModal.startDate",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 140,
+      "context": "<p className=\"font-medium text-gray-500\">{t('recruitmentPage.jobDetailModal.startDate')}</p>"
+    },
+    {
+      "key": "recruitmentPage.jobDetailModal.salary",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 148,
+      "context": "<p className=\"font-medium text-gray-500\">{t('recruitmentPage.jobDetailModal.salary')}</p>"
+    },
+    {
+      "key": "buttons.cancel",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 161,
+      "context": "<Button type=\"button\" variant=\"light\" size=\"lg\" onClick={onClose}>{t('buttons.cancel')}</Button>"
+    },
+    {
+      "key": "recruitmentPage.jobDetailModal.applyNow",
+      "file": "components/recruitment/JobDetailModal.tsx",
+      "line": 162,
+      "context": "<Button type=\"button\" variant=\"primary\" size=\"lg\" onClick={() => onApply(job)}>{t('recruitmentPage.jobDetailModal.applyNow')}</Button>"
+    },
+    {
+      "key": "common:createGroupChatModal.error.minParticipants",
+      "file": "components/messaging/CreateGroupChatModal.tsx",
+      "line": 36,
+      "context": "alert(t('common:createGroupChatModal.error.minParticipants'));"
+    },
+    {
+      "key": "common:createGroupChatModal.error.minParticipants",
+      "file": "components/messaging/CreateGroupChatModal.tsx",
+      "line": 36,
+      "context": "alert(t('common:createGroupChatModal.error.minParticipants'));"
+    },
+    {
+      "key": "common:createGroupChatModal.title",
+      "file": "components/messaging/CreateGroupChatModal.tsx",
+      "line": 52,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal\">{t('common:createGroupChatModal.title')}</h2>"
+    },
+    {
+      "key": "common:createGroupChatModal.title",
+      "file": "components/messaging/CreateGroupChatModal.tsx",
+      "line": 52,
+      "context": "<h2 className=\"text-xl font-semibold text-swiss-charcoal\">{t('common:createGroupChatModal.title')}</h2>"
+    },
+    {
+      "key": "common:createGroupChatModal.groupNameLabel",
+      "file": "components/messaging/CreateGroupChatModal.tsx",
+      "line": 57,
+      "context": "<label htmlFor=\"groupName\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:createGroupChatModal.groupNameLabel')}</label>"
+    },
+    {
+      "key": "common:createGroupChatModal.groupNameLabel",
+      "file": "components/messaging/CreateGroupChatModal.tsx",
+      "line": 57,
+      "context": "<label htmlFor=\"groupName\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:createGroupChatModal.groupNameLabel')}</label>"
+    },
+    {
+      "key": "common:createGroupChatModal.groupNamePlaceholder",
+      "file": "components/messaging/CreateGroupChatModal.tsx",
+      "line": 64,
+      "context": "placeholder={t('common:createGroupChatModal.groupNamePlaceholder')}"
+    },
+    {
+      "key": "common:createGroupChatModal.groupNamePlaceholder",
+      "file": "components/messaging/CreateGroupChatModal.tsx",
+      "line": 64,
+      "context": "placeholder={t('common:createGroupChatModal.groupNamePlaceholder')}"
+    },
+    {
+      "key": "common:createGroupChatModal.selectParticipantsLabel",
+      "file": "components/messaging/CreateGroupChatModal.tsx",
+      "line": 68,
+      "context": "<label className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:createGroupChatModal.selectParticipantsLabel')}</label>"
+    },
+    {
+      "key": "common:createGroupChatModal.selectParticipantsLabel",
+      "file": "components/messaging/CreateGroupChatModal.tsx",
+      "line": 68,
+      "context": "<label className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:createGroupChatModal.selectParticipantsLabel')}</label>"
+    },
+    {
+      "key": "common:buttons.cancel",
+      "file": "components/messaging/CreateGroupChatModal.tsx",
+      "line": 86,
+      "context": "<Button variant=\"light\" onClick={onClose}>{t('common:buttons.cancel')}</Button>"
+    },
+    {
+      "key": "common:buttons.cancel",
+      "file": "components/messaging/CreateGroupChatModal.tsx",
+      "line": 86,
+      "context": "<Button variant=\"light\" onClick={onClose}>{t('common:buttons.cancel')}</Button>"
+    },
+    {
+      "key": "common:createGroupChatModal.createButton",
+      "file": "components/messaging/CreateGroupChatModal.tsx",
+      "line": 88,
+      "context": "{t('common:createGroupChatModal.createButton')}"
+    },
+    {
+      "key": "common:createGroupChatModal.createButton",
+      "file": "components/messaging/CreateGroupChatModal.tsx",
+      "line": 88,
+      "context": "{t('common:createGroupChatModal.createButton')}"
+    },
+    {
+      "key": "unknownUser",
+      "file": "components/messaging/ConversationListItem.tsx",
+      "line": 33,
+      "context": "displayName = otherParticipantId ? conversation.participantNames[otherParticipantId] : t('unknownUser');"
+    },
+    {
+      "key": "youPrefix",
+      "file": "components/messaging/ConversationListItem.tsx",
+      "line": 63,
+      "context": "{conversation.lastMessageSenderId === currentUser.id ? t('youPrefix') : ''}"
+    },
+    {
+      "key": "noMessagesYet",
+      "file": "components/messaging/ConversationListItem.tsx",
+      "line": 64,
+      "context": "{conversation.lastMessageSnippet || t('noMessagesYet')}"
+    },
+    {
+      "key": "searchPlaceholder",
+      "file": "components/messaging/ConversationList.tsx",
+      "line": 40,
+      "context": "placeholder={t('searchPlaceholder')}"
+    },
+    {
+      "key": "searchPlaceholder",
+      "file": "components/messaging/ConversationList.tsx",
+      "line": 44,
+      "context": "aria-label={t('searchPlaceholder')}"
+    },
+    {
+      "key": "filters.all",
+      "file": "components/messaging/ConversationList.tsx",
+      "line": 52,
+      "context": "{t('filters.all')}"
+    },
+    {
+      "key": "filters.unread",
+      "file": "components/messaging/ConversationList.tsx",
+      "line": 58,
+      "context": "{t('filters.unread')}"
+    },
+    {
+      "key": "noConversationsFound",
+      "file": "components/messaging/ConversationList.tsx",
+      "line": 64,
+      "context": "<p className=\"text-center text-sm text-gray-400 py-10\">{t('noConversationsFound')}</p>"
+    },
+    {
+      "key": "selectConversationToView",
+      "file": "components/messaging/ChatWindow.tsx",
+      "line": 36,
+      "context": "{t('selectConversationToView')}"
+    },
+    {
+      "key": "conversationFallbackTitle",
+      "file": "components/messaging/ChatWindow.tsx",
+      "line": 50,
+      "context": "chatTitle = otherParticipantId ? activeConversation.participantNames[otherParticipantId] : t('conversationFallbackTitle');"
+    },
+    {
+      "key": "attachFile",
+      "file": "components/messaging/ChatWindow.tsx",
+      "line": 76,
+      "context": "<Button type=\"button\" variant=\"ghost\" className=\"!p-2 text-gray-500 hover:text-swiss-teal\" aria-label={t('attachFile')} onClick={() => alert(t('attachFile') + ' TBD')}>"
+    },
+    {
+      "key": "attachFile",
+      "file": "components/messaging/ChatWindow.tsx",
+      "line": 76,
+      "context": "<Button type=\"button\" variant=\"ghost\" className=\"!p-2 text-gray-500 hover:text-swiss-teal\" aria-label={t('attachFile')} onClick={() => alert(t('attachFile') + ' TBD')}>"
+    },
+    {
+      "key": "addEmoji",
+      "file": "components/messaging/ChatWindow.tsx",
+      "line": 79,
+      "context": "<Button type=\"button\" variant=\"ghost\" className=\"!p-2 text-gray-500 hover:text-swiss-teal\" aria-label={t('addEmoji')} onClick={() => alert(t('addEmoji') + ' TBD')}>"
+    },
+    {
+      "key": "addEmoji",
+      "file": "components/messaging/ChatWindow.tsx",
+      "line": 79,
+      "context": "<Button type=\"button\" variant=\"ghost\" className=\"!p-2 text-gray-500 hover:text-swiss-teal\" aria-label={t('addEmoji')} onClick={() => alert(t('addEmoji') + ' TBD')}>"
+    },
+    {
+      "key": "typeMessagePlaceholder",
+      "file": "components/messaging/ChatWindow.tsx",
+      "line": 86,
+      "context": "placeholder={t('typeMessagePlaceholder')}"
+    },
+    {
+      "key": "typeMessagePlaceholder",
+      "file": "components/messaging/ChatWindow.tsx",
+      "line": 89,
+      "context": "aria-label={t('typeMessagePlaceholder')}"
+    },
+    {
+      "key": "buttons.sendMessage",
+      "file": "components/messaging/ChatWindow.tsx",
+      "line": 91,
+      "context": "<Button type=\"submit\" variant=\"primary\" size=\"md\" className=\"!p-2.5\" aria-label={t('buttons.sendMessage')}>"
+    },
+    {
+      "key": "supplierCard.specializesIn",
+      "file": "components/marketplace/SupplierCard.tsx",
+      "line": 84,
+      "context": "{t('supplierCard.specializesIn', { mainCategoriesTagline })}"
+    },
+    {
+      "key": "supplierCard.viewProfileAndProducts",
+      "file": "components/marketplace/SupplierCard.tsx",
+      "line": 95,
+      "context": "{t('supplierCard.viewProfileAndProducts')}"
+    },
+    {
+      "key": "serviceRequestModal.preferredDateLabel",
+      "file": "components/marketplace/ServiceRequestModal.tsx",
+      "line": 72,
+      "context": "<label htmlFor=\"preferredDateModal\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t(\"serviceRequestModal.preferredDateLabel\")}</label>"
+    },
+    {
+      "key": "serviceRequestModal.notesLabel",
+      "file": "components/marketplace/ServiceRequestModal.tsx",
+      "line": 85,
+      "context": "<label htmlFor=\"notesModal\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t(\"serviceRequestModal.notesLabel\")}</label>"
+    },
+    {
+      "key": "serviceRequestModal.submitButton",
+      "file": "components/marketplace/ServiceRequestModal.tsx",
+      "line": 98,
+      "context": "<Button type=\"submit\" variant=\"secondary\">{t(\"serviceRequestModal.submitButton\")}</Button>"
+    },
+    {
+      "key": "orderRequestModal.title",
+      "file": "components/marketplace/OrderRequestModal.tsx",
+      "line": 48,
+      "context": "<h2 id=\"orderRequestModalTitle\" className=\"text-xl font-semibold text-swiss-charcoal\">{t('orderRequestModal.title', { productTitle: product.title })}</h2>"
+    },
+    {
+      "key": "buttons.close",
+      "file": "components/marketplace/OrderRequestModal.tsx",
+      "line": 49,
+      "context": "<button onClick={onClose} className=\"p-1 rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors\" aria-label={t('buttons.close')}>"
+    },
+    {
+      "key": "orderRequestModal.labels.product",
+      "file": "components/marketplace/OrderRequestModal.tsx",
+      "line": 57,
+      "context": "<label htmlFor=\"productName\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('orderRequestModal.labels.product')}</label>"
+    },
+    {
+      "key": "orderRequestModal.labels.supplier",
+      "file": "components/marketplace/OrderRequestModal.tsx",
+      "line": 67,
+      "context": "<label htmlFor=\"supplierName\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('orderRequestModal.labels.supplier')}</label>"
+    },
+    {
+      "key": "orderRequestModal.labels.quantity",
+      "file": "components/marketplace/OrderRequestModal.tsx",
+      "line": 77,
+      "context": "<label htmlFor=\"quantity\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('orderRequestModal.labels.quantity')}</label>"
+    },
+    {
+      "key": "orderRequestModal.labels.notes",
+      "file": "components/marketplace/OrderRequestModal.tsx",
+      "line": 89,
+      "context": "<label htmlFor=\"notes\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('orderRequestModal.labels.notes')}</label>"
+    },
+    {
+      "key": "orderRequestModal.placeholders.notes",
+      "file": "components/marketplace/OrderRequestModal.tsx",
+      "line": 96,
+      "context": "placeholder={t('orderRequestModal.placeholders.notes')}"
+    },
+    {
+      "key": "buttons.cancel",
+      "file": "components/marketplace/OrderRequestModal.tsx",
+      "line": 101,
+      "context": "<Button type=\"button\" variant=\"light\" onClick={onClose}>{t('buttons.cancel')}</Button>"
+    },
+    {
+      "key": "buttons.submitRequest",
+      "file": "components/marketplace/OrderRequestModal.tsx",
+      "line": 102,
+      "context": "<Button type=\"submit\" variant=\"primary\">{t('buttons.submitRequest')}</Button>"
+    },
+    {
+      "key": "appName",
+      "file": "components/layout/Sidebar.tsx",
+      "line": 162,
+      "context": "<h1 className=\"text-xl font-bold text-swiss-charcoal\">{t('appName')}</h1>"
+    },
+    {
+      "key": "appName",
+      "file": "components/layout/Sidebar.tsx",
+      "line": 170,
+      "context": "<h1 className=\"text-2xl font-bold text-swiss-charcoal\">{t('appName')}</h1>"
+    },
+    {
+      "key": "sidebar.currentPlan",
+      "file": "components/layout/Sidebar.tsx",
+      "line": 249,
+      "context": "<p className=\"text-sm text-swiss-charcoal font-semibold\">{t('sidebar.currentPlan', { plan: currentUser.plan })}</p>"
+    },
+    {
+      "key": "sidebar.manageSubscriptionDesc",
+      "file": "components/layout/Sidebar.tsx",
+      "line": 250,
+      "context": "<p className=\"text-xs text-gray-600 mb-2.5\">{t('sidebar.manageSubscriptionDesc')}</p>"
+    },
+    {
+      "key": "sidebar.billingSubscription",
+      "file": "components/layout/Sidebar.tsx",
+      "line": 260,
+      "context": "{t('sidebar.billingSubscription')}"
+    },
+    {
+      "key": "navbar.toggleNavigation",
+      "file": "components/layout/Navbar.tsx",
+      "line": 60,
+      "context": "aria-label={t('navbar.toggleNavigation')}"
+    },
+    {
+      "key": "navbar.goBackPreviousPage",
+      "file": "components/layout/Navbar.tsx",
+      "line": 68,
+      "context": "aria-label={t('navbar.goBackPreviousPage')}"
+    },
+    {
+      "key": "navbar.searchPlaceholder",
+      "file": "components/layout/Navbar.tsx",
+      "line": 78,
+      "context": "placeholder={t('navbar.searchPlaceholder')}"
+    },
+    {
+      "key": "navbar.searchPlaceholder",
+      "file": "components/layout/Navbar.tsx",
+      "line": 80,
+      "context": "aria-label={t('navbar.searchPlaceholder')}"
+    },
+    {
+      "key": "navbar.viewShoppingCart",
+      "file": "components/layout/Navbar.tsx",
+      "line": 91,
+      "context": "aria-label={t('navbar.viewShoppingCart')}"
+    },
+    {
+      "key": "navbar.notifications",
+      "file": "components/layout/Navbar.tsx",
+      "line": 106,
+      "context": "aria-label={t('navbar.notifications')}"
+    },
+    {
+      "key": "navbar.notificationsCount",
+      "file": "components/layout/Navbar.tsx",
+      "line": 119,
+      "context": "{t('navbar.notificationsCount', { count: totalNotificationsCount })}"
+    },
+    {
+      "key": "buttons.dismiss",
+      "file": "components/layout/Navbar.tsx",
+      "line": 129,
+      "context": "{t('buttons.dismiss')}"
+    },
+    {
+      "key": "navbar.newMessages",
+      "file": "components/layout/Navbar.tsx",
+      "line": 135,
+      "context": "<p className=\"font-medium text-swiss-teal\">{t('navbar.newMessages')}</p>"
+    },
+    {
+      "key": "navbar.unreadMessages",
+      "file": "components/layout/Navbar.tsx",
+      "line": 136,
+      "context": "<p className=\"text-xs text-gray-500\">{t('navbar.unreadMessages', { count: totalUnreadMessages })}</p>"
+    },
+    {
+      "key": "navbar.noNewNotifications",
+      "file": "components/layout/Navbar.tsx",
+      "line": 140,
+      "context": "<p className=\"px-4 py-3 text-sm text-gray-500 text-center\">{t('navbar.noNewNotifications')}</p>"
+    },
+    {
+      "key": "navbar.viewAll",
+      "file": "components/layout/Navbar.tsx",
+      "line": 145,
+      "context": "{t('navbar.viewAll')}"
+    },
+    {
+      "key": "navbar.userMenu",
+      "file": "components/layout/Navbar.tsx",
+      "line": 159,
+      "context": "aria-label={t('navbar.userMenu')}"
+    },
+    {
+      "key": "sidebar.settings",
+      "file": "components/layout/Navbar.tsx",
+      "line": 180,
+      "context": "{t('sidebar.settings')}"
+    },
+    {
+      "key": "navbar.signOut",
+      "file": "components/layout/Navbar.tsx",
+      "line": 187,
+      "context": "{t('navbar.signOut')}"
+    },
+    {
+      "key": "leadCard.alert.missingParentInfo",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 57,
+      "context": "alert(t('leadCard.alert.missingParentInfo'));"
+    },
+    {
+      "key": "leadCard.status.notResponded",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 68,
+      "context": "case FoundationLeadResponseStatus.NOT_RESPONDED: return { className: 'bg-gray-200 text-gray-700', label: t('leadCard.status.notResponded') };"
+    },
+    {
+      "key": "leadCard.status.interested",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 69,
+      "context": "case FoundationLeadResponseStatus.INTERESTED: return { className: 'bg-green-100 text-green-700', label: t('leadCard.status.interested') };"
+    },
+    {
+      "key": "leadCard.status.notInterested",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 70,
+      "context": "case FoundationLeadResponseStatus.NOT_INTERESTED: return { className: 'bg-red-100 text-red-700', label: t('leadCard.status.notInterested') };"
+    },
+    {
+      "key": "leadCard.status.needsMoreInfo",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 71,
+      "context": "case FoundationLeadResponseStatus.NEEDS_MORE_INFO: return { className: 'bg-yellow-100 text-yellow-700', label: t('leadCard.status.needsMoreInfo') };"
+    },
+    {
+      "key": "leadCard.status.enrolled",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 72,
+      "context": "case FoundationLeadResponseStatus.ENROLLED: return { className: 'bg-purple-100 text-purple-700', label: t('leadCard.status.enrolled') };"
+    },
+    {
+      "key": "leadCard.title",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 84,
+      "context": "{t('leadCard.title', { name: lead.contactName })}"
+    },
+    {
+      "key": "leadCard.forLocation",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 91,
+      "context": "{t('leadCard.forLocation', { canton: lead.canton, municipality: lead.municipality ? `- ${lead.municipality}` : '' })}"
+    },
+    {
+      "key": "leadCard.childAge",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 96,
+      "context": "<p><strong>{t('leadCard.childAge')}:</strong> {lead.childAge}</p>"
+    },
+    {
+      "key": "leadCard.desiredStart",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 97,
+      "context": "<p><strong>{t('leadCard.desiredStart')}:</strong> {new Date(lead.desiredStartDate).toLocaleDateString()}</p>"
+    },
+    {
+      "key": "leadCard.submittedOn",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 98,
+      "context": "<p><strong>{t('leadCard.submittedOn')}:</strong> {new Date(lead.submissionDate).toLocaleDateString()}</p>"
+    },
+    {
+      "key": "leadCard.notes",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 99,
+      "context": "{lead.specialNeeds && <p><strong>{t('leadCard.notes')}:</strong> <span className=\"italic\">{lead.specialNeeds}</span></p>}"
+    },
+    {
+      "key": "leadCard.defaultMessages.interested",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 114,
+      "context": "onClick={() => handleResponse(FoundationLeadResponseStatus.INTERESTED, t('leadCard.defaultMessages.interested'))}"
+    },
+    {
+      "key": "leadCard.buttons.interested",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 117,
+      "context": "{t('leadCard.buttons.interested')}"
+    },
+    {
+      "key": "leadCard.defaultMessages.notInterested",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 123,
+      "context": "onClick={() => handleResponse(FoundationLeadResponseStatus.NOT_INTERESTED, t('leadCard.defaultMessages.notInterested'))}"
+    },
+    {
+      "key": "leadCard.buttons.notInterested",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 126,
+      "context": "{t('leadCard.buttons.notInterested')}"
+    },
+    {
+      "key": "leadCard.buttons.needInfo",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 135,
+      "context": "{t('leadCard.buttons.needInfo')}"
+    },
+    {
+      "key": "leadCard.questionFor",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 141,
+      "context": "{t('leadCard.questionFor', { name: lead.contactName })}:"
+    },
+    {
+      "key": "leadCard.questionPlaceholder",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 149,
+      "context": "placeholder={t('leadCard.questionPlaceholder')}"
+    },
+    {
+      "key": "buttons.cancel",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 152,
+      "context": "<Button variant=\"ghost\" size=\"sm\" onClick={() => setShowResponseInput(false)}>{t('buttons.cancel')}</Button>"
+    },
+    {
+      "key": "leadCard.buttons.sendQuestion",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 160,
+      "context": "{t('leadCard.buttons.sendQuestion')}"
+    },
+    {
+      "key": "leadCard.yourResponse",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 172,
+      "context": "<p className=\"font-medium\">{t('leadCard.yourResponse')}: <span className={`${currentStatusInfo.className} px-1.5 py-0.5 rounded`}>{currentStatusInfo.label}</span></p>"
+    },
+    {
+      "key": "leadCard.messageSent",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 173,
+      "context": "{myResponse.messageToParent && <p className=\"italic mt-1\">{t('leadCard.messageSent')}: \"{myResponse.messageToParent}\"</p>}"
+    },
+    {
+      "key": "leadCard.buttons.messageParent",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 182,
+      "context": "{t('leadCard.buttons.messageParent')}"
+    },
+    {
+      "key": "leadCard.defaultMessages.enrolled",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 190,
+      "context": "onClick={() => handleResponse(FoundationLeadResponseStatus.ENROLLED, t('leadCard.defaultMessages.enrolled'))}"
+    },
+    {
+      "key": "leadCard.buttons.markEnrolled",
+      "file": "components/foundation/LeadCard.tsx",
+      "line": 192,
+      "context": "{t('leadCard.buttons.markEnrolled')}"
+    },
+    {
+      "key": "Cannot submit order. User not logged in, supplier info missing, or cart is empty.",
+      "file": "components/cart/OrderSummaryDrawer.tsx",
+      "line": 34,
+      "context": "alert(t(\"Cannot submit order. User not logged in, supplier info missing, or cart is empty.\"));"
+    },
+    {
+      "key": "orderSummaryDrawer.title",
+      "file": "components/cart/OrderSummaryDrawer.tsx",
+      "line": 89,
+      "context": "{t(\"orderSummaryDrawer.title\")}"
+    },
+    {
+      "key": "orderSummaryDrawer.closePanel",
+      "file": "components/cart/OrderSummaryDrawer.tsx",
+      "line": 97,
+      "context": "<span className=\"sr-only\">{t(\"orderSummaryDrawer.closePanel\")}</span>"
+    },
+    {
+      "key": "orderSummaryDrawer.emptyCart",
+      "file": "components/cart/OrderSummaryDrawer.tsx",
+      "line": 106,
+      "context": "<p className=\"text-gray-500\">{t(\"orderSummaryDrawer.emptyCart\")}</p>"
+    },
+    {
+      "key": "orderSummaryDrawer.itemsFrom",
+      "file": "components/cart/OrderSummaryDrawer.tsx",
+      "line": 111,
+      "context": "<p className=\"text-sm text-gray-600 mb-2\">{t(\"orderSummaryDrawer.itemsFrom\")}: <span className=\"font-medium text-swiss-teal\">{cartSupplierInfo?.name || 'Supplier'}</span></p>"
+    },
+    {
+      "key": "orderSummaryDrawer.specialInstructions",
+      "file": "components/cart/OrderSummaryDrawer.tsx",
+      "line": 160,
+      "context": "{t(\"orderSummaryDrawer.specialInstructions\")}"
+    },
+    {
+      "key": "orderSummaryDrawer.subtotal",
+      "file": "components/cart/OrderSummaryDrawer.tsx",
+      "line": 173,
+      "context": "<p>{t(\"orderSummaryDrawer.subtotal\")}</p>"
+    },
+    {
+      "key": "orderSummaryDrawer.shippingNote",
+      "file": "components/cart/OrderSummaryDrawer.tsx",
+      "line": 176,
+      "context": "<p className=\"mt-0.5 text-sm text-gray-500\">{t(\"orderSummaryDrawer.shippingNote\")}</p>"
+    },
+    {
+      "key": "orderSummaryDrawer.continueShopping",
+      "file": "components/cart/OrderSummaryDrawer.tsx",
+      "line": 196,
+      "context": "{t(\"orderSummaryDrawer.continueShopping\")} <span aria-hidden=\"true\"> &rarr;</span>"
+    },
+    {
+      "key": "Title and Message are required.",
+      "file": "components/admin/PolicyAlertModal.tsx",
+      "line": 57,
+      "context": "alert(t(\"Title and Message are required.\"));"
+    },
+    {
+      "key": "policyAlertModal.labels.title",
+      "file": "components/admin/PolicyAlertModal.tsx",
+      "line": 87,
+      "context": "<label htmlFor=\"title\" className=\"block text-sm font-medium text-gray-700\">{t(\"policyAlertModal.labels.title\")} *</label>"
+    },
+    {
+      "key": "policyAlertModal.labels.message",
+      "file": "components/admin/PolicyAlertModal.tsx",
+      "line": 91,
+      "context": "<label htmlFor=\"message\" className=\"block text-sm font-medium text-gray-700\">{t(\"policyAlertModal.labels.message\")} *</label>"
+    },
+    {
+      "key": "policyAlertModal.labels.type",
+      "file": "components/admin/PolicyAlertModal.tsx",
+      "line": 96,
+      "context": "<label htmlFor=\"type\" className=\"block text-sm font-medium text-gray-700\">{t(\"policyAlertModal.labels.type\")} *</label>"
+    },
+    {
+      "key": "policyAlertModal.labels.regionScope",
+      "file": "components/admin/PolicyAlertModal.tsx",
+      "line": 102,
+      "context": "<label htmlFor=\"regionScope\" className=\"block text-sm font-medium text-gray-700\">{t(\"policyAlertModal.labels.regionScope\")} *</label>"
+    },
+    {
+      "key": "policyAlertModal.labels.displayStartDate",
+      "file": "components/admin/PolicyAlertModal.tsx",
+      "line": 110,
+      "context": "<label htmlFor=\"displayStartDate\" className=\"block text-sm font-medium text-gray-700\">{t(\"policyAlertModal.labels.displayStartDate\")}</label>"
+    },
+    {
+      "key": "policyAlertModal.labels.displayEndDate",
+      "file": "components/admin/PolicyAlertModal.tsx",
+      "line": 114,
+      "context": "<label htmlFor=\"displayEndDate\" className=\"block text-sm font-medium text-gray-700\">{t(\"policyAlertModal.labels.displayEndDate\")}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.error.selectFileOrLink",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 192,
+      "context": "alert(t('common:contentUploadModal.error.selectFileOrLink'));"
+    },
+    {
+      "key": "common:contentUploadModal.error.selectFileOrLink",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 192,
+      "context": "alert(t('common:contentUploadModal.error.selectFileOrLink'));"
+    },
+    {
+      "key": "common:contentUploadModal.title.edit",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 205,
+      "context": "? t('common:contentUploadModal.title.edit', { contentType: t(`contentUploadModal.contentType.${contentType}`)})"
+    },
+    {
+      "key": "common:contentUploadModal.title.edit",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 205,
+      "context": "? t('common:contentUploadModal.title.edit', { contentType: t(`contentUploadModal.contentType.${contentType}`)})"
+    },
+    {
+      "key": "common:contentUploadModal.labels.descriptionPreview",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 208,
+      "context": "const descriptionLabel = contentType === 'policy' ? t('common:contentUploadModal.labels.descriptionPreview') : t('common:contentUploadModal.labels.description');"
+    },
+    {
+      "key": "common:contentUploadModal.labels.description",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 208,
+      "context": "const descriptionLabel = contentType === 'policy' ? t('common:contentUploadModal.labels.descriptionPreview') : t('common:contentUploadModal.labels.description');"
+    },
+    {
+      "key": "common:contentUploadModal.labels.descriptionPreview",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 208,
+      "context": "const descriptionLabel = contentType === 'policy' ? t('common:contentUploadModal.labels.descriptionPreview') : t('common:contentUploadModal.labels.description');"
+    },
+    {
+      "key": "common:contentUploadModal.labels.description",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 208,
+      "context": "const descriptionLabel = contentType === 'policy' ? t('common:contentUploadModal.labels.descriptionPreview') : t('common:contentUploadModal.labels.description');"
+    },
+    {
+      "key": "common:languageSwitcher.enShort",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 214,
+      "context": "{ value: 'EN', label: t('common:languageSwitcher.enShort') },"
+    },
+    {
+      "key": "common:languageSwitcher.enShort",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 214,
+      "context": "{ value: 'EN', label: t('common:languageSwitcher.enShort') },"
+    },
+    {
+      "key": "common:languageSwitcher.frShort",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 215,
+      "context": "{ value: 'FR', label: t('common:languageSwitcher.frShort') },"
+    },
+    {
+      "key": "common:languageSwitcher.frShort",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 215,
+      "context": "{ value: 'FR', label: t('common:languageSwitcher.frShort') },"
+    },
+    {
+      "key": "common:languageSwitcher.deShort",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 216,
+      "context": "{ value: 'DE', label: t('common:languageSwitcher.deShort') },"
+    },
+    {
+      "key": "common:languageSwitcher.deShort",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 216,
+      "context": "{ value: 'DE', label: t('common:languageSwitcher.deShort') },"
+    },
+    {
+      "key": "common:contentUploadModal.labels.title",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 251,
+      "context": "<label htmlFor=\"title\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.title')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.title",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 251,
+      "context": "<label htmlFor=\"title\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.title')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.category",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 255,
+      "context": "<label htmlFor=\"category\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.category')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.category",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 255,
+      "context": "<label htmlFor=\"category\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.category')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.contentType",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 267,
+      "context": "{renderButtonSelect('type', formData.type, Object.values(ELearningContentType).map(v => ({value: v, label: t(`contentUploadModal.eLearningTypes.${v.toLowerCase()}` as const, v)})), t('common:contentUploadModal.labels.contentType'), true)}"
+    },
+    {
+      "key": "common:contentUploadModal.labels.contentType",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 267,
+      "context": "{renderButtonSelect('type', formData.type, Object.values(ELearningContentType).map(v => ({value: v, label: t(`contentUploadModal.eLearningTypes.${v.toLowerCase()}` as const, v)})), t('common:contentUploadModal.labels.contentType'), true)}"
+    },
+    {
+      "key": "common:contentUploadModal.labels.language",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 268,
+      "context": "{renderButtonSelect('language', formData.language, languageOptions, t('common:contentUploadModal.labels.language'), true)}"
+    },
+    {
+      "key": "common:contentUploadModal.labels.language",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 268,
+      "context": "{renderButtonSelect('language', formData.language, languageOptions, t('common:contentUploadModal.labels.language'), true)}"
+    },
+    {
+      "key": "common:contentUploadModal.labels.duration",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 272,
+      "context": "<label htmlFor=\"duration\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.duration')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.duration",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 272,
+      "context": "<label htmlFor=\"duration\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.duration')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.placeholders.duration",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 273,
+      "context": "<input type=\"text\" name=\"duration\" id=\"duration\" value={formData.duration || ''} onChange={handleInputChange} className={`${STANDARD_INPUT_FIELD} mt-1`} placeholder={t('common:contentUploadModal.placeholders.duration')}/>"
+    },
+    {
+      "key": "common:contentUploadModal.placeholders.duration",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 273,
+      "context": "<input type=\"text\" name=\"duration\" id=\"duration\" value={formData.duration || ''} onChange={handleInputChange} className={`${STANDARD_INPUT_FIELD} mt-1`} placeholder={t('common:contentUploadModal.placeholders.duration')}/>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.lessons",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 278,
+      "context": "<label htmlFor=\"lessons\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.lessons')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.lessons",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 278,
+      "context": "<label htmlFor=\"lessons\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.lessons')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.linkUrl",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 284,
+      "context": "<label htmlFor=\"fileUrl\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.linkUrl')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.linkUrl",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 284,
+      "context": "<label htmlFor=\"fileUrl\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.linkUrl')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.placeholders.linkUrl",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 285,
+      "context": "<input type=\"url\" name=\"fileUrl\" id=\"fileUrl\" value={formData.fileUrl || ''} onChange={handleInputChange} required className={`${STANDARD_INPUT_FIELD} mt-1`} placeholder={t('common:contentUploadModal.placeholders.linkUrl')}/>"
+    },
+    {
+      "key": "common:contentUploadModal.placeholders.linkUrl",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 285,
+      "context": "<input type=\"url\" name=\"fileUrl\" id=\"fileUrl\" value={formData.fileUrl || ''} onChange={handleInputChange} required className={`${STANDARD_INPUT_FIELD} mt-1`} placeholder={t('common:contentUploadModal.placeholders.linkUrl')}/>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.accessRoles",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 289,
+      "context": "<label className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.accessRoles')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.accessRoles",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 289,
+      "context": "<label className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.accessRoles')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.status",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 300,
+      "context": "<label htmlFor=\"status\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.status')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.status",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 300,
+      "context": "<label htmlFor=\"status\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.status')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.statusOptions.draft",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 302,
+      "context": "<option value=\"Draft\">{t('common:contentUploadModal.statusOptions.draft')}</option>"
+    },
+    {
+      "key": "common:contentUploadModal.statusOptions.draft",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 302,
+      "context": "<option value=\"Draft\">{t('common:contentUploadModal.statusOptions.draft')}</option>"
+    },
+    {
+      "key": "common:contentUploadModal.statusOptions.published",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 303,
+      "context": "<option value=\"Published\">{t('common:contentUploadModal.statusOptions.published')}</option>"
+    },
+    {
+      "key": "common:contentUploadModal.statusOptions.published",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 303,
+      "context": "<option value=\"Published\">{t('common:contentUploadModal.statusOptions.published')}</option>"
+    },
+    {
+      "key": "common:contentUploadModal.statusOptions.archived",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 304,
+      "context": "<option value=\"Archived\">{t('common:contentUploadModal.statusOptions.archived')}</option>"
+    },
+    {
+      "key": "common:contentUploadModal.statusOptions.archived",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 304,
+      "context": "<option value=\"Archived\">{t('common:contentUploadModal.statusOptions.archived')}</option>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.documentTitle",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 313,
+      "context": "<label htmlFor=\"title\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.documentTitle')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.documentTitle",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 313,
+      "context": "<label htmlFor=\"title\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.documentTitle')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.category",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 318,
+      "context": "<label htmlFor=\"category\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.category')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.category",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 318,
+      "context": "<label htmlFor=\"category\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.category')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.language",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 323,
+      "context": "{renderButtonSelect('language', formData.language, languageOptions, t('common:contentUploadModal.labels.language'), true)}"
+    },
+    {
+      "key": "common:contentUploadModal.labels.language",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 323,
+      "context": "{renderButtonSelect('language', formData.language, languageOptions, t('common:contentUploadModal.labels.language'), true)}"
+    },
+    {
+      "key": "common:contentUploadModal.labels.fileType",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 326,
+      "context": "<label htmlFor=\"fileType\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.fileType')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.fileType",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 326,
+      "context": "<label htmlFor=\"fileType\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.fileType')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.version",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 334,
+      "context": "<label htmlFor=\"version\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.version')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.version",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 334,
+      "context": "<label htmlFor=\"version\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.version')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.placeholders.version",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 335,
+      "context": "<input type=\"text\" name=\"version\" id=\"version\" value={formData.version || ''} onChange={handleInputChange} className={`${STANDARD_INPUT_FIELD} mt-1`} placeholder={t('common:contentUploadModal.placeholders.version')}/>"
+    },
+    {
+      "key": "common:contentUploadModal.placeholders.version",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 335,
+      "context": "<input type=\"text\" name=\"version\" id=\"version\" value={formData.version || ''} onChange={handleInputChange} className={`${STANDARD_INPUT_FIELD} mt-1`} placeholder={t('common:contentUploadModal.placeholders.version')}/>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.status",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 338,
+      "context": "<label htmlFor=\"status\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.status')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.status",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 338,
+      "context": "<label htmlFor=\"status\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.status')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.statusOptions.draft",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 340,
+      "context": "<option value=\"Draft\">{t('common:contentUploadModal.statusOptions.draft')}</option>"
+    },
+    {
+      "key": "common:contentUploadModal.statusOptions.draft",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 340,
+      "context": "<option value=\"Draft\">{t('common:contentUploadModal.statusOptions.draft')}</option>"
+    },
+    {
+      "key": "common:contentUploadModal.statusOptions.published",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 341,
+      "context": "<option value=\"Published\">{t('common:contentUploadModal.statusOptions.published')}</option>"
+    },
+    {
+      "key": "common:contentUploadModal.statusOptions.published",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 341,
+      "context": "<option value=\"Published\">{t('common:contentUploadModal.statusOptions.published')}</option>"
+    },
+    {
+      "key": "common:contentUploadModal.statusOptions.archived",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 342,
+      "context": "<option value=\"Archived\">{t('common:contentUploadModal.statusOptions.archived')}</option>"
+    },
+    {
+      "key": "common:contentUploadModal.statusOptions.archived",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 342,
+      "context": "<option value=\"Archived\">{t('common:contentUploadModal.statusOptions.archived')}</option>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.title",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 351,
+      "context": "<label htmlFor=\"policyTitle\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.title')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.title",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 351,
+      "context": "<label htmlFor=\"policyTitle\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.title')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.category",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 356,
+      "context": "<label htmlFor=\"policyCategory\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.category')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.category",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 356,
+      "context": "<label htmlFor=\"policyCategory\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.category')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.language",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 361,
+      "context": "{renderButtonSelect('language', formData.language, languageOptions, t('common:contentUploadModal.labels.language'), true)}"
+    },
+    {
+      "key": "common:contentUploadModal.labels.language",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 361,
+      "context": "{renderButtonSelect('language', formData.language, languageOptions, t('common:contentUploadModal.labels.language'), true)}"
+    },
+    {
+      "key": "common:contentUploadModal.labels.country",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 365,
+      "context": "<label htmlFor=\"policyCountry\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.country')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.country",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 365,
+      "context": "<label htmlFor=\"policyCountry\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.country')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.regionCanton",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 371,
+      "context": "<label htmlFor=\"policyRegion\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.regionCanton')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.regionCanton",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 371,
+      "context": "<label htmlFor=\"policyRegion\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.regionCanton')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.policyType",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 379,
+      "context": "<label htmlFor=\"policyPolicyType\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.policyType')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.policyType",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 379,
+      "context": "<label htmlFor=\"policyPolicyType\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.policyType')} <span className=\"text-red-500 ml-0.5\">*</span></label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.criticality",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 385,
+      "context": "<label htmlFor=\"isCritical\" className=\"block text-sm font-medium text-gray-700 mb-1.5\">{t('common:contentUploadModal.labels.criticality')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.criticality",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 385,
+      "context": "<label htmlFor=\"isCritical\" className=\"block text-sm font-medium text-gray-700 mb-1.5\">{t('common:contentUploadModal.labels.criticality')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.markAsCritical",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 393,
+      "context": "<span className=\"sr-only\">{t('common:contentUploadModal.labels.markAsCritical')}</span>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.markAsCritical",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 393,
+      "context": "<span className=\"sr-only\">{t('common:contentUploadModal.labels.markAsCritical')}</span>"
+    },
+    {
+      "key": "common:contentUploadModal.criticalityOptions.critical",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 396,
+      "context": "<span className=\"ml-2 text-sm text-gray-600\">{formData.isCritical ? t('common:contentUploadModal.criticalityOptions.critical') : t('common:contentUploadModal.criticalityOptions.normal')}</span>"
+    },
+    {
+      "key": "common:contentUploadModal.criticalityOptions.normal",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 396,
+      "context": "<span className=\"ml-2 text-sm text-gray-600\">{formData.isCritical ? t('common:contentUploadModal.criticalityOptions.critical') : t('common:contentUploadModal.criticalityOptions.normal')}</span>"
+    },
+    {
+      "key": "common:contentUploadModal.criticalityOptions.critical",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 396,
+      "context": "<span className=\"ml-2 text-sm text-gray-600\">{formData.isCritical ? t('common:contentUploadModal.criticalityOptions.critical') : t('common:contentUploadModal.criticalityOptions.normal')}</span>"
+    },
+    {
+      "key": "common:contentUploadModal.criticalityOptions.normal",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 396,
+      "context": "<span className=\"ml-2 text-sm text-gray-600\">{formData.isCritical ? t('common:contentUploadModal.criticalityOptions.critical') : t('common:contentUploadModal.criticalityOptions.normal')}</span>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.effectiveDate",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 401,
+      "context": "<label htmlFor=\"policyEffectiveDate\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.effectiveDate')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.effectiveDate",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 401,
+      "context": "<label htmlFor=\"policyEffectiveDate\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.effectiveDate')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.status",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 405,
+      "context": "<label htmlFor=\"policyStatus\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.status')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.status",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 405,
+      "context": "<label htmlFor=\"policyStatus\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.status')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.externalLink",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 412,
+      "context": "<label htmlFor=\"policyExternalLink\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.externalLink')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.externalLink",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 412,
+      "context": "<label htmlFor=\"policyExternalLink\" className=\"block text-sm font-medium text-gray-700 mb-1\">{t('common:contentUploadModal.labels.externalLink')}</label>"
+    },
+    {
+      "key": "common:contentUploadModal.placeholders.externalLink",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 413,
+      "context": "<input type=\"url\" name=\"externalLink\" id=\"policyExternalLink\" value={formData.externalLink || ''} onChange={handleInputChange} className={policySpecificInputClass} placeholder={t('common:contentUploadModal.placeholders.externalLink')}/>"
+    },
+    {
+      "key": "common:contentUploadModal.placeholders.externalLink",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 413,
+      "context": "<input type=\"url\" name=\"externalLink\" id=\"policyExternalLink\" value={formData.externalLink || ''} onChange={handleInputChange} className={policySpecificInputClass} placeholder={t('common:contentUploadModal.placeholders.externalLink')}/>"
+    },
+    {
+      "key": "common:buttons.close",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 428,
+      "context": "<button onClick={onClose} className=\"p-1 rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors\" aria-label={t('common:buttons.close')}>"
+    },
+    {
+      "key": "common:buttons.close",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 428,
+      "context": "<button onClick={onClose} className=\"p-1 rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors\" aria-label={t('common:buttons.close')}>"
+    },
+    {
+      "key": "common:contentUploadModal.labels.currentFile",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 442,
+      "context": "{existingContent && (existingContent as any).fileUrl && !file ? t('common:contentUploadModal.labels.currentFile', { fileName: (existingContent as any).fileUrl}) :"
+    },
+    {
+      "key": "common:contentUploadModal.labels.currentFile",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 442,
+      "context": "{existingContent && (existingContent as any).fileUrl && !file ? t('common:contentUploadModal.labels.currentFile', { fileName: (existingContent as any).fileUrl}) :"
+    },
+    {
+      "key": "common:contentUploadModal.labels.uploadFileType",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 443,
+      "context": "(contentType === 'e-learning' && (formData.type === ELearningContentType.PDF || formData.type === ELearningContentType.VIDEO) ? t('common:contentUploadModal.labels.uploadFileType', { fileType: formData.type}) : t('common:contentUploadModal.labels.uploadFile'))}"
+    },
+    {
+      "key": "common:contentUploadModal.labels.uploadFile",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 443,
+      "context": "(contentType === 'e-learning' && (formData.type === ELearningContentType.PDF || formData.type === ELearningContentType.VIDEO) ? t('common:contentUploadModal.labels.uploadFileType', { fileType: formData.type}) : t('common:contentUploadModal.labels.uploadFile'))}"
+    },
+    {
+      "key": "common:contentUploadModal.labels.uploadFileType",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 443,
+      "context": "(contentType === 'e-learning' && (formData.type === ELearningContentType.PDF || formData.type === ELearningContentType.VIDEO) ? t('common:contentUploadModal.labels.uploadFileType', { fileType: formData.type}) : t('common:contentUploadModal.labels.uploadFile'))}"
+    },
+    {
+      "key": "common:contentUploadModal.labels.uploadFile",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 443,
+      "context": "(contentType === 'e-learning' && (formData.type === ELearningContentType.PDF || formData.type === ELearningContentType.VIDEO) ? t('common:contentUploadModal.labels.uploadFileType', { fileType: formData.type}) : t('common:contentUploadModal.labels.uploadFile'))}"
+    },
+    {
+      "key": "common:contentUploadModal.fileUpload.browse",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 451,
+      "context": "<span>{t('common:contentUploadModal.fileUpload.browse')}</span>"
+    },
+    {
+      "key": "common:contentUploadModal.fileUpload.browse",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 451,
+      "context": "<span>{t('common:contentUploadModal.fileUpload.browse')}</span>"
+    },
+    {
+      "key": "common:contentUploadModal.fileUpload.dragAndDrop",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 454,
+      "context": "<p className=\"pl-1 text-gray-500\">{t('common:contentUploadModal.fileUpload.dragAndDrop')}</p>"
+    },
+    {
+      "key": "common:contentUploadModal.fileUpload.dragAndDrop",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 454,
+      "context": "<p className=\"pl-1 text-gray-500\">{t('common:contentUploadModal.fileUpload.dragAndDrop')}</p>"
+    },
+    {
+      "key": "common:contentUploadModal.fileUpload.eLearningAllowedTypes",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 457,
+      "context": "{contentType==='e-learning' ? t('common:contentUploadModal.fileUpload.eLearningAllowedTypes') : t('common:contentUploadModal.fileUpload.hrPolicyAllowedTypes')}"
+    },
+    {
+      "key": "common:contentUploadModal.fileUpload.hrPolicyAllowedTypes",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 457,
+      "context": "{contentType==='e-learning' ? t('common:contentUploadModal.fileUpload.eLearningAllowedTypes') : t('common:contentUploadModal.fileUpload.hrPolicyAllowedTypes')}"
+    },
+    {
+      "key": "common:contentUploadModal.fileUpload.eLearningAllowedTypes",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 457,
+      "context": "{contentType==='e-learning' ? t('common:contentUploadModal.fileUpload.eLearningAllowedTypes') : t('common:contentUploadModal.fileUpload.hrPolicyAllowedTypes')}"
+    },
+    {
+      "key": "common:contentUploadModal.fileUpload.hrPolicyAllowedTypes",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 457,
+      "context": "{contentType==='e-learning' ? t('common:contentUploadModal.fileUpload.eLearningAllowedTypes') : t('common:contentUploadModal.fileUpload.hrPolicyAllowedTypes')}"
+    },
+    {
+      "key": "common:contentUploadModal.fileUpload.selected",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 461,
+      "context": "{file && <p className=\"mt-2 text-sm text-gray-500\"><PaperClipIcon className=\"w-4 h-4 inline mr-1\"/> {t('common:contentUploadModal.fileUpload.selected', { fileName: file.name })}</p>}"
+    },
+    {
+      "key": "common:contentUploadModal.fileUpload.selected",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 461,
+      "context": "{file && <p className=\"mt-2 text-sm text-gray-500\"><PaperClipIcon className=\"w-4 h-4 inline mr-1\"/> {t('common:contentUploadModal.fileUpload.selected', { fileName: file.name })}</p>}"
+    },
+    {
+      "key": "common:buttons.cancel",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 472,
+      "context": "<Button type=\"button\" variant=\"light\" onClick={onClose} disabled={isUploading}>{t('common:buttons.cancel')}</Button>"
+    },
+    {
+      "key": "common:buttons.cancel",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 472,
+      "context": "<Button type=\"button\" variant=\"light\" onClick={onClose} disabled={isUploading}>{t('common:buttons.cancel')}</Button>"
+    },
+    {
+      "key": "common:contentUploadModal.buttons.uploading",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 474,
+      "context": "{isUploading ? t('common:contentUploadModal.buttons.uploading') : (existingContent ? t('common:buttons.saveChanges') : t('common:contentUploadModal.buttons.upload'))}"
+    },
+    {
+      "key": "common:buttons.saveChanges",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 474,
+      "context": "{isUploading ? t('common:contentUploadModal.buttons.uploading') : (existingContent ? t('common:buttons.saveChanges') : t('common:contentUploadModal.buttons.upload'))}"
+    },
+    {
+      "key": "common:contentUploadModal.buttons.upload",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 474,
+      "context": "{isUploading ? t('common:contentUploadModal.buttons.uploading') : (existingContent ? t('common:buttons.saveChanges') : t('common:contentUploadModal.buttons.upload'))}"
+    },
+    {
+      "key": "common:contentUploadModal.buttons.uploading",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 474,
+      "context": "{isUploading ? t('common:contentUploadModal.buttons.uploading') : (existingContent ? t('common:buttons.saveChanges') : t('common:contentUploadModal.buttons.upload'))}"
+    },
+    {
+      "key": "common:buttons.saveChanges",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 474,
+      "context": "{isUploading ? t('common:contentUploadModal.buttons.uploading') : (existingContent ? t('common:buttons.saveChanges') : t('common:contentUploadModal.buttons.upload'))}"
+    },
+    {
+      "key": "common:contentUploadModal.buttons.upload",
+      "file": "components/admin/ContentUploadModal.tsx",
+      "line": 474,
+      "context": "{isUploading ? t('common:contentUploadModal.buttons.uploading') : (existingContent ? t('common:buttons.saveChanges') : t('common:contentUploadModal.buttons.upload'))}"
+    },
+    {
+      "key": "settingsTeamPermissions.confirmRemoveMember",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 40,
+      "context": "if (window.confirm(t('settingsTeamPermissions.confirmRemoveMember'))) {"
+    },
+    {
+      "key": "settingsTeamPermissions.passwordResetSentAlert",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 47,
+      "context": "alert(t('settingsTeamPermissions.passwordResetSentAlert', { memberId }));"
+    },
+    {
+      "key": "settings:page.teamPermissions",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 59,
+      "context": "<SettingsSectionWrapper title={t('settings:page.teamPermissions')} icon={UsersIcon}>"
+    },
+    {
+      "key": "settings:page.teamPermissions",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 59,
+      "context": "<SettingsSectionWrapper title={t('settings:page.teamPermissions')} icon={UsersIcon}>"
+    },
+    {
+      "key": "settingsTeamPermissions.inviteNewMember",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 61,
+      "context": "<h3 className=\"text-md font-semibold text-swiss-charcoal mb-2\">{t('settingsTeamPermissions.inviteNewMember')}</h3>"
+    },
+    {
+      "key": "settingsTeamPermissions.emailAddress",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 64,
+      "context": "<label htmlFor=\"inviteEmail\" className=\"block text-xs font-medium text-gray-500 mb-1\">{t('settingsTeamPermissions.emailAddress')}</label>"
+    },
+    {
+      "key": "settingsTeamPermissions.emailPlaceholder",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 71,
+      "context": "placeholder={t('settingsTeamPermissions.emailPlaceholder')}"
+    },
+    {
+      "key": "settingsTeamPermissions.role",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 77,
+      "context": "<label htmlFor=\"inviteRole\" className=\"block text-xs font-medium text-gray-500 mb-1\">{t('settingsTeamPermissions.role')}</label>"
+    },
+    {
+      "key": "settingsTeamPermissions.sendInvite",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 89,
+      "context": "{t('settingsTeamPermissions.sendInvite')}"
+    },
+    {
+      "key": "settingsTeamPermissions.currentTeamMembers",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 94,
+      "context": "<h3 className=\"text-md font-semibold text-swiss-charcoal mb-3\">{t('settingsTeamPermissions.currentTeamMembers')}</h3>"
+    },
+    {
+      "key": "settingsTeamPermissions.noTeamMembers",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 96,
+      "context": "<p className=\"text-gray-500\">{t('settingsTeamPermissions.noTeamMembers')}</p>"
+    },
+    {
+      "key": "settingsTeamPermissions.table.email",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 102,
+      "context": "<th className=\"px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('settingsTeamPermissions.table.email')}</th>"
+    },
+    {
+      "key": "settingsTeamPermissions.table.role",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 103,
+      "context": "<th className=\"px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('settingsTeamPermissions.table.role')}</th>"
+    },
+    {
+      "key": "settingsTeamPermissions.table.status",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 104,
+      "context": "<th className=\"px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('settingsTeamPermissions.table.status')}</th>"
+    },
+    {
+      "key": "settingsTeamPermissions.table.actions",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 105,
+      "context": "<th className=\"px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('settingsTeamPermissions.table.actions')}</th>"
+    },
+    {
+      "key": "settingsTeamPermissions.roles.editor",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 112,
+      "context": "<td className=\"px-4 py-3 whitespace-nowrap text-sm text-gray-600\">{member.role === 'Editor' ? t('settingsTeamPermissions.roles.editor') : t('settingsTeamPermissions.roles.viewer')}</td>"
+    },
+    {
+      "key": "settingsTeamPermissions.roles.viewer",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 112,
+      "context": "<td className=\"px-4 py-3 whitespace-nowrap text-sm text-gray-600\">{member.role === 'Editor' ? t('settingsTeamPermissions.roles.editor') : t('settingsTeamPermissions.roles.viewer')}</td>"
+    },
+    {
+      "key": "settingsTeamPermissions.resetPasswordTooltip",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 120,
+      "context": "<Button variant=\"ghost\" size=\"xs\" onClick={() => handleResetPassword(member.id)} title={t('settingsTeamPermissions.resetPasswordTooltip')}>"
+    },
+    {
+      "key": "settingsTeamPermissions.removeMemberTooltip",
+      "file": "components/settings/sections/TeamPermissionsSettings.tsx",
+      "line": 123,
+      "context": "<Button variant=\"ghost\" size=\"xs\" className=\"text-swiss-coral\" onClick={() => handleRemoveMember(member.id)} title={t('settingsTeamPermissions.removeMemberTooltip')}>"
+    },
+    {
+      "key": "settingsPromoCodeManager.confirmDelete",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 36,
+      "context": "if (window.confirm(t('settingsPromoCodeManager.confirmDelete'))) {"
+    },
+    {
+      "key": "settingsPromoCodeManager.discountTypes.percentage",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 44,
+      "context": "case 'Percentage': return t('settingsPromoCodeManager.discountTypes.percentage', { value: promo.value });"
+    },
+    {
+      "key": "settingsPromoCodeManager.discountTypes.fixedAmount",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 45,
+      "context": "case 'FixedAmount': return t('settingsPromoCodeManager.discountTypes.fixedAmount', { value: promo.value });"
+    },
+    {
+      "key": "settingsPromoCodeManager.discountTypes.freeMinutes",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 46,
+      "context": "case 'FreeMinutes': return t('settingsPromoCodeManager.discountTypes.freeMinutes', { value: promo.value });"
+    },
+    {
+      "key": "settings:page.promoCodeManager",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 52,
+      "context": "<SettingsSectionWrapper title={t('settings:page.promoCodeManager')} icon={TagIcon}>"
+    },
+    {
+      "key": "settings:page.promoCodeManager",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 52,
+      "context": "<SettingsSectionWrapper title={t('settings:page.promoCodeManager')} icon={TagIcon}>"
+    },
+    {
+      "key": "settingsPromoCodeManager.addNewCode",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 55,
+      "context": "{t('settingsPromoCodeManager.addNewCode')}"
+    },
+    {
+      "key": "settingsPromoCodeManager.noCodesYet",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 60,
+      "context": "<p className=\"text-gray-500 text-center py-4\">{t('settingsPromoCodeManager.noCodesYet')}</p>"
+    },
+    {
+      "key": "settingsPromoCodeManager.table.code",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 66,
+      "context": "<th className=\"px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('settingsPromoCodeManager.table.code')}</th>"
+    },
+    {
+      "key": "settingsPromoCodeManager.table.discountOffer",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 67,
+      "context": "<th className=\"px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('settingsPromoCodeManager.table.discountOffer')}</th>"
+    },
+    {
+      "key": "settingsPromoCodeManager.table.expiry",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 68,
+      "context": "<th className=\"px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('settingsPromoCodeManager.table.expiry')}</th>"
+    },
+    {
+      "key": "settingsPromoCodeManager.table.status",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 69,
+      "context": "<th className=\"px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('settingsPromoCodeManager.table.status')}</th>"
+    },
+    {
+      "key": "settingsPromoCodeManager.table.actions",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 70,
+      "context": "<th className=\"px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">{t('settingsPromoCodeManager.table.actions')}</th>"
+    },
+    {
+      "key": "buttons.edit",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 91,
+      "context": "<PencilSquareIcon className=\"w-4 h-4\"/> {t('buttons.edit')}"
+    },
+    {
+      "key": "buttons.delete",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 94,
+      "context": "<TrashIcon className=\"w-4 h-4\"/> {t('buttons.delete')}"
+    },
+    {
+      "key": "settingsPromoCodeManager.addEditModal.editTitle",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 114,
+      "context": "<h3 className=\"text-lg font-semibold mb-4\">{editingPromo ? t('settingsPromoCodeManager.addEditModal.editTitle') : t('settingsPromoCodeManager.addEditModal.addTitle')}</h3>"
+    },
+    {
+      "key": "settingsPromoCodeManager.addEditModal.addTitle",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 114,
+      "context": "<h3 className=\"text-lg font-semibold mb-4\">{editingPromo ? t('settingsPromoCodeManager.addEditModal.editTitle') : t('settingsPromoCodeManager.addEditModal.addTitle')}</h3>"
+    },
+    {
+      "key": "settingsPromoCodeManager.addEditModal.placeholder",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 115,
+      "context": "<p className=\"text-sm text-gray-600 mb-4\">{t('settingsPromoCodeManager.addEditModal.placeholder')}</p>"
+    },
+    {
+      "key": "buttons.cancel",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 117,
+      "context": "<Button variant=\"light\" onClick={() => setIsModalOpen(false)}>{t('buttons.cancel')}</Button>"
+    },
+    {
+      "key": "settingsPromoCodeManager.addEditModal.save",
+      "file": "components/settings/sections/PromoCodeManagerSettings.tsx",
+      "line": 118,
+      "context": "<Button variant=\"primary\" onClick={() => { /* Mock submit */ setIsModalOpen(false); }}>{t('settingsPromoCodeManager.addEditModal.save')}</Button>"
+    },
+    {
+      "key": "settingsPrivacyData.confirmGDPRDelete",
+      "file": "components/settings/sections/PrivacyDataSettings.tsx",
+      "line": 30,
+      "context": "if (window.confirm(t('settingsPrivacyData.confirmGDPRDelete'))) {"
+    },
+    {
+      "key": "settingsPrivacyData.deletionRequestSubmittedHelpText",
+      "file": "components/settings/sections/PrivacyDataSettings.tsx",
+      "line": 32,
+      "context": "alert(t('settingsPrivacyData.deletionRequestSubmittedHelpText'));"
+    },
+    {
+      "key": "settings:page.privacyData",
+      "file": "components/settings/sections/PrivacyDataSettings.tsx",
+      "line": 38,
+      "context": "<SettingsSectionWrapper title={t('settings:page.privacyData')} icon={LockClosedIcon}>"
+    },
+    {
+      "key": "settings:page.privacyData",
+      "file": "components/settings/sections/PrivacyDataSettings.tsx",
+      "line": 38,
+      "context": "<SettingsSectionWrapper title={t('settings:page.privacyData')} icon={LockClosedIcon}>"
+    },
+    {
+      "key": "settingsPrivacyData.dataDeletion",
+      "file": "components/settings/sections/PrivacyDataSettings.tsx",
+      "line": 61,
+      "context": "<label className=\"form-label md:pt-2\">{t('settingsPrivacyData.dataDeletion')}</label>"
+    },
+    {
+      "key": "settingsPrivacyData.deletionRequestSubmitted",
+      "file": "components/settings/sections/PrivacyDataSettings.tsx",
+      "line": 69,
+      "context": "{settings.gdprDataDeletionRequestMade ? t('settingsPrivacyData.deletionRequestSubmitted') : t('settingsPrivacyData.requestGDPRDeletion')}"
+    },
+    {
+      "key": "settingsPrivacyData.requestGDPRDeletion",
+      "file": "components/settings/sections/PrivacyDataSettings.tsx",
+      "line": 69,
+      "context": "{settings.gdprDataDeletionRequestMade ? t('settingsPrivacyData.deletionRequestSubmitted') : t('settingsPrivacyData.requestGDPRDeletion')}"
+    },
+    {
+      "key": "settingsPrivacyData.deletionRequestSubmittedHelpText",
+      "file": "components/settings/sections/PrivacyDataSettings.tsx",
+      "line": 72,
+      "context": "<p className=\"text-xs text-yellow-600 mt-1\">{t('settingsPrivacyData.deletionRequestSubmittedHelpText')}</p>"
+    },
+    {
+      "key": "settingsPrivacyData.requestDeletionHelpText",
+      "file": "components/settings/sections/PrivacyDataSettings.tsx",
+      "line": 75,
+      "context": "<p className=\"text-xs text-gray-500 mt-1\">{t('settingsPrivacyData.requestDeletionHelpText')}</p>"
+    },
+    {
+      "key": "settings:page.notificationPreferences",
+      "file": "components/settings/sections/NotificationPreferencesSettings.tsx",
+      "line": 31,
+      "context": "<SettingsSectionWrapper title={t('settings:page.notificationPreferences')} icon={BellAlertIcon}>"
+    },
+    {
+      "key": "settings:page.notificationPreferences",
+      "file": "components/settings/sections/NotificationPreferencesSettings.tsx",
+      "line": 31,
+      "context": "<SettingsSectionWrapper title={t('settings:page.notificationPreferences')} icon={BellAlertIcon}>"
+    },
+    {
+      "key": "settingsNotificationPreferences.digestFrequency",
+      "file": "components/settings/sections/NotificationPreferencesSettings.tsx",
+      "line": 51,
+      "context": "<label className=\"form-label md:pt-2\">{t('settingsNotificationPreferences.digestFrequency')} <span className=\"text-swiss-coral\">*</span></label>"
+    },
+    {
+      "key": "settingsNotificationPreferences.promoRedemptionAlertsToggle",
+      "file": "components/settings/sections/NotificationPreferencesSettings.tsx",
+      "line": 69,
+      "context": "<label htmlFor=\"promoRedemptionAlertsToggle\" className=\"form-label md:pt-2\">{t('settingsNotificationPreferences.promoRedemptionAlertsToggle')} <span className=\"text-swiss-coral\">*</span></label>"
+    },
+    {
+      "key": "settingsNotificationPreferences.promoRedemptionAlertsToggle",
+      "file": "components/settings/sections/NotificationPreferencesSettings.tsx",
+      "line": 78,
+      "context": "aria-label={t('settingsNotificationPreferences.promoRedemptionAlertsToggle')}"
+    },
+    {
+      "key": "settingsNotificationPreferences.promoRedemptionAlertsToggle",
+      "file": "components/settings/sections/NotificationPreferencesSettings.tsx",
+      "line": 80,
+      "context": "<span className=\"sr-only\">{t('settingsNotificationPreferences.promoRedemptionAlertsToggle')}</span>"
+    },
+    {
+      "key": "settings:page.defaults",
+      "file": "components/settings/sections/DefaultsSettings.tsx",
+      "line": 31,
+      "context": "<SettingsSectionWrapper title={t('settings:page.defaults')} icon={AdjustmentsHorizontalIcon}>"
+    },
+    {
+      "key": "settings:page.defaults",
+      "file": "components/settings/sections/DefaultsSettings.tsx",
+      "line": 31,
+      "context": "<SettingsSectionWrapper title={t('settings:page.defaults')} icon={AdjustmentsHorizontalIcon}>"
+    },
+    {
+      "key": "settingsDefaults.autoRespondToggle",
+      "file": "components/settings/sections/DefaultsSettings.tsx",
+      "line": 34,
+      "context": "<label htmlFor=\"autoRespondToggle\" className=\"form-label md:pt-2\">{t('settingsDefaults.autoRespondToggle')}</label>"
+    },
+    {
+      "key": "settingsDefaults.autoRespondToggle",
+      "file": "components/settings/sections/DefaultsSettings.tsx",
+      "line": 43,
+      "context": "aria-label={t('settingsDefaults.autoRespondToggle')}"
+    },
+    {
+      "key": "settingsDefaults.autoRespondToggle",
+      "file": "components/settings/sections/DefaultsSettings.tsx",
+      "line": 45,
+      "context": "<span className=\"sr-only\">{t('settingsDefaults.autoRespondToggle')}</span>"
+    },
+    {
+      "key": "settingsDefaults.autoRespondHelpText",
+      "file": "components/settings/sections/DefaultsSettings.tsx",
+      "line": 48,
+      "context": "<p className=\"text-xs text-gray-500 mt-1\">{t('settingsDefaults.autoRespondHelpText')}</p>"
+    },
+    {
+      "key": "settingsDefaults.defaultMOQ",
+      "file": "components/settings/sections/DefaultsSettings.tsx",
+      "line": 54,
+      "context": "<label htmlFor=\"defaultMOQ\" className=\"form-label md:pt-2\">{t('settingsDefaults.defaultMOQ')}</label>"
+    },
+    {
+      "key": "settingsDefaults.defaultMOQPlaceholder",
+      "file": "components/settings/sections/DefaultsSettings.tsx",
+      "line": 63,
+      "context": "placeholder={t('settingsDefaults.defaultMOQPlaceholder')}"
+    },
+    {
+      "key": "settingsDefaults.autoAcceptOrderQtyLimit",
+      "file": "components/settings/sections/DefaultsSettings.tsx",
+      "line": 67,
+      "context": "<label htmlFor=\"autoAcceptOrderQtyLimit\" className=\"form-label md:pt-2\">{t('settingsDefaults.autoAcceptOrderQtyLimit')}</label>"
+    },
+    {
+      "key": "settingsDefaults.autoAcceptOrderQtyLimitPlaceholder",
+      "file": "components/settings/sections/DefaultsSettings.tsx",
+      "line": 76,
+      "context": "placeholder={t('settingsDefaults.autoAcceptOrderQtyLimitPlaceholder')}"
+    },
+    {
+      "key": "settingsDefaults.defaultConsultationLength",
+      "file": "components/settings/sections/DefaultsSettings.tsx",
+      "line": 85,
+      "context": "<label className=\"form-label md:pt-2\">{t('settingsDefaults.defaultConsultationLength')}</label>"
+    },
+    {
+      "key": "settings:page.contactBooking",
+      "file": "components/settings/sections/ContactBookingSettings.tsx",
+      "line": 39,
+      "context": "<SettingsSectionWrapper title={t('settings:page.contactBooking')} icon={PhoneIcon}>"
+    },
+    {
+      "key": "settings:page.contactBooking",
+      "file": "components/settings/sections/ContactBookingSettings.tsx",
+      "line": 39,
+      "context": "<SettingsSectionWrapper title={t('settings:page.contactBooking')} icon={PhoneIcon}>"
+    },
+    {
+      "key": "settingsContactBooking.preferredContactMethod",
+      "file": "components/settings/sections/ContactBookingSettings.tsx",
+      "line": 42,
+      "context": "<label className=\"form-label md:pt-2\">{t('settingsContactBooking.preferredContactMethod')} <span className=\"text-swiss-coral\">*</span></label>"
+    },
+    {
+      "key": "settingsContactBooking.avgResponseTime",
+      "file": "components/settings/sections/ContactBookingSettings.tsx",
+      "line": 60,
+      "context": "<label htmlFor=\"avgResponseType\" className=\"form-label md:pt-2\">{t('settingsContactBooking.avgResponseTime')} <span className=\"text-swiss-coral\">*</span></label>"
+    },
+    {
+      "key": "settingsContactBooking.externalBookingLink",
+      "file": "components/settings/sections/ContactBookingSettings.tsx",
+      "line": 75,
+      "context": "<label htmlFor=\"externalBookingLink\" className=\"form-label md:pt-2\">{t('settingsContactBooking.externalBookingLink')}</label>"
+    },
+    {
+      "key": "settingsContactBooking.externalBookingLinkPlaceholder",
+      "file": "components/settings/sections/ContactBookingSettings.tsx",
+      "line": 84,
+      "context": "placeholder={t('settingsContactBooking.externalBookingLinkPlaceholder')}"
+    },
+    {
+      "key": "settingsContactBooking.directOrderLink",
+      "file": "components/settings/sections/ContactBookingSettings.tsx",
+      "line": 91,
+      "context": "<label htmlFor=\"directOrderLink\" className=\"form-label md:pt-2\">{t('settingsContactBooking.directOrderLink')}</label>"
+    },
+    {
+      "key": "settingsContactBooking.directOrderLinkPlaceholder",
+      "file": "components/settings/sections/ContactBookingSettings.tsx",
+      "line": 100,
+      "context": "placeholder={t('settingsContactBooking.directOrderLinkPlaceholder')}"
+    },
+    {
+      "key": "settingsContactBooking.directOrderLinkHelpText",
+      "file": "components/settings/sections/ContactBookingSettings.tsx",
+      "line": 102,
+      "context": "<p className=\"text-xs text-gray-500 mt-1\">{t('settingsContactBooking.directOrderLinkHelpText')}</p>"
+    },
+    {
+      "key": "settingsContactBooking.calComLink",
+      "file": "components/settings/sections/ContactBookingSettings.tsx",
+      "line": 112,
+      "context": "<label htmlFor=\"calComLink\" className=\"form-label md:pt-2\">{t('settingsContactBooking.calComLink')}</label>"
+    },
+    {
+      "key": "settingsContactBooking.calComLinkPlaceholder",
+      "file": "components/settings/sections/ContactBookingSettings.tsx",
+      "line": 121,
+      "context": "placeholder={t('settingsContactBooking.calComLinkPlaceholder')}"
+    },
+    {
+      "key": "settingsContactBooking.deliveryTypeToggleRemote",
+      "file": "components/settings/sections/ContactBookingSettings.tsx",
+      "line": 126,
+      "context": "<label htmlFor=\"deliveryTypeToggleRemote\" className=\"form-label md:pt-2\">{t('settingsContactBooking.deliveryTypeToggleRemote')}</label>"
+    },
+    {
+      "key": "settingsContactBooking.deliveryTypeToggleRemote",
+      "file": "components/settings/sections/ContactBookingSettings.tsx",
+      "line": 135,
+      "context": "aria-label={t('settingsContactBooking.deliveryTypeToggleRemote')}"
+    },
+    {
+      "key": "settingsContactBooking.deliveryTypeToggleRemote",
+      "file": "components/settings/sections/ContactBookingSettings.tsx",
+      "line": 137,
+      "context": "<span className=\"sr-only\">{t('settingsContactBooking.deliveryTypeToggleRemote')}</span>"
+    },
+    {
+      "key": "settings:page.companyProfile",
+      "file": "components/settings/sections/CompanyProfileSettings.tsx",
+      "line": 42,
+      "context": "<SettingsSectionWrapper title={t('settings:page.companyProfile')} icon={BuildingOfficeIcon}>"
+    },
+    {
+      "key": "settings:page.companyProfile",
+      "file": "components/settings/sections/CompanyProfileSettings.tsx",
+      "line": 42,
+      "context": "<SettingsSectionWrapper title={t('settings:page.companyProfile')} icon={BuildingOfficeIcon}>"
+    },
+    {
+      "key": "settingsCompanyProfile.companyName",
+      "file": "components/settings/sections/CompanyProfileSettings.tsx",
+      "line": 45,
+      "context": "<label htmlFor=\"companyName\" className=\"form-label md:pt-2\">{t('settingsCompanyProfile.companyName')} <span className=\"text-swiss-coral\">*</span></label>"
+    },
+    {
+      "key": "settingsCompanyProfile.logo",
+      "file": "components/settings/sections/CompanyProfileSettings.tsx",
+      "line": 59,
+      "context": "<label className=\"form-label\">{t('settingsCompanyProfile.logo')}</label>"
+    },
+    {
+      "key": "settingsCompanyProfile.coverImage",
+      "file": "components/settings/sections/CompanyProfileSettings.tsx",
+      "line": 66,
+      "context": "<label className=\"form-label\">{t('settingsCompanyProfile.coverImage')}</label>"
+    },
+    {
+      "key": "settingsCompanyProfile.aboutText",
+      "file": "components/settings/sections/CompanyProfileSettings.tsx",
+      "line": 73,
+      "context": "<label htmlFor=\"aboutText\" className=\"form-label md:pt-2\">{t('settingsCompanyProfile.aboutText')}</label>"
+    },
+    {
+      "key": "settingsCompanyProfile.aboutTextLength",
+      "file": "components/settings/sections/CompanyProfileSettings.tsx",
+      "line": 84,
+      "context": "<p className=\"text-xs text-gray-400 text-right mt-1\">{t('settingsCompanyProfile.aboutTextLength', { length: settings.aboutText?.length || 0 })}</p>"
+    },
+    {
+      "key": "settingsCompanyProfile.vatNumber",
+      "file": "components/settings/sections/CompanyProfileSettings.tsx",
+      "line": 88,
+      "context": "<label htmlFor=\"vatNumber\" className=\"form-label md:pt-2\">{t('settingsCompanyProfile.vatNumber')}</label>"
+    },
+    {
+      "key": "settingsCompanyProfile.regionsServed",
+      "file": "components/settings/sections/CompanyProfileSettings.tsx",
+      "line": 101,
+      "context": "<label className=\"form-label\">{t('settingsCompanyProfile.regionsServed')}</label>"
+    },
+    {
+      "key": "settingsCompanyProfile.selectCanton",
+      "file": "components/settings/sections/CompanyProfileSettings.tsx",
+      "line": 103,
+      "context": "{/* <ChipInput selectedChips={settings.regionsServed || []} availableOptions={SWISS_CANTONS} onChange={(newChips) => onChange('regionsServed', newChips)} placeholder={t('settingsCompanyProfile.selectCanton')} /> */}"
+    },
+    {
+      "key": "settingsCompanyProfile.cantonsHelpText",
+      "file": "components/settings/sections/CompanyProfileSettings.tsx",
+      "line": 104,
+      "context": "<p className=\"text-xs text-gray-500 mb-2\">{t('settingsCompanyProfile.cantonsHelpText')}</p>"
+    },
+    {
+      "key": "settingsCompanyProfile.languagesSpoken",
+      "file": "components/settings/sections/CompanyProfileSettings.tsx",
+      "line": 120,
+      "context": "<label className=\"form-label\">{t('settingsCompanyProfile.languagesSpoken')}</label>"
+    },
+    {
+      "key": "settingsCompanyProfile.selectLanguage",
+      "file": "components/settings/sections/CompanyProfileSettings.tsx",
+      "line": 122,
+      "context": "{/* <ChipInput selectedChips={settings.languagesSpoken || []} availableOptions={['EN', 'FR', 'DE']} onChange={(newChips) => onChange('languagesSpoken', newChips)} placeholder={t('settingsCompanyProfile.selectLanguage')} /> */}"
+    },
+    {
+      "key": "settingsCompanyProfile.languagesHelpText",
+      "file": "components/settings/sections/CompanyProfileSettings.tsx",
+      "line": 123,
+      "context": "<p className=\"text-xs text-gray-500 mb-2\">{t('settingsCompanyProfile.languagesHelpText')}</p>"
+    },
+    {
+      "key": "settingsBillingSubscription.yourCurrentPlan",
+      "file": "components/settings/sections/BillingSubscriptionSettings.tsx",
+      "line": 29,
+      "context": "actionButton = <Button variant=\"secondary\" size=\"md\" className=\"w-full\" disabled>{t('settingsBillingSubscription.yourCurrentPlan')}</Button>;"
+    },
+    {
+      "key": "settingsBillingSubscription.upgradePlan",
+      "file": "components/settings/sections/BillingSubscriptionSettings.tsx",
+      "line": 31,
+      "context": "actionButton = <Button variant=\"primary\" size=\"md\" className=\"w-full\" onClick={() => onSelectPlan(plan.name)}>{t('settingsBillingSubscription.upgradePlan')}</Button>;"
+    },
+    {
+      "key": "settingsBillingSubscription.downgradePlan",
+      "file": "components/settings/sections/BillingSubscriptionSettings.tsx",
+      "line": 33,
+      "context": "actionButton = <Button variant=\"outline\" size=\"md\" className=\"w-full\" onClick={() => onSelectPlan(plan.name)}>{t('settingsBillingSubscription.downgradePlan')}</Button>;"
+    },
+    {
+      "key": "settingsBillingSubscription.yourCurrentPlan",
+      "file": "components/settings/sections/BillingSubscriptionSettings.tsx",
+      "line": 40,
+      "context": "<span className=\"px-3 py-1 text-xs font-semibold tracking-wide text-white uppercase bg-swiss-mint rounded-full\">{t('settingsBillingSubscription.yourCurrentPlan')}</span>"
+    },
+    {
+      "key": "settings:page.billingSubscription",
+      "file": "components/settings/sections/BillingSubscriptionSettings.tsx",
+      "line": 78,
+      "context": "<SettingsSectionWrapper title={t('settings:page.billingSubscription')} icon={WalletIcon}>"
+    },
+    {
+      "key": "settings:page.billingSubscription",
+      "file": "components/settings/sections/BillingSubscriptionSettings.tsx",
+      "line": 78,
+      "context": "<SettingsSectionWrapper title={t('settings:page.billingSubscription')} icon={WalletIcon}>"
+    },
+    {
+      "key": "settingsBillingSubscription.currentPlan",
+      "file": "components/settings/sections/BillingSubscriptionSettings.tsx",
+      "line": 80,
+      "context": "<h3 className=\"text-md font-medium text-gray-700\">{t('settingsBillingSubscription.currentPlan')}</h3>"
+    },
+    {
+      "key": "settingsBillingSubscription.nextInvoiceOn",
+      "file": "components/settings/sections/BillingSubscriptionSettings.tsx",
+      "line": 82,
+      "context": "{settings.nextInvoiceDate && <p className=\"text-sm text-gray-500 mt-0.5\">{t('settingsBillingSubscription.nextInvoiceOn', { date: new Date(settings.nextInvoiceDate).toLocaleDateString() })}</p>}"
+    },
+    {
+      "key": "settingsBillingSubscription.manageSubscriptionTitle",
+      "file": "components/settings/sections/BillingSubscriptionSettings.tsx",
+      "line": 97,
+      "context": "<h3 className=\"text-xl font-semibold text-swiss-charcoal mb-2\">{t('settingsBillingSubscription.manageSubscriptionTitle')}</h3>"
+    },
+    {
+      "key": "settingsBillingSubscription.manageSubscriptionDescription",
+      "file": "components/settings/sections/BillingSubscriptionSettings.tsx",
+      "line": 98,
+      "context": "<p className=\"text-sm text-gray-500 mb-4\">{t('settingsBillingSubscription.manageSubscriptionDescription')}</p>"
+    },
+    {
+      "key": "settingsBillingSubscription.managePaymentButton",
+      "file": "components/settings/sections/BillingSubscriptionSettings.tsx",
+      "line": 106,
+      "context": "{t('settingsBillingSubscription.managePaymentButton')}"
+    },
+    {
+      "key": "settingsBillingSubscription.cancelSubscription",
+      "file": "components/settings/sections/BillingSubscriptionSettings.tsx",
+      "line": 113,
+      "context": "{t('settingsBillingSubscription.cancelSubscription')}"
+    },
+    {
+      "key": "settingsBillingSubscription.stripePortalLinkNotConfigured",
+      "file": "components/settings/sections/BillingSubscriptionSettings.tsx",
+      "line": 116,
+      "context": "{!settings.stripePortalLink && <p className=\"text-xs text-gray-400 mt-2\">{t('settingsBillingSubscription.stripePortalLinkNotConfigured')}</p>}"
+    },
+    {
+      "key": "settingsBillingSubscription.confirmCancelTitle",
+      "file": "components/settings/sections/BillingSubscriptionSettings.tsx",
+      "line": 122,
+      "context": "<h3 className=\"text-lg font-semibold mb-2 text-swiss-coral\">{t('settingsBillingSubscription.confirmCancelTitle')}</h3>"
+    },
+    {
+      "key": "settingsBillingSubscription.confirmCancelMessage",
+      "file": "components/settings/sections/BillingSubscriptionSettings.tsx",
+      "line": 123,
+      "context": "<p className=\"text-sm text-gray-600 mb-4\">{t('settingsBillingSubscription.confirmCancelMessage')}</p>"
+    },
+    {
+      "key": "settingsBillingSubscription.keepSubscription",
+      "file": "components/settings/sections/BillingSubscriptionSettings.tsx",
+      "line": 125,
+      "context": "<Button variant=\"light\" onClick={() => setIsCancelModalOpen(false)}>{t('settingsBillingSubscription.keepSubscription')}</Button>"
+    },
+    {
+      "key": "settingsBillingSubscription.yesCancel",
+      "file": "components/settings/sections/BillingSubscriptionSettings.tsx",
+      "line": 126,
+      "context": "<Button variant=\"danger\" onClick={() => alert('Subscription cancelled (mock action)')}>{t('settingsBillingSubscription.yesCancel')}</Button>"
+    },
+    {
+      "key": "settings:page.analyticsPreferences",
+      "file": "components/settings/sections/AnalyticsPreferencesSettings.tsx",
+      "line": 27,
+      "context": "<SettingsSectionWrapper title={t('settings:page.analyticsPreferences')} icon={ChartPieIcon}>"
+    },
+    {
+      "key": "settings:page.analyticsPreferences",
+      "file": "components/settings/sections/AnalyticsPreferencesSettings.tsx",
+      "line": 27,
+      "context": "<SettingsSectionWrapper title={t('settings:page.analyticsPreferences')} icon={ChartPieIcon}>"
+    },
+    {
+      "key": "settingsAnalyticsPreferences.timeZone",
+      "file": "components/settings/sections/AnalyticsPreferencesSettings.tsx",
+      "line": 30,
+      "context": "<label htmlFor=\"timeZone\" className=\"form-label md:pt-2\">{t('settingsAnalyticsPreferences.timeZone')} <span className=\"text-swiss-coral\">*</span></label>"
+    },
+    {
+      "key": "settingsAnalyticsPreferences.currency",
+      "file": "components/settings/sections/AnalyticsPreferencesSettings.tsx",
+      "line": 45,
+      "context": "<label htmlFor=\"currency\" className=\"form-label md:pt-2\">{t('settingsAnalyticsPreferences.currency')} <span className=\"text-swiss-coral\">*</span></label>"
+    },
+    {
+      "key": "settingsAnalyticsPreferences.benchmarkData",
+      "file": "components/settings/sections/AnalyticsPreferencesSettings.tsx",
+      "line": 60,
+      "context": "<label htmlFor=\"anonymisedBenchmarkDataOptIn\" className=\"form-label md:pt-2\">{t('settingsAnalyticsPreferences.benchmarkData')}</label>"
+    },
+    {
+      "key": "settingsAnalyticsPreferences.benchmarkData",
+      "file": "components/settings/sections/AnalyticsPreferencesSettings.tsx",
+      "line": 69,
+      "context": "aria-label={t('settingsAnalyticsPreferences.benchmarkData')}"
+    },
+    {
+      "key": "settingsAnalyticsPreferences.benchmarkData",
+      "file": "components/settings/sections/AnalyticsPreferencesSettings.tsx",
+      "line": 71,
+      "context": "<span className=\"sr-only\">{t('settingsAnalyticsPreferences.benchmarkData')}</span>"
+    },
+    {
+      "key": "settingsAnalyticsPreferences.benchmarkDataHelpText",
+      "file": "components/settings/sections/AnalyticsPreferencesSettings.tsx",
+      "line": 74,
+      "context": "<p className=\"text-xs text-gray-500 mt-1\">{t('settingsAnalyticsPreferences.benchmarkDataHelpText')}</p>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.notifications.infoUpdated",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 69,
+      "context": "addNotification({ title: t('common:settingsAccountSecurity.notifications.infoUpdated'), message: '', type: 'success' });"
+    },
+    {
+      "key": "common:settingsAccountSecurity.notifications.infoUpdated",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 69,
+      "context": "addNotification({ title: t('common:settingsAccountSecurity.notifications.infoUpdated'), message: '', type: 'success' });"
+    },
+    {
+      "key": "common:forms.passwordsDoNotMatch",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 77,
+      "context": "addNotification({ title: t('common:forms.passwordsDoNotMatch'), message: '', type: 'error' });"
+    },
+    {
+      "key": "common:forms.passwordsDoNotMatch",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 77,
+      "context": "addNotification({ title: t('common:forms.passwordsDoNotMatch'), message: '', type: 'error' });"
+    },
+    {
+      "key": "common:forms.passwordTooShort",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 82,
+      "context": "addNotification({ title: t('common:forms.passwordTooShort'), message: '', type: 'error' });"
+    },
+    {
+      "key": "common:forms.passwordTooShort",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 82,
+      "context": "addNotification({ title: t('common:forms.passwordTooShort'), message: '', type: 'error' });"
+    },
+    {
+      "key": "common:settingsAccountSecurity.notifications.passwordChanged",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 90,
+      "context": "addNotification({ title: t('common:settingsAccountSecurity.notifications.passwordChanged'), message: '', type: 'success' });"
+    },
+    {
+      "key": "common:settingsAccountSecurity.notifications.passwordChanged",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 90,
+      "context": "addNotification({ title: t('common:settingsAccountSecurity.notifications.passwordChanged'), message: '', type: 'success' });"
+    },
+    {
+      "key": "common:errors.unknown",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 93,
+      "context": "const message = error instanceof Error ? error.message : t('common:errors.unknown');"
+    },
+    {
+      "key": "common:errors.unknown",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 93,
+      "context": "const message = error instanceof Error ? error.message : t('common:errors.unknown');"
+    },
+    {
+      "key": "settingsPrivacyData.confirmGDPRDelete",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 102,
+      "context": "if (window.confirm(t('settingsPrivacyData.confirmGDPRDelete'))) {"
+    },
+    {
+      "key": "common:settingsAccountSecurity.dangerZone.finalConfirmation",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 103,
+      "context": "if (window.confirm(t('common:settingsAccountSecurity.dangerZone.finalConfirmation'))) {"
+    },
+    {
+      "key": "common:settingsAccountSecurity.dangerZone.finalConfirmation",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 103,
+      "context": "if (window.confirm(t('common:settingsAccountSecurity.dangerZone.finalConfirmation'))) {"
+    },
+    {
+      "key": "settingsPrivacyData.deletionRequestSubmittedHelpText",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 106,
+      "context": "alert(t('settingsPrivacyData.deletionRequestSubmittedHelpText'));"
+    },
+    {
+      "key": "settings:page.accountSecurity",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 114,
+      "context": "<SettingsSectionWrapper title={t('settings:page.accountSecurity')} icon={UserCircleIcon}>"
+    },
+    {
+      "key": "settings:page.accountSecurity",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 114,
+      "context": "<SettingsSectionWrapper title={t('settings:page.accountSecurity')} icon={UserCircleIcon}>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.personalInfo.title",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 118,
+      "context": "<h3 className=\"text-lg font-medium text-gray-900\">{t('common:settingsAccountSecurity.personalInfo.title')}</h3>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.personalInfo.title",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 118,
+      "context": "<h3 className=\"text-lg font-medium text-gray-900\">{t('common:settingsAccountSecurity.personalInfo.title')}</h3>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.personalInfo.orgNameLabel",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 132,
+      "context": "<label htmlFor=\"orgName\" className=\"form-label md:pt-2\">{t('common:settingsAccountSecurity.personalInfo.orgNameLabel')}</label>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.personalInfo.orgNameLabel",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 132,
+      "context": "<label htmlFor=\"orgName\" className=\"form-label md:pt-2\">{t('common:settingsAccountSecurity.personalInfo.orgNameLabel')}</label>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.personalInfo.emailLabel",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 139,
+      "context": "<div className=\"form-label md:pt-2\">{t('common:settingsAccountSecurity.personalInfo.emailLabel')}</div>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.personalInfo.emailLabel",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 139,
+      "context": "<div className=\"form-label md:pt-2\">{t('common:settingsAccountSecurity.personalInfo.emailLabel')}</div>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.personalInfo.accountTypeLabel",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 143,
+      "context": "<div className=\"form-label md:pt-2\">{t('common:settingsAccountSecurity.personalInfo.accountTypeLabel')}</div>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.personalInfo.accountTypeLabel",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 143,
+      "context": "<div className=\"form-label md:pt-2\">{t('common:settingsAccountSecurity.personalInfo.accountTypeLabel')}</div>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.personalInfo.memberSinceLabel",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 147,
+      "context": "<div className=\"form-label md:pt-2\">{t('common:settingsAccountSecurity.personalInfo.memberSinceLabel')}</div>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.personalInfo.memberSinceLabel",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 147,
+      "context": "<div className=\"form-label md:pt-2\">{t('common:settingsAccountSecurity.personalInfo.memberSinceLabel')}</div>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.personalInfo.updateInfoButton",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 153,
+      "context": "<Button type=\"submit\" variant=\"secondary\">{t('common:settingsAccountSecurity.personalInfo.updateInfoButton')}</Button>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.personalInfo.updateInfoButton",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 153,
+      "context": "<Button type=\"submit\" variant=\"secondary\">{t('common:settingsAccountSecurity.personalInfo.updateInfoButton')}</Button>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.changePassword.title",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 161,
+      "context": "<h3 className=\"text-lg font-medium text-gray-900\">{t('common:settingsAccountSecurity.changePassword.title')}</h3>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.changePassword.title",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 161,
+      "context": "<h3 className=\"text-lg font-medium text-gray-900\">{t('common:settingsAccountSecurity.changePassword.title')}</h3>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.changePassword.currentPasswordLabel",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 163,
+      "context": "<label htmlFor=\"currentPassword\" className=\"form-label md:pt-2\">{t('common:settingsAccountSecurity.changePassword.currentPasswordLabel')}</label>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.changePassword.currentPasswordLabel",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 163,
+      "context": "<label htmlFor=\"currentPassword\" className=\"form-label md:pt-2\">{t('common:settingsAccountSecurity.changePassword.currentPasswordLabel')}</label>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.changePassword.newPasswordLabel",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 169,
+      "context": "<label htmlFor=\"newPassword\" className=\"form-label md:pt-2\">{t('common:settingsAccountSecurity.changePassword.newPasswordLabel')}</label>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.changePassword.newPasswordLabel",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 169,
+      "context": "<label htmlFor=\"newPassword\" className=\"form-label md:pt-2\">{t('common:settingsAccountSecurity.changePassword.newPasswordLabel')}</label>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.changePassword.confirmNewPasswordLabel",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 175,
+      "context": "<label htmlFor=\"confirmNewPassword\" className=\"form-label md:pt-2\">{t('common:settingsAccountSecurity.changePassword.confirmNewPasswordLabel')}</label>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.changePassword.confirmNewPasswordLabel",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 175,
+      "context": "<label htmlFor=\"confirmNewPassword\" className=\"form-label md:pt-2\">{t('common:settingsAccountSecurity.changePassword.confirmNewPasswordLabel')}</label>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.changePassword.updatePasswordButton",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 183,
+      "context": "{isUpdatingPassword ? 'Updating...' : t('common:settingsAccountSecurity.changePassword.updatePasswordButton')}"
+    },
+    {
+      "key": "common:settingsAccountSecurity.changePassword.updatePasswordButton",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 183,
+      "context": "{isUpdatingPassword ? 'Updating...' : t('common:settingsAccountSecurity.changePassword.updatePasswordButton')}"
+    },
+    {
+      "key": "common:settingsAccountSecurity.dangerZone.title",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 195,
+      "context": "<h3 className=\"text-lg font-medium text-swiss-coral flex items-center\"><ShieldExclamationIcon className=\"w-5 h-5 mr-2\"/> {t('common:settingsAccountSecurity.dangerZone.title')}</h3>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.dangerZone.title",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 195,
+      "context": "<h3 className=\"text-lg font-medium text-swiss-coral flex items-center\"><ShieldExclamationIcon className=\"w-5 h-5 mr-2\"/> {t('common:settingsAccountSecurity.dangerZone.title')}</h3>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.dangerZone.deleteAccountTitle",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 198,
+      "context": "<p className=\"font-medium\">{t('common:settingsAccountSecurity.dangerZone.deleteAccountTitle')}</p>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.dangerZone.deleteAccountTitle",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 198,
+      "context": "<p className=\"font-medium\">{t('common:settingsAccountSecurity.dangerZone.deleteAccountTitle')}</p>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.dangerZone.deleteAccountSubtitle",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 199,
+      "context": "<p className=\"text-xs text-gray-500\">{t('common:settingsAccountSecurity.dangerZone.deleteAccountSubtitle')}</p>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.dangerZone.deleteAccountSubtitle",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 199,
+      "context": "<p className=\"text-xs text-gray-500\">{t('common:settingsAccountSecurity.dangerZone.deleteAccountSubtitle')}</p>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.dangerZone.deleteAccountButton",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 202,
+      "context": "<Button variant=\"danger\" onClick={handleAccountDeletion}>{t('common:settingsAccountSecurity.dangerZone.deleteAccountButton')}</Button>"
+    },
+    {
+      "key": "common:settingsAccountSecurity.dangerZone.deleteAccountButton",
+      "file": "components/settings/sections/AccountSecuritySettings.tsx",
+      "line": 202,
+      "context": "<Button variant=\"danger\" onClick={handleAccountDeletion}>{t('common:settingsAccountSecurity.dangerZone.deleteAccountButton')}</Button>"
+    }
+  ]
+}

--- a/missing-translations-report.json
+++ b/missing-translations-report.json
@@ -1,0 +1,2320 @@
+{
+  "timestamp": "2025-11-10T15:27:04.217Z",
+  "translationRoot": "packages/translations/locales/en",
+  "namespaces": [
+    "admin",
+    "auth",
+    "common",
+    "content",
+    "dashboard",
+    "marketplace",
+    "messages",
+    "parentLeadForm",
+    "pricing",
+    "recruitment",
+    "settings",
+    "signup",
+    "users"
+  ],
+  "directoriesScanned": [
+    "frontend",
+    "admin"
+  ],
+  "totals": {
+    "filesScanned": 214,
+    "candidateKeysFound": 1544,
+    "uniqueMissingKeys": 113
+  },
+  "missingKeys": [
+    {
+      "key": "ariaLabels.gridView",
+      "namespace": null,
+      "keyPath": "ariaLabels.gridView",
+      "occurrences": [
+        {
+          "file": "frontend/pages/MarketplacePage.tsx",
+          "lines": [
+            300
+          ],
+          "snippets": [
+            {
+              "line": 300,
+              "text": "aria-label={t('ariaLabels.gridView')}"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "ariaLabels.listView",
+      "namespace": null,
+      "keyPath": "ariaLabels.listView",
+      "occurrences": [
+        {
+          "file": "frontend/pages/MarketplacePage.tsx",
+          "lines": [
+            310
+          ],
+          "snippets": [
+            {
+              "line": 310,
+              "text": "aria-label={t('ariaLabels.listView')}"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "common:buttons.verifyEmail",
+      "namespace": "common",
+      "keyPath": "buttons.verifyEmail",
+      "occurrences": [
+        {
+          "file": "frontend/pages/SignupPage.tsx",
+          "lines": [
+            659
+          ],
+          "snippets": [
+            {
+              "line": 659,
+              "text": "{(isLoading || isVerifying) ? t('common:verifying', 'Verifying...') : t('common:buttons.verifyEmail', 'Verify Email')}"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "common:errors.genericErrorMessage",
+      "namespace": "common",
+      "keyPath": "errors.genericErrorMessage",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/OrganizationProfileForm.tsx",
+          "lines": [
+            81,
+            165
+          ],
+          "snippets": [
+            {
+              "line": 81,
+              "text": "message: t('common:errors.genericErrorMessage'),"
+            },
+            {
+              "line": 165,
+              "text": "message: t('common:errors.genericErrorMessage'),"
+            }
+          ]
+        },
+        {
+          "file": "frontend/pages/ServiceProviderSettingsPage.tsx",
+          "lines": [
+            121,
+            226
+          ],
+          "snippets": [
+            {
+              "line": 121,
+              "text": "message: t('common:errors.genericErrorMessage'),"
+            },
+            {
+              "line": 226,
+              "text": "message: t('common:errors.genericErrorMessage'),"
+            }
+          ]
+        },
+        {
+          "file": "frontend/pages/SettingsPage.tsx",
+          "lines": [
+            148,
+            303
+          ],
+          "snippets": [
+            {
+              "line": 148,
+              "text": "message: t('common:errors.genericErrorMessage'),"
+            },
+            {
+              "line": 303,
+              "text": "message: t('common:errors.genericErrorMessage'),"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "common:errors.genericErrorTitle",
+      "namespace": "common",
+      "keyPath": "errors.genericErrorTitle",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/OrganizationProfileForm.tsx",
+          "lines": [
+            80,
+            164
+          ],
+          "snippets": [
+            {
+              "line": 80,
+              "text": "title: t('common:errors.genericErrorTitle'),"
+            },
+            {
+              "line": 164,
+              "text": "title: t('common:errors.genericErrorTitle'),"
+            }
+          ]
+        },
+        {
+          "file": "frontend/pages/ServiceProviderSettingsPage.tsx",
+          "lines": [
+            120,
+            225
+          ],
+          "snippets": [
+            {
+              "line": 120,
+              "text": "title: t('common:errors.genericErrorTitle'),"
+            },
+            {
+              "line": 225,
+              "text": "title: t('common:errors.genericErrorTitle'),"
+            }
+          ]
+        },
+        {
+          "file": "frontend/pages/SettingsPage.tsx",
+          "lines": [
+            147,
+            302
+          ],
+          "snippets": [
+            {
+              "line": 147,
+              "text": "title: t('common:errors.genericErrorTitle'),"
+            },
+            {
+              "line": 302,
+              "text": "title: t('common:errors.genericErrorTitle'),"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "common:labels.verificationCode",
+      "namespace": "common",
+      "keyPath": "labels.verificationCode",
+      "occurrences": [
+        {
+          "file": "frontend/pages/SignupPage.tsx",
+          "lines": [
+            634
+          ],
+          "snippets": [
+            {
+              "line": 634,
+              "text": "{t('common:labels.verificationCode', 'Verification Code')}"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "common:loginPage.accountNotFound",
+      "namespace": "common",
+      "keyPath": "loginPage.accountNotFound",
+      "occurrences": [
+        {
+          "file": "frontend/pages/LoginPage.tsx",
+          "lines": [
+            106
+          ],
+          "snippets": [
+            {
+              "line": 106,
+              "text": "errorMessage = t('common:loginPage.accountNotFound', 'No account found with this email address.');"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "common:loginPage.incorrectPassword",
+      "namespace": "common",
+      "keyPath": "loginPage.incorrectPassword",
+      "occurrences": [
+        {
+          "file": "frontend/pages/LoginPage.tsx",
+          "lines": [
+            103
+          ],
+          "snippets": [
+            {
+              "line": 103,
+              "text": "errorMessage = t('common:loginPage.incorrectPassword', 'Incorrect password. Please try again.');"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "common:loginPage.invalidEmail",
+      "namespace": "common",
+      "keyPath": "loginPage.invalidEmail",
+      "occurrences": [
+        {
+          "file": "frontend/pages/LoginPage.tsx",
+          "lines": [
+            109
+          ],
+          "snippets": [
+            {
+              "line": 109,
+              "text": "errorMessage = t('common:loginPage.invalidEmail', 'Please enter a valid email address.');"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "educatorApplicationsPage.unknownFoundation",
+      "namespace": null,
+      "keyPath": "educatorApplicationsPage.unknownFoundation",
+      "occurrences": [
+        {
+          "file": "frontend/pages/educator/EducatorApplicationsPage.tsx",
+          "lines": [
+            47
+          ],
+          "snippets": [
+            {
+              "line": 47,
+              "text": "<td className=\"px-6 py-4 whitespace-nowrap text-gray-500\">{app.foundationName ?? t('educatorApplicationsPage.unknownFoundation', 'N/A')}</td>"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "educatorSupportPage.faq.findJobs.a",
+      "namespace": null,
+      "keyPath": "educatorSupportPage.faq.findJobs.a",
+      "occurrences": [
+        {
+          "file": "frontend/pages/educator/EducatorSupportPage.tsx",
+          "lines": [
+            35
+          ],
+          "snippets": [
+            {
+              "line": 35,
+              "text": "{ questionKey: \"educatorSupportPage.faq.findJobs.q\", answerKey: \"educatorSupportPage.faq.findJobs.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "educatorSupportPage.faq.findJobs.q",
+      "namespace": null,
+      "keyPath": "educatorSupportPage.faq.findJobs.q",
+      "occurrences": [
+        {
+          "file": "frontend/pages/educator/EducatorSupportPage.tsx",
+          "lines": [
+            35
+          ],
+          "snippets": [
+            {
+              "line": 35,
+              "text": "{ questionKey: \"educatorSupportPage.faq.findJobs.q\", answerKey: \"educatorSupportPage.faq.findJobs.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "educatorSupportPage.faq.notifications.a",
+      "namespace": null,
+      "keyPath": "educatorSupportPage.faq.notifications.a",
+      "occurrences": [
+        {
+          "file": "frontend/pages/educator/EducatorSupportPage.tsx",
+          "lines": [
+            37
+          ],
+          "snippets": [
+            {
+              "line": 37,
+              "text": "{ questionKey: \"educatorSupportPage.faq.notifications.q\", answerKey: \"educatorSupportPage.faq.notifications.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "educatorSupportPage.faq.notifications.q",
+      "namespace": null,
+      "keyPath": "educatorSupportPage.faq.notifications.q",
+      "occurrences": [
+        {
+          "file": "frontend/pages/educator/EducatorSupportPage.tsx",
+          "lines": [
+            37
+          ],
+          "snippets": [
+            {
+              "line": 37,
+              "text": "{ questionKey: \"educatorSupportPage.faq.notifications.q\", answerKey: \"educatorSupportPage.faq.notifications.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "educatorSupportPage.faq.trackApplications.a",
+      "namespace": null,
+      "keyPath": "educatorSupportPage.faq.trackApplications.a",
+      "occurrences": [
+        {
+          "file": "frontend/pages/educator/EducatorSupportPage.tsx",
+          "lines": [
+            36
+          ],
+          "snippets": [
+            {
+              "line": 36,
+              "text": "{ questionKey: \"educatorSupportPage.faq.trackApplications.q\", answerKey: \"educatorSupportPage.faq.trackApplications.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "educatorSupportPage.faq.trackApplications.q",
+      "namespace": null,
+      "keyPath": "educatorSupportPage.faq.trackApplications.q",
+      "occurrences": [
+        {
+          "file": "frontend/pages/educator/EducatorSupportPage.tsx",
+          "lines": [
+            36
+          ],
+          "snippets": [
+            {
+              "line": 36,
+              "text": "{ questionKey: \"educatorSupportPage.faq.trackApplications.q\", answerKey: \"educatorSupportPage.faq.trackApplications.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "educatorSupportPage.faq.updateProfile.a",
+      "namespace": null,
+      "keyPath": "educatorSupportPage.faq.updateProfile.a",
+      "occurrences": [
+        {
+          "file": "frontend/pages/educator/EducatorSupportPage.tsx",
+          "lines": [
+            34
+          ],
+          "snippets": [
+            {
+              "line": 34,
+              "text": "{ questionKey: \"educatorSupportPage.faq.updateProfile.q\", answerKey: \"educatorSupportPage.faq.updateProfile.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "educatorSupportPage.faq.updateProfile.q",
+      "namespace": null,
+      "keyPath": "educatorSupportPage.faq.updateProfile.q",
+      "occurrences": [
+        {
+          "file": "frontend/pages/educator/EducatorSupportPage.tsx",
+          "lines": [
+            34
+          ],
+          "snippets": [
+            {
+              "line": 34,
+              "text": "{ questionKey: \"educatorSupportPage.faq.updateProfile.q\", answerKey: \"educatorSupportPage.faq.updateProfile.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "errors.accountExists",
+      "namespace": null,
+      "keyPath": "errors.accountExists",
+      "occurrences": [
+        {
+          "file": "frontend/pages/SignupPage.tsx",
+          "lines": [
+            330
+          ],
+          "snippets": [
+            {
+              "line": 330,
+              "text": "errorMessage = t('errors.accountExists', 'An account with this email already exists');"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "errors.passwordPwned",
+      "namespace": null,
+      "keyPath": "errors.passwordPwned",
+      "occurrences": [
+        {
+          "file": "frontend/pages/SignupPage.tsx",
+          "lines": [
+            333
+          ],
+          "snippets": [
+            {
+              "line": 333,
+              "text": "errorMessage = t('errors.passwordPwned', 'This password has been found in a data breach. Please choose a different password');"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "errors.passwordWeak",
+      "namespace": null,
+      "keyPath": "errors.passwordWeak",
+      "occurrences": [
+        {
+          "file": "frontend/pages/SignupPage.tsx",
+          "lines": [
+            336
+          ],
+          "snippets": [
+            {
+              "line": 336,
+              "text": "errorMessage = t('errors.passwordWeak', 'Password is not strong enough');"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationDashboard.activity.jobApplication",
+      "namespace": null,
+      "keyPath": "foundationDashboard.activity.jobApplication",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationDashboardPage.tsx",
+          "lines": [
+            38
+          ],
+          "snippets": [
+            {
+              "line": 38,
+              "text": "{ id: 2, icon: BriefcaseIcon, textKey: 'foundationDashboard.activity.jobApplication', details: 'J. Miller for Lead Educator', time: t('dashboardPage.timeAgo.hours', { count: 1 }), color: 'text-swiss-teal' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationDashboard.activity.newMessage",
+      "namespace": null,
+      "keyPath": "foundationDashboard.activity.newMessage",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationDashboardPage.tsx",
+          "lines": [
+            41
+          ],
+          "snippets": [
+            {
+              "line": 41,
+              "text": "{ id: 5, icon: ChatBubbleLeftEllipsisIcon, textKey: 'foundationDashboard.activity.newMessage', details: 'From candidate T. Fischer', time: t('dashboardPage.timeAgo.yesterday'), color: 'text-gray-500' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationDashboard.activity.orderConfirmation",
+      "namespace": null,
+      "keyPath": "foundationDashboard.activity.orderConfirmation",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationDashboardPage.tsx",
+          "lines": [
+            39
+          ],
+          "snippets": [
+            {
+              "line": 39,
+              "text": "{ id: 3, icon: BanknotesIcon, textKey: 'foundationDashboard.activity.orderConfirmation', details: '#ORD123 from EcoToys', time: t('dashboardPage.timeAgo.hours', { count: 3 }), color: 'text-swiss-sand' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationDashboard.activity.parentInquiry",
+      "namespace": null,
+      "keyPath": "foundationDashboard.activity.parentInquiry",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationDashboardPage.tsx",
+          "lines": [
+            37
+          ],
+          "snippets": [
+            {
+              "line": 37,
+              "text": "{ id: 1, icon: InboxArrowDownIcon, textKey: 'foundationDashboard.activity.parentInquiry', details: 'S. Dubois for a 2-year-old', time: t('dashboardPage.timeAgo.minutes', { count: 15 }), color: 'text-swiss-mint' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationDashboard.activity.serviceUpdate",
+      "namespace": null,
+      "keyPath": "foundationDashboard.activity.serviceUpdate",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationDashboardPage.tsx",
+          "lines": [
+            40
+          ],
+          "snippets": [
+            {
+              "line": 40,
+              "text": "{ id: 4, icon: DocumentTextIcon, textKey: 'foundationDashboard.activity.serviceUpdate', details: 'ProClean confirmed cleaning for Friday', time: t('dashboardPage.timeAgo.hours', { count: 5 }), color: 'text-swiss-coral' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationDashboard.calendar.event1",
+      "namespace": null,
+      "keyPath": "foundationDashboard.calendar.event1",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationDashboardPage.tsx",
+          "lines": [
+            52
+          ],
+          "snippets": [
+            {
+              "line": 52,
+              "text": "{ time: '10:00', titleKey: 'foundationDashboard.calendar.event1' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationDashboard.calendar.event2",
+      "namespace": null,
+      "keyPath": "foundationDashboard.calendar.event2",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationDashboardPage.tsx",
+          "lines": [
+            53
+          ],
+          "snippets": [
+            {
+              "line": 53,
+              "text": "{ time: '14:00', titleKey: 'foundationDashboard.calendar.event2' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationDashboard.calendar.event3",
+      "namespace": null,
+      "keyPath": "foundationDashboard.calendar.event3",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationDashboardPage.tsx",
+          "lines": [
+            54
+          ],
+          "snippets": [
+            {
+              "line": 54,
+              "text": "{ time: '16:30', titleKey: 'foundationDashboard.calendar.event3' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationDashboard.quickActions.browseMarketplace",
+      "namespace": null,
+      "keyPath": "foundationDashboard.quickActions.browseMarketplace",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationDashboardPage.tsx",
+          "lines": [
+            46
+          ],
+          "snippets": [
+            {
+              "line": 46,
+              "text": "{ labelKey: 'foundationDashboard.quickActions.browseMarketplace', onClick: () => navigate('/marketplace'), icon: ShoppingBagIcon },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationDashboard.quickActions.postJob",
+      "namespace": null,
+      "keyPath": "foundationDashboard.quickActions.postJob",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationDashboardPage.tsx",
+          "lines": [
+            45
+          ],
+          "snippets": [
+            {
+              "line": 45,
+              "text": "{ labelKey: 'foundationDashboard.quickActions.postJob', onClick: () => navigate('/recruitment'), icon: BriefcaseIcon },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationDashboard.quickActions.viewAnalytics",
+      "namespace": null,
+      "keyPath": "foundationDashboard.quickActions.viewAnalytics",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationDashboardPage.tsx",
+          "lines": [
+            48
+          ],
+          "snippets": [
+            {
+              "line": 48,
+              "text": "{ labelKey: 'foundationDashboard.quickActions.viewAnalytics', onClick: () => navigate('/foundation/analytics'), icon: PresentationChartLineIcon },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationDashboard.quickActions.viewParentLeads",
+      "namespace": null,
+      "keyPath": "foundationDashboard.quickActions.viewParentLeads",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationDashboardPage.tsx",
+          "lines": [
+            47
+          ],
+          "snippets": [
+            {
+              "line": 47,
+              "text": "{ labelKey: 'foundationDashboard.quickActions.viewParentLeads', onClick: () => navigate('/foundation/leads'), icon: UserGroupIcon },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationDashboard.quickStats.availableSpots",
+      "namespace": null,
+      "keyPath": "foundationDashboard.quickStats.availableSpots",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationDashboardPage.tsx",
+          "lines": [
+            31
+          ],
+          "snippets": [
+            {
+              "line": 31,
+              "text": "{ labelKey: 'foundationDashboard.quickStats.availableSpots', value: '5', icon: UserPlusIcon, color: 'text-swiss-sand' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationDashboard.quickStats.enrolled",
+      "namespace": null,
+      "keyPath": "foundationDashboard.quickStats.enrolled",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationDashboardPage.tsx",
+          "lines": [
+            30
+          ],
+          "snippets": [
+            {
+              "line": 30,
+              "text": "{ labelKey: 'foundationDashboard.quickStats.enrolled', value: '45 / 50', trend: '+2', icon: UsersIcon, color: 'text-swiss-mint' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationDashboard.quickStats.pendingApps",
+      "namespace": null,
+      "keyPath": "foundationDashboard.quickStats.pendingApps",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationDashboardPage.tsx",
+          "lines": [
+            32
+          ],
+          "snippets": [
+            {
+              "line": 32,
+              "text": "{ labelKey: 'foundationDashboard.quickStats.pendingApps', value: '3', icon: InboxArrowDownIcon, color: 'text-swiss-coral' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationDashboard.quickStats.upcomingAppointments",
+      "namespace": null,
+      "keyPath": "foundationDashboard.quickStats.upcomingAppointments",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationDashboardPage.tsx",
+          "lines": [
+            33
+          ],
+          "snippets": [
+            {
+              "line": 33,
+              "text": "{ labelKey: 'foundationDashboard.quickStats.upcomingAppointments', value: '2', icon: CalendarDaysIcon, color: 'text-swiss-teal' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationSupportPage.faq.manageLeads.a",
+      "namespace": null,
+      "keyPath": "foundationSupportPage.faq.manageLeads.a",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationSupportPage.tsx",
+          "lines": [
+            34
+          ],
+          "snippets": [
+            {
+              "line": 34,
+              "text": "{ questionKey: \"foundationSupportPage.faq.manageLeads.q\", answerKey: \"foundationSupportPage.faq.manageLeads.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationSupportPage.faq.manageLeads.q",
+      "namespace": null,
+      "keyPath": "foundationSupportPage.faq.manageLeads.q",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationSupportPage.tsx",
+          "lines": [
+            34
+          ],
+          "snippets": [
+            {
+              "line": 34,
+              "text": "{ questionKey: \"foundationSupportPage.faq.manageLeads.q\", answerKey: \"foundationSupportPage.faq.manageLeads.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationSupportPage.faq.manageProfile.a",
+      "namespace": null,
+      "keyPath": "foundationSupportPage.faq.manageProfile.a",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationSupportPage.tsx",
+          "lines": [
+            36
+          ],
+          "snippets": [
+            {
+              "line": 36,
+              "text": "{ questionKey: \"foundationSupportPage.faq.manageProfile.q\", answerKey: \"foundationSupportPage.faq.manageProfile.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationSupportPage.faq.manageProfile.q",
+      "namespace": null,
+      "keyPath": "foundationSupportPage.faq.manageProfile.q",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationSupportPage.tsx",
+          "lines": [
+            36
+          ],
+          "snippets": [
+            {
+              "line": 36,
+              "text": "{ questionKey: \"foundationSupportPage.faq.manageProfile.q\", answerKey: \"foundationSupportPage.faq.manageProfile.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationSupportPage.faq.recruitment.a",
+      "namespace": null,
+      "keyPath": "foundationSupportPage.faq.recruitment.a",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationSupportPage.tsx",
+          "lines": [
+            37
+          ],
+          "snippets": [
+            {
+              "line": 37,
+              "text": "{ questionKey: \"foundationSupportPage.faq.recruitment.q\", answerKey: \"foundationSupportPage.faq.recruitment.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationSupportPage.faq.recruitment.q",
+      "namespace": null,
+      "keyPath": "foundationSupportPage.faq.recruitment.q",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationSupportPage.tsx",
+          "lines": [
+            37
+          ],
+          "snippets": [
+            {
+              "line": 37,
+              "text": "{ questionKey: \"foundationSupportPage.faq.recruitment.q\", answerKey: \"foundationSupportPage.faq.recruitment.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationSupportPage.faq.useMarketplace.a",
+      "namespace": null,
+      "keyPath": "foundationSupportPage.faq.useMarketplace.a",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationSupportPage.tsx",
+          "lines": [
+            35
+          ],
+          "snippets": [
+            {
+              "line": 35,
+              "text": "{ questionKey: \"foundationSupportPage.faq.useMarketplace.q\", answerKey: \"foundationSupportPage.faq.useMarketplace.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "foundationSupportPage.faq.useMarketplace.q",
+      "namespace": null,
+      "keyPath": "foundationSupportPage.faq.useMarketplace.q",
+      "occurrences": [
+        {
+          "file": "frontend/pages/foundation/FoundationSupportPage.tsx",
+          "lines": [
+            35
+          ],
+          "snippets": [
+            {
+              "line": 35,
+              "text": "{ questionKey: \"foundationSupportPage.faq.useMarketplace.q\", answerKey: \"foundationSupportPage.faq.useMarketplace.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "hrProcedures.noDocumentsInCategory",
+      "namespace": null,
+      "keyPath": "hrProcedures.noDocumentsInCategory",
+      "occurrences": [
+        {
+          "file": "frontend/pages/HRProceduresPage.tsx",
+          "lines": [
+            254
+          ],
+          "snippets": [
+            {
+              "line": 254,
+              "text": "{filteredDocs.length === 0 && selectedCategory && <p className=\"text-center text-gray-500 py-8\">{t('hrProcedures.noDocumentsInCategory', { category: selectedCategory })}</p>}"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "labels.availabilityDate",
+      "namespace": null,
+      "keyPath": "labels.availabilityDate",
+      "occurrences": [
+        {
+          "file": "frontend/pages/RecruitmentPage.tsx",
+          "lines": [
+            431
+          ],
+          "snippets": [
+            {
+              "line": 431,
+              "text": "<input type=\"date\" placeholder={t('labels.availabilityDate')} className={STANDARD_INPUT_FIELD} aria-label={t('labels.availabilityDate')} />"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "languageSwitcher.de",
+      "namespace": null,
+      "keyPath": "languageSwitcher.de",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/CompanyProfileSettings.tsx",
+          "lines": [
+            21
+          ],
+          "snippets": [
+            {
+              "line": 21,
+              "text": "{ labelKey: 'languageSwitcher.de', value: 'DE'},"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "languageSwitcher.en",
+      "namespace": null,
+      "keyPath": "languageSwitcher.en",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/CompanyProfileSettings.tsx",
+          "lines": [
+            19
+          ],
+          "snippets": [
+            {
+              "line": 19,
+              "text": "{ labelKey: 'languageSwitcher.en', value: 'EN'},"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "languageSwitcher.fr",
+      "namespace": null,
+      "keyPath": "languageSwitcher.fr",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/CompanyProfileSettings.tsx",
+          "lines": [
+            20
+          ],
+          "snippets": [
+            {
+              "line": 20,
+              "text": "{ labelKey: 'languageSwitcher.fr', value: 'FR'},"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "parentDashboard.quickActions.browseServices",
+      "namespace": null,
+      "keyPath": "parentDashboard.quickActions.browseServices",
+      "occurrences": [
+        {
+          "file": "frontend/pages/parent/ParentDashboardPage.tsx",
+          "lines": [
+            26
+          ],
+          "snippets": [
+            {
+              "line": 26,
+              "text": "{ labelKey: 'parentDashboard.quickActions.browseServices', path: '/marketplace/services', icon: WrenchScrewdriverIcon, variant: 'outline' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "parentDashboard.quickActions.findDaycare",
+      "namespace": null,
+      "keyPath": "parentDashboard.quickActions.findDaycare",
+      "occurrences": [
+        {
+          "file": "frontend/pages/parent/ParentDashboardPage.tsx",
+          "lines": [
+            23
+          ],
+          "snippets": [
+            {
+              "line": 23,
+              "text": "{ labelKey: 'parentDashboard.quickActions.findDaycare', path: '/parent-lead-form', icon: HomeIcon, variant: 'primary' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "parentDashboard.quickActions.updateProfile",
+      "namespace": null,
+      "keyPath": "parentDashboard.quickActions.updateProfile",
+      "occurrences": [
+        {
+          "file": "frontend/pages/parent/ParentDashboardPage.tsx",
+          "lines": [
+            25
+          ],
+          "snippets": [
+            {
+              "line": 25,
+              "text": "{ labelKey: 'parentDashboard.quickActions.updateProfile', path: '/settings', icon: UserCircleIcon, variant: 'outline' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "parentDashboard.quickActions.viewEnquiries",
+      "namespace": null,
+      "keyPath": "parentDashboard.quickActions.viewEnquiries",
+      "occurrences": [
+        {
+          "file": "frontend/pages/parent/ParentDashboardPage.tsx",
+          "lines": [
+            24
+          ],
+          "snippets": [
+            {
+              "line": 24,
+              "text": "{ labelKey: 'parentDashboard.quickActions.viewEnquiries', path: '/parent/enquiries', icon: ClipboardDocumentListIcon, variant: 'secondary' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "recruitment:recruitmentPage.labels.locationUnknown",
+      "namespace": "recruitment",
+      "keyPath": "recruitmentPage.labels.locationUnknown",
+      "occurrences": [
+        {
+          "file": "frontend/pages/educator/EducatorJobBoardPage.tsx",
+          "lines": [
+            58
+          ],
+          "snippets": [
+            {
+              "line": 58,
+              "text": "<p><MapPinIcon className=\"w-4 h-4 inline mr-1.5 text-gray-400\" />{job.location ?? t('recruitment:recruitmentPage.labels.locationUnknown', 'Location TBD')}</p>"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "recruitmentPage.contractTypes.cdd",
+      "namespace": null,
+      "keyPath": "recruitmentPage.contractTypes.cdd",
+      "occurrences": [
+        {
+          "file": "frontend/components/recruitment/JobPostModal.tsx",
+          "lines": [
+            160
+          ],
+          "snippets": [
+            {
+              "line": 160,
+              "text": "<option value=\"CDD\">{t('recruitmentPage.contractTypes.cdd', 'CDD')}</option>"
+            }
+          ]
+        },
+        {
+          "file": "frontend/pages/RecruitmentPage.tsx",
+          "lines": [
+            49
+          ],
+          "snippets": [
+            {
+              "line": 49,
+              "text": "return t('recruitmentPage.contractTypes.cdd', 'CDD');"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "recruitmentPage.contractTypes.cdi",
+      "namespace": null,
+      "keyPath": "recruitmentPage.contractTypes.cdi",
+      "occurrences": [
+        {
+          "file": "frontend/components/recruitment/JobPostModal.tsx",
+          "lines": [
+            159
+          ],
+          "snippets": [
+            {
+              "line": 159,
+              "text": "<option value=\"CDI\">{t('recruitmentPage.contractTypes.cdi', 'CDI')}</option>"
+            }
+          ]
+        },
+        {
+          "file": "frontend/pages/RecruitmentPage.tsx",
+          "lines": [
+            47
+          ],
+          "snippets": [
+            {
+              "line": 47,
+              "text": "return t('recruitmentPage.contractTypes.cdi', 'CDI');"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "recruitmentPage.contractTypes.fullTime",
+      "namespace": null,
+      "keyPath": "recruitmentPage.contractTypes.fullTime",
+      "occurrences": [
+        {
+          "file": "frontend/components/recruitment/JobPostModal.tsx",
+          "lines": [
+            157
+          ],
+          "snippets": [
+            {
+              "line": 157,
+              "text": "<option value=\"FULL_TIME\">{t('recruitmentPage.contractTypes.fullTime', 'Full-time')}</option>"
+            }
+          ]
+        },
+        {
+          "file": "frontend/pages/RecruitmentPage.tsx",
+          "lines": [
+            43
+          ],
+          "snippets": [
+            {
+              "line": 43,
+              "text": "return t('recruitmentPage.contractTypes.fullTime', 'Full-time');"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "recruitmentPage.contractTypes.internship",
+      "namespace": null,
+      "keyPath": "recruitmentPage.contractTypes.internship",
+      "occurrences": [
+        {
+          "file": "frontend/components/recruitment/JobPostModal.tsx",
+          "lines": [
+            161
+          ],
+          "snippets": [
+            {
+              "line": 161,
+              "text": "<option value=\"INTERNSHIP\">{t('recruitmentPage.contractTypes.internship', 'Internship')}</option>"
+            }
+          ]
+        },
+        {
+          "file": "frontend/pages/RecruitmentPage.tsx",
+          "lines": [
+            52
+          ],
+          "snippets": [
+            {
+              "line": 52,
+              "text": "return t('recruitmentPage.contractTypes.internship', 'Internship');"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "recruitmentPage.contractTypes.partTime",
+      "namespace": null,
+      "keyPath": "recruitmentPage.contractTypes.partTime",
+      "occurrences": [
+        {
+          "file": "frontend/components/recruitment/JobPostModal.tsx",
+          "lines": [
+            158
+          ],
+          "snippets": [
+            {
+              "line": 158,
+              "text": "<option value=\"PART_TIME\">{t('recruitmentPage.contractTypes.partTime', 'Part-time')}</option>"
+            }
+          ]
+        },
+        {
+          "file": "frontend/pages/RecruitmentPage.tsx",
+          "lines": [
+            45
+          ],
+          "snippets": [
+            {
+              "line": 45,
+              "text": "return t('recruitmentPage.contractTypes.partTime', 'Part-time');"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "recruitmentPage.jobStatus.closed",
+      "namespace": null,
+      "keyPath": "recruitmentPage.jobStatus.closed",
+      "occurrences": [
+        {
+          "file": "frontend/pages/RecruitmentPage.tsx",
+          "lines": [
+            36
+          ],
+          "snippets": [
+            {
+              "line": 36,
+              "text": "return { className: 'bg-red-100 text-red-700', label: t('recruitmentPage.jobStatus.closed', 'Closed') };"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "recruitmentPage.jobStatus.draft",
+      "namespace": null,
+      "keyPath": "recruitmentPage.jobStatus.draft",
+      "occurrences": [
+        {
+          "file": "frontend/pages/RecruitmentPage.tsx",
+          "lines": [
+            31
+          ],
+          "snippets": [
+            {
+              "line": 31,
+              "text": "return { className: 'bg-yellow-100 text-yellow-700', label: t('recruitmentPage.jobStatus.draft', 'Draft') };"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "recruitmentPage.jobStatus.filled",
+      "namespace": null,
+      "keyPath": "recruitmentPage.jobStatus.filled",
+      "occurrences": [
+        {
+          "file": "frontend/pages/RecruitmentPage.tsx",
+          "lines": [
+            33
+          ],
+          "snippets": [
+            {
+              "line": 33,
+              "text": "return { className: 'bg-blue-100 text-blue-700', label: t('recruitmentPage.jobStatus.filled', 'Filled') };"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "recruitmentPage.jobStatus.published",
+      "namespace": null,
+      "keyPath": "recruitmentPage.jobStatus.published",
+      "occurrences": [
+        {
+          "file": "frontend/pages/RecruitmentPage.tsx",
+          "lines": [
+            29
+          ],
+          "snippets": [
+            {
+              "line": 29,
+              "text": "return { className: 'bg-green-100 text-green-700', label: t('recruitmentPage.jobStatus.published', 'Published') };"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "recruitmentPage.labels.applications",
+      "namespace": null,
+      "keyPath": "recruitmentPage.labels.applications",
+      "occurrences": [
+        {
+          "file": "frontend/pages/RecruitmentPage.tsx",
+          "lines": [
+            74
+          ],
+          "snippets": [
+            {
+              "line": 74,
+              "text": "<p><UserGroupIcon className=\"w-4 h-4 inline mr-2 text-gray-400\" />{t('recruitmentPage.labels.applications')}: {job.applicationsCount}</p>"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "recruitmentPage.labels.locationUnknown",
+      "namespace": null,
+      "keyPath": "recruitmentPage.labels.locationUnknown",
+      "occurrences": [
+        {
+          "file": "frontend/pages/RecruitmentPage.tsx",
+          "lines": [
+            71
+          ],
+          "snippets": [
+            {
+              "line": 71,
+              "text": "<p><MapPinIcon className=\"w-4 h-4 inline mr-2 text-gray-400\" />{job.location ?? t('recruitmentPage.labels.locationUnknown', 'Location TBD')}</p>"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "recruitmentPage.labels.startDate",
+      "namespace": null,
+      "keyPath": "recruitmentPage.labels.startDate",
+      "occurrences": [
+        {
+          "file": "frontend/pages/RecruitmentPage.tsx",
+          "lines": [
+            73
+          ],
+          "snippets": [
+            {
+              "line": 73,
+              "text": "<p><CalendarDaysIcon className=\"w-4 h-4 inline mr-2 text-gray-400\" />{t('recruitmentPage.labels.startDate')}: {formattedStartDate}</p>"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "recruitmentPage.labels.startDateTbd",
+      "namespace": null,
+      "keyPath": "recruitmentPage.labels.startDateTbd",
+      "occurrences": [
+        {
+          "file": "frontend/pages/RecruitmentPage.tsx",
+          "lines": [
+            56
+          ],
+          "snippets": [
+            {
+              "line": 56,
+              "text": "const formattedStartDate = job.startDate ? new Date(job.startDate).toLocaleDateString() : t('recruitmentPage.labels.startDateTbd', 'To be determined');"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "recruitmentPage.viewApplicantsModal.loading",
+      "namespace": null,
+      "keyPath": "recruitmentPage.viewApplicantsModal.loading",
+      "occurrences": [
+        {
+          "file": "frontend/components/recruitment/ViewApplicantsModal.tsx",
+          "lines": [
+            45
+          ],
+          "snippets": [
+            {
+              "line": 45,
+              "text": "return <p className=\"text-gray-500 text-center py-8\">{t('recruitmentPage.viewApplicantsModal.loading', 'Loading applications...')}</p>;"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "recruitmentPage.viewApplicantsModal.unknownCandidate",
+      "namespace": null,
+      "keyPath": "recruitmentPage.viewApplicantsModal.unknownCandidate",
+      "occurrences": [
+        {
+          "file": "frontend/components/recruitment/ViewApplicantsModal.tsx",
+          "lines": [
+            63
+          ],
+          "snippets": [
+            {
+              "line": 63,
+              "text": "<p className=\"font-medium text-swiss-charcoal\">{application.candidateName ?? t('recruitmentPage.viewApplicantsModal.unknownCandidate', 'Candidate')}</p>"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "roleManagement.userDetailDrawer.suspendUserButton",
+      "namespace": null,
+      "keyPath": "roleManagement.userDetailDrawer.suspendUserButton",
+      "occurrences": [
+        {
+          "file": "frontend/pages/UsersPage.tsx",
+          "lines": [
+            151
+          ],
+          "snippets": [
+            {
+              "line": 151,
+              "text": "<Button variant=\"danger\" className=\"w-full\" onClick={() => handleStatusUpdate('Inactive')} leftIcon={XCircleIcon}>{t('roleManagement.userDetailDrawer.suspendUserButton')}</Button>"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "roleManagement.userDetailDrawer.updateRoleButton",
+      "namespace": null,
+      "keyPath": "roleManagement.userDetailDrawer.updateRoleButton",
+      "occurrences": [
+        {
+          "file": "frontend/pages/UsersPage.tsx",
+          "lines": [
+            148
+          ],
+          "snippets": [
+            {
+              "line": 148,
+              "text": "<Button variant=\"secondary\" className=\"w-full\" onClick={handleRoleUpdate}>{t('roleManagement.userDetailDrawer.updateRoleButton')}</Button>"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "roleManagement.userProfileUpdated",
+      "namespace": null,
+      "keyPath": "roleManagement.userProfileUpdated",
+      "occurrences": [
+        {
+          "file": "frontend/pages/UsersPage.tsx",
+          "lines": [
+            208
+          ],
+          "snippets": [
+            {
+              "line": 208,
+              "text": "alert(t('roleManagement.userProfileUpdated', { name: updatedUser.name }));"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "serviceProviderSupportPage.faq.listService.a",
+      "namespace": null,
+      "keyPath": "serviceProviderSupportPage.faq.listService.a",
+      "occurrences": [
+        {
+          "file": "frontend/pages/service-provider/ServiceProviderSupportPage.tsx",
+          "lines": [
+            34
+          ],
+          "snippets": [
+            {
+              "line": 34,
+              "text": "{ questionKey: \"serviceProviderSupportPage.faq.listService.q\", answerKey: \"serviceProviderSupportPage.faq.listService.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "serviceProviderSupportPage.faq.listService.q",
+      "namespace": null,
+      "keyPath": "serviceProviderSupportPage.faq.listService.q",
+      "occurrences": [
+        {
+          "file": "frontend/pages/service-provider/ServiceProviderSupportPage.tsx",
+          "lines": [
+            34
+          ],
+          "snippets": [
+            {
+              "line": 34,
+              "text": "{ questionKey: \"serviceProviderSupportPage.faq.listService.q\", answerKey: \"serviceProviderSupportPage.faq.listService.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "serviceProviderSupportPage.faq.profileInfo.a",
+      "namespace": null,
+      "keyPath": "serviceProviderSupportPage.faq.profileInfo.a",
+      "occurrences": [
+        {
+          "file": "frontend/pages/service-provider/ServiceProviderSupportPage.tsx",
+          "lines": [
+            37
+          ],
+          "snippets": [
+            {
+              "line": 37,
+              "text": "{ questionKey: \"serviceProviderSupportPage.faq.profileInfo.q\", answerKey: \"serviceProviderSupportPage.faq.profileInfo.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "serviceProviderSupportPage.faq.profileInfo.q",
+      "namespace": null,
+      "keyPath": "serviceProviderSupportPage.faq.profileInfo.q",
+      "occurrences": [
+        {
+          "file": "frontend/pages/service-provider/ServiceProviderSupportPage.tsx",
+          "lines": [
+            37
+          ],
+          "snippets": [
+            {
+              "line": 37,
+              "text": "{ questionKey: \"serviceProviderSupportPage.faq.profileInfo.q\", answerKey: \"serviceProviderSupportPage.faq.profileInfo.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "serviceProviderSupportPage.faq.respondRequests.a",
+      "namespace": null,
+      "keyPath": "serviceProviderSupportPage.faq.respondRequests.a",
+      "occurrences": [
+        {
+          "file": "frontend/pages/service-provider/ServiceProviderSupportPage.tsx",
+          "lines": [
+            35
+          ],
+          "snippets": [
+            {
+              "line": 35,
+              "text": "{ questionKey: \"serviceProviderSupportPage.faq.respondRequests.q\", answerKey: \"serviceProviderSupportPage.faq.respondRequests.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "serviceProviderSupportPage.faq.respondRequests.q",
+      "namespace": null,
+      "keyPath": "serviceProviderSupportPage.faq.respondRequests.q",
+      "occurrences": [
+        {
+          "file": "frontend/pages/service-provider/ServiceProviderSupportPage.tsx",
+          "lines": [
+            35
+          ],
+          "snippets": [
+            {
+              "line": 35,
+              "text": "{ questionKey: \"serviceProviderSupportPage.faq.respondRequests.q\", answerKey: \"serviceProviderSupportPage.faq.respondRequests.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "serviceProviderSupportPage.faq.updateAvailability.a",
+      "namespace": null,
+      "keyPath": "serviceProviderSupportPage.faq.updateAvailability.a",
+      "occurrences": [
+        {
+          "file": "frontend/pages/service-provider/ServiceProviderSupportPage.tsx",
+          "lines": [
+            36
+          ],
+          "snippets": [
+            {
+              "line": 36,
+              "text": "{ questionKey: \"serviceProviderSupportPage.faq.updateAvailability.q\", answerKey: \"serviceProviderSupportPage.faq.updateAvailability.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "serviceProviderSupportPage.faq.updateAvailability.q",
+      "namespace": null,
+      "keyPath": "serviceProviderSupportPage.faq.updateAvailability.q",
+      "occurrences": [
+        {
+          "file": "frontend/pages/service-provider/ServiceProviderSupportPage.tsx",
+          "lines": [
+            36
+          ],
+          "snippets": [
+            {
+              "line": 36,
+              "text": "{ questionKey: \"serviceProviderSupportPage.faq.updateAvailability.q\", answerKey: \"serviceProviderSupportPage.faq.updateAvailability.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "settingsAnalyticsPreferences.currencies.chf",
+      "namespace": null,
+      "keyPath": "settingsAnalyticsPreferences.currencies.chf",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/AnalyticsPreferencesSettings.tsx",
+          "lines": [
+            21
+          ],
+          "snippets": [
+            {
+              "line": 21,
+              "text": "const CURRENCIES = [{value: 'CHF', labelKey: 'settingsAnalyticsPreferences.currencies.chf'}, {value: 'EUR', labelKey: 'settingsAnalyticsPreferences.currencies.eur'}];"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "settingsAnalyticsPreferences.currencies.eur",
+      "namespace": null,
+      "keyPath": "settingsAnalyticsPreferences.currencies.eur",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/AnalyticsPreferencesSettings.tsx",
+          "lines": [
+            21
+          ],
+          "snippets": [
+            {
+              "line": 21,
+              "text": "const CURRENCIES = [{value: 'CHF', labelKey: 'settingsAnalyticsPreferences.currencies.chf'}, {value: 'EUR', labelKey: 'settingsAnalyticsPreferences.currencies.eur'}];"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "settingsContactBooking.contactMethods.email",
+      "namespace": null,
+      "keyPath": "settingsContactBooking.contactMethods.email",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/ContactBookingSettings.tsx",
+          "lines": [
+            20
+          ],
+          "snippets": [
+            {
+              "line": 20,
+              "text": "{ labelKey: 'settingsContactBooking.contactMethods.email', value: 'Email' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "settingsContactBooking.contactMethods.phone",
+      "namespace": null,
+      "keyPath": "settingsContactBooking.contactMethods.phone",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/ContactBookingSettings.tsx",
+          "lines": [
+            21
+          ],
+          "snippets": [
+            {
+              "line": 21,
+              "text": "{ labelKey: 'settingsContactBooking.contactMethods.phone', value: 'Phone' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "settingsContactBooking.contactMethods.platformForm",
+      "namespace": null,
+      "keyPath": "settingsContactBooking.contactMethods.platformForm",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/ContactBookingSettings.tsx",
+          "lines": [
+            22
+          ],
+          "snippets": [
+            {
+              "line": 22,
+              "text": "{ labelKey: 'settingsContactBooking.contactMethods.platformForm', value: 'Platform Form' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "settingsContactBooking.responseTimes.lessThan24h",
+      "namespace": null,
+      "keyPath": "settingsContactBooking.responseTimes.lessThan24h",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/ContactBookingSettings.tsx",
+          "lines": [
+            26
+          ],
+          "snippets": [
+            {
+              "line": 26,
+              "text": "{ labelKey: 'settingsContactBooking.responseTimes.lessThan24h', value: '< 24 h' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "settingsContactBooking.responseTimes.other",
+      "namespace": null,
+      "keyPath": "settingsContactBooking.responseTimes.other",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/ContactBookingSettings.tsx",
+          "lines": [
+            28
+          ],
+          "snippets": [
+            {
+              "line": 28,
+              "text": "{ labelKey: 'settingsContactBooking.responseTimes.other', value: 'Other' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "settingsContactBooking.responseTimes.twoToThreeDays",
+      "namespace": null,
+      "keyPath": "settingsContactBooking.responseTimes.twoToThreeDays",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/ContactBookingSettings.tsx",
+          "lines": [
+            27
+          ],
+          "snippets": [
+            {
+              "line": 27,
+              "text": "{ labelKey: 'settingsContactBooking.responseTimes.twoToThreeDays', value: '2–3 d' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "settingsNotificationPreferences.digestFrequencies.daily",
+      "namespace": null,
+      "keyPath": "settingsNotificationPreferences.digestFrequencies.daily",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/NotificationPreferencesSettings.tsx",
+          "lines": [
+            20
+          ],
+          "snippets": [
+            {
+              "line": 20,
+              "text": "{ labelKey: 'settingsNotificationPreferences.digestFrequencies.daily', value: 'Daily' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "settingsNotificationPreferences.digestFrequencies.none",
+      "namespace": null,
+      "keyPath": "settingsNotificationPreferences.digestFrequencies.none",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/NotificationPreferencesSettings.tsx",
+          "lines": [
+            22
+          ],
+          "snippets": [
+            {
+              "line": 22,
+              "text": "{ labelKey: 'settingsNotificationPreferences.digestFrequencies.none', value: 'None' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "settingsNotificationPreferences.digestFrequencies.weekly",
+      "namespace": null,
+      "keyPath": "settingsNotificationPreferences.digestFrequencies.weekly",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/NotificationPreferencesSettings.tsx",
+          "lines": [
+            21
+          ],
+          "snippets": [
+            {
+              "line": 21,
+              "text": "{ labelKey: 'settingsNotificationPreferences.digestFrequencies.weekly', value: 'Weekly' },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "settingsNotificationPreferences.newRequestEmailToggleProvider",
+      "namespace": null,
+      "keyPath": "settingsNotificationPreferences.newRequestEmailToggleProvider",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/NotificationPreferencesSettings.tsx",
+          "lines": [
+            28
+          ],
+          "snippets": [
+            {
+              "line": 28,
+              "text": "const newRequestLabelKey = isProvider ? \"settingsNotificationPreferences.newRequestEmailToggleProvider\" : \"settingsNotificationPreferences.newRequestEmailToggleSupplier\";"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "settingsNotificationPreferences.newRequestEmailToggleSupplier",
+      "namespace": null,
+      "keyPath": "settingsNotificationPreferences.newRequestEmailToggleSupplier",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/NotificationPreferencesSettings.tsx",
+          "lines": [
+            28
+          ],
+          "snippets": [
+            {
+              "line": 28,
+              "text": "const newRequestLabelKey = isProvider ? \"settingsNotificationPreferences.newRequestEmailToggleProvider\" : \"settingsNotificationPreferences.newRequestEmailToggleSupplier\";"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "settingsPrivacyData.hidePricesHelpText",
+      "namespace": null,
+      "keyPath": "settingsPrivacyData.hidePricesHelpText",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/PrivacyDataSettings.tsx",
+          "lines": [
+            25
+          ],
+          "snippets": [
+            {
+              "line": 25,
+              "text": "const hidePubliclyHelpTextKey = userRole === UserRole.PRODUCT_SUPPLIER"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "settingsPrivacyData.hidePricesPublicly",
+      "namespace": null,
+      "keyPath": "settingsPrivacyData.hidePricesPublicly",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/PrivacyDataSettings.tsx",
+          "lines": [
+            21
+          ],
+          "snippets": [
+            {
+              "line": 21,
+              "text": "const hidePubliclyLabelKey = userRole === UserRole.PRODUCT_SUPPLIER"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "settingsPrivacyData.hideRateHelpText",
+      "namespace": null,
+      "keyPath": "settingsPrivacyData.hideRateHelpText",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/PrivacyDataSettings.tsx",
+          "lines": [
+            26
+          ],
+          "snippets": [
+            {
+              "line": 26,
+              "text": "? \"settingsPrivacyData.hidePricesHelpText\""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "settingsPrivacyData.hideStartingRatePublicly",
+      "namespace": null,
+      "keyPath": "settingsPrivacyData.hideStartingRatePublicly",
+      "occurrences": [
+        {
+          "file": "frontend/components/settings/sections/PrivacyDataSettings.tsx",
+          "lines": [
+            22
+          ],
+          "snippets": [
+            {
+              "line": 22,
+              "text": "? \"settingsPrivacyData.hidePricesPublicly\""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "sidebar.applications",
+      "namespace": null,
+      "keyPath": "sidebar.applications",
+      "occurrences": [
+        {
+          "file": "frontend/components/layout/Sidebar.tsx",
+          "lines": [
+            88
+          ],
+          "snippets": [
+            {
+              "line": 88,
+              "text": "{ path: '/educator/applications', nameKey: 'sidebar.applications', icon: ClipboardDocumentListIcon, roles: [UserRole.EDUCATOR] },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "sidebar.homeFindCreche",
+      "namespace": null,
+      "keyPath": "sidebar.homeFindCreche",
+      "occurrences": [
+        {
+          "file": "frontend/components/layout/Sidebar.tsx",
+          "lines": [
+            92
+          ],
+          "snippets": [
+            {
+              "line": 92,
+              "text": "{ path: '/parent-lead-form', nameKey: 'sidebar.homeFindCreche', icon: HomeIcon, roles: [UserRole.PARENT] },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "sidebar.myRequests",
+      "namespace": null,
+      "keyPath": "sidebar.myRequests",
+      "occurrences": [
+        {
+          "file": "frontend/components/layout/Sidebar.tsx",
+          "lines": [
+            56,
+            93
+          ],
+          "snippets": [
+            {
+              "line": 56,
+              "text": "{ path: '/service-provider/requests', nameKey: 'sidebar.myRequests', icon: InboxArrowDownIcon, roles: [UserRole.SERVICE_PROVIDER] },"
+            },
+            {
+              "line": 93,
+              "text": "{ path: '/parent/enquiries', nameKey: 'sidebar.myRequests', icon: ClipboardDocumentListIcon, roles: [UserRole.PARENT] },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "sidebar.orders",
+      "namespace": null,
+      "keyPath": "sidebar.orders",
+      "occurrences": [
+        {
+          "file": "frontend/components/layout/Sidebar.tsx",
+          "lines": [
+            50
+          ],
+          "snippets": [
+            {
+              "line": 50,
+              "text": "{ path: '/supplier/orders', nameKey: 'sidebar.orders', icon: ShoppingBagIcon, roles: [UserRole.PRODUCT_SUPPLIER] },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "sidebar.organisationProfile",
+      "namespace": null,
+      "keyPath": "sidebar.organisationProfile",
+      "occurrences": [
+        {
+          "file": "frontend/components/layout/Sidebar.tsx",
+          "lines": [
+            83
+          ],
+          "snippets": [
+            {
+              "line": 83,
+              "text": "{ path: '/foundation/organisation-profile', nameKey: 'sidebar.organisationProfile', icon: BuildingOfficeIcon, roles: [UserRole.FOUNDATION] }, // Kept for Foundation, hidden for Admin/SA"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "sidebar.productMarketplace",
+      "namespace": null,
+      "keyPath": "sidebar.productMarketplace",
+      "occurrences": [
+        {
+          "file": "frontend/components/layout/Sidebar.tsx",
+          "lines": [
+            51
+          ],
+          "snippets": [
+            {
+              "line": 51,
+              "text": "{ path: '/supplier/product-listings', nameKey: 'sidebar.productMarketplace', icon: ListBulletIcon, roles: [UserRole.PRODUCT_SUPPLIER] },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "sidebar.serviceMarketplace",
+      "namespace": null,
+      "keyPath": "sidebar.serviceMarketplace",
+      "occurrences": [
+        {
+          "file": "frontend/components/layout/Sidebar.tsx",
+          "lines": [
+            57
+          ],
+          "snippets": [
+            {
+              "line": 57,
+              "text": "{ path: '/service-provider/service-listings', nameKey: 'sidebar.serviceMarketplace', icon: WrenchScrewdriverIcon, roles: [UserRole.SERVICE_PROVIDER] },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "supplierSupportPage.faq.addProduct.a",
+      "namespace": null,
+      "keyPath": "supplierSupportPage.faq.addProduct.a",
+      "occurrences": [
+        {
+          "file": "frontend/pages/supplier/SupplierSupportPage.tsx",
+          "lines": [
+            34
+          ],
+          "snippets": [
+            {
+              "line": 34,
+              "text": "{ questionKey: \"supplierSupportPage.faq.addProduct.q\", answerKey: \"supplierSupportPage.faq.addProduct.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "supplierSupportPage.faq.addProduct.q",
+      "namespace": null,
+      "keyPath": "supplierSupportPage.faq.addProduct.q",
+      "occurrences": [
+        {
+          "file": "frontend/pages/supplier/SupplierSupportPage.tsx",
+          "lines": [
+            34
+          ],
+          "snippets": [
+            {
+              "line": 34,
+              "text": "{ questionKey: \"supplierSupportPage.faq.addProduct.q\", answerKey: \"supplierSupportPage.faq.addProduct.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "supplierSupportPage.faq.commissionRates.a",
+      "namespace": null,
+      "keyPath": "supplierSupportPage.faq.commissionRates.a",
+      "occurrences": [
+        {
+          "file": "frontend/pages/supplier/SupplierSupportPage.tsx",
+          "lines": [
+            37
+          ],
+          "snippets": [
+            {
+              "line": 37,
+              "text": "{ questionKey: \"supplierSupportPage.faq.commissionRates.q\", answerKey: \"supplierSupportPage.faq.commissionRates.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "supplierSupportPage.faq.commissionRates.q",
+      "namespace": null,
+      "keyPath": "supplierSupportPage.faq.commissionRates.q",
+      "occurrences": [
+        {
+          "file": "frontend/pages/supplier/SupplierSupportPage.tsx",
+          "lines": [
+            37
+          ],
+          "snippets": [
+            {
+              "line": 37,
+              "text": "{ questionKey: \"supplierSupportPage.faq.commissionRates.q\", answerKey: \"supplierSupportPage.faq.commissionRates.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "supplierSupportPage.faq.manageProfile.a",
+      "namespace": null,
+      "keyPath": "supplierSupportPage.faq.manageProfile.a",
+      "occurrences": [
+        {
+          "file": "frontend/pages/supplier/SupplierSupportPage.tsx",
+          "lines": [
+            36
+          ],
+          "snippets": [
+            {
+              "line": 36,
+              "text": "{ questionKey: \"supplierSupportPage.faq.manageProfile.q\", answerKey: \"supplierSupportPage.faq.manageProfile.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "supplierSupportPage.faq.manageProfile.q",
+      "namespace": null,
+      "keyPath": "supplierSupportPage.faq.manageProfile.q",
+      "occurrences": [
+        {
+          "file": "frontend/pages/supplier/SupplierSupportPage.tsx",
+          "lines": [
+            36
+          ],
+          "snippets": [
+            {
+              "line": 36,
+              "text": "{ questionKey: \"supplierSupportPage.faq.manageProfile.q\", answerKey: \"supplierSupportPage.faq.manageProfile.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "supplierSupportPage.faq.processOrders.a",
+      "namespace": null,
+      "keyPath": "supplierSupportPage.faq.processOrders.a",
+      "occurrences": [
+        {
+          "file": "frontend/pages/supplier/SupplierSupportPage.tsx",
+          "lines": [
+            35
+          ],
+          "snippets": [
+            {
+              "line": 35,
+              "text": "{ questionKey: \"supplierSupportPage.faq.processOrders.q\", answerKey: \"supplierSupportPage.faq.processOrders.a\" },"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "supplierSupportPage.faq.processOrders.q",
+      "namespace": null,
+      "keyPath": "supplierSupportPage.faq.processOrders.q",
+      "occurrences": [
+        {
+          "file": "frontend/pages/supplier/SupplierSupportPage.tsx",
+          "lines": [
+            35
+          ],
+          "snippets": [
+            {
+              "line": 35,
+              "text": "{ questionKey: \"supplierSupportPage.faq.processOrders.q\", answerKey: \"supplierSupportPage.faq.processOrders.a\" },"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/check-i18n-keys.ts
+++ b/scripts/check-i18n-keys.ts
@@ -8,6 +8,10 @@
 
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const LOCALES_DIR = path.join(__dirname, '../packages/translations/locales');
 const USED_KEYS_FILE = path.join(__dirname, '../i18n-used-keys.json');

--- a/scripts/extract-i18n-keys.ts
+++ b/scripts/extract-i18n-keys.ts
@@ -8,7 +8,11 @@
 
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { glob } from 'glob';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const FRONTEND_DIR = path.join(__dirname, '../frontend');
 const OUTPUT_FILE = path.join(__dirname, '../i18n-used-keys.json');

--- a/scripts/find-missing-translations.ts
+++ b/scripts/find-missing-translations.ts
@@ -1,0 +1,474 @@
+#!/usr/bin/env ts-node
+/**
+ * Scan frontend-facing projects for translation keys whose localized values
+ * are missing from the shared translation resources.
+ *
+ * The script searches for string literals that look like i18next keys (optionally
+ * with namespaces) and verifies that they exist in the English locale files
+ * under packages/translations/locales/en.
+ *
+ * Usage:
+ *   TS_NODE_COMPILER_OPTIONS='{"module":"esnext"}' pnpm ts-node scripts/find-missing-translations.ts
+ * or
+ *   TS_NODE_COMPILER_OPTIONS='{"module":"esnext"}' pnpm exec ts-node scripts/find-missing-translations.ts
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+type TranslationNode = Record<string, unknown>;
+
+interface TranslationResources {
+  [namespace: string]: TranslationNode;
+}
+
+interface SearchTarget {
+  label: string;
+  root: string;
+}
+
+interface Occurrence {
+  file: string;
+  relativeFile: string;
+  lines: Set<number>;
+  snippets: Map<number, string>;
+}
+
+interface MissingKeyRecord {
+  key: string;
+  namespace: string | null;
+  keyPath: string;
+  occurrences: Map<string, Occurrence>; // keyed by file path
+}
+
+interface Report {
+  timestamp: string;
+  translationRoot: string;
+  namespaces: string[];
+  directoriesScanned: string[];
+  totals: {
+    filesScanned: number;
+    candidateKeysFound: number;
+    uniqueMissingKeys: number;
+  };
+  missingKeys: Array<{
+    key: string;
+    namespace: string | null;
+    keyPath: string;
+    occurrences: Array<{
+      file: string;
+      lines: number[];
+      snippets: Array<{ line: number; text: string }>;
+    }>;
+  }>;
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const TRANSLATION_DIR = path.join(PROJECT_ROOT, 'packages/translations/locales/en');
+
+const SEARCH_TARGETS: SearchTarget[] = [
+  { label: 'frontend', root: path.join(PROJECT_ROOT, 'frontend') },
+  { label: 'admin', root: path.join(PROJECT_ROOT, 'admin') },
+];
+
+const IGNORE_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  '.turbo',
+  '.next',
+  '.git',
+  'coverage',
+  '.idea',
+  '.vscode',
+  '__tests__',
+  '__mocks__',
+  'tests',
+  'test',
+  'playwright',
+  'e2e',
+]);
+
+const SUPPORTED_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
+
+const T_CALL_PATTERN = /\bt\(\s*['"`]([^'"`]+)['"`]/g;
+const I18N_KEY_PATTERN = /\bi18nKey\s*=\s*['"`]([^'"`]+)['"`]/g;
+const PROPERTY_KEY_PATTERN = /\b([A-Za-z0-9_]+Key)\s*:\s*['"`]([^'"`]+)['"`]/g;
+const CONST_KEY_PATTERN = /\bconst\s+([A-Za-z0-9_]+Key)\s*=\s*([^;]+);/g;
+const STRING_LITERAL_PATTERN = /['"`]([^'"`]+)['"`]/g;
+
+const TRANSLATION_KEY_FORMAT =
+  /^([a-z][\w-]*:)?[a-zA-Z][\w-]*(\.[a-zA-Z][\w-]*)+$/;
+
+const PROPERTY_KEY_WHITELIST = new Set([
+  'labelKey',
+  'textKey',
+  'titleKey',
+  'subtitleKey',
+  'buttonKey',
+  'messageKey',
+  'descriptionKey',
+  'helpTextKey',
+  'tooltipKey',
+  'valueKey',
+  'ariaLabelKey',
+  'nameKey',
+  'ctaKey',
+  'headerKey',
+  'questionKey',
+  'answerKey',
+  'statKey',
+  'statusKey',
+  'sectionKey',
+  'tabKey',
+  'cardKey',
+  'itemKey',
+  'slideKey',
+  'chipKey',
+  'badgeKey',
+  'optionKey',
+  'stepKey',
+  'fieldKey',
+  'placeholderKey',
+  'drawerKey',
+  'modalKey',
+  'summaryKey',
+]);
+
+const KNOWN_PREFIXES = new Set<string>();
+
+function loadTranslations(): TranslationResources {
+  if (!fs.existsSync(TRANSLATION_DIR)) {
+    throw new Error(`Translation directory not found: ${TRANSLATION_DIR}`);
+  }
+
+  KNOWN_PREFIXES.clear();
+  const resources: TranslationResources = {};
+  const files = fs
+    .readdirSync(TRANSLATION_DIR)
+    .filter(file => file.endsWith('.json'));
+
+  for (const file of files) {
+    const namespace = path.basename(file, '.json');
+    const filePath = path.join(TRANSLATION_DIR, file);
+    const content = fs.readFileSync(filePath, 'utf8');
+    try {
+      resources[namespace] = JSON.parse(content);
+      Object.keys(resources[namespace]).forEach(key => {
+        KNOWN_PREFIXES.add(key);
+      });
+    } catch (error) {
+      throw new Error(`Failed to parse ${file}: ${(error as Error).message}`);
+    }
+  }
+
+  return resources;
+}
+
+function resolveTranslation(
+  resources: TranslationResources,
+  namespace: string,
+  keyPath: string,
+): boolean {
+  const ns = resources[namespace];
+  if (!ns) {
+    return false;
+  }
+
+  const parts = keyPath.split('.');
+  let current: unknown = ns;
+  for (const part of parts) {
+    if (
+      current &&
+      typeof current === 'object' &&
+      !Array.isArray(current) &&
+      Object.prototype.hasOwnProperty.call(current, part)
+    ) {
+      current = (current as Record<string, unknown>)[part];
+    } else {
+      return false;
+    }
+  }
+
+  if (
+    typeof current === 'string' ||
+    typeof current === 'number' ||
+    typeof current === 'boolean'
+  ) {
+    return true;
+  }
+
+  // Treat objects (e.g., nested groups without terminal value) as unresolved
+  return false;
+}
+
+function keyExists(
+  resources: TranslationResources,
+  rawKey: string,
+): { exists: boolean; namespace: string | null; keyPath: string } {
+  if (rawKey.includes(':')) {
+    const [namespace, keyPath] = rawKey.split(':', 2);
+    const exists = resolveTranslation(resources, namespace, keyPath);
+    return { exists, namespace, keyPath };
+  }
+
+  // Try default namespace first
+  const defaultNamespace = 'common';
+  if (resolveTranslation(resources, defaultNamespace, rawKey)) {
+    return { exists: true, namespace: defaultNamespace, keyPath: rawKey };
+  }
+
+  // Fallback: check every namespace to see if the key exists anywhere
+  for (const namespace of Object.keys(resources)) {
+    if (namespace === defaultNamespace) {
+      continue;
+    }
+    if (resolveTranslation(resources, namespace, rawKey)) {
+      return { exists: true, namespace, keyPath: rawKey };
+    }
+  }
+
+  return { exists: false, namespace: null, keyPath: rawKey };
+}
+
+function collectFiles(root: string): string[] {
+  const results: string[] = [];
+
+  function walk(currentDir: string) {
+    const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (IGNORE_DIRS.has(entry.name)) {
+        continue;
+      }
+
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.isFile()) {
+        const ext = path.extname(entry.name);
+        if (SUPPORTED_EXTENSIONS.has(ext)) {
+          results.push(fullPath);
+        }
+      }
+    }
+  }
+
+  walk(root);
+  return results;
+}
+
+function extractCandidates(content: string): Array<{ key: string; index: number }> {
+  const candidates: Array<{ key: string; index: number }> = [];
+
+  const addCandidate = (key: string, index: number) => {
+    if (!key || !key.includes('.') || key.includes('${')) {
+      return;
+    }
+    if (!TRANSLATION_KEY_FORMAT.test(key)) {
+      return;
+    }
+    if (!key.includes(':')) {
+      const prefix = key.split('.')[0];
+      if (!KNOWN_PREFIXES.has(prefix) && !/[A-Z]/.test(key)) {
+        return;
+      }
+    }
+    if (key.toLowerCase().startsWith('http')) {
+      return;
+    }
+    candidates.push({ key, index });
+  };
+
+  let match: RegExpExecArray | null;
+
+  while ((match = T_CALL_PATTERN.exec(content)) !== null) {
+    addCandidate(match[1], match.index);
+  }
+
+  while ((match = I18N_KEY_PATTERN.exec(content)) !== null) {
+    addCandidate(match[1], match.index);
+  }
+
+  while ((match = PROPERTY_KEY_PATTERN.exec(content)) !== null) {
+    const propName = match[1];
+    if (!PROPERTY_KEY_WHITELIST.has(propName)) {
+      continue;
+    }
+    addCandidate(match[2], match.index);
+  }
+
+  while ((match = CONST_KEY_PATTERN.exec(content)) !== null) {
+    const valueExpr = match[2];
+    let stringMatch: RegExpExecArray | null;
+    while ((stringMatch = STRING_LITERAL_PATTERN.exec(valueExpr)) !== null) {
+      addCandidate(stringMatch[1], match.index + stringMatch.index);
+    }
+  }
+
+  return candidates;
+}
+
+function ensureOccurrence(record: MissingKeyRecord, file: string, relative: string): Occurrence {
+  if (!record.occurrences.has(file)) {
+    record.occurrences.set(file, {
+      file,
+      relativeFile: relative,
+      lines: new Set<number>(),
+      snippets: new Map<number, string>(),
+    });
+  }
+  return record.occurrences.get(file)!;
+}
+
+function addOccurrence(
+  record: MissingKeyRecord,
+  file: string,
+  relativeFile: string,
+  lineNumber: number,
+  lineText: string,
+): void {
+  const occurrence = ensureOccurrence(record, file, relativeFile);
+  occurrence.lines.add(lineNumber);
+  if (!occurrence.snippets.has(lineNumber)) {
+    occurrence.snippets.set(lineNumber, lineText.trim());
+  }
+}
+
+function relativePath(file: string): string {
+  return path.relative(PROJECT_ROOT, file);
+}
+
+function createReport(
+  resources: TranslationResources,
+  missing: Map<string, MissingKeyRecord>,
+  filesScanned: number,
+  candidateKeysFound: number,
+): Report {
+  return {
+    timestamp: new Date().toISOString(),
+    translationRoot: relativePath(TRANSLATION_DIR),
+    namespaces: Object.keys(resources).sort(),
+    directoriesScanned: SEARCH_TARGETS.map(target =>
+      relativePath(target.root),
+    ),
+    totals: {
+      filesScanned,
+      candidateKeysFound,
+      uniqueMissingKeys: missing.size,
+    },
+    missingKeys: Array.from(missing.values())
+      .sort((a, b) => a.key.localeCompare(b.key))
+      .map(record => ({
+        key: record.key,
+        namespace: record.namespace,
+        keyPath: record.keyPath,
+        occurrences: Array.from(record.occurrences.values())
+          .sort((a, b) => a.relativeFile.localeCompare(b.relativeFile))
+          .map(occurrence => ({
+            file: occurrence.relativeFile,
+            lines: Array.from(occurrence.lines).sort((a, b) => a - b),
+            snippets: Array.from(occurrence.snippets.entries())
+              .sort((a, b) => a[0] - b[0])
+              .map(([line, text]) => ({
+                line,
+                text,
+              })),
+          })),
+      })),
+  };
+}
+
+function main() {
+  const resources = loadTranslations();
+
+  const missing = new Map<string, MissingKeyRecord>();
+  let candidateKeyCount = 0;
+  let filesScanned = 0;
+
+  for (const target of SEARCH_TARGETS) {
+    if (!fs.existsSync(target.root)) {
+      console.warn(`⚠️  Skipping missing directory: ${target.root}`);
+      continue;
+    }
+
+    const files = collectFiles(target.root);
+    filesScanned += files.length;
+
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf8');
+      const rel = relativePath(file);
+      const lines = content.split('\n');
+      const candidates = extractCandidates(content);
+
+      for (const candidate of candidates) {
+        const rawKey = candidate.key;
+        candidateKeyCount += 1;
+
+        const { exists, namespace, keyPath } = keyExists(resources, rawKey);
+        if (exists) {
+          continue;
+        }
+
+        const keyId = namespace ? `${namespace}:${keyPath}` : rawKey;
+        if (!missing.has(keyId)) {
+          missing.set(keyId, {
+            key: rawKey,
+            namespace,
+            keyPath,
+            occurrences: new Map<string, Occurrence>(),
+          });
+        }
+
+        const record = missing.get(keyId)!;
+
+        const beforeIndex = content.slice(0, candidate.index);
+        const lineNumber = beforeIndex.split('\n').length;
+        const lineText = lines[lineNumber - 1] ?? '';
+
+        addOccurrence(record, file, rel, lineNumber, lineText);
+      }
+    }
+  }
+
+  const report = createReport(resources, missing, filesScanned, candidateKeyCount);
+
+  const outputPath = path.join(PROJECT_ROOT, 'missing-translations-report.json');
+  fs.writeFileSync(outputPath, JSON.stringify(report, null, 2), 'utf8');
+
+  console.log('🔎 Missing translation scan complete.\n');
+  console.log(`   Directories scanned: ${report.directoriesScanned.join(', ')}`);
+  console.log(`   Files scanned:       ${report.totals.filesScanned}`);
+  console.log(`   Candidate keys:      ${report.totals.candidateKeysFound}`);
+  console.log(`   Missing keys found:  ${report.totals.uniqueMissingKeys}`);
+  console.log(`\n📝 Report written to ${relativePath(outputPath)}\n`);
+
+  if (report.missingKeys.length > 0) {
+    console.log('Top missing keys:');
+    report.missingKeys.slice(0, 20).forEach(record => {
+      const ns = record.namespace ? `${record.namespace}:` : '';
+      const firstOccurrence = record.occurrences[0];
+      const location =
+        firstOccurrence && firstOccurrence.lines.length > 0
+          ? `${firstOccurrence.file}:${firstOccurrence.lines[0]}`
+          : 'unknown';
+      console.log(`   - ${ns}${record.keyPath} (${location})`);
+    });
+    if (report.missingKeys.length > 20) {
+      console.log(`   ... and ${report.missingKeys.length - 20} more`);
+    }
+  } else {
+    console.log('✅ No missing translation keys detected!');
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error('❌ Failed to complete missing translation scan.');
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+}
+


### PR DESCRIPTION
Update i18n key extraction scripts for Node 22 compatibility and generate a baseline of all used translation keys to facilitate identifying missing translations.

The existing i18n tooling was not compatible with Node 22, preventing accurate identification of translation key usage. This update fixes the scripts and provides a comprehensive `i18n-used-keys.json` file, which is a critical first step towards systematically finding and resolving all instances of untranslated strings appearing on the frontend.

---
<a href="https://cursor.com/background-agent?bcId=bc-810f4536-35c3-4ed3-a50e-0a025d77cb01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-810f4536-35c3-4ed3-a50e-0a025d77cb01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

