### PR TITLE
Debug parent signup webhook errors

### DIFF
--- a/frontend/src/hooks/useWebhookStatus.ts
+++ b/frontend/src/hooks/useWebhookStatus.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useAuth } from '@clerk/clerk-react';
+import { apiService } from '@/services/api';
 
 interface WebhookStatus {
   exists: boolean;
@@ -25,21 +26,21 @@ export const useWebhookStatus = () => {
 
   const checkWebhookStatus = useCallback(async (): Promise<'pending' | 'processing' | 'ready' | 'error'> => {
     try {
-      const token = await getToken();
-      
-      if (!token) {
-        console.warn('[Signup Debug] webhook-status: missing auth token, session not yet active');
-        setStatus('processing');
-        return 'processing';
-      }
-      
-      // Note: No clerkId in URL - backend reads it from authenticated session
-      const response = await fetch('/api/users/webhook-status', {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-      });
+        const token = await getToken();
+
+        if (!token) {
+          console.warn('[Signup Debug] webhook-status: missing auth token, session not yet active');
+          setStatus('processing');
+          return 'processing';
+        }
+
+        // Note: No clerkId in URL - backend reads it from authenticated session
+        const response = await fetch(`${apiService.apiBaseUrl}/users/webhook-status`, {
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+        });
 
 
       if (!response.ok) {


### PR DESCRIPTION
Update webhook status polling to use the correct API base URL, resolving a JSON parsing error during parent signup verification.

The previous relative `fetch` call (`/api/users/webhook-status`) was hitting Vite's HTML fallback, causing a `SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON` when attempting to parse the HTML response as JSON. Explicitly using `apiService.apiBaseUrl` ensures the request targets the backend API.

---
<a href="https://cursor.com/background-agent?bcId=bc-915fde4e-71f9-4216-b4ed-debb151c5c2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-915fde4e-71f9-4216-b4ed-debb151c5c2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

