### PR TITLE
Investigate missing region column error

### DIFF
--- a/api/prisma/migrations/20251220000002_add_region_column_to_organizations/migration.sql
+++ b/api/prisma/migrations/20251220000002_add_region_column_to_organizations/migration.sql
@@ -1,0 +1,19 @@
+-- Add region column to organizations table if missing
+-- This fixes the P2022 error: "The column `region` does not exist in the current database"
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_schema = 'public' 
+        AND table_name = 'organizations' 
+        AND column_name = 'region'
+    ) THEN
+        ALTER TABLE "public"."organizations" ADD COLUMN "region" TEXT;
+        RAISE NOTICE '✅ Added region column to organizations table';
+    ELSE
+        RAISE NOTICE '⏭️  region column already exists in organizations table';
+    END IF;
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE NOTICE '⚠️  Error adding region column: %', SQLERRM;
+END $$;


### PR DESCRIPTION
Add `region` column to the `organizations` table to resolve `P2022` Prisma error due to a missing database column.

The `region` column was defined in the Prisma schema but was missing in the deployed database, leading to `PrismaClientKnownRequestError: P2022` when attempting to create or update an organization. This migration safely adds the missing column.

---
<a href="https://cursor.com/background-agent?bcId=bc-a825135b-0547-44e7-a732-0fe1d02a30a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a825135b-0547-44e7-a732-0fe1d02a30a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

