### PR TITLE
Fix user profile view in settings

### DIFF
--- a/frontend/components/profile/OrganizationPublicProfile.tsx
+++ b/frontend/components/profile/OrganizationPublicProfile.tsx
@@ -34,11 +34,12 @@ const OrganizationPublicProfile: React.FC<OrganizationPublicProfileProps> = ({ u
   }
 
   const role = user.role;
+  const organizationName = organization.name || user.orgName || 'Organization';
   const coverImageUrl =
-    organization.coverImageUrl ?? `https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1600&q=80`;
+    organization.coverImageUrl ?? user.orgCoverImageUrl ?? `https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1600&q=80`;
   const logoUrl =
-    organization.logoUrl ??
-    `https://ui-avatars.com/api/?name=${encodeURIComponent(organization.name)}&background=2DD4BF&color=ffffff&size=128&rounded=true`;
+    organization.logoUrl ?? user.orgLogoUrl ??
+    `https://ui-avatars.com/api/?name=${encodeURIComponent(organizationName)}&background=2DD4BF&color=ffffff&size=128&rounded=true`;
 
   const tagList = useMemo(() => {
     if (role === UserRole.SERVICE_PROVIDER) {
@@ -71,9 +72,9 @@ const OrganizationPublicProfile: React.FC<OrganizationPublicProfileProps> = ({ u
         </div>
         <div className="p-6 pt-28 sm:pt-6 sm:pl-36 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
           <div>
-            <h1 className="text-3xl font-bold text-swiss-charcoal">{organization.name}</h1>
+            <h1 className="text-3xl font-bold text-swiss-charcoal">{organization.name || user.orgName || t('profile:organization.unnamed', 'Unnamed Organization')}</h1>
             <p className="text-gray-500 capitalize">
-              {organization.type?.toString()?.replace(/_/g, ' ').toLowerCase()}
+              {organization.type?.toString()?.replace(/_/g, ' ').toLowerCase() || user.orgType?.toString()?.replace(/_/g, ' ').toLowerCase() || ''}
             </p>
             {!!tagList.length && (
               <div className="mt-3 flex flex-wrap gap-2">

--- a/frontend/pages/ProfilePage.tsx
+++ b/frontend/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -9,6 +9,7 @@ import {
   BuildingOfficeIcon,
 } from '@heroicons/react/24/outline';
 import { useAppContext } from '../contexts/AppContext';
+import { useAuthContext } from '../providers/AuthProvider';
 import { UserRole } from '../types';
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
@@ -16,8 +17,32 @@ import OrganizationPublicProfile from '../components/profile/OrganizationPublicP
 
 const ProfilePage: React.FC = () => {
   const { currentUser } = useAppContext();
+  const { refreshCurrentUser } = useAuthContext();
   const { t, i18n } = useTranslation(['profile', 'common']);
   const navigate = useNavigate();
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  // Refresh user data when the profile page loads to ensure we have the latest organization data
+  useEffect(() => {
+    const refreshUserData = async () => {
+      if (!currentUser) return;
+      
+      // Only refresh if user should have an organization profile but doesn't have primaryOrganization
+      const shouldHaveOrgProfile = [UserRole.FOUNDATION, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER].includes(currentUser.role);
+      if (shouldHaveOrgProfile && !currentUser.primaryOrganization) {
+        setIsRefreshing(true);
+        try {
+          await refreshCurrentUser();
+        } catch (error) {
+          console.error('Failed to refresh user data:', error);
+        } finally {
+          setIsRefreshing(false);
+        }
+      }
+    };
+
+    refreshUserData();
+  }, [currentUser?.id, refreshCurrentUser]);
 
   const locale = i18n.language || 'en';
 
@@ -62,9 +87,11 @@ const ProfilePage: React.FC = () => {
     return <div className="p-6 text-center text-gray-500">{t('common:loading', 'Loading...')}</div>;
   }
 
-  const showPublicOrganizationProfile =
-    !!currentUser.primaryOrganization &&
+  const shouldShowPublicOrganizationProfile =
     [UserRole.FOUNDATION, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER].includes(currentUser.role);
+  
+  const hasPrimaryOrganization = !!currentUser.primaryOrganization;
+  const showPublicOrganizationProfile = shouldShowPublicOrganizationProfile && hasPrimaryOrganization;
 
   const avatarUrl =
     currentUser.avatarUrl ||
@@ -84,15 +111,44 @@ const ProfilePage: React.FC = () => {
         </div>
       </div>
 
-        {showPublicOrganizationProfile && (
+        {shouldShowPublicOrganizationProfile && (
           <>
-            <Card className="p-6 bg-swiss-mint/5 border border-swiss-mint/40 text-sm text-swiss-charcoal">
-              {t(
-                'profile:publicViewNotice',
-                'This preview shows how your organization profile appears to other users on the platform.',
-              )}
-            </Card>
-            <OrganizationPublicProfile user={currentUser} />
+            {hasPrimaryOrganization ? (
+              <>
+                <Card className="p-6 bg-swiss-mint/5 border border-swiss-mint/40 text-sm text-swiss-charcoal">
+                  {t(
+                    'profile:publicViewNotice',
+                    'This preview shows how your organization profile appears to other users on the platform.',
+                  )}
+                </Card>
+                <OrganizationPublicProfile user={currentUser} />
+              </>
+            ) : (
+              <Card className="p-6 bg-yellow-50 border border-yellow-200 text-sm text-yellow-800">
+                <div className="flex items-start gap-3">
+                  <BuildingOfficeIcon className="w-5 h-5 text-yellow-600 mt-0.5 flex-shrink-0" />
+                  <div>
+                    <p className="font-medium mb-1">
+                      {t('profile:organization.setupRequired', 'Organization Profile Setup Required')}
+                    </p>
+                    <p className="text-yellow-700">
+                      {t(
+                        'profile:organization.setupMessage',
+                        'Your organization profile is not yet set up. Complete your organization information in Settings to see your public profile preview here.',
+                      )}
+                    </p>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => navigate('/settings')}
+                      className="mt-3"
+                    >
+                      {t('profile:actions.goToSettings', 'Go to Settings')}
+                    </Button>
+                  </div>
+                </div>
+              </Card>
+            )}
           </>
         )}
 


### PR DESCRIPTION
Ensure the 'View Profile' page always displays content, either the public organization profile or guidance for setup, and gracefully handles missing organization data.

The "View Profile" page was showing an empty screen for users whose `primaryOrganization` was not yet fully configured, despite their role indicating they should have an organization profile. This PR addresses this by introducing a fallback message with a link to settings, ensuring the personal profile card is always visible, and adding robust fallbacks for missing organization fields in the public profile component. A user data refresh is also added to ensure the most current information is displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-a677f515-377e-40c2-883c-d5f873e06b24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a677f515-377e-40c2-883c-d5f873e06b24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

