### PR TITLE
Correct category field capitalization

### DIFF
--- a/frontend/components/profile/OrganizationPublicProfile.tsx
+++ b/frontend/components/profile/OrganizationPublicProfile.tsx
@@ -414,7 +414,7 @@ const OrganizationPublicProfile: React.FC<OrganizationPublicProfileProps> = ({
                       <div className="flex-1 min-w-0">
                         <h3 className="font-semibold text-swiss-charcoal">{product.title}</h3>
                         {product.category && (
-                          <p className="text-xs uppercase tracking-wide text-gray-400 mt-1">{product.category}</p>
+                          <p className="text-xs tracking-wide text-gray-400 mt-1">{product.category}</p>
                         )}
                         {product.description && (
                           <p className="text-sm text-gray-600 mt-2 line-clamp-2">{product.description}</p>


### PR DESCRIPTION
Remove `uppercase` CSS class from category display to show text in normal casing.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1a89430-e269-4333-80c0-5a1e02b67cf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d1a89430-e269-4333-80c0-5a1e02b67cf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

