### PR TITLE
Fix failing build and migration scripts

### DIFF
--- a/api/scripts/fix-categories-migration.sh
+++ b/api/scripts/fix-categories-migration.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+API_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PRISMA_SCHEMA_PATH="$API_DIR/prisma/schema.prisma"
+
+cd "$API_DIR"
+
 echo "🔧 Fixing categories migration..."
 
 if [ -z "${DATABASE_URL:-}" ]; then
@@ -10,13 +16,13 @@ fi
 
 # First, try to mark the failed migration as rolled back
 echo "📋 Marking failed migration as rolled back..."
-npx prisma migrate resolve --rolled-back "20251119100000_add_categories_array_fields" || {
+npx prisma migrate resolve --schema "$PRISMA_SCHEMA_PATH" --rolled-back "20251119100000_add_categories_array_fields" || {
     echo "⚠️  Migration not found in failed state, continuing..."
 }
 
 # Execute the SQL to ensure columns exist
 echo "🔄 Ensuring category columns exist..."
-npx prisma db execute --stdin << 'EOF'
+npx prisma db execute --schema "$PRISMA_SCHEMA_PATH" --stdin << 'EOF'
 DO $$
 BEGIN
     -- Add categories column to products table
@@ -72,6 +78,6 @@ EOF
 
 # Mark the migration as applied
 echo "✅ Marking migration as applied..."
-npx prisma migrate resolve --applied "20251119100000_add_categories_array_fields"
+npx prisma migrate resolve --schema "$PRISMA_SCHEMA_PATH" --applied "20251119100000_add_categories_array_fields"
 
 echo "✅ Categories migration fixed successfully!"

--- a/api/scripts/prebuild-db-setup.mjs
+++ b/api/scripts/prebuild-db-setup.mjs
@@ -33,18 +33,23 @@ const runPrisma = (args, { silent = false, allowFailure = false, input } = {}) =
     throw result.error;
   }
 
