### PR TITLE
Fix user response build errors

### DIFF
--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -5,6 +5,33 @@ import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { PrincipalService } from '../principal/principal.service';
 
+const userProfileInclude = {
+  organizations: {
+    include: {
+      organization: {
+        include: {
+          logoAsset: true,
+          coverAsset: true,
+          products: {
+            include: {
+              imageAsset: true,
+            },
+          },
+          serviceProviders: {
+            include: {
+              services: true,
+            },
+          },
+          jobListings: true,
+        },
+      },
+    },
+  },
+} as const satisfies Prisma.UserInclude;
+
+type UserProfileInclude = typeof userProfileInclude;
+type UserWithProfile = Prisma.UserGetPayload<{ include: UserProfileInclude }>;
+
 export interface FindAllUsersParams {
   page: number;
   limit: number;
@@ -16,30 +43,6 @@ export interface FindAllUsersParams {
 export class UsersService {
   constructor(private prisma: PrismaService, private readonly principal: PrincipalService) {}
 
-  private readonly userProfileInclude = {
-    organizations: {
-      include: {
-        organization: {
-          include: {
-            logoAsset: true,
-            coverAsset: true,
-            products: {
-              include: {
-                imageAsset: true,
-              },
-            },
-            serviceProviders: {
-              include: {
-                services: true,
-              },
-            },
-            jobListings: true,
-          },
-        },
-      },
-    },
-  } satisfies Prisma.UserInclude;
-
   private serializeDate(value: Date | string | null | undefined): string | null | undefined {
     if (value instanceof Date) {
       return value.toISOString();
@@ -48,7 +51,7 @@ export class UsersService {
   }
 
   private buildUserResponse(
-    user: Prisma.UserGetPayload<{ include: typeof this.userProfileInclude }>,
+    user: UserWithProfile | null,
     appUser: { id: string; clerkId: string; email: string | null; role: UserRole },
   ) {
     if (!user) {
@@ -348,7 +351,10 @@ export class UsersService {
     }
 
     try {
-      const result = await this.principal.getOrBootstrapAccountAndProfile(clerkId, this.userProfileInclude);
+      const result = await this.principal.getOrBootstrapAccountAndProfile<typeof userProfileInclude>(
+        clerkId,
+        userProfileInclude,
+      );
       return this.buildUserResponse(result.user, {
         id: result.appUser.id,
         clerkId: result.appUser.clerkId,


### PR DESCRIPTION
Fixes a TypeScript build error in `users.service.ts` by preserving the literal type of the `userProfileInclude` object.

The `userProfileInclude` object's type was widening to `Prisma.UserInclude`, causing `result.user` to lose its specific literal include typing. This resulted in a `TS2345` error when passing `result.user` to `buildUserResponse`. The fix uses `as const` and a dedicated type alias (`UserWithProfile`) to maintain strong typing throughout the user retrieval and response building process.

---
<a href="https://cursor.com/background-agent?bcId=bc-329f9c7e-6433-4c2a-bfda-c2481883eee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-329f9c7e-6433-4c2a-bfda-c2481883eee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

