### PR TITLE
Analyze backend build failure during prisma migration

### DIFF
--- a/api/prisma/migrations/20251114140526_add_i18n_translation_tables/migration.sql
+++ b/api/prisma/migrations/20251114140526_add_i18n_translation_tables/migration.sql
@@ -1,15 +1,68 @@
--- CreateEnum
-CREATE TYPE "TranslationStatus" AS ENUM ('PENDING', 'MT_DONE', 'REVIEWED', 'APPROVED');
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_type WHERE typname = 'TranslationStatus'
+    ) THEN
+        CREATE TYPE "TranslationStatus" AS ENUM ('PENDING', 'MT_DONE', 'REVIEWED', 'APPROVED');
+    END IF;
+END
+$$;
+
+-- Ensure base table exists with the post-migration shape
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name = 'entity_translations'
+    ) THEN
+        CREATE TABLE "entity_translations" (
+            "entityType" TEXT NOT NULL,
+            "entityId" TEXT NOT NULL,
+            "lang" TEXT NOT NULL,
+            "field" TEXT NOT NULL,
+            "text" TEXT NOT NULL,
+            "origin" TEXT NOT NULL DEFAULT 'machine',
+            "verified" BOOLEAN NOT NULL DEFAULT false,
+            "sourceHash" TEXT NOT NULL,
+            "updatedAt" TIMESTAMP(3) NOT NULL,
+            "approvedAt" TIMESTAMP(3),
+            "approvedBy" TEXT,
+            "mtProvider" TEXT,
+            "reviewedAt" TIMESTAMP(3),
+            "reviewedBy" TEXT,
+            "status" "TranslationStatus" NOT NULL DEFAULT 'PENDING',
+            "translatedAt" TIMESTAMP(3),
+            CONSTRAINT "entity_translations_pkey" PRIMARY KEY ("entityType","entityId","lang","field")
+        );
+    END IF;
+END
+$$;
 
 -- AlterTable
