### PR TITLE
Investigate frontend build syntax error

### DIFF
--- a/frontend/pages/supplier/SupplierProductListingsPage.tsx
+++ b/frontend/pages/supplier/SupplierProductListingsPage.tsx
@@ -613,14 +613,13 @@ const SupplierProductListingsPage: React.FC = () => {
             </div>
           )}
         </Card>
-      </div>
-      <ProductUploadModal
-        isOpen={isModalOpen}
-        onClose={closeModal}
-        onSubmit={handleSubmitProduct}
-        initialProduct={editingProduct}
-        isSubmitting={isSubmitting}
-      />
+        <ProductUploadModal
+          isOpen={isModalOpen}
+          onClose={closeModal}
+          onSubmit={handleSubmitProduct}
+          initialProduct={editingProduct}
+          isSubmitting={isSubmitting}
+        />
     </div>
   );
 };


### PR DESCRIPTION
Remove an extraneous `</div>` tag to fix a JSX imbalance that caused a build failure.

The build error "Expected ')' but found 'isOpen'" was due to `ProductUploadModal` being rendered outside its intended parent `div`, creating an invalid JSX structure. Moving the modal inside the `Card`'s wrapper resolves this.

---
<a href="https://cursor.com/background-agent?bcId=bc-471de814-179d-4790-8d15-8d16fc898bfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-471de814-179d-4790-8d15-8d16fc898bfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

