### PR TITLE
Mock login for all user roles

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -81,15 +81,15 @@ import ProfilePage from './pages/ProfilePage';
 
 const ProtectedRoute: React.FC<{ children: React.ReactElement; roles: UserRole[] }> = ({ children, roles }): React.ReactElement | null => {
   const { currentUser } = useAppContext();
-  const { isLoaded, isSignedIn } = useAuth();
-  const location = useLocation();
 
   if (!currentUser) {
-    return <Navigate to="/login" replace />; // Fallback, ProtectedLayout is primary guard
+    return <Navigate to="/login" replace />;
   }
+
   if (!roles.includes(currentUser.role)) {
-    return <Navigate to="/dashboard" replace />; // Redirect to their own dashboard if role mismatches
+    return <Navigate to="/dashboard" replace />;
   }
+
   return children;
 };
 
@@ -119,11 +119,13 @@ const RoleBasedDashboardRedirect: React.FC = () => {
 const ProtectedLayout: React.FC = () => {
   const { currentUser } = useAppContext();
   const { isLoaded, isSignedIn } = useAuth();
-  const { isLoading: isAuthLoading } = useAuthContext();
+  const { isLoading: isAuthLoading, isUsingMockLogin } = useAuthContext();
   const location = useLocation();
 
-  // Wait for Clerk to load before checking authentication
-  if (!isLoaded) {
+  const shouldBypassClerkChecks = isUsingMockLogin;
+
+  // Wait for Clerk to load before checking authentication (unless using mock session)
+  if (!isLoaded && !shouldBypassClerkChecks) {
     return (
       <div className="min-h-screen bg-page-bg flex items-center justify-center">
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-swiss-mint"></div>
@@ -131,15 +133,15 @@ const ProtectedLayout: React.FC = () => {
     );
   }
 
-  // User not signed in to Clerk ? redirect to login
-  if (!isSignedIn) {
+  // User not signed in to Clerk? redirect to login unless mock session is active
+  if (!isSignedIn && !shouldBypassClerkChecks) {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
   // Signed in to Clerk but no currentUser yet
   if (!currentUser) {
-    // Still loading from backend ? show loading screen (prevents redirect during sync)
-    if (isAuthLoading) {
+    // Still loading from backend or establishing mock session? show loading screen (prevents redirect during sync)
+    if (isAuthLoading || shouldBypassClerkChecks) {
       return (
         <div className="min-h-screen bg-page-bg flex items-center justify-center">
           <div className="text-center">

--- a/frontend/mock/mockUsers.ts
+++ b/frontend/mock/mockUsers.ts
@@ -1,0 +1,154 @@
+import { User, UserRole } from '../types';
+
+export interface MockRoleLoginOption {
+  role: UserRole;
+  label: string;
+  description: string;
+  user: User;
+}
+
+const DEFAULT_CREATED_AT = '2024-01-15T09:00:00.000Z';
+const DEFAULT_MEMBER_SINCE = '2024-01-20T09:00:00.000Z';
+
+const roleSlug = (role: UserRole) => role.toLowerCase();
+
+const createMockUser = (role: UserRole, overrides: Partial<User>): User => {
+  const slug = roleSlug(role);
+  const firstName = overrides.firstName ?? `Mock`;
+  const lastName = overrides.lastName ?? overrides.name?.split(' ').slice(-1)[0] ?? role.replace(/_/g, ' ');
+  const nowIso = new Date().toISOString();
+
+  const base: User = {
+    id: overrides.id ?? `mock-${slug}-user`,
+    clerkId: overrides.clerkId ?? `mock-${slug}-clerk`,
+    email: overrides.email ?? `mock+${slug}@procreche.com`,
+    firstName,
+    lastName,
+    role,
+    isActive: true,
+    createdAt: overrides.createdAt ?? DEFAULT_CREATED_AT,
+    updatedAt: overrides.updatedAt ?? nowIso,
+    name: overrides.name ?? `${firstName} ${lastName}`.trim(),
+    status: overrides.status ?? 'Active',
+    lastLogin: overrides.lastLogin ?? nowIso,
+    memberSince: overrides.memberSince ?? DEFAULT_MEMBER_SINCE,
+    avatarUrl:
+      overrides.avatarUrl ??
+      `https://api.dicebear.com/7.x/initials/svg?seed=${encodeURIComponent(
+        `${firstName} ${lastName}`.trim(),
+      )}`,
+    orgId: overrides.orgId,
+    orgName: overrides.orgName,
+    region: overrides.region ?? 'Geneva',
+    plan: overrides.plan,
+    phoneNumber: overrides.phoneNumber,
+    workExperience: overrides.workExperience,
+    education: overrides.education,
+    certifications: overrides.certifications,
+    skills: overrides.skills,
+    availability: overrides.availability,
+    cvUrl: overrides.cvUrl,
+    stripeCustomerId: overrides.stripeCustomerId,
+    lastActiveAt: overrides.lastActiveAt ?? nowIso,
+  };
+
+  return { ...base, ...overrides };
+};
+
+export const MOCK_ROLE_LOGIN_OPTIONS: MockRoleLoginOption[] = [
+  {
+    role: UserRole.SUPER_ADMIN,
+    label: 'Super Admin',
+    description: 'Full platform control with all administrative modules.',
+    user: createMockUser(UserRole.SUPER_ADMIN, {
+      firstName: 'Sienna',
+      lastName: 'Owner',
+      email: 'mock.superadmin@procreche.com',
+    }),
+  },
+  {
+    role: UserRole.ADMIN,
+    label: 'Admin',
+    description: 'Manage content, policies, and platform settings.',
+    user: createMockUser(UserRole.ADMIN, {
+      firstName: 'Alex',
+      lastName: 'Admin',
+      email: 'mock.admin@procreche.com',
+    }),
+  },
+  {
+    role: UserRole.FOUNDATION,
+    label: 'Foundation (Daycare)',
+    description: 'Explore the daycare operator dashboard and workflows.',
+    user: createMockUser(UserRole.FOUNDATION, {
+      firstName: 'Fiona',
+      lastName: 'Daycare',
+      email: 'mock.foundation@procreche.com',
+      orgId: 'org-foundation-001',
+      orgName: 'Kinderwelt Daycare',
+      plan: 'Essential',
+      region: 'Zurich',
+    }),
+  },
+  {
+    role: UserRole.PRODUCT_SUPPLIER,
+    label: 'Product Supplier',
+    description: 'Preview marketplace listings and supplier tools.',
+    user: createMockUser(UserRole.PRODUCT_SUPPLIER, {
+      firstName: 'Samuel',
+      lastName: 'Supplier',
+      email: 'mock.supplier@procreche.com',
+      orgId: 'org-supplier-001',
+      orgName: 'EduToys AG',
+      plan: 'Supplier',
+      region: 'Basel',
+    }),
+  },
+  {
+    role: UserRole.SERVICE_PROVIDER,
+    label: 'Service Provider',
+    description: 'Review service requests and provider features.',
+    user: createMockUser(UserRole.SERVICE_PROVIDER, {
+      firstName: 'Sofia',
+      lastName: 'Services',
+      email: 'mock.service@procreche.com',
+      orgId: 'org-service-001',
+      orgName: 'CleanCare Facilities',
+      plan: 'Service Provider',
+      region: 'Geneva',
+    }),
+  },
+  {
+    role: UserRole.PARENT,
+    label: 'Parent',
+    description: 'View the parent enquiry experience and dashboards.',
+    user: createMockUser(UserRole.PARENT, {
+      firstName: 'Pauline',
+      lastName: 'Parent',
+      email: 'mock.parent@procreche.com',
+      region: 'Vaud',
+    }),
+  },
+  {
+    role: UserRole.EDUCATOR,
+    label: 'Job Seeker / Candidate',
+    description: 'Experience the recruitment and application portal.',
+    user: createMockUser(UserRole.EDUCATOR, {
+      firstName: 'Elliot',
+      lastName: 'Educator',
+      email: 'mock.educator@procreche.com',
+      workExperience: '5 years in early childhood education',
+      education: 'Bachelor of Education',
+      skills: ['Curriculum Planning', 'Parent Communication', 'First Aid'],
+    }),
+  },
+];
+
+export const getMockUserByRole = (role: UserRole): User | null => {
+  const option = MOCK_ROLE_LOGIN_OPTIONS.find((item) => item.role === role);
+  if (!option) {
+    return null;
+  }
+
+  return { ...option.user };
+};

--- a/frontend/pages/LoginPage.tsx
+++ b/frontend/pages/LoginPage.tsx
@@ -5,10 +5,12 @@ import { useTranslation } from 'react-i18next';
 import { STANDARD_INPUT_FIELD, APP_NAME } from '../constants';
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
-import { SquaresPlusIcon, EyeIcon, EyeSlashIcon, CheckCircleIcon, HomeIcon } from '@heroicons/react/24/outline';
+import { SquaresPlusIcon, EyeIcon, EyeSlashIcon, CheckCircleIcon, HomeIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
 import LanguageSwitcher from '../components/ui/LanguageSwitcher';
 import { useAppContext } from '../contexts/AppContext';
 import { useAuthContext } from '../providers/AuthProvider';
+import { MOCK_ROLE_LOGIN_OPTIONS, getMockUserByRole } from '../mock/mockUsers';
+import { UserRole } from '../types';
 
 // Social icons
 const GoogleIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
@@ -33,7 +35,16 @@ const LoginPage: React.FC = () => {
   const { signIn, isLoaded: isSignInLoaded, setActive } = useSignIn();
   const { isSignedIn, isLoaded: isAuthLoaded } = useAuth();
   const { currentUser } = useAppContext();
-  const { isLoading: isAuthLoading, authError, clearAuthError, logout, isSigningOut: isSigningOutGlobal } = useAuthContext();
+  const {
+    isLoading: isAuthLoading,
+    authError,
+    clearAuthError,
+    logout,
+    isSigningOut: isSigningOutGlobal,
+    isMockLoginEnabled,
+    isUsingMockLogin,
+    startMockLogin,
+  } = useAuthContext();
   
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -157,6 +168,24 @@ const LoginPage: React.FC = () => {
     }
   };
 
+  const handleMockLogin = (role: UserRole) => {
+    if (!isMockLoginEnabled) {
+      return;
+    }
+    setError('');
+    clearAuthError();
+
+    const mockUser = getMockUserByRole(role);
+    if (!mockUser) {
+      console.warn(`Mock login requested for unsupported role: ${role}`);
+      setError('Mock login is not available for this role yet.');
+      return;
+    }
+
+    startMockLogin(mockUser);
+    navigate('/dashboard', { replace: true });
+  };
+
   const handleLogout = async () => {
     setError('');
     clearAuthError();
@@ -172,83 +201,102 @@ const LoginPage: React.FC = () => {
     }
   };
 
-  // STRICT RENDERING GATES - Wait for Clerk to load before showing anything
-  if (!isSignInLoaded || !isAuthLoaded) {
-    return (
-      <div className="min-h-screen bg-page-bg flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-swiss-mint"></div>
-      </div>
-    );
-  }
+    // STRICT RENDERING GATES - Wait for Clerk to load before showing anything unless mock login is enabled
+    if ((!isSignInLoaded || !isAuthLoaded) && !isMockLoginEnabled) {
+      return (
+        <div className="min-h-screen bg-page-bg flex items-center justify-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-swiss-mint"></div>
+        </div>
+      );
+    }
 
-  // SCENARIO A: Already signed in when landing on /login
-  // Show "Active Session" UI - let user choose to go to dashboard or sign out
-  if (isSignedIn && currentUser) {
-    return (
-      <div className="min-h-screen bg-page-bg flex flex-col items-center justify-center p-4 sm:p-6 lg:p-8">
-        <Card className="w-full max-w-md p-8 shadow-xl">
-          <div className="text-center mb-8">
-            <SquaresPlusIcon className="h-12 w-12 text-swiss-mint mx-auto mb-3" />
-            <h1 className="text-2xl font-bold text-swiss-charcoal">
-              {t('common:loginPage.title', { appName: APP_NAME })}
-            </h1>
-          </div>
+    const hasActiveSession = Boolean(currentUser && (isSignedIn || isUsingMockLogin));
 
-          <div className="space-y-6">
-            <div className="flex justify-center mb-4">
-              <CheckCircleIcon className="w-16 h-16 text-swiss-mint" />
+    // SCENARIO A: Already signed in when landing on /login
+    // Show "Active Session" UI - let user choose to go to dashboard or sign out
+    if (hasActiveSession && currentUser) {
+      const sessionTitle = isUsingMockLogin
+        ? 'Mock Session Active'
+        : t('common:loginPage.alreadySignedInTitle', 'Active Session Detected');
+      const sessionDescription = isUsingMockLogin
+        ? 'You are previewing the platform with a mock account. Choose an option below to continue.'
+        : t(
+            'common:loginPage.alreadySignedInDescription',
+            'You are already logged in. Choose an option below to continue.',
+          );
+      const sessionFooterNote = isUsingMockLogin
+        ? 'Mock session: authentication bypass enabled for sandbox use.'
+        : t('common:loginPage.noAccount');
+
+      return (
+        <div className="min-h-screen bg-page-bg flex flex-col items-center justify-center p-4 sm:p-6 lg:p-8">
+          <Card className="w-full max-w-md p-8 shadow-xl">
+            <div className="text-center mb-8">
+              <SquaresPlusIcon className="h-12 w-12 text-swiss-mint mx-auto mb-3" />
+              <h1 className="text-2xl font-bold text-swiss-charcoal">
+                {t('common:loginPage.title', { appName: APP_NAME })}
+              </h1>
             </div>
-            <h2 className="text-2xl font-bold text-swiss-charcoal text-center">
-              {t('common:loginPage.alreadySignedInTitle', 'Active Session Detected')}
-            </h2>
-            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-              <p className="text-sm text-blue-800 text-center">
-                <strong>Welcome back, {currentUser.firstName || 'User'}!</strong>
-              </p>
-              <p className="text-xs text-blue-700 text-center mt-2">
-                {t('common:loginPage.alreadySignedInDescription', 'You are already logged in. Choose an option below to continue.')}
-              </p>
-            </div>
-            <div className="flex flex-col space-y-3">
-              <Button
-                type="button"
-                variant="primary"
-                size="lg"
-                className="w-full"
-                onClick={() => navigate('/dashboard', { replace: true })}
-              >
-                {t('common:loginPage.goToDashboard', 'Go to Dashboard')}
-              </Button>
-              <Button
-                type="button"
-                variant="secondary"
-                className="w-full"
-                onClick={handleLogout}
-                disabled={isSigningOut}
-              >
-                {isSigningOut
-                  ? t('common:loginPage.signingOut', 'Signing Out...')
-                  : t('common:loginPage.signOutButton', 'Sign Out')}
-              </Button>
-            </div>
-          </div>
 
-          <div className="mt-8 text-center text-sm text-gray-600 space-y-2">
-            <p>
-              {t('common:loginPage.noAccount')}{' '}
-              <Link to="/signup" className="font-medium text-swiss-mint hover:underline">
-                {t('common:buttons.signup')}
-              </Link>
-            </p>
-          </div>
+            <div className="space-y-6">
+              <div className="flex justify-center mb-4">
+                <CheckCircleIcon className="w-16 h-16 text-swiss-mint" />
+              </div>
+              <h2 className="text-2xl font-bold text-swiss-charcoal text-center">
+                {sessionTitle}
+              </h2>
+              <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+                <p className="text-sm text-blue-800 text-center">
+                  <strong>Welcome back, {currentUser.firstName || 'User'}!</strong>
+                </p>
+                <p className="text-xs text-blue-700 text-center mt-2">
+                  {sessionDescription}
+                </p>
+              </div>
+              <div className="flex flex-col space-y-3">
+                <Button
+                  type="button"
+                  variant="primary"
+                  size="lg"
+                  className="w-full"
+                  onClick={() => navigate('/dashboard', { replace: true })}
+                >
+                  {t('common:loginPage.goToDashboard', 'Go to Dashboard')}
+                </Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="w-full"
+                  onClick={handleLogout}
+                  disabled={isSigningOut}
+                >
+                  {isSigningOut
+                    ? t('common:loginPage.signingOut', 'Signing Out...')
+                    : t('common:loginPage.signOutButton', 'Sign Out')}
+                </Button>
+              </div>
+            </div>
 
-          <div className="mt-6 flex justify-center">
-            <LanguageSwitcher />
-          </div>
-        </Card>
-      </div>
-    );
-  }
+            <div className="mt-8 text-center text-sm text-gray-600 space-y-2">
+              {isUsingMockLogin ? (
+                <p className="text-xs text-gray-500">{sessionFooterNote}</p>
+              ) : (
+                <p>
+                  {sessionFooterNote}{' '}
+                  <Link to="/signup" className="font-medium text-swiss-mint hover:underline">
+                    {t('common:buttons.signup')}
+                  </Link>
+                </p>
+              )}
+            </div>
+
+            <div className="mt-6 flex justify-center">
+              <LanguageSwitcher />
+            </div>
+          </Card>
+        </div>
+      );
+    }
 
   // Show loading state during sign-out to prevent flash of error screen
   // Use global isSigningOut from AuthProvider to catch sign-out from any page
@@ -411,6 +459,39 @@ const LoginPage: React.FC = () => {
                 </Button>
               </div>
             </div>
+
+          {isMockLoginEnabled && (
+            <div className="mt-8">
+              <div className="rounded-lg border border-dashed border-swiss-mint/50 bg-swiss-mint/5 p-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-swiss-mint">Quick role preview</p>
+                <p className="mt-2 text-xs text-gray-600">
+                  Launch a mock session to explore different user dashboards instantly.
+                </p>
+                <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                  {MOCK_ROLE_LOGIN_OPTIONS.map((option) => (
+                    <Button
+                      key={option.role}
+                      type="button"
+                      variant="light"
+                      size="md"
+                      className="w-full items-start justify-between text-left"
+                      rightIcon={ArrowRightIcon}
+                      onClick={() => handleMockLogin(option.role)}
+                      data-role={`mock-login-${option.role.toLowerCase()}`}
+                    >
+                      <span className="flex flex-col items-start">
+                        <span className="font-medium text-swiss-charcoal">{option.label}</span>
+                        <span className="text-xs text-gray-500">{option.description}</span>
+                      </span>
+                    </Button>
+                  ))}
+                </div>
+              </div>
+              <p className="mt-3 text-xs text-gray-500">
+                Mock sessions skip real authentication and do not persist updates.
+              </p>
+            </div>
+          )}
 
         <div className="mt-8 text-center text-sm text-gray-600 space-y-2">
           <p>

--- a/frontend/providers/AuthProvider.tsx
+++ b/frontend/providers/AuthProvider.tsx
@@ -12,6 +12,33 @@ import { User } from '../types';
 import { API_ENDPOINTS } from '../services/api-endpoints';
 import { apiService, ApiError } from '../services/api';
 
+const MOCK_AUTH_STORAGE_KEY = 'mock-auth-user';
+
+const resolveMockLoginEnabled = (): boolean => {
+  const flag = import.meta.env.VITE_ENABLE_MOCK_LOGIN;
+  if (flag === 'true') {
+    return true;
+  }
+  if (flag === 'false') {
+    return false;
+  }
+  return import.meta.env.DEV;
+};
+
+const mergeUserProfile = (user: User, updates: Partial<User>): User => {
+  const merged: User = { ...user, ...updates };
+
+  if (updates.firstName !== undefined || updates.lastName !== undefined) {
+    const newFirstName = updates.firstName ?? user.firstName;
+    const newLastName = updates.lastName ?? user.lastName;
+    merged.name = `${newFirstName} ${newLastName}`.trim();
+  } else if (updates.name) {
+    merged.name = updates.name;
+  }
+
+  return merged;
+};
+
 const BACKEND_SYNC_ERROR_KEY = 'common:loginPage.backendSyncError';
 const BACKEND_USER_CREATION_ERROR_KEY = 'common:loginPage.backendUserCreationError';
 const WEBHOOK_RETRY_ATTEMPTS = 2;
@@ -37,6 +64,8 @@ interface AuthContextType {
   setCurrentUser: React.Dispatch<React.SetStateAction<User | null>>;
   isLoading: boolean;
   isAuthenticated: boolean;
+  isMockLoginEnabled: boolean;
+  isUsingMockLogin: boolean;
   authError: string | null;
   isSigningOut: boolean;
   clearAuthError: () => void;
@@ -46,6 +75,7 @@ interface AuthContextType {
   updateCurrentUserInfo: (updatedInfo: Partial<User>) => Promise<void>;
   refreshCurrentUser: () => Promise<void>;
   changePassword: (currentPassword: string, newPassword: string) => Promise<void>;
+  startMockLogin: (user: User) => void;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -55,18 +85,32 @@ interface AuthProviderProps {
 }
 
 const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
+  const isMockLoginEnabled = resolveMockLoginEnabled();
   const { user: clerkUser, isLoaded: clerkIsLoaded } = useUser();
   const { getToken, signOut: clerkSignOut, isSignedIn } = useAuth();
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [authError, setAuthError] = useState<string | null>(null);
   const [isSigningOut, setIsSigningOut] = useState(false);
+  const [mockSessionUser, setMockSessionUser] = useState<User | null>(() => {
+    if (!isMockLoginEnabled || typeof window === 'undefined') {
+      return null;
+    }
+    try {
+      const stored = window.localStorage.getItem(MOCK_AUTH_STORAGE_KEY);
+      return stored ? (JSON.parse(stored) as User) : null;
+    } catch (error) {
+      console.warn('Failed to restore mock session user from storage', error);
+      return null;
+    }
+  });
 
   const syncAttemptRef = useRef<SyncAttemptState>(INITIAL_SYNC_STATE);
   const syncInFlightRef = useRef(false);
 
   const clerkUserId = clerkUser?.id ?? null;
-  const isAuthenticated = Boolean(clerkUser && isSignedIn);
+  const isMockSessionActive = Boolean(isMockLoginEnabled && mockSessionUser);
+  const isAuthenticated = Boolean(isMockSessionActive || (clerkUser && isSignedIn));
 
   const transformBackendUser = useCallback((user: any): User => {
     const transformed = {
@@ -96,6 +140,17 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
 
     return BACKEND_SYNC_ERROR_KEY;
   }, []);
+
+  useEffect(() => {
+    if (!isMockLoginEnabled || typeof window === 'undefined') {
+      return;
+    }
+    if (mockSessionUser) {
+      window.localStorage.setItem(MOCK_AUTH_STORAGE_KEY, JSON.stringify(mockSessionUser));
+    } else {
+      window.localStorage.removeItem(MOCK_AUTH_STORAGE_KEY);
+    }
+  }, [mockSessionUser, isMockLoginEnabled]);
 
   const fetchUserFromBackend = useCallback(
     async (clerkId: string, attempt = 0): Promise<User> => {
@@ -228,6 +283,18 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
   );
 
   useEffect(() => {
+    if (isMockSessionActive && mockSessionUser) {
+      setCurrentUser(mockSessionUser);
+      setAuthError(null);
+      setIsLoading(false);
+      syncAttemptRef.current = {
+        clerkId: mockSessionUser.clerkId ?? 'mock-session',
+        status: 'success',
+        lastAttempt: Date.now(),
+      };
+      return;
+    }
+
     if (!clerkIsLoaded) {
       setIsLoading(true);
       return;
@@ -326,7 +393,7 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
     return () => {
       cancelled = true;
     };
-  }, [clerkIsLoaded, clerkUserId, isSignedIn, fetchUserFromBackend, determineAuthErrorKey]);
+    }, [isMockSessionActive, mockSessionUser, clerkIsLoaded, clerkUserId, isSignedIn, fetchUserFromBackend, determineAuthErrorKey]);
 
   const login = async (email: string, password?: string): Promise<{ success: boolean; message?: string }> => {
     // Clerk handles authentication, this is just for compatibility
@@ -334,7 +401,55 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
     return { success: true };
   };
 
+  const startMockLogin = useCallback(
+    (user: User) => {
+      if (!isMockLoginEnabled) {
+        console.warn('Mock login attempted but the feature flag is disabled.');
+        return;
+      }
+
+      const nowIso = new Date().toISOString();
+      const normalizedUser: User = mergeUserProfile(
+        {
+          ...user,
+          id: user.id ?? `mock-${user.role.toLowerCase()}-user`,
+          clerkId: user.clerkId ?? `mock-${user.role.toLowerCase()}-clerk`,
+          isActive: user.isActive ?? true,
+          createdAt: user.createdAt ?? nowIso,
+          updatedAt: nowIso,
+          lastLogin: nowIso,
+          lastActiveAt: nowIso,
+          memberSince: user.memberSince ?? user.createdAt ?? nowIso,
+          status: user.status ?? 'Active',
+        },
+        {},
+      );
+
+      setMockSessionUser(normalizedUser);
+      setCurrentUser(normalizedUser);
+      setAuthError(null);
+      setIsLoading(false);
+      setIsSigningOut(false);
+      syncAttemptRef.current = {
+        clerkId: normalizedUser.clerkId ?? 'mock-session',
+        status: 'success',
+        lastAttempt: Date.now(),
+      };
+    },
+    [isMockLoginEnabled],
+  );
+
   const logout = useCallback(async () => {
+    if (isMockSessionActive) {
+      setIsSigningOut(true);
+      setMockSessionUser(null);
+      setCurrentUser(null);
+      setAuthError(null);
+      syncAttemptRef.current = INITIAL_SYNC_STATE;
+      setIsSigningOut(false);
+      return;
+    }
+
     try {
       setIsSigningOut(true);
       // Clear local user state first
@@ -351,7 +466,7 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
     } finally {
       setIsSigningOut(false);
     }
-  }, [clerkSignOut]);
+  }, [clerkSignOut, isMockSessionActive]);
 
   const signup = async (formData: any, role: any): Promise<{ success: boolean; message?: string; redirectTo?: string }> => {
     // Clerk handles signup, this is just for compatibility
@@ -360,11 +475,21 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
 
   const updateCurrentUserInfo = useCallback(
     async (updatedInfo: Partial<User>) => {
+        if (isMockSessionActive && mockSessionUser) {
+          const updatedUser = mergeUserProfile(mockSessionUser, {
+            ...updatedInfo,
+            updatedAt: new Date().toISOString(),
+          });
+          setMockSessionUser(updatedUser);
+          setCurrentUser(updatedUser);
+          setAuthError(null);
+          return;
+        }
 
-      if (!currentUser) {
-        console.error('Cannot update user: current user is not loaded');
-        return;
-      }
+        if (!currentUser) {
+          console.error('Cannot update user: current user is not loaded');
+          return;
+        }
 
       try {
         const token = await getToken();
@@ -432,11 +557,15 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
         throw error;
       }
     },
-    [currentUser, getToken, transformBackendUser, clerkUserId]
+      [isMockSessionActive, mockSessionUser, currentUser, getToken, transformBackendUser, clerkUserId]
   );
 
   const changePassword = useCallback(
     async (currentPassword: string, newPassword: string) => {
+      if (isMockSessionActive) {
+        throw new Error('Password changes are disabled while using a mock login session.');
+      }
+
       if (!clerkUser) {
         throw new Error('Authenticated user is not available');
       }
@@ -488,10 +617,21 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
         console.error('Password change audit logging failed', auditError);
       }
     },
-    [clerkUser, getToken]
+      [isMockSessionActive, clerkUser, getToken]
   );
 
   const refreshCurrentUser = useCallback(async () => {
+    if (isMockSessionActive && mockSessionUser) {
+      setCurrentUser(mockSessionUser);
+      setAuthError(null);
+      syncAttemptRef.current = {
+        clerkId: mockSessionUser.clerkId ?? 'mock-session',
+        status: 'success',
+        lastAttempt: Date.now(),
+      };
+      return;
+    }
+
     if (!clerkIsLoaded) {
       throw new Error('Clerk is not loaded yet');
     }
@@ -508,7 +648,7 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
       status: 'success',
       lastAttempt: Date.now(),
     };
-  }, [clerkIsLoaded, clerkUserId, fetchUserFromBackend]);
+  }, [isMockSessionActive, mockSessionUser, clerkIsLoaded, clerkUserId, fetchUserFromBackend]);
 
   return (
     <AuthContext.Provider
@@ -517,10 +657,13 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
         setCurrentUser,
         isLoading,
         isAuthenticated,
+        isMockLoginEnabled,
+        isUsingMockLogin: isMockSessionActive,
         authError,
         isSigningOut,
         clearAuthError: () => setAuthError(null),
         login,
+        startMockLogin,
         logout,
         signup,
         updateCurrentUserInfo,


### PR DESCRIPTION
Implement a mock login bypass to enable quick preview of the platform for various user roles.

This feature allows developers and testers to quickly switch between different user role perspectives (Foundations, service providers, product suppliers, parents, job seekers/candidates, admin, super admin) directly from the login page. It introduces mock user profiles, extends the authentication provider to manage these mock sessions, and updates frontend guards to recognize and allow mock sessions, bypassing standard authentication flows. The functionality is controlled by a `VITE_ENABLE_MOCK_LOGIN` feature flag.

---
<a href="https://cursor.com/background-agent?bcId=bc-4116ac0c-71c8-41c3-b0ab-2d667bf6d3ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4116ac0c-71c8-41c3-b0ab-2d667bf6d3ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