-ALTER TABLE "entity_translations" ADD COLUMN     "approvedAt" TIMESTAMP(3),
-ADD COLUMN     "approvedBy" TEXT,
-ADD COLUMN     "mtProvider" TEXT,
-ADD COLUMN     "reviewedAt" TIMESTAMP(3),
-ADD COLUMN     "reviewedBy" TEXT,
-ADD COLUMN     "status" "TranslationStatus" NOT NULL DEFAULT 'PENDING',
-ADD COLUMN     "translatedAt" TIMESTAMP(3),
-ALTER COLUMN "updatedAt" DROP DEFAULT;
+ALTER TABLE "entity_translations" ADD COLUMN IF NOT EXISTS     "approvedAt" TIMESTAMP(3),
+ADD COLUMN IF NOT EXISTS     "approvedBy" TEXT,
+ADD COLUMN IF NOT EXISTS     "mtProvider" TEXT,
+ADD COLUMN IF NOT EXISTS     "reviewedAt" TIMESTAMP(3),
+ADD COLUMN IF NOT EXISTS     "reviewedBy" TEXT,
+ADD COLUMN IF NOT EXISTS     "status" "TranslationStatus" NOT NULL DEFAULT 'PENDING',
+ADD COLUMN IF NOT EXISTS     "translatedAt" TIMESTAMP(3);
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'entity_translations'
+          AND column_name = 'updatedAt'
+          AND column_default IS NOT NULL
+    ) THEN
+        ALTER TABLE "entity_translations" ALTER COLUMN "updatedAt" DROP DEFAULT;
+    END IF;
+END
+$$;
 
 -- CreateTable
 CREATE TABLE "static_translations" (
@@ -88,37 +141,26 @@ CREATE TABLE "mt_cost_tracking" (
 );
 
 -- CreateIndex
-CREATE INDEX "static_translations_namespace_lang_idx" ON "static_translations"("namespace", "lang");
+CREATE INDEX IF NOT EXISTS "static_translations_namespace_lang_idx" ON "static_translations"("namespace", "lang");
 
--- CreateIndex
-CREATE INDEX "static_translations_key_idx" ON "static_translations"("key");
+CREATE INDEX IF NOT EXISTS "static_translations_key_idx" ON "static_translations"("key");
 
--- CreateIndex
-CREATE INDEX "translation_memory_sourceLang_targetLang_idx" ON "translation_memory"("sourceLang", "targetLang");
+CREATE INDEX IF NOT EXISTS "translation_memory_sourceLang_targetLang_idx" ON "translation_memory"("sourceLang", "targetLang");
 
--- CreateIndex
-CREATE UNIQUE INDEX "translation_memory_sourceTextHash_sourceLang_targetLang_key" ON "translation_memory"("sourceTextHash", "sourceLang", "targetLang");
+CREATE UNIQUE INDEX IF NOT EXISTS "translation_memory_sourceTextHash_sourceLang_targetLang_key" ON "translation_memory"("sourceTextHash", "sourceLang", "targetLang");
 
--- CreateIndex
-CREATE UNIQUE INDEX "translation_releases_version_key" ON "translation_releases"("version");
+CREATE UNIQUE INDEX IF NOT EXISTS "translation_releases_version_key" ON "translation_releases"("version");
 
--- CreateIndex
-CREATE INDEX "translation_releases_isActive_createdAt_idx" ON "translation_releases"("isActive", "createdAt");
+CREATE INDEX IF NOT EXISTS "translation_releases_isActive_createdAt_idx" ON "translation_releases"("isActive", "createdAt");
 
--- CreateIndex
-CREATE INDEX "translation_audit_logs_type_createdAt_idx" ON "translation_audit_logs"("type", "createdAt");
+CREATE INDEX IF NOT EXISTS "translation_audit_logs_type_createdAt_idx" ON "translation_audit_logs"("type", "createdAt");
 
--- CreateIndex
-CREATE INDEX "translation_audit_logs_userId_createdAt_idx" ON "translation_audit_logs"("userId", "createdAt");
+CREATE INDEX IF NOT EXISTS "translation_audit_logs_userId_createdAt_idx" ON "translation_audit_logs"("userId", "createdAt");
 
--- CreateIndex
-CREATE INDEX "mt_cost_tracking_date_provider_idx" ON "mt_cost_tracking"("date", "provider");
+CREATE INDEX IF NOT EXISTS "mt_cost_tracking_date_provider_idx" ON "mt_cost_tracking"("date", "provider");
 
--- CreateIndex
-CREATE UNIQUE INDEX "mt_cost_tracking_date_provider_sourceLang_targetLang_key" ON "mt_cost_tracking"("date", "provider", "sourceLang", "targetLang");
+CREATE UNIQUE INDEX IF NOT EXISTS "mt_cost_tracking_date_provider_sourceLang_targetLang_key" ON "mt_cost_tracking"("date", "provider", "sourceLang", "targetLang");
 
--- CreateIndex
-CREATE INDEX "entity_translations_entityType_lang_idx" ON "entity_translations"("entityType", "lang");
+CREATE INDEX IF NOT EXISTS "entity_translations_entityType_lang_idx" ON "entity_translations"("entityType", "lang");
 
--- CreateIndex
-CREATE INDEX "entity_translations_status_updatedAt_idx" ON "entity_translations"("status", "updatedAt");
+CREATE INDEX IF NOT EXISTS "entity_translations_status_updatedAt_idx" ON "entity_translations"("status", "updatedAt");

--- a/api/scripts/prebuild-db-setup.mjs
+++ b/api/scripts/prebuild-db-setup.mjs
@@ -286,11 +286,91 @@ ALTER TABLE "products"
   );
 };
 