+  const stdout = typeof result.stdout === 'string' ? result.stdout : '';
+  const stderr = typeof result.stderr === 'string' ? result.stderr : '';
+  const stdoutTrimmed = stdout.trim();
+  const stderrTrimmed = stderr.trim();
+  const combinedOutput = [stdoutTrimmed, stderrTrimmed].filter(Boolean).join('\n');
+
   if (result.status !== 0) {
-    const output = (result.stderr || result.stdout || '').trim();
     if (allowFailure) {
-      if (output) {
-        warn(output);
+      if (combinedOutput) {
+        warn(combinedOutput);
       }
-      return '';
+      return stdoutTrimmed || stderrTrimmed;
     }
-    throw new Error(`prisma ${args.join(' ')} failed${output ? `: ${output}` : ''}`);
+    throw new Error(`prisma ${args.join(' ')} failed${combinedOutput ? `: ${combinedOutput}` : ''}`);
   }
 
-  return (result.stdout || '').trim();
+  return stdoutTrimmed;
 };
 
 const parseJsonOutput = (raw) => {

--- a/api/scripts/render-build-with-recovery.sh
+++ b/api/scripts/render-build-with-recovery.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+API_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PRISMA_SCHEMA_PATH="$API_DIR/prisma/schema.prisma"
+
+cd "$API_DIR"
+
 CONTENT_CATEGORY_MIGRATION_ID="20251117145622_add_content_category_field"
 
 check_content_category_column() {
     local tmp result
     tmp=$(mktemp)
-    if ! npx prisma db execute --stdin >"$tmp" 2>&1 <<'EOSQL'
+    if ! npx prisma db execute --schema "$PRISMA_SCHEMA_PATH" --stdin >"$tmp" 2>&1 <<'EOSQL'
 SELECT 
     CASE 
         WHEN EXISTS (
@@ -47,7 +53,7 @@ node ./scripts/prebuild-db-setup.mjs || {
 }
 
 echo "🔄 Step 2: Deploying database migrations..."
-if npx prisma migrate deploy --schema prisma/schema.prisma; then
+if npx prisma migrate deploy --schema "$PRISMA_SCHEMA_PATH"; then
     echo "✅ Migrations deployed successfully"
 else
     MIGRATION_EXIT_CODE=$?
@@ -55,7 +61,7 @@ else
     
     # Get migration status
     echo "📋 Checking migration status..."
-    MIGRATION_STATUS=$(npx prisma migrate status --schema prisma/schema.prisma 2>&1) || true
+    MIGRATION_STATUS=$(npx prisma migrate status --schema "$PRISMA_SCHEMA_PATH" 2>&1) || true
     echo "$MIGRATION_STATUS"
     
     # Check if categories migration failed (multiple patterns)
@@ -71,7 +77,7 @@ else
         
         # Retry migration deployment after fix
         echo "🔄 Retrying migration deployment..."
-        if npx prisma migrate deploy --schema prisma/schema.prisma; then
+        if npx prisma migrate deploy --schema "$PRISMA_SCHEMA_PATH"; then
             echo "✅ Migrations deployed successfully after recovery"
         else
             echo "⚠️  Migration still showing issues, checking if columns exist..."
@@ -79,7 +85,7 @@ else
             # Verify columns exist in database
             echo "🔍 Verifying database schema..."
             VERIFY_TMP=$(mktemp)
-            if ! npx prisma db execute --stdin >"$VERIFY_TMP" 2>&1 <<'EOSQL'
+            if ! npx prisma db execute --schema "$PRISMA_SCHEMA_PATH" --stdin >"$VERIFY_TMP" 2>&1 <<'EOSQL'
 SELECT 
     CASE 
         WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'products' AND column_name = 'categories') 
@@ -108,12 +114,12 @@ EOSQL
             # If columns exist, mark migration as applied and continue
             if echo "$VERIFY_RESULT" | grep -q "EXISTS" && ! echo "$VERIFY_RESULT" | grep -q "MISSING"; then
                 echo "✅ Columns exist in database, marking migration as applied..."
-                npx prisma migrate resolve --applied "20251119100000_add_categories_array_fields" --schema prisma/schema.prisma || true
+                npx prisma migrate resolve --applied "20251119100000_add_categories_array_fields" --schema "$PRISMA_SCHEMA_PATH" || true
                 echo "✅ Build can continue - schema is correct"
             else
                 echo "❌ Columns are missing from database"
                 echo "📋 Final migration status:"
-                npx prisma migrate status --schema prisma/schema.prisma || true
+                npx prisma migrate status --schema "$PRISMA_SCHEMA_PATH" || true
                 exit 1
             fi
         fi
@@ -124,7 +130,7 @@ EOSQL
 
         if echo "$CONTENT_STATUS" | grep -q "MISSING"; then
             echo "🛠️  Column missing, applying manual schema patch..."
-            if npx prisma db execute --stdin <<'EOSQL'
+            if npx prisma db execute --schema "$PRISMA_SCHEMA_PATH" --stdin <<'EOSQL'
 ALTER TABLE "assets" ADD COLUMN IF NOT EXISTS "contentCategory" TEXT;
 CREATE INDEX IF NOT EXISTS "assets_contentCategory_idx" ON "assets"("contentCategory");
 EOSQL
@@ -138,7 +144,7 @@ EOSQL
         fi
 
         echo "🔄 Retrying migration deployment after content category fix..."
-        if npx prisma migrate deploy --schema prisma/schema.prisma; then
+        if npx prisma migrate deploy --schema "$PRISMA_SCHEMA_PATH"; then
             echo "✅ Migrations deployed successfully after content category fix"
         else
             echo "⚠️  Migration still failing, verifying schema state..."
@@ -147,12 +153,12 @@ EOSQL
 
             if echo "$CONTENT_STATUS" | grep -q "EXISTS" && ! echo "$CONTENT_STATUS" | grep -q "MISSING"; then
                 echo "✅ Column confirmed, marking migration as applied..."
-                npx prisma migrate resolve --applied "$CONTENT_CATEGORY_MIGRATION_ID" --schema prisma/schema.prisma || true
+                npx prisma migrate resolve --applied "$CONTENT_CATEGORY_MIGRATION_ID" --schema "$PRISMA_SCHEMA_PATH" || true
                 echo "✅ Build can continue - schema is correct"
             else
                 echo "❌ Content category column still missing after fix attempt"
                 echo "📋 Final migration status:"
-                npx prisma migrate status --schema prisma/schema.prisma || true
+                npx prisma migrate status --schema "$PRISMA_SCHEMA_PATH" || true
                 exit 1
             fi
         fi
@@ -160,18 +166,18 @@ EOSQL
         echo "🩹 Attempting automatic repair by rerunning pre-build cleanup..."
         if node ./scripts/prebuild-db-setup.mjs; then
             echo "🔄 Retrying migration deployment after automatic repair..."
-            if npx prisma migrate deploy --schema prisma/schema.prisma; then
+            if npx prisma migrate deploy --schema "$PRISMA_SCHEMA_PATH"; then
                 echo "✅ Migrations deployed successfully after automatic repair"
             else
                 echo "❌ Migration deployment failed after automatic repair attempts"
                 echo "📋 Migration status:"
-                npx prisma migrate status --schema prisma/schema.prisma || true
+                npx prisma migrate status --schema "$PRISMA_SCHEMA_PATH" || true
                 exit 1
             fi
         else
             echo "⚠️  Automatic repair script encountered an issue"
             echo "📋 Migration status:"
-            npx prisma migrate status --schema prisma/schema.prisma || true
+            npx prisma migrate status --schema "$PRISMA_SCHEMA_PATH" || true
             exit 1
         fi
     fi

--- a/api/scripts/start-with-migration.sh
+++ b/api/scripts/start-with-migration.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+API_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PRISMA_SCHEMA_PATH="$API_DIR/prisma/schema.prisma"
+
+cd "$API_DIR"
 
 echo "🚀 Starting API with database migration..."
 
@@ -15,7 +22,7 @@ max_attempts=30
 attempt=1
 
 while [ $attempt -le $max_attempts ]; do
-    if npx prisma db execute --stdin <<< "SELECT 1;" > /dev/null 2>&1; then
+    if npx prisma db execute --schema "$PRISMA_SCHEMA_PATH" --stdin <<< "SELECT 1;" > /dev/null 2>&1; then
         echo "✅ Database connection successful"
         break
     else
@@ -32,7 +39,7 @@ fi
 
 # Run database migrations
 echo "🔄 Running database migrations..."
-if npx prisma migrate deploy; then
+if npx prisma migrate deploy --schema "$PRISMA_SCHEMA_PATH"; then
     echo "✅ Database migrations completed successfully"
 else
     echo "❌ Database migration failed"

--- a/api/scripts/test-role-system.sh
+++ b/api/scripts/test-role-system.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
 # Comprehensive Role System Testing Script
-set -e
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+API_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCHEMA_PATH="$API_DIR/prisma/schema.prisma"
+
+cd "$API_DIR"
 
 echo "🧪 Role System Comprehensive Testing"
 echo "===================================="
@@ -38,7 +44,7 @@ run_test() {
 run_test "Environment Setup" "[ -f .env.test ] && echo 'Test environment configured'"
 
 # 2. Database Connection
-run_test "Database Connection" "npx prisma db execute --sql 'SELECT 1' > /dev/null 2>&1"
+run_test "Database Connection" "npx prisma db execute --schema $SCHEMA_PATH --sql 'SELECT 1' > /dev/null 2>&1"
 
 # 3. Schema Validation
 run_test "Schema Validation" "npx prisma validate"

--- a/render.yaml
+++ b/render.yaml
@@ -24,7 +24,7 @@ services:
     name: pc-solutions-api
     env: node
     plan: starter
-    buildCommand: cd api && pnpm install && pnpm run build
+    buildCommand: cd api && pnpm install && pnpm run build:render
     startCommand: cd api && pnpm run start:prod
     envVars:
       - key: NODE_ENV


### PR DESCRIPTION
Fixes Render backend build failures by making Prisma migration and recovery scripts robust and schema-aware.

The build was failing due to Prisma commands in helper scripts not consistently passing the `--schema` argument, leading to `Either --url or --schema must be provided` errors. Additionally, the `runPrisma` helper in `prebuild-db-setup.mjs` was not correctly capturing output on non-zero exits, preventing automatic migration recovery. This PR ensures all Prisma commands are schema-aware, `runPrisma` provides full output for recovery, and the Render build command now invokes the complete prebuild and recovery pipeline.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c4b11b4-9a07-443e-b83f-62cb201fbc5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7c4b11b4-9a07-443e-b83f-62cb201fbc5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

