### PR TITLE
Investigate pnpm lockfile build failure

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -106,7 +106,7 @@
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.1",
-    "@prisma/client": "^5.7.0",
+    "@prisma/client": "^6.17.1",
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@types/bcryptjs": "^2.4.2",


### PR DESCRIPTION
Update `@prisma/client` version in `api/package.json` to resolve `pnpm install --frozen-lockfile` build failure.

The build failed because `api/package.json` specified `@prisma/client` `^5.7.0`, while `pnpm-lock.yaml` and the `prisma` CLI (`^6.16.2`) indicated a dependency on `^6.17.1`. This update aligns the `package.json` with the lockfile, allowing the frozen installation to proceed.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ad83cc5-33ad-4131-9e59-70f2130c114b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7ad83cc5-33ad-4131-9e59-70f2130c114b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