+const ensureTranslationInfrastructure = () => {
+  const sql = `
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_type WHERE typname = 'TranslationStatus'
+    ) THEN
+        CREATE TYPE "TranslationStatus" AS ENUM ('PENDING', 'MT_DONE', 'REVIEWED', 'APPROVED');
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name = 'entity_translations'
+    ) THEN
+        CREATE TABLE "entity_translations" (
+            "entityType" TEXT NOT NULL,
+            "entityId" TEXT NOT NULL,
+            "lang" TEXT NOT NULL,
+            "field" TEXT NOT NULL,
+            "text" TEXT NOT NULL,
+            "origin" TEXT NOT NULL DEFAULT 'machine',
+            "verified" BOOLEAN NOT NULL DEFAULT false,
+            "sourceHash" TEXT NOT NULL,
+            "updatedAt" TIMESTAMP(3) NOT NULL,
+            "approvedAt" TIMESTAMP(3),
+            "approvedBy" TEXT,
+            "mtProvider" TEXT,
+            "reviewedAt" TIMESTAMP(3),
+            "reviewedBy" TEXT,
+            "status" "TranslationStatus" NOT NULL DEFAULT 'PENDING',
+            "translatedAt" TIMESTAMP(3),
+            CONSTRAINT "entity_translations_pkey" PRIMARY KEY ("entityType","entityId","lang","field")
+        );
+    END IF;
+END
+$$;
+
+ALTER TABLE "entity_translations"
+    ADD COLUMN IF NOT EXISTS "approvedAt" TIMESTAMP(3),
+    ADD COLUMN IF NOT EXISTS "approvedBy" TEXT,
+    ADD COLUMN IF NOT EXISTS "mtProvider" TEXT,
+    ADD COLUMN IF NOT EXISTS "reviewedAt" TIMESTAMP(3),
+    ADD COLUMN IF NOT EXISTS "reviewedBy" TEXT,
+    ADD COLUMN IF NOT EXISTS "status" "TranslationStatus" NOT NULL DEFAULT 'PENDING',
+    ADD COLUMN IF NOT EXISTS "translatedAt" TIMESTAMP(3);
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'entity_translations'
+          AND column_name = 'updatedAt'
+          AND column_default IS NOT NULL
+    ) THEN
+        ALTER TABLE "entity_translations"
+        ALTER COLUMN "updatedAt" DROP DEFAULT;
+    END IF;
+END
+$$;
+`;
+
+  runPrisma(
+    ['db', 'execute', '--schema', SCHEMA_PATH, '--stdin'],
+    { silent: true, input: sql },
+  );
+};
+
 const handleFailedMigration = (migration) => {
   switch (migration) {
     case '20251104140358_add_asset_metadata_field':
       log(`   • Resolving ${migration} (metadata column)`);
       ensureMetadataColumn();
+      resolveMigration('applied', migration);
+      break;
+    case '20251114140526_add_i18n_translation_tables':
+      log(`   • Resolving ${migration} (translation infrastructure)`);
+      ensureTranslationInfrastructure();
       resolveMigration('applied', migration);
       break;
     case '20251119100000_add_categories_array_fields':
@@ -313,6 +393,9 @@ const handleFailedMigration = (migration) => {
 log('🔧 Running database pre-build cleanup...');
 log(`📍 Database URL: ${process.env.DATABASE_URL ? '[SET]' : '[NOT SET]'}`);
 log(`📍 Schema path: ${SCHEMA_PATH}`);
+
+log('🔁 Ensuring translation infrastructure is present...');
+ensureTranslationInfrastructure();
 
 const failedMigrations = getFailedMigrations();
 

--- a/api/scripts/render-build-with-recovery.sh
+++ b/api/scripts/render-build-with-recovery.sh
@@ -52,7 +52,10 @@ else
             
             # Verify columns exist in database
             echo "🔍 Verifying database schema..."
-            VERIFY_RESULT=$(npx prisma db execute --stdin <<'EOSQL' 2>&1) || true
+            VERIFY_TMP=$(mktemp)
+            if ! npx prisma db execute --stdin >"$VERIFY_TMP" 2>&1 <<'EOSQL'; then
+                :
+            fi
 SELECT 
     CASE 
         WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'products' AND column_name = 'categories') 
@@ -70,6 +73,8 @@ SELECT
         ELSE 'organizations.productCategories MISSING'
     END as orgs_check;
 EOSQL
+            VERIFY_RESULT=$(cat "$VERIFY_TMP")
+            rm -f "$VERIFY_TMP"
             
             echo "$VERIFY_RESULT"
             
@@ -86,10 +91,23 @@ EOSQL
             fi
         fi
     else
-        echo "❌ Migration deployment failed for unknown reason"
-        echo "📋 Migration status:"
-        npx prisma migrate status --schema prisma/schema.prisma || true
-        exit 1
+        echo "🩹 Attempting automatic repair by rerunning pre-build cleanup..."
+        if node ./scripts/prebuild-db-setup.mjs; then
+            echo "🔄 Retrying migration deployment after automatic repair..."
+            if npx prisma migrate deploy --schema prisma/schema.prisma; then
+                echo "✅ Migrations deployed successfully after automatic repair"
+            else
+                echo "❌ Migration deployment failed after automatic repair attempts"
+                echo "📋 Migration status:"
+                npx prisma migrate status --schema prisma/schema.prisma || true
+                exit 1
+            fi
+        else
+            echo "⚠️  Automatic repair script encountered an issue"
+            echo "📋 Migration status:"
+            npx prisma migrate status --schema prisma/schema.prisma || true
+            exit 1
+        fi
     fi
 fi
 


### PR DESCRIPTION
Make i18n translation migration idempotent and enhance build recovery script to prevent database migration failures.

The backend build was failing because a Prisma migration (`20251114140526_add_i18n_translation_tables`) attempted to `ALTER TABLE "entity_translations"` when the table did not exist in the production database, resulting in a `P3018 / 42P01` error. This PR makes the migration self-healing by conditionally creating the table and columns, proactively ensures the translation infrastructure in the prebuild script, and improves the build recovery script to handle unknown migration failures more robustly while also fixing a heredoc warning.

---
<a href="https://cursor.com/background-agent?bcId=bc-e39000d1-2d3e-42ff-80cc-416c51d7bd19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e39000d1-2d3e-42ff-80cc-416c51d7bd19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

