### PR TITLE
Investigate backend render build failure

### DIFF
--- a/api/scripts/prebuild-db-setup.mjs
+++ b/api/scripts/prebuild-db-setup.mjs
@@ -61,22 +61,47 @@ const parseJsonOutput = (raw) => {
   return JSON.parse(trimmed.slice(jsonStart));
 };
 
+let cachedJsonStatusSupport;
+
+const prismaMigrateStatusSupportsJson = () => {
+  if (typeof cachedJsonStatusSupport === 'boolean') {
+    return cachedJsonStatusSupport;
+  }
+
+  try {
+    const helpOutput = runPrisma(
+      ['migrate', 'status', '--help'],
+      { silent: true },
+    );
+    cachedJsonStatusSupport = /\B--json\b/.test(helpOutput) || /--output(?:\s+|\=)json/.test(helpOutput);
+  } catch (error) {
+    cachedJsonStatusSupport = false;
+    warn(`⚠️  Unable to determine Prisma CLI JSON support: ${error.message}`);
+  }
+
+  return cachedJsonStatusSupport;
+};
+
 const getFailedMigrations = () => {
   try {
-    // First try JSON format
-    const raw = runPrisma(
-      ['migrate', 'status', '--schema', SCHEMA_PATH, '--json'],
-      { silent: true, allowFailure: true },
-    );
-    if (raw) {
-      try {
-        const parsed = parseJsonOutput(raw);
-        if (Array.isArray(parsed.failedMigrationNames) && parsed.failedMigrationNames.length > 0) {
-          log(`📋 Detected failed migrations via JSON: ${parsed.failedMigrationNames.join(', ')}`);
-          return parsed.failedMigrationNames;
+    const supportsJson = prismaMigrateStatusSupportsJson();
+
+    if (supportsJson) {
+      // First try JSON format if supported
+      const raw = runPrisma(
+        ['migrate', 'status', '--schema', SCHEMA_PATH, '--json'],
+        { silent: true, allowFailure: true },
+      );
+      if (raw) {
+        try {
+          const parsed = parseJsonOutput(raw);
+          if (Array.isArray(parsed.failedMigrationNames) && parsed.failedMigrationNames.length > 0) {
+            log(`📋 Detected failed migrations via JSON: ${parsed.failedMigrationNames.join(', ')}`);
+            return parsed.failedMigrationNames;
+          }
+        } catch (parseError) {
+          warn(`⚠️  Could not parse JSON status, trying text format...`);
         }
-      } catch (parseError) {
-        warn(`⚠️  Could not parse JSON status, trying text format...`);
       }
     }
     

--- a/api/src/marketplace/marketplace.service.ts
+++ b/api/src/marketplace/marketplace.service.ts
@@ -18,10 +18,38 @@ export class MarketplaceService {
 
   // Product Management
   async createProduct(createProductDto: CreateProductDto, supplierId: string) {
+    const {
+      imageAssetId,
+      deliveryFees,
+      volumePricing,
+      variants,
+      ...productData
+    } = createProductDto;
+    const toJsonValue = <T>(value: T | undefined) =>
+      value === undefined ? undefined : (value as unknown as Prisma.InputJsonValue);
+
     return this.prisma.product.create({
       data: {
-        ...createProductDto,
-        supplierId,
+        ...productData,
+        ...(toJsonValue(deliveryFees) !== undefined && {
+          deliveryFees: toJsonValue(deliveryFees),
+        }),
+        ...(toJsonValue(volumePricing) !== undefined && {
+          volumePricing: toJsonValue(volumePricing),
+        }),
+        ...(toJsonValue(variants) !== undefined && {
+          variants: toJsonValue(variants),
+        }),
+        supplier: {
+          connect: { id: supplierId },
+        },
+        ...(imageAssetId
+          ? {
+              imageAsset: {
+                connect: { id: imageAssetId },
+              },
+            }
+          : {}),
       },
       include: {
         supplier: true,


### PR DESCRIPTION
Fixes backend build failure by adapting Prisma migration status check for `--json` support and correctly mapping product creation DTO fields to Prisma relations and JSON types.

The build was failing due to two main issues:
1. The `prisma migrate status --json` command was not universally supported, leading to an "unknown option" error during pre-build cleanup. The script now checks for `--json` support via `--help` and falls back to text parsing if not available.
2. TypeScript errors (TS2322) occurred in `marketplace.service.ts` because `supplierId` and `imageAssetId` were not being connected as relations, and array/object fields like `deliveryFees`, `volumePricing`, and `variants` were not correctly cast to `Prisma.InputJsonValue` for JSON column storage.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8d61b94-a57b-431c-be21-a827c4a8001a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d8d61b94-a57b-431c-be21-a827c4a8001a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

