### PR TITLE
Investigate backend build typescript errors

### DIFF
--- a/api/src/principal/principal.service.ts
+++ b/api/src/principal/principal.service.ts
@@ -131,7 +131,7 @@ export class PrincipalService {
     userId: string,
     data: { hidePubliclyToggle?: boolean; gdprDataDeletionRequestMade?: boolean },
   ) {
-    return this.prisma.userNotificationPreferences.upsert({
+    const prefs = await this.prisma.userNotificationPreferences.upsert({
       where: { userId },
       update: {
         contentModeration: data.hidePubliclyToggle,
@@ -141,8 +141,13 @@ export class PrincipalService {
         userId,
         contentModeration: data.hidePubliclyToggle ?? false,
         systemAdmin: data.gdprDataDeletionRequestMade ?? false,
-      },
-    });
+        },
+      });
+
+    return {
+      hidePubliclyToggle: prefs.contentModeration ?? false,
+      gdprDataDeletionRequestMade: prefs.systemAdmin ?? false,
+    };
   }
 
   async getNotificationSettings(userId: string) {

--- a/api/src/settings/settings.controller.ts
+++ b/api/src/settings/settings.controller.ts
@@ -831,13 +831,9 @@ export class SettingsController {
   async getPrivacySettings(@Request() req) {
     const { profileId } = this.getContext(req);
     const prefs = await this.principal.getPrivacyPrefs(profileId);
-    // Map to consistent front-end shape
     return {
       success: true,
-      data: {
-        hidePubliclyToggle: prefs.contentModeration,
-        gdprDataDeletionRequestMade: prefs.systemAdmin,
-      },
+      data: prefs,
     };
   }
 
@@ -847,14 +843,10 @@ export class SettingsController {
   async updatePrivacySettings(@Request() req, @Body() payload: UpdatePrivacySettingsDto) {
     const { profileId } = this.getContext(req);
     const updated = await this.principal.updatePrivacyPrefs(profileId, payload);
-    // Return consistent front-end shape
     return {
       success: true,
       message: 'Privacy settings updated successfully',
-      data: {
-        hidePubliclyToggle: updated.contentModeration,
-        gdprDataDeletionRequestMade: updated.systemAdmin,
-      },
+      data: updated,
     };
   }
 


### PR DESCRIPTION
Fixes TypeScript build errors by ensuring privacy settings objects have a consistent shape across the controller and service.

The `settings.controller.ts` was attempting to access `contentModeration` and `systemAdmin` directly from the `prefs` object, which caused `TS2339` errors. The `principal.service.ts` now explicitly maps the database fields to the expected `hidePubliclyToggle` and `gdprDataDeletionRequestMade` properties, which the controller then uses directly.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a2f6234-1fb2-448b-9298-5953752866e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8a2f6234-1fb2-448b-9298-5953752866e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies privacy settings response to `{ hidePubliclyToggle, gdprDataDeletionRequestMade }` by mapping in `PrincipalService` and returning it directly from controller.
> 
> - **API (Privacy Settings)**
>   - `PrincipalService.updatePrivacyPrefs`: stores upsert result and returns normalized `{ hidePubliclyToggle, gdprDataDeletionRequestMade }`.
>   - `PrincipalService.getPrivacyPrefs`: returns normalized shape from DB fields.
>   - `SettingsController` (`GET/PATCH /settings/privacy`): returns `data` from service directly; removes manual field mapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a184f421bcee835c01b2c4ae8fef7412c8f61f56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->