### PR TITLE
Fix uppercase service categories display

### DIFF
--- a/admin/src/pages/Services.tsx
+++ b/admin/src/pages/Services.tsx
@@ -20,6 +20,7 @@ import { useTranslation } from 'react-i18next'
 
 import EditServiceModal from '../components/services/EditServiceModal'
 import { Service } from '../types/api'
+import { formatServiceCategory } from '../utils/serviceFormatting'
 
 
 const Services: React.FC = () => {
@@ -140,7 +141,7 @@ const Services: React.FC = () => {
                   </div>
                   <div>
                     <h3 className="text-lg font-semibold text-gray-900">{service.title}</h3>
-                    <p className="text-sm text-gray-600">{service.category}</p>
+                    <p className="text-sm text-gray-600">{formatServiceCategory(t, service.category)}</p>
                   </div>
                 </div>
                 <div className="flex items-center space-x-4">

--- a/admin/src/utils/serviceFormatting.ts
+++ b/admin/src/utils/serviceFormatting.ts
@@ -1,0 +1,32 @@
+import { TFunction } from 'i18next';
+import { ServiceCategory, ServiceDeliveryType } from '../types';
+
+const humanize = (value: string) =>
+  value
+    .replace(/_/g, ' ')
+    .trim()
+    .toLowerCase()
+    .replace(/\b\w/g, char => char.toUpperCase());
+
+export const formatServiceCategory = (
+  t: TFunction,
+  category?: ServiceCategory | string | null,
+) => {
+  if (!category) {
+    return t('common:serviceCategories.OTHER', humanize('OTHER'));
+  }
+
+  const normalizedKey = String(category).toUpperCase();
+  return t(`common:serviceCategories.${normalizedKey}`, humanize(String(category)));
+};
+
+export const formatServiceDeliveryType = (
+  t: TFunction,
+  deliveryType?: ServiceDeliveryType | string | null,
+) => {
+  if (!deliveryType) {
+    return t('common:notAvailable', 'N/A');
+  }
+
+  return t(`common:serviceDeliveryTypes.${deliveryType}`, deliveryType);
+};

--- a/frontend/components/settings/sections/CompanyProfileSettings.tsx
+++ b/frontend/components/settings/sections/CompanyProfileSettings.tsx
@@ -18,6 +18,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../../../contexts/AppContext';
 import FileUploadZone from '../../ui/FileUploadZone';
+import { formatServiceCategory } from '../../../utils/serviceFormatting';
 
 interface CompanyProfileSettingsProps {
   settings: SettingsFormData;
@@ -489,7 +490,7 @@ const CompanyProfileSettings: React.FC<CompanyProfileSettingsProps> = ({ setting
                             : 'bg-white text-gray-700 border-gray-300 hover:border-swiss-teal'
                         }`}
                       >
-                        {option.replace(/_/g, ' ')}
+                        {formatServiceCategory(t, option)}
                       </button>
                     ))}
                   </div>


### PR DESCRIPTION
Format service categories to display as human-readable, translated text instead of raw uppercase enum values.

Previously, service categories in `CompanyProfileSettings.tsx` (frontend) and `Services.tsx` (admin panel) were displayed directly from their uppercase enum values (e.g., 'CLEANING'). This PR introduces a `formatServiceCategory` utility to correctly translate and humanize these values, ensuring proper display across the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-08f47375-041b-4ece-9940-feb841cf5eb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-08f47375-041b-4ece-9940-feb841cf5eb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

