### PR TITLE
Investigate supplier login visibility

### DIFF
--- a/frontend/components/supplier/ProductUploadModal.tsx
+++ b/frontend/components/supplier/ProductUploadModal.tsx
@@ -402,12 +402,12 @@ const ProductUploadModal: React.FC<ProductUploadModalProps> = ({
     );
 
     return (
-      <div
-        className="fixed inset-0 z-[110] flex items-center justify-center bg-black/40 backdrop-blur-sm px-4 py-6"
+        <div
+          className="fixed inset-0 z-[110] flex items-center justify-center bg-black/40 backdrop-blur-sm px-4 py-6"
         onClick={onClose}
       >
         <div
-          className="w-full max-w-6xl bg-white rounded-2xl shadow-2xl flex flex-col max-h-[90vh]"
+            className="w-full max-w-6xl bg-white rounded-2xl shadow-2xl flex flex-col max-h-[90vh] min-h-0"
           onClick={(event) => event.stopPropagation()}
         >
           <div className="flex items-center justify-between border-b border-gray-100 px-6 py-4">
@@ -432,8 +432,8 @@ const ProductUploadModal: React.FC<ProductUploadModalProps> = ({
             </button>
           </div>
 
-          <form className="flex-1 flex flex-col" onSubmit={handleSubmit}>
-            <div className="flex-1 overflow-y-auto px-6 py-5 space-y-8">
+            <form className="flex-1 flex flex-col min-h-0" onSubmit={handleSubmit}>
+              <div className="flex-1 overflow-y-auto px-6 py-5 space-y-8">
               <Section
                 title={sectionLabel('basics', 'Product basics')}
                 description={helper(


### PR DESCRIPTION
Fix scrolling in the "Add Product" form by adding `min-h-0` to nested flex columns.

The modal body and form were nested flex columns without `min-height: 0`, which prevented the `overflow-y-auto` from taking effect within the `max-h-[90vh]` container. Adding `min-h-0` allows the inner content to properly overflow and become scrollable.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8f8f000-c2f0-419a-bc32-b979c8420be6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d8f8f000-c2f0-419a-bc32-b979c8420be6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

