### PR TITLE
Investigate login page module load error

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,23 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>ProCrèche Solutions Suisse</title>
-  <script async src="https://ga.jspm.io/npm:es-module-shims@1.10.0/dist/es-module-shims.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@300;400;500;600;700;800&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-<script type="importmap">
-{
-  "imports": {
-    "react": "https://esm.sh/react@^19.1.0",
-    "react-dom/": "https://esm.sh/react-dom@^19.1.0/",
-    "react-router-dom": "https://esm.sh/react-router-dom@^7.6.2",
-    "react-i18next": "https://esm.sh/react-i18next@^15.5.3",
-    "react/": "https://esm.sh/react@^19.1.0/",
-    "@heroicons/react/": "https://esm.sh/@heroicons/react@^2.2.0/",
-    "i18next": "https://esm.sh/i18next@^25.2.1",
-    "i18next-http-backend": "https://esm.sh/i18next-http-backend@^3.0.2",
-    "i18next-browser-languagedetector": "https://esm.sh/i18next-browser-languagedetector@^8.2.0"
-  }
-}
-</script>
 </head>
 <body>
   <div id="root"></div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,9 @@
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');


### PR DESCRIPTION
Fix login page loading by resolving Vite configuration issues and removing conflicting importmap.

The login page failed to load due to a MIME type error, where the browser received `index.html` instead of the expected JavaScript module. This was caused by `vite.config.ts` failing due to incorrect `__dirname` usage in an ES Module context, and a conflicting `importmap` in `index.html` interfering with Vite's bundling.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d53e04e-3994-4a04-b4ad-5a244c5dd380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2d53e04e-3994-4a04-b4ad-5a244c5dd380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

