### PR TITLE
Investigate typescript type conversion error in users service

### DIFF
--- a/api/src/principal/principal.service.ts
+++ b/api/src/principal/principal.service.ts
@@ -2,25 +2,19 @@ import { Injectable, Logger, NotFoundException, UnauthorizedException } from '@n
 import { PrismaService } from '../prisma/prisma.service';
 import { Prisma, UserRole } from '@prisma/client';
 
-export interface BootstrapResult {
+type UserPayload<TInclude extends Prisma.UserInclude | undefined> = Prisma.UserGetPayload<
+  TInclude extends Prisma.UserInclude ? { include: TInclude } : {}
+>;
+
+export type BootstrapResult<TInclude extends Prisma.UserInclude | undefined = undefined> = {
   appUser: {
     id: string;
     clerkId: string;
     email: string | null;
     role: UserRole;
   };
-  user: {
-    id: string;
-    clerkId: string;
-    email: string;
-    firstName: string | null;
-    lastName: string | null;
-    role: UserRole;
-    isActive: boolean;
-    createdAt: Date;
-    updatedAt: Date;
-  } & Record<string, unknown>;
-}
+  user: UserPayload<TInclude>;
+};
 
 @Injectable()
 export class PrincipalService {
@@ -36,7 +30,7 @@ export class PrincipalService {
   async getOrBootstrapAccountAndProfile<TInclude extends Prisma.UserInclude | undefined = undefined>(
     clerkId: string | undefined,
     include?: TInclude,
-  ): Promise<BootstrapResult & (TInclude extends undefined ? {} : { user: Prisma.UserGetPayload<{ include: TInclude }> })> {
+  ): Promise<BootstrapResult<TInclude>> {
     const startTime = Date.now();
 
     if (!clerkId) {
@@ -88,8 +82,8 @@ export class PrincipalService {
 
     return {
       appUser,
-      user: user as any,
-    } as BootstrapResult & (TInclude extends undefined ? {} : { user: Prisma.UserGetPayload<{ include: TInclude }> });
+      user: user as UserPayload<TInclude>,
+    };
   }
 
   async getOrDefaultNotificationPrefs(userId: string) {

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -349,7 +349,7 @@ export class UsersService {
 
     try {
       const result = await this.principal.getOrBootstrapAccountAndProfile(clerkId, this.userProfileInclude);
-      return this.buildUserResponse(result.user as Prisma.UserGetPayload<{ include: typeof this.userProfileInclude }>, {
+      return this.buildUserResponse(result.user, {
         id: result.appUser.id,
         clerkId: result.appUser.clerkId,
         email: result.appUser.email,


### PR DESCRIPTION
Rework `PrincipalService`'s `BootstrapResult` typing to resolve a TS2352 build error in `UsersService`.

The previous `BootstrapResult` type included a `Record<string, unknown>` which created an incompatible string index signature, leading to a `TS2352` error when attempting to cast the `user` object within `UsersService.findByClerkId`. By making `BootstrapResult` generic and precisely typing the `user` property based on the `Prisma.UserGetPayload` with optional includes, the type conflict is resolved, allowing the build to succeed.

---
<a href="https://cursor.com/background-agent?bcId=bc-d80c4968-9498-4349-8dfd-8920de28124e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d80c4968-9498-4349-8dfd-8920de28124e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

