### PR TITLE
Investigate save settings CORS and server errors

### DIFF
--- a/api/src/auth/guards/clerk-auth.guard.ts
+++ b/api/src/auth/guards/clerk-auth.guard.ts
@@ -52,6 +52,13 @@ export class ClerkAuthGuard implements CanActivate {
   }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    
+    // Allow OPTIONS requests (CORS preflight) - they don't have auth headers
+    if (request.method === 'OPTIONS') {
+      return true;
+    }
+    
     // Check if route is public
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
       context.getHandler(),
@@ -62,7 +69,6 @@ export class ClerkAuthGuard implements CanActivate {
       return true;
     }
     
-    const request = context.switchToHttp().getRequest();
     const authHeader = request.headers['authorization'];
     
     if (!authHeader?.startsWith('Bearer ')) {

--- a/api/src/principal/ensure-profile.interceptor.ts
+++ b/api/src/principal/ensure-profile.interceptor.ts
@@ -17,6 +17,11 @@ export class EnsureProfileInterceptor implements NestInterceptor {
   async intercept(context: ExecutionContext, next: CallHandler): Promise<Observable<any>> {
     const req = context.switchToHttp().getRequest();
 
+    // Skip OPTIONS requests (CORS preflight) - they don't have auth headers
+    if (req.method === 'OPTIONS') {
+      return next.handle();
+    }
+
     const clerkUserId: string | undefined = req?.context?.clerkUserId ?? req?.context?.userId ?? req?.user?.clerkId;
 
     if (!clerkUserId) {


### PR DESCRIPTION
Skip authentication guards and interceptors for CORS preflight (OPTIONS) requests to resolve CORS policy errors.

CORS preflight (OPTIONS) requests were being blocked by `EnsureProfileInterceptor` and `ClerkAuthGuard` because they do not contain authentication headers. This prevented the CORS middleware from setting the necessary `Access-Control-Allow-Origin` header, leading to browser-side CORS policy errors and preventing subsequent PATCH requests from being sent.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9345fca-bb19-4539-9885-ff6a6efba1c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d9345fca-bb19-4539-9885-ff6a6efba1c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

