### PR TITLE
Fix failed prisma migration deployment

### DIFF
--- a/api/scripts/prebuild-db-setup.mjs
+++ b/api/scripts/prebuild-db-setup.mjs
@@ -403,12 +403,24 @@ log('🔁 Ensuring translation infrastructure is present...');
 ensureTranslationInfrastructure();
 
 const failedMigrations = getFailedMigrations();
+const forcedMigrationsEnv = process.env.FORCE_RESOLVE_MIGRATIONS || '';
+const forcedMigrations = forcedMigrationsEnv
+  .split(',')
+  .map((migration) => migration.trim())
+  .filter(Boolean);
+const forcedOnly = forcedMigrations.filter((migration) => !failedMigrations.includes(migration));
+const migrationsToProcess = [...new Set([...failedMigrations, ...forcedMigrations])];
 
-if (failedMigrations.length === 0) {
+if (migrationsToProcess.length === 0) {
   log('✅ No failed migrations detected.');
 } else {
-  log(`❗ Detected ${failedMigrations.length} failed migration(s). Attempting automatic cleanup...`);
-  failedMigrations.forEach((migration) => {
+  if (failedMigrations.length > 0) {
+    log(`❗ Detected ${failedMigrations.length} failed migration(s). Attempting automatic cleanup...`);
+  }
+  if (forcedOnly.length > 0) {
+    log(`⚙️  Force-resolving migration(s): ${forcedOnly.join(', ')}`);
+  }
+  migrationsToProcess.forEach((migration) => {
     log(`   🔄 Processing: ${migration}`);
     handleFailedMigration(migration);
   });

--- a/api/scripts/render-build-with-recovery.sh
+++ b/api/scripts/render-build-with-recovery.sh
@@ -8,6 +8,8 @@ PRISMA_SCHEMA_PATH="$API_DIR/prisma/schema.prisma"
 cd "$API_DIR"
 
 CONTENT_CATEGORY_MIGRATION_ID="20251117145622_add_content_category_field"
+TRANSLATION_MIGRATION_ID="20251114140526_add_i18n_translation_tables"
+MIGRATION_LAST_OUTPUT=""
 
 check_content_category_column() {
     local tmp result
@@ -33,6 +35,20 @@ EOSQL
     echo "$result"
 }
 
+run_prisma_migrate_deploy() {
+    local output exit_code
+    if output=$(npx prisma migrate deploy --schema "$PRISMA_SCHEMA_PATH" 2>&1); then
+        MIGRATION_LAST_OUTPUT="$output"
+        printf '%s\n' "$output"
+        return 0
+    else
+        exit_code=$?
+        MIGRATION_LAST_OUTPUT="$output"
+        printf '%s\n' "$output"
+        return $exit_code
+    fi
+}
+
 echo "🚀 Starting Render build with migration recovery..."
 
 if [ -z "${DATABASE_URL:-}" ]; then
@@ -53,7 +69,7 @@ node ./scripts/prebuild-db-setup.mjs || {
 }
 
 echo "🔄 Step 2: Deploying database migrations..."
-if npx prisma migrate deploy --schema "$PRISMA_SCHEMA_PATH"; then
+if run_prisma_migrate_deploy; then
     echo "✅ Migrations deployed successfully"
 else
     MIGRATION_EXIT_CODE=$?
@@ -77,7 +93,7 @@ else
         
         # Retry migration deployment after fix
         echo "🔄 Retrying migration deployment..."
-        if npx prisma migrate deploy --schema "$PRISMA_SCHEMA_PATH"; then
+        if run_prisma_migrate_deploy; then
             echo "✅ Migrations deployed successfully after recovery"
         else
             echo "⚠️  Migration still showing issues, checking if columns exist..."
@@ -123,6 +139,24 @@ EOSQL
                 exit 1
             fi
         fi
+    elif echo "$MIGRATION_LAST_OUTPUT" | grep -q "$TRANSLATION_MIGRATION_ID" || echo "$MIGRATION_STATUS" | grep -q "$TRANSLATION_MIGRATION_ID"; then
+        echo "🔧 Detected failed translation infrastructure migration, attempting automatic fix..."
+        if FORCE_RESOLVE_MIGRATIONS="$TRANSLATION_MIGRATION_ID" node ./scripts/prebuild-db-setup.mjs; then
+            echo "🔄 Retrying migration deployment after translation fix..."
+            if run_prisma_migrate_deploy; then
+                echo "✅ Migrations deployed successfully after translation fix"
+            else
+                echo "❌ Translation migration still failing"
+                echo "📋 Final migration status:"
+                npx prisma migrate status --schema "$PRISMA_SCHEMA_PATH" || true
+                exit 1
+            fi
+        else
+            echo "⚠️  Translation recovery script encountered an issue"
+            echo "📋 Migration status:"
+            npx prisma migrate status --schema "$PRISMA_SCHEMA_PATH" || true
+            exit 1
+        fi
     elif echo "$MIGRATION_STATUS" | grep -q "$CONTENT_CATEGORY_MIGRATION_ID"; then
         echo "🔧 Detected pending content category migration, attempting automatic fix..."
         CONTENT_STATUS=$(check_content_category_column)
@@ -144,7 +178,7 @@ EOSQL
         fi
 
         echo "🔄 Retrying migration deployment after content category fix..."
-        if npx prisma migrate deploy --schema "$PRISMA_SCHEMA_PATH"; then
+        if run_prisma_migrate_deploy; then
             echo "✅ Migrations deployed successfully after content category fix"
         else
             echo "⚠️  Migration still failing, verifying schema state..."
@@ -166,7 +200,7 @@ EOSQL
         echo "🩹 Attempting automatic repair by rerunning pre-build cleanup..."
         if node ./scripts/prebuild-db-setup.mjs; then
             echo "🔄 Retrying migration deployment after automatic repair..."
-            if npx prisma migrate deploy --schema "$PRISMA_SCHEMA_PATH"; then
+            if run_prisma_migrate_deploy; then
                 echo "✅ Migrations deployed successfully after automatic repair"
             else
                 echo "❌ Migration deployment failed after automatic repair attempts"


### PR DESCRIPTION
Enhance Prisma migration recovery to automatically resolve the `add_i18n_translation_tables` migration failure, unblocking deployments.

Previous deployments failed due to a `P3009` error caused by a stuck `20251114140526_add_i18n_translation_tables` migration. The existing recovery script only addressed content-category migrations and didn't detect or resolve this specific failure, leading to repeated build failures. This PR introduces logic to parse `prisma migrate deploy` output for specific failed migrations and force-resolve them via `prebuild-db-setup.mjs`, ensuring subsequent migrations can proceed.

---
<a href="https://cursor.com/background-agent?bcId=bc-707af8e3-30eb-4b7e-ac5d-c2870ed6d7db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-707af8e3-30eb-4b7e-ac5d-c2870ed6d7db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

