### PR TITLE
Debug settings page i18n reference error

### DIFF
--- a/frontend/components/foundation/LeadCard.tsx
+++ b/frontend/components/foundation/LeadCard.tsx
@@ -16,7 +16,7 @@ interface LeadCardProps {
 }
 
 const LeadCard: React.FC<LeadCardProps> = ({ lead, foundationOrgId, onUpdateLead }) => {
-  const { t } = useTranslation(['dashboard', 'common']);
+  const { t, i18n } = useTranslation(['dashboard', 'common']);
   const [showResponseInput, setShowResponseInput] = useState(false);
   const [responseText, setResponseText] = useState('');
   const { currentUser } = useAppContext(); // Assuming foundation name comes from currentUser or org lookup

--- a/frontend/components/recruitment/ViewApplicantsModal.tsx
+++ b/frontend/components/recruitment/ViewApplicantsModal.tsx
@@ -23,7 +23,7 @@ const ViewApplicantsModal: React.FC<ViewApplicantsModalProps> = ({
   isLoading,
   error,
 }) => {
-  const { t } = useTranslation(['dashboard', 'common', 'recruitment']);
+  const { t, i18n } = useTranslation(['dashboard', 'common', 'recruitment']);
   const navigate = useNavigate();
   const { startOrGetConversation } = useMessaging();
 

--- a/frontend/components/service-provider/ServiceRequestDetailModal.tsx
+++ b/frontend/components/service-provider/ServiceRequestDetailModal.tsx
@@ -14,7 +14,7 @@ interface ServiceRequestDetailModalProps {
 }
 
 const ServiceRequestDetailModal: React.FC<ServiceRequestDetailModalProps> = ({ request, isOpen, onClose, onUpdateStatus }) => {
-  const { t } = useTranslation(['dashboard', 'common']);
+  const { t, i18n } = useTranslation(['dashboard', 'common']);
   const navigate = useNavigate();
 
   if (!isOpen || !request) return null;

--- a/frontend/components/settings/sections/AccountSecuritySettings.tsx
+++ b/frontend/components/settings/sections/AccountSecuritySettings.tsx
@@ -17,7 +17,7 @@ interface AccountSecuritySettingsProps {
 }
 
 const AccountSecuritySettings: React.FC<AccountSecuritySettingsProps> = ({ settings, onChange, userRole }) => {
-  const { t } = useTranslation(['dashboard', 'common']);
+  const { t, i18n } = useTranslation(['dashboard', 'common']);
   const { currentUser, updateCurrentUserInfo } = useAppContext();
   const { changePassword } = useAuthContext();
   const { addNotification } = useNotifications();

--- a/frontend/components/settings/sections/BillingSubscriptionSettings.tsx
+++ b/frontend/components/settings/sections/BillingSubscriptionSettings.tsx
@@ -16,7 +16,7 @@ interface BillingSubscriptionSettingsProps {
 }
 
 const PlanCard: React.FC<{ plan: PricingPlan, currentPlanName?: string, onSelectPlan: (planName: string) => void }> = ({ plan, currentPlanName, onSelectPlan }) => {
-    const { t } = useTranslation(['dashboard', 'common']);
+    const { t, i18n } = useTranslation(['dashboard', 'common']);
     const { translatePlan } = usePricingTranslations();
     const translatedPlan = translatePlan(plan);
     const isCurrentPlan = plan.name === currentPlanName;

--- a/frontend/components/settings/sections/PromoCodeManagerSettings.tsx
+++ b/frontend/components/settings/sections/PromoCodeManagerSettings.tsx
@@ -17,7 +17,7 @@ interface PromoCodeManagerSettingsProps {
 }
 
 const PromoCodeManagerSettings: React.FC<PromoCodeManagerSettingsProps> = ({ settings, onChange, userRole }) => {
-  const { t } = useTranslation(['dashboard', 'common']);
+  const { t, i18n } = useTranslation(['dashboard', 'common']);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingPromo, setEditingPromo] = useState<PromoCode | null>(null);
 

--- a/frontend/components/supplier/OrderRequestDetailModal.tsx
+++ b/frontend/components/supplier/OrderRequestDetailModal.tsx
@@ -14,7 +14,7 @@ interface OrderRequestDetailModalProps {
 }
 
 const OrderRequestDetailModal: React.FC<OrderRequestDetailModalProps> = ({ order, isOpen, onClose, onUpdateStatus }) => {
-  const { t } = useTranslation(['dashboard', 'common']);
+  const { t, i18n } = useTranslation(['dashboard', 'common']);
   const navigate = useNavigate();
 
   if (!isOpen || !order) return null;

--- a/frontend/pages/ELearningPage.tsx
+++ b/frontend/pages/ELearningPage.tsx
@@ -19,7 +19,7 @@ interface CourseMaterialCardProps {
 }
 
 const CourseMaterialCard: React.FC<CourseMaterialCardProps> = ({ item, onPreview }) => {
-  const { t } = useTranslation(['content', 'common']);
+  const { t, i18n } = useTranslation(['content', 'common']);
   const typeSpecifics = {
     [ELearningContentType.COURSE]: { icon: AcademicCapIcon, actionText: t('eLearning.actions.viewCourse'), actionIcon: EyeIcon, color: 'text-swiss-mint' },
     [ELearningContentType.VIDEO]: { icon: VideoCameraIcon, actionText: t('eLearning.actions.watchVideo'), actionIcon: PlayIcon, color: 'text-swiss-teal' },

--- a/frontend/pages/FileGalleryPage.tsx
+++ b/frontend/pages/FileGalleryPage.tsx
@@ -20,7 +20,7 @@ const formatBytes = (bytes: number, decimals = 2) => {
 };
 
 const FileCard: React.FC<{ file: DocumentItem; onPreview: (file: DocumentItem) => void; onDownload: (file: DocumentItem) => void }> = ({ file, onPreview, onDownload }) => {
-  const { t } = useTranslation(['dashboard', 'common']);
+  const { t, i18n } = useTranslation(['dashboard', 'common']);
   return (
     <Card className="p-4 flex flex-col group" hoverEffect>
       <div className="flex-grow">

--- a/frontend/pages/HRProceduresPage.tsx
+++ b/frontend/pages/HRProceduresPage.tsx
@@ -29,7 +29,7 @@ const normalizeHrCategory = (value: unknown): HRCategory => {
 };
 
 const HRDocumentCard: React.FC<HRDocumentCardProps> = ({ doc, onToggleFavorite, onPreview, onDownload }) => {
-  const { t } = useTranslation(['content', 'common']);
+  const { t, i18n } = useTranslation(['content', 'common']);
   const fileTypeColors = {
     PDF: 'text-red-500',
     DOCX: 'text-blue-500',

--- a/frontend/pages/ParentEnquiriesPage.tsx
+++ b/frontend/pages/ParentEnquiriesPage.tsx
@@ -12,7 +12,7 @@ import { useNavigate } from 'react-router-dom';
 import Button from '../components/ui/Button';
 
 const ParentEnquiriesPage: React.FC = () => {
-  const { t } = useTranslation(['dashboard', 'common']);
+  const { t, i18n } = useTranslation(['dashboard', 'common']);
   const { currentUser, leads } = useAppContext();
   const { startOrGetConversation } = useMessaging();
   const navigate = useNavigate();

--- a/frontend/pages/RecruitmentPage.tsx
+++ b/frontend/pages/RecruitmentPage.tsx
@@ -21,7 +21,7 @@ interface FoundationJobListingCardProps {
 }
 
 const FoundationJobListingCard: React.FC<FoundationJobListingCardProps> = ({ job, onEdit, onViewApplicants }) => {
-  const { t } = useTranslation(['recruitment', 'common']);
+  const { t, i18n } = useTranslation(['recruitment', 'common']);
 
   const statusMeta = useMemo(() => {
     switch (job.status) {

--- a/frontend/pages/StatePoliciesPage.tsx
+++ b/frontend/pages/StatePoliciesPage.tsx
@@ -94,7 +94,7 @@ const normalizePolicyType = (value: unknown): PolicyType | undefined => {
 };
 
 const StatePoliciesPage: React.FC = () => {
-  const { t } = useTranslation(['content', 'common', 'dashboard']);
+  const { t, i18n } = useTranslation(['content', 'common', 'dashboard']);
   const { currentUser } = useAppContext();
   const { authenticatedRequest, authenticatedUpload, authenticatedDownload } = useAuthenticatedApi();
   const [searchTerm, setSearchTerm] = useState('');

--- a/frontend/pages/UsersPage.tsx
+++ b/frontend/pages/UsersPage.tsx
@@ -17,7 +17,7 @@ interface UserRowProps {
 }
 
 const UserRow: React.FC<UserRowProps> = ({ user, onUserSelect, onDeleteUser, isSuperAdmin }) => {
-  const { t } = useTranslation(['users', 'common']);
+  const { t, i18n } = useTranslation(['users', 'common']);
   const { currentUser } = useAppContext();
   const statusColors = {
     Active: 'bg-green-100 text-green-700',

--- a/frontend/pages/admin/ContentManagementDashboardPage.tsx
+++ b/frontend/pages/admin/ContentManagementDashboardPage.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState, useMemo, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../../contexts/AppContext';
 // [FIX] Imported ELEARNING_CATEGORIES and HR_CATEGORIES for valid default values.
 import { UserRole, Course, HRDocument, PolicyDocument, UploadableContentType, ELEARNING_CATEGORIES, HR_CATEGORIES, ELearningContentType, ELearningCategory, HRCategory, PolicyCategory, POLICY_CATEGORIES } from '../../types';
@@ -34,6 +35,7 @@ const ContentManagementDashboardPage: React.FC = () => {
   const { currentUser } = useAppContext();
   const { authenticatedRequest } = useAuthenticatedApi();
   const navigate = useNavigate();
+  const { i18n } = useTranslation();
   
   // Fetch real data from API instead of mocks
   const [courses, setCourses] = useState<Course[]>([]);

--- a/frontend/pages/admin/DiscountTerminationsPage.tsx
+++ b/frontend/pages/admin/DiscountTerminationsPage.tsx
@@ -9,7 +9,7 @@ import Button from '../../components/ui/Button';
 import { TagIcon, CheckCircleIcon, ShieldExclamationIcon, InboxIcon } from '@heroicons/react/24/outline';
 
 const DiscountTerminationsPage: React.FC = () => {
-    const { t } = useTranslation(['admin', 'common']);
+    const { t, i18n } = useTranslation(['admin', 'common']);
     const { vendorClients, updateVendorClientStatus } = useAppContext();
 
     // Mock: In a real app, this would be based on actual organization status.

--- a/frontend/pages/educator/EducatorApplicationsPage.tsx
+++ b/frontend/pages/educator/EducatorApplicationsPage.tsx
@@ -7,7 +7,7 @@ import { useAppContext } from '../../contexts/AppContext';
 import { Application, ApplicationStatus } from '../../types';
 
 const EducatorApplicationsPage: React.FC = () => {
-  const { t } = useTranslation(['dashboard', 'common']);
+  const { t, i18n } = useTranslation(['dashboard', 'common']);
   const { applications } = useAppContext();
 
   const getStatusInfo = (status: ApplicationStatus) => {

--- a/frontend/pages/educator/EducatorJobBoardPage.tsx
+++ b/frontend/pages/educator/EducatorJobBoardPage.tsx
@@ -17,7 +17,7 @@ interface EducatorJobCardProps {
 }
 
 const EducatorJobCard: React.FC<EducatorJobCardProps> = ({ job, onViewDetails }) => {
-  const { t } = useTranslation(['dashboard', 'common', 'recruitment']);
+  const { t, i18n } = useTranslation(['dashboard', 'common', 'recruitment']);
 
   const contractTypeMeta = useMemo(() => {
     switch (job.contractType) {

--- a/frontend/pages/foundation/FoundationOrdersAppointmentsPage.tsx
+++ b/frontend/pages/foundation/FoundationOrdersAppointmentsPage.tsx
@@ -13,7 +13,7 @@ import { useMessaging } from '../../contexts/MessagingContext';
 import { useNavigate } from 'react-router-dom';
 
 const FoundationOrdersAppointmentsPage: React.FC = () => {
-  const { t } = useTranslation(['dashboard', 'common']);
+  const { t, i18n } = useTranslation(['dashboard', 'common']);
   const { currentUser, serviceRequests } = useAppContext();
   const [activeTabIndex, setActiveTabIndex] = useState(0);
   const { startOrGetConversation } = useMessaging();

--- a/frontend/pages/parent/ParentEnquiriesPage.tsx
+++ b/frontend/pages/parent/ParentEnquiriesPage.tsx
@@ -8,7 +8,7 @@ import { ClipboardDocumentListIcon, ClockIcon, CheckCircleIcon, InformationCircl
 import { useTranslation } from 'react-i18next';
 
 const ParentEnquiriesPage: React.FC = () => {
-  const { t } = useTranslation(['dashboard', 'common']);
+  const { t, i18n } = useTranslation(['dashboard', 'common']);
   const { currentUser, leads } = useAppContext();
 
   if (!currentUser || currentUser.role !== 'Parent') {

--- a/frontend/pages/service-provider/ServiceProviderRequestsPage.tsx
+++ b/frontend/pages/service-provider/ServiceProviderRequestsPage.tsx
@@ -9,7 +9,7 @@ import ServiceRequestDetailModal from '../../components/service-provider/Service
 import { InboxIcon } from '@heroicons/react/24/outline';
 
 const ServiceProviderRequestsPage: React.FC = () => {
-  const { t } = useTranslation(['dashboard', 'common']);
+  const { t, i18n } = useTranslation(['dashboard', 'common']);
   const { currentUser, serviceRequests: allRequests } = useAppContext();
   const [requests, setRequests] = useState(allRequests);
   const [statusFilter, setStatusFilter] = useState<ServiceRequestStatus | 'All'>('All');

--- a/frontend/pages/supplier/SupplierDashboardPage.tsx
+++ b/frontend/pages/supplier/SupplierDashboardPage.tsx
@@ -10,7 +10,7 @@ import { MOCK_ORDERS, MOCK_PRODUCTS, MOCK_ORGANIZATIONS } from '../../constants'
 import { OrderRequestStatus } from '../../types';
 
 const SupplierDashboardPage: React.FC = () => {
-  const { t } = useTranslation(['dashboard', 'common']);
+  const { t, i18n } = useTranslation(['dashboard', 'common']);
   const navigate = useNavigate();
   const { currentUser } = useAppContext();
 

--- a/frontend/pages/supplier/SupplierOrdersPage.tsx
+++ b/frontend/pages/supplier/SupplierOrdersPage.tsx
@@ -8,7 +8,7 @@ import Button from '../../components/ui/Button';
 import OrderRequestDetailModal from '../../components/supplier/OrderRequestDetailModal';
 
 const SupplierOrdersPage: React.FC = () => {
-  const { t } = useTranslation(['dashboard', 'common']);
+  const { t, i18n } = useTranslation(['dashboard', 'common']);
   const { currentUser } = useAppContext();
   const [orders, setOrders] = useState<Order[]>(MOCK_ORDERS);
   const [statusFilter, setStatusFilter] = useState<OrderRequestStatus | 'All'>('All');


### PR DESCRIPTION
Fixes `ReferenceError: i18n is not defined` by ensuring `i18n` is destructured from `useTranslation` in all affected components.

A recent commit (`cca53e1ad`) introduced `toLocaleDateString(i18n.language)` calls across various components. However, these components did not import or destructure the `i18n` instance, leading to runtime errors and preventing affected pages (like settings) from loading. This PR resolves the issue by explicitly making `i18n` available where `i18n.language` is used.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8598a9a-7671-4330-acd6-824c949d50ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b8598a9a-7671-4330-acd6-824c949d50ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `i18n` from `useTranslation` across affected components to enable `toLocaleDateString(i18n.language)` and prevent ReferenceError.
> 
> - **i18n/date formatting**:
>   - Destructure `i18n` from `useTranslation` in components/pages that call `toLocaleDateString(i18n.language)`, ensuring locale-aware dates and eliminating `ReferenceError`.
>   - Touchpoints include: settings (account, billing, promo codes), recruitment (views/modals/job cards), educator pages, supplier pages (dashboard/orders/detail modal), service provider pages/modals, foundation orders/appointments, parent enquiries (both routes), file gallery, e-learning, HR procedures, state policies, users, and admin content dashboard.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0286481c9f974834dcdc28d9f948ae7674e56fb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->