### PR TITLE
Fix top bar on edit profile page

### DIFF
--- a/frontend/pages/ProfileEditPage.tsx
+++ b/frontend/pages/ProfileEditPage.tsx
@@ -296,50 +296,50 @@ const ProfileEditPage: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <div className="bg-white border-b border-gray-200 sticky top-0 z-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-16">
-            <div className="flex items-center space-x-4">
-              <Button
-                variant="light"
-                leftIcon={ArrowLeftIcon}
-                onClick={() => navigate('/settings')}
-              >
-                {t('common:buttons.back', 'Back')}
-              </Button>
-              <h1 className="text-xl font-semibold text-gray-900">
-                {t('common:settingsPage.profile', 'Edit Profile')}
-              </h1>
-            </div>
-            <div className="flex items-center space-x-3">
-              {saveSuccess && (
-                <div className="flex items-center space-x-2 text-green-600">
-                  <CheckCircleIcon className="w-5 h-5" />
-                  <span className="text-sm font-medium">{t('common:buttons.profileUpdated', 'Profile updated!')}</span>
-                </div>
-              )}
-              <Button
-                variant="primary"
-                onClick={handleSave}
-                disabled={isSaving}
-                className="bg-swiss-mint hover:bg-opacity-90"
-              >
-                {isSaving
-                  ? `${t('common:buttons.saving', 'Saving')}...`
-                  : t('common:buttons.saveChanges', 'Save Changes')}
-              </Button>
+        {/* Header */}
+        <div className="bg-white border-b border-gray-200">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex items-center justify-between h-16">
+              <div className="flex items-center space-x-4">
+                <Button
+                  variant="light"
+                  leftIcon={ArrowLeftIcon}
+                  onClick={() => navigate('/settings')}
+                >
+                  {t('common:buttons.back', 'Back')}
+                </Button>
+                <h1 className="text-xl font-semibold text-gray-900">
+                  {t('common:settingsPage.profile', 'Edit Profile')}
+                </h1>
+              </div>
+              <div className="flex items-center space-x-3">
+                {saveSuccess && (
+                  <div className="flex items-center space-x-2 text-green-600">
+                    <CheckCircleIcon className="w-5 h-5" />
+                    <span className="text-sm font-medium">{t('common:buttons.profileUpdated', 'Profile updated!')}</span>
+                  </div>
+                )}
+                <Button
+                  variant="primary"
+                  onClick={handleSave}
+                  disabled={isSaving}
+                  className="bg-swiss-mint hover:bg-opacity-90"
+                >
+                  {isSaving
+                    ? `${t('common:buttons.saving', 'Saving')}...`
+                    : t('common:buttons.saveChanges', 'Save Changes')}
+                </Button>
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      {/* Profile Form Content */}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {renderProfileForm()}
+        {/* Profile Form Content */}
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          {renderProfileForm()}
+        </div>
       </div>
-    </div>
-  );
+    );
 };
 
 export default ProfileEditPage;


### PR DESCRIPTION
Remove sticky positioning from the edit profile page header so it scrolls with the content.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce76f4f7-f07b-48c3-b1b1-2cc7785ef8d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ce76f4f7-f07b-48c3-b1b1-2cc7785ef8d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes sticky positioning from the edit profile header so it scrolls with the page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a5c079130d98b00f552224ca2b7cd463a341a34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->