### PR TITLE
Check for company profile save in logs

### DIFF
--- a/api/src/settings/settings.controller.ts
+++ b/api/src/settings/settings.controller.ts
@@ -111,12 +111,13 @@ export class SettingsController {
         },
       });
 
-      const userOrg = await tx.userOrganization.findFirst({
+      let userOrg = await tx.userOrganization.findFirst({
         where: { userId: profileId },
         include: { organization: true },
       });
 
       if (userOrg?.organization) {
+        // Update existing organization
         await tx.organization.update({
           where: { id: userOrg.organizationId },
           data: {
@@ -127,6 +128,30 @@ export class SettingsController {
             languages: settings.languages,
             capacity: settings.capacity,
             pedagogy: settings.pedagogy,
+          },
+        });
+      } else {
+        // Create new organization if it doesn't exist
+        const newOrganization = await tx.organization.create({
+          data: {
+            name: settings.companyName,
+            type: 'FOUNDATION',
+            phoneNumber: settings.phoneNumber,
+            region: settings.address,
+            canton: settings.canton,
+            languages: settings.languages,
+            capacity: settings.capacity,
+            pedagogy: settings.pedagogy,
+            isActive: true,
+          },
+        });
+
+        // Link user to the new organization
+        await tx.userOrganization.create({
+          data: {
+            userId: profileId,
+            organizationId: newOrganization.id,
+            role: UserRole.FOUNDATION,
           },
         });
       }
@@ -273,12 +298,13 @@ export class SettingsController {
         },
       });
 
-      const userOrg = await tx.userOrganization.findFirst({
+      let userOrg = await tx.userOrganization.findFirst({
         where: { userId: profileId },
         include: { organization: true },
       });
 
       if (userOrg?.organization) {
+        // Update existing organization
         await tx.organization.update({
           where: { id: userOrg.organizationId },
           data: {
@@ -291,6 +317,32 @@ export class SettingsController {
             minimumOrderQuantity: settings.minimumOrderQuantity,
             directOrderLink: settings.directOrderLink,
             catalogUrl: settings.catalogUrl,
+          },
+        });
+      } else {
+        // Create new organization if it doesn't exist
+        const newOrganization = await tx.organization.create({
+          data: {
+            name: settings.companyName,
+            type: 'PRODUCT_SUPPLIER',
+            phoneNumber: settings.phoneNumber,
+            region: settings.address,
+            canton: settings.canton,
+            productCategory: settings.productCategory,
+            serviceType: settings.serviceType,
+            minimumOrderQuantity: settings.minimumOrderQuantity,
+            directOrderLink: settings.directOrderLink,
+            catalogUrl: settings.catalogUrl,
+            isActive: true,
+          },
+        });
+
+        // Link user to the new organization
+        await tx.userOrganization.create({
+          data: {
+            userId: profileId,
+            organizationId: newOrganization.id,
+            role: UserRole.PRODUCT_SUPPLIER,
           },
         });
       }
@@ -368,12 +420,13 @@ export class SettingsController {
         },
       });
 
-      const userOrg = await tx.userOrganization.findFirst({
+      let userOrg = await tx.userOrganization.findFirst({
         where: { userId: profileId },
         include: { organization: true },
       });
 
       if (userOrg?.organization) {
+        // Update existing organization
         await tx.organization.update({
           where: { id: userOrg.organizationId },
           data: {
@@ -384,6 +437,30 @@ export class SettingsController {
             serviceCategories: settings.serviceCategories,
             deliveryType: settings.deliveryType,
             bookingLink: settings.bookingLink,
+          },
+        });
+      } else {
+        // Create new organization if it doesn't exist
+        const newOrganization = await tx.organization.create({
+          data: {
+            name: settings.companyName,
+            type: 'SERVICE_PROVIDER',
+            phoneNumber: settings.phoneNumber,
+            region: settings.address,
+            canton: settings.canton,
+            serviceCategories: settings.serviceCategories,
+            deliveryType: settings.deliveryType,
+            bookingLink: settings.bookingLink,
+            isActive: true,
+          },
+        });
+
+        // Link user to the new organization
+        await tx.userOrganization.create({
+          data: {
+            userId: profileId,
+            organizationId: newOrganization.id,
+            role: UserRole.SERVICE_PROVIDER,
           },
         });
       }


### PR DESCRIPTION
Create `Organization` and `UserOrganization` records if they don't exist when updating settings.

Previously, company profile data was not displayed because the settings controller would silently skip saving organization details if a `UserOrganization` record was missing for Foundation, Supplier, and Service Provider roles. This fix ensures an organization is created and linked if not present, allowing profile data to be saved and displayed correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7c67cff-be36-4a3a-a051-9bc27c058984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f7c67cff-be36-4a3a-a051-9bc27c058984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

