### PR TITLE
Debug product supplier settings page error

### DIFF
--- a/frontend/pages/SettingsPage.tsx
+++ b/frontend/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAppContext } from '../contexts/AppContext';
 import { useNotifications } from '../contexts/NotificationContext';
@@ -230,7 +230,9 @@ const SettingsPage: React.FC = () => {
     { id: 'analyticsPreferences', nameKey: 'common:settingsPage.analyticsPreferences', icon: ChartPieIcon, component: AnalyticsPreferencesSettings, roles: [UserRole.PRODUCT_SUPPLIER] },
   ];
 
-  const availableSections = sections.filter(section => currentUser && section.roles.includes(currentUser.role));
+  const availableSections = useMemo(() => {
+    return sections.filter(section => currentUser && section.roles.includes(currentUser.role));
+  }, [currentUser?.role]);
 
   useEffect(() => {
     if (availableSections.length > 0 && !activeSectionId) {
@@ -238,9 +240,9 @@ const SettingsPage: React.FC = () => {
     }
   }, [availableSections, activeSectionId]);
 
-  const handleFormChange = (field: keyof SettingsFormData, value: any) => {
+  const handleFormChange = useCallback((field: keyof SettingsFormData, value: any) => {
     setFormData(prev => (prev ? { ...prev, [field]: value } : null));
-  };
+  }, []);
 
   const handleSave = async () => {
     if (!formData || !currentUser) {
@@ -414,8 +416,11 @@ const SettingsPage: React.FC = () => {
 
   const userRole = currentUser.role;
 
-  const renderFoundationLayout = () => {
-    const tabsConfig = availableSections.map(section => ({
+  const tabsConfig = useMemo(() => {
+    if (userRole !== UserRole.FOUNDATION) {
+      return [];
+    }
+    return availableSections.map(section => ({
       label: t(section.nameKey),
       icon: section.icon,
       content: (
@@ -424,6 +429,9 @@ const SettingsPage: React.FC = () => {
         </div>
       ),
     }));
+  }, [availableSections, formData, userRole, t, handleFormChange]);
+
+  const renderFoundationLayout = () => {
     const activeTabIndex = availableSections.findIndex(section => section.id === activeSectionId);
 
     return (


### PR DESCRIPTION
Memoize `availableSections`, `tabsConfig`, and `handleFormChange` to prevent infinite re-renders on the product supplier settings page.

React error #310 (too many re-renders) occurred because `availableSections` and `tabsConfig` were recreated on every render, causing a `useEffect` to trigger repeatedly. Memoizing these values and `handleFormChange` stabilizes their references, resolving the re-render loop.

---
<a href="https://cursor.com/background-agent?bcId=bc-099085b2-d212-4680-8501-0bdc6a8af0ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-099085b2-d212-4680-8501-0bdc6a8af0ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

