### PR TITLE
Fix google sso client id error

### DIFF
--- a/AUTHENTICATION_SETUP.md
+++ b/AUTHENTICATION_SETUP.md
@@ -345,6 +345,42 @@ To enable Google SSO for production or custom domains, follow these detailed ste
 
 > **Note**: It may take a few minutes for Google credentials to propagate. If you still see errors immediately after setup, wait 5 minutes and try again.
 
+### Step-by-Step: Configuring Facebook OAuth Credentials
+
+To enable Facebook SSO for production or custom domains, follow these detailed steps:
+
+#### 1. Create a Facebook App
+1. Go to [Facebook for Developers](https://developers.facebook.com/).
+2. Log in and click **My Apps** in the top right.
+3. Click **Create App**.
+4. Select **Authenticate and request data from users with Facebook Login** (or "Consumer" if using the older wizard) and click **Next**.
+5. Enter your **App Name** (e.g., "PC Solutions Platform") and **App Contact Email**.
+6. Click **Create app**.
+
+#### 2. Set Up Facebook Login
+1. In the App Dashboard, find **Facebook Login** under "Add products to your app" and click **Set Up**.
+2. Select **Web** as the platform.
+3. Enter your **Site URL** (e.g., `https://dash.procrechesolutions.com`) and click **Save**.
+4. In the left sidebar, under **Facebook Login**, click **Settings**.
+5. Find **Valid OAuth Redirect URIs**.
+6. Go to your Clerk Dashboard > Social Connections > Facebook.
+7. Copy the **Authorized redirect URI** value.
+8. Paste it into the **Valid OAuth Redirect URIs** field in Facebook.
+9. Click **Save Changes**.
+
+#### 3. Connect to Clerk
+1. In the Facebook App Dashboard sidebar, go to **App settings > Basic**.
+2. Copy the **App ID**.
+3. Paste it into the **Client ID** field in your Clerk Dashboard (Facebook settings).
+4. Click **Show** next to **App Secret**, copy it.
+5. Paste it into the **Client Secret** field in your Clerk Dashboard.
+6. Click **Save** in Clerk.
+
+#### 4. Go Live
+1. By default, your Facebook app is in "Development" mode (only you can log in).
+2. To allow public users, toggle the **App Mode** switch at the top of the dashboard to **Live**.
+3. You may need to provide a Privacy Policy URL and Terms of Service URL in **App settings > Basic** before switching to Live.
+
 ## Next Steps
 
 1. **User Profile Management**: Implement profile editing

--- a/AUTHENTICATION_SETUP.md
+++ b/AUTHENTICATION_SETUP.md
@@ -303,6 +303,47 @@ This error occurs when the Google Social Connection is enabled in Clerk but not 
    - Copy the **Client ID** and **Client Secret** from Google to your Clerk Dashboard.
 6. Save the changes in Clerk.
 
+### Step-by-Step: Configuring Google OAuth Credentials
+
+To enable Google SSO for production or custom domains, follow these detailed steps:
+
+#### 1. Create a Google Cloud Project
+1. Go to the [Google Cloud Console](https://console.cloud.google.com/).
+2. Click the project dropdown at the top and select **New Project**.
+3. Name your project (e.g., "PC Solutions Auth") and click **Create**.
+
+#### 2. Configure OAuth Consent Screen
+1. In the left sidebar, go to **APIs & Services > OAuth consent screen**.
+2. Select **External** (unless you only want users from your own Google Workspace organization).
+3. Click **Create**.
+4. Fill in the required fields:
+   - **App name**: Your app's name (e.g., "PC Solutions Platform").
+   - **User support email**: Your email address.
+   - **Developer contact information**: Your email address.
+5. Click **Save and Continue** through the Scopes and Test Users sections (defaults are usually fine for basic login).
+6. Return to the dashboard.
+
+#### 3. Create OAuth Client ID
+1. In the left sidebar, go to **APIs & Services > Credentials**.
+2. Click **+ CREATE CREDENTIALS** and select **OAuth client ID**.
+3. Select **Web application** as the Application type.
+4. Name it (e.g., "Clerk Production").
+5. Under **Authorized redirect URIs**:
+   - Go to your Clerk Dashboard > Social Connections > Google.
+   - Copy the **Authorized redirect URI** value (e.g., `https://clerk.your-domain.com/v1/oauth/callback`).
+   - Paste it into the Google Console's "Authorized redirect URIs" field.
+6. Click **Create**.
+
+#### 4. Connect to Clerk
+1. After creating the credentials, Google will show a modal with your **Client ID** and **Client Secret**.
+2. Copy the **Client ID**.
+3. Paste it into the **Client ID** field in your Clerk Dashboard (Google settings).
+4. Copy the **Client Secret**.
+5. Paste it into the **Client Secret** field in your Clerk Dashboard.
+6. Click **Save** in Clerk.
+
+> **Note**: It may take a few minutes for Google credentials to propagate. If you still see errors immediately after setup, wait 5 minutes and try again.
+
 ## Next Steps
 
 1. **User Profile Management**: Implement profile editing

--- a/AUTHENTICATION_SETUP.md
+++ b/AUTHENTICATION_SETUP.md
@@ -332,6 +332,7 @@ To enable Google SSO for production or custom domains, follow these detailed ste
    - Go to your Clerk Dashboard > Social Connections > Google.
    - Copy the **Authorized redirect URI** value (e.g., `https://clerk.your-domain.com/v1/oauth/callback`).
    - Paste it into the Google Console's "Authorized redirect URIs" field.
+   > **Note**: You generally do **not** need to add "Authorized JavaScript origins" when using Clerk with the redirect flow. The "Authorized redirect URI" is the critical setting.
 6. Click **Create**.
 
 #### 4. Connect to Clerk

--- a/AUTHENTICATION_SETUP.md
+++ b/AUTHENTICATION_SETUP.md
@@ -283,6 +283,26 @@ curl -H "Authorization: Bearer <admin_jwt_token>" \
 - Use Clerk dashboard to verify user data
 - Test JWT tokens with online tools
 
+### Google SSO Error: "Missing required parameter: client_id"
+
+If you encounter the error `Error 400: invalid_request Missing required parameter: client_id` when attempting to sign up or log in with Google:
+
+**Cause:**
+This error occurs when the Google Social Connection is enabled in Clerk but not properly configured with Google Cloud credentials. This is common when:
+1. You are running the application on a domain other than `localhost` (e.g., a cloud IDE url, `ngrok`, or production domain).
+2. You are using a Clerk Production instance but haven't configured Google OAuth credentials.
+3. You are using a Clerk Development instance with "Shared Credentials" on a non-localhost domain (Clerk's shared credentials only work on localhost).
+
+**Solution:**
+1. Go to your [Clerk Dashboard](https://dashboard.clerk.com).
+2. Navigate to **User & Authentication > Social Connections**.
+3. Click on the **Google** provider settings.
+4. Ensure **Use custom credentials** is enabled (required for production or non-localhost development).
+5. You must create a Project in [Google Cloud Console](https://console.cloud.google.com/), set up OAuth 2.0 credentials, and:
+   - Copy the **Authorized redirect URI** from Clerk to your Google OAuth Client configuration.
+   - Copy the **Client ID** and **Client Secret** from Google to your Clerk Dashboard.
+6. Save the changes in Clerk.
+
 ## Next Steps
 
 1. **User Profile Management**: Implement profile editing


### PR DESCRIPTION
Add a troubleshooting section to `AUTHENTICATION_SETUP.md` for the "Missing required parameter: client_id" error during Google SSO.

This error commonly occurs when the Google Social Connection in Clerk is not properly configured with Google Cloud credentials, especially when running the application on a domain other than `localhost`. The new section provides clear steps to resolve this configuration issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-4b61859a-7132-48e3-8a6f-a41814239838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4b61859a-7132-48e3-8a6f-a41814239838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

