### PR TITLE
Investigate login site loading issue

### DIFF
--- a/api/src/content/content.controller.ts
+++ b/api/src/content/content.controller.ts
@@ -207,7 +207,7 @@ export class ContentController {
    */
 
   @Get('state-policies')
-  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.EDUCATOR, UserRole.FOUNDATION, UserRole.PARENT, UserRole.PRODUCT_SUPPLIER)
   async getStatePolicies(
     @Query(new ValidationPipe({ transform: true, whitelist: true }))
     query: GetStatePoliciesQueryDto,


### PR DESCRIPTION
Allow additional user roles to access state policies endpoint to fix login site loading issues.

The login site was failing to load for non-admin users (e.g., `PARENT`) due to a 403 Forbidden error when attempting to fetch `/api/content/state-policies`. This endpoint was previously restricted to `ADMIN` and `SUPER_ADMIN` roles only. This change expands access to include `EDUCATOR`, `FOUNDATION`, `PARENT`, and `PRODUCT_SUPPLIER` roles, resolving the access denial.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f4fa4c2-45f4-4e73-bb28-e213e11c4587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f4fa4c2-45f4-4e73-bb28-e213e11c4587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

