### PR TITLE
Investigate vite build error in settings page

### DIFF
--- a/frontend/pages/SettingsPage.tsx
+++ b/frontend/pages/SettingsPage.tsx
@@ -132,6 +132,7 @@ const SettingsPage: React.FC = () => {
             deliveryType: data.deliveryType || org?.deliveryType || '',
             bookingLink: data.bookingLink || org?.bookingLink || '',
           } as Partial<SettingsFormData>;
+        }
 
         const [privacyResponse, notificationResponse] = await Promise.all([
           request<{ success: boolean; data?: any }>('/settings/privacy'),


### PR DESCRIPTION
Add missing closing brace to `SettingsPage.tsx` to fix a build failure caused by an orphaned `catch` block.

The `else if (currentUser.role === UserRole.SERVICE_PROVIDER)` block was missing its closing brace, which prematurely closed the `try` block. This left the subsequent `catch` block without a matching `try`, leading to a build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-731b26d2-ab6b-484c-b3ab-5c0cdc9292d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-731b26d2-ab6b-484c-b3ab-5c0cdc9292d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

