### PR TITLE
Fix category text capitalization

### DIFF
--- a/admin/src/utils/serviceFormatting.ts
+++ b/admin/src/utils/serviceFormatting.ts
@@ -1,12 +1,18 @@
 import { TFunction } from 'i18next';
 import { ServiceCategory, ServiceDeliveryType } from '../types';
 
-const humanize = (value: string) =>
+export const humanize = (value: string) =>
   value
     .replace(/_/g, ' ')
     .trim()
     .toLowerCase()
     .replace(/\b\w/g, char => char.toUpperCase());
+
+// Format any category string to proper case (not uppercase)
+export const formatCategory = (category: string | null | undefined): string => {
+  if (!category) return '';
+  return humanize(String(category));
+};
 
 export const formatServiceCategory = (
   t: TFunction,

--- a/frontend/components/profile/OrganizationPublicProfile.tsx
+++ b/frontend/components/profile/OrganizationPublicProfile.tsx
@@ -16,7 +16,7 @@ import {
 import Card from '../ui/Card';
 import Button from '../ui/Button';
 import { User, UserRole, Product, Service, JobListing, Organization } from '../../types';
-import { formatServiceCategory, formatServiceDeliveryType } from '../../utils/serviceFormatting';
+import { formatServiceCategory, formatServiceDeliveryType, formatCategory } from '../../utils/serviceFormatting';
 
 type OrganizationPublicProfileProps = {
   user?: User;
@@ -316,7 +316,7 @@ const OrganizationPublicProfile: React.FC<OrganizationPublicProfileProps> = ({
                         {t('profile:organization.productCategory', { defaultValue: 'Product Category' })}
                       </p>
                       <p className="text-gray-700">
-                        {organization.productCategory || <span className="text-gray-400 italic text-xs">Not specified</span>}
+                        {organization.productCategory ? formatCategory(organization.productCategory) : <span className="text-gray-400 italic text-xs">Not specified</span>}
                       </p>
                     </div>
 
@@ -414,7 +414,7 @@ const OrganizationPublicProfile: React.FC<OrganizationPublicProfileProps> = ({
                       <div className="flex-1 min-w-0">
                         <h3 className="font-semibold text-swiss-charcoal">{product.title}</h3>
                         {product.category && (
-                          <p className="text-xs tracking-wide text-gray-400 mt-1">{product.category}</p>
+                          <p className="text-xs tracking-wide text-gray-400 mt-1">{formatCategory(product.category)}</p>
                         )}
                         {product.description && (
                           <p className="text-sm text-gray-600 mt-2 line-clamp-2">{product.description}</p>

--- a/frontend/pages/ELearningPage.tsx
+++ b/frontend/pages/ELearningPage.tsx
@@ -11,6 +11,7 @@ import { useAppContext } from '../contexts/AppContext';
 import { useTranslation } from 'react-i18next';
 import { useAuthenticatedApi } from '../hooks/useAuthenticatedApi';
 import DocumentPreviewModal from '../components/DocumentPreviewModal';
+import { formatCategory } from '../utils/serviceFormatting';
 
 interface CourseMaterialCardProps {
   item: Course;
@@ -242,7 +243,7 @@ const ELearningPage: React.FC = () => {
                         <option key={cat} value={cat}>
                           {cat === 'All'
                             ? t('eLearning.allCategoriesLabel', { defaultValue: 'All Categories' })
-                            : (ELEARNING_CATEGORY_LABELS[cat] || cat)}
+                            : (ELEARNING_CATEGORY_LABELS[cat] || formatCategory(cat))}
                         </option>
                       ))}
                   </select>

--- a/frontend/pages/HRProceduresPage.tsx
+++ b/frontend/pages/HRProceduresPage.tsx
@@ -178,7 +178,7 @@ const HRProceduresPage: React.FC = () => {
         return false;
       }
 
-      const categoryLabel = HR_CATEGORY_LABELS[doc.category] || doc.category;
+      const categoryLabel = HR_CATEGORY_LABELS[doc.category] || formatCategory(doc.category);
       const matchesSearch =
         doc.title.toLowerCase().includes(searchLower) ||
         doc.category.toLowerCase().includes(searchLower) ||

--- a/frontend/pages/HRProceduresPage.tsx
+++ b/frontend/pages/HRProceduresPage.tsx
@@ -12,6 +12,7 @@ import { useAppContext } from '../contexts/AppContext';
 import DocumentPreviewModal from '../components/DocumentPreviewModal';
 import { useTranslation } from 'react-i18next'; // Import useTranslation
 import { useAuthenticatedApi } from '../hooks/useAuthenticatedApi';
+import { formatCategory } from '../utils/serviceFormatting';
 
 interface HRDocumentCardProps {
   doc: HRDocument;
@@ -43,7 +44,7 @@ const HRDocumentCard: React.FC<HRDocumentCardProps> = ({ doc, onToggleFavorite, 
             <DocumentDuplicateIcon className={`w-10 h-10 ${fileTypeColors[doc.fileType] || 'text-gray-500'}`} />
             <div className="ml-3">
               <h3 className="text-lg font-semibold text-swiss-charcoal group-hover:text-swiss-mint transition-colors">{doc.title}</h3>
-              <p className="text-xs text-gray-500">{t('hrProcedures.documentCard.categoryLabel', { category: HR_CATEGORY_LABELS[doc.category as HRCategory] || doc.category })}</p>
+              <p className="text-xs text-gray-500">{t('hrProcedures.documentCard.categoryLabel', { category: HR_CATEGORY_LABELS[doc.category as HRCategory] || formatCategory(doc.category) })}</p>
               {doc.language && <p className="text-xs text-gray-500">{t('hrProcedures.documentCard.languageLabel', { language: doc.language })} {doc.version && t('hrProcedures.documentCard.versionLabel', { version: doc.version })}</p>}
             </div>
           </div>
@@ -278,7 +279,7 @@ const HRProceduresPage: React.FC = () => {
       )}
 
       <h2 className="text-2xl font-semibold text-swiss-charcoal mt-8 mb-4">
-        {selectedCategory ? t('hrProcedures.documentsInCategoryTitle', { category: HR_CATEGORY_LABELS[selectedCategory] || selectedCategory }) : t('hrProcedures.allDocumentsCategory')}
+        {selectedCategory ? t('hrProcedures.documentsInCategoryTitle', { category: HR_CATEGORY_LABELS[selectedCategory] || formatCategory(selectedCategory) }) : t('hrProcedures.allDocumentsCategory')}
         <span className="text-base font-normal text-gray-500 ml-2">{t('hrProcedures.allItemsCount', { count: filteredDocs.length })}</span>
       </h2>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -292,7 +293,7 @@ const HRProceduresPage: React.FC = () => {
           />
         ))}
       </div>
-      {filteredDocs.length === 0 && selectedCategory && <p className="text-center text-gray-500 py-8">{t('hrProcedures.noDocumentsInCategory', { category: HR_CATEGORY_LABELS[selectedCategory] || selectedCategory })}</p>}
+      {filteredDocs.length === 0 && selectedCategory && <p className="text-center text-gray-500 py-8">{t('hrProcedures.noDocumentsInCategory', { category: HR_CATEGORY_LABELS[selectedCategory] || formatCategory(selectedCategory) })}</p>}
       {filteredDocs.length === 0 && !selectedCategory && totalPublishedDocs > 0 && <p className="text-center text-gray-500 py-8">{t('hrProcedures.noDocumentsMatchSearch')}</p>}
 
       {previewDoc && (

--- a/frontend/pages/StatePoliciesPage.tsx
+++ b/frontend/pages/StatePoliciesPage.tsx
@@ -10,7 +10,8 @@ import { useAppContext } from '../contexts/AppContext';
 import PolicyAlertModal from '../components/admin/PolicyAlertModal';
 import DocumentPreviewModal from '../components/DocumentPreviewModal';
 import { useTranslation } from 'react-i18next';
-import { useAuthenticatedApi } from '../hooks/useAuthenticatedApi'; 
+import { useAuthenticatedApi } from '../hooks/useAuthenticatedApi';
+import { formatCategory } from '../utils/serviceFormatting'; 
 
 interface PolicyDocumentCardProps {
   doc: PolicyDocument;
@@ -46,7 +47,7 @@ const PolicyDocumentCard: React.FC<PolicyDocumentCardProps> = ({ doc, onPreview,
             </div>
         )}
         <h3 className="text-lg font-semibold text-swiss-charcoal mb-1">{doc.title}</h3>
-        <p className="text-xs text-gray-500 mb-2">Category: {POLICY_CATEGORY_LABELS[doc.category] || doc.category} {doc.region && `(${doc.region})`} {doc.country && `- ${doc.country}`}</p>
+        <p className="text-xs text-gray-500 mb-2">Category: {POLICY_CATEGORY_LABELS[doc.category] || formatCategory(doc.category)} {doc.region && `(${doc.region})`} {doc.country && `- ${doc.country}`}</p>
         {doc.status && (
           <span className={`text-xs font-medium px-2 py-0.5 rounded-full inline-flex items-center ${statusColors[doc.status] || 'bg-gray-100 text-gray-700'}`}>
             {statusIcons[doc.status] || <InformationCircleIcon className="w-4 h-4 inline mr-1" />} {doc.status}

--- a/frontend/pages/partner/PartnerDetailPage.tsx
+++ b/frontend/pages/partner/PartnerDetailPage.tsx
@@ -15,7 +15,7 @@ import { ArrowLeftIcon, BuildingStorefrontIcon, CogIcon, ShoppingCartIcon, TagIc
 import { useTranslation } from 'react-i18next';
 import { useMessaging } from '../../contexts/MessagingContext';
 import ActiveClientToggle from '../../components/shared/ActiveClientToggle';
-import { formatServiceCategory, formatServiceDeliveryType } from '../../utils/serviceFormatting';
+import { formatServiceCategory, formatServiceDeliveryType, formatCategory } from '../../utils/serviceFormatting';
 
 
 interface ProductItemProps {
@@ -52,7 +52,7 @@ const ProductItemCard: React.FC<ProductItemProps> = ({ product, partner, isFound
       <img src={product.imageUrl || `https://picsum.photos/seed/${product.id}/100/100`} alt={product.title} className="w-full sm:w-24 h-24 object-cover rounded-md flex-shrink-0" />
       <div className="flex-grow">
         <h3 className="text-md font-semibold text-swiss-charcoal group-hover:text-swiss-mint">{product.title}</h3>
-        <p className="text-xs text-gray-500">{product.category}</p>
+        <p className="text-xs text-gray-500">{formatCategory(product.category)}</p>
         <p className="text-sm text-gray-600 mt-1 line-clamp-2">{product.description}</p>
         <div className="flex items-center space-x-3 mt-1.5">
           {product.price && <p className="text-md font-semibold text-swiss-teal">CHF {product.price.toFixed(2)}</p>}

--- a/frontend/pages/supplier/SupplierProductListingsPage.tsx
+++ b/frontend/pages/supplier/SupplierProductListingsPage.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../../contexts/AppContext';
 import { Product, StockStatus } from '../../types';
 import { MOCK_PRODUCTS, ICON_INPUT_FIELD } from '../../constants';
+import { formatCategory } from '../../utils/serviceFormatting';
 
 const SupplierProductListingsPage: React.FC = () => {
   const { t } = useTranslation(['dashboard', 'common']);
@@ -88,7 +89,7 @@ const SupplierProductListingsPage: React.FC = () => {
                       </div>
                       <div className="ml-4">
                         <div className="text-sm font-medium text-gray-900">{product.title}</div>
-                        <div className="text-sm text-gray-500">{product.category}</div>
+                        <div className="text-sm text-gray-500">{formatCategory(product.category)}</div>
                       </div>
                     </div>
                   </td>

--- a/frontend/utils/serviceFormatting.ts
+++ b/frontend/utils/serviceFormatting.ts
@@ -1,12 +1,18 @@
 import { TFunction } from 'i18next';
 import { ServiceCategory, ServiceDeliveryType } from '../types';
 
-const humanize = (value: string) =>
+export const humanize = (value: string) =>
   value
     .replace(/_/g, ' ')
     .trim()
     .toLowerCase()
     .replace(/\b\w/g, char => char.toUpperCase());
+
+// Format any category string to proper case (not uppercase)
+export const formatCategory = (category: string | null | undefined): string => {
+  if (!category) return '';
+  return humanize(String(category));
+};
 
 export const formatServiceCategory = (
   t: TFunction,


### PR DESCRIPTION
Add a `formatCategory` helper and apply it to all category displays to ensure text is shown in proper case instead of uppercase.

---
<a href="https://cursor.com/background-agent?bcId=bc-64b94a82-df06-4471-964b-48ede5ed6155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-64b94a82-df06-4471-964b-48ede5ed6155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

