### PR TITLE
Adjust logo sizes on login and navbar

### DIFF
--- a/admin/src/components/Sidebar.tsx
+++ b/admin/src/components/Sidebar.tsx
@@ -68,11 +68,11 @@ const Sidebar: React.FC<SidebarProps> = ({ sidebarOpen, setSidebarOpen }) => {
           <img
             src={getAdminLogo()}
             alt="Admin Logo"
-            className="h-11 w-11 object-contain mr-2.5"
+            className="h-[55px] w-[55px] object-contain mr-2.5"
           />
         ) : (
-          <div className="h-11 w-11 bg-swiss-mint mr-2.5 flex items-center justify-center rounded">
-            <Shield className="h-6 w-6 text-white" />
+          <div className="h-[55px] w-[55px] bg-swiss-mint mr-2.5 flex items-center justify-center rounded">
+            <Shield className="h-[30px] w-[30px] text-white" />
           </div>
         )}
         <h1 className="text-2xl font-bold text-swiss-charcoal">Admin</h1>

--- a/admin/src/components/auth/AdminCustomLoginFormNew.tsx
+++ b/admin/src/components/auth/AdminCustomLoginFormNew.tsx
@@ -175,15 +175,15 @@ export default function AdminCustomLoginForm() {
       <div className="min-h-screen bg-page-bg flex flex-col items-center justify-center p-4 sm:p-6 lg:p-8">
         <Card className="w-full max-w-md p-8 shadow-xl">
           <div className="text-center mb-8">
-            <div className="mx-auto h-20 w-20 bg-swiss-mint rounded-full flex items-center justify-center mb-6">
+            <div className="mx-auto h-[92px] w-[92px] bg-swiss-mint rounded-full flex items-center justify-center mb-6">
               {getAdminLogo(settings) ? (
                 <img 
                   src={getAdminLogo(settings)!} 
                   alt="Admin Logo" 
-                  className="h-10 w-10 object-contain"
+                  className="h-[46px] w-[46px] object-contain"
                 />
               ) : (
-                <SquaresPlusIcon className="h-10 w-10 text-white" />
+                <SquaresPlusIcon className="h-[46px] w-[46px] text-white" />
               )}
             </div>
           </div>
@@ -246,15 +246,15 @@ export default function AdminCustomLoginForm() {
     <div className="min-h-screen bg-page-bg flex flex-col items-center justify-center p-4 sm:p-6 lg:p-8">
       <Card className="w-full max-w-md p-8 shadow-xl">
         <div className="text-center mb-8">
-          <div className="mx-auto h-20 w-20 bg-swiss-mint rounded-full flex items-center justify-center mb-6">
+          <div className="mx-auto h-[92px] w-[92px] bg-swiss-mint rounded-full flex items-center justify-center mb-6">
             {getAdminLogo(settings) ? (
               <img 
                 src={getAdminLogo(settings)!} 
                 alt="Admin Logo" 
-                className="h-10 w-10 object-contain"
+                className="h-[46px] w-[46px] object-contain"
               />
             ) : (
-              <SquaresPlusIcon className="h-10 w-10 text-white" />
+              <SquaresPlusIcon className="h-[46px] w-[46px] text-white" />
             )}
           </div>
           <h1 className="text-2xl font-bold text-swiss-charcoal">Admin Dashboard</h1>

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -167,9 +167,9 @@ const Sidebar: React.FC<SidebarProps> = ({ onLinkClick, isMobileView }) => {
         <div className="flex justify-between items-center h-20 px-4 border-b border-gray-200/80">
             <div className="flex items-center">
                 {settings?.logoAsset?.publicUrl ? (
-                  <img src={settings.logoAsset.publicUrl} alt={settings.siteName || t('appName')} className="h-10 w-auto mr-2" />
+                  <img src={settings.logoAsset.publicUrl} alt={settings.siteName || t('appName')} className="h-[50px] w-auto mr-2" />
                 ) : (
-                  <SquaresPlusIcon className="h-10 w-10 text-swiss-mint mr-2" />
+                  <SquaresPlusIcon className="h-[50px] w-[50px] text-swiss-mint mr-2" />
                 )}
             </div>
           {/* Close button for mobile view - managed by MainLayout now */}
@@ -178,9 +178,9 @@ const Sidebar: React.FC<SidebarProps> = ({ onLinkClick, isMobileView }) => {
       {!isMobileView && (
         <div className="h-20 flex items-center justify-center px-6 border-b border-gray-200/80"> 
             {settings?.logoAsset?.publicUrl ? (
-              <img src={settings.logoAsset.publicUrl} alt={settings.siteName || t('appName')} className="h-11 w-auto mr-2.5" />
+              <img src={settings.logoAsset.publicUrl} alt={settings.siteName || t('appName')} className="h-[55px] w-auto mr-2.5" />
             ) : (
-              <SquaresPlusIcon className="h-11 w-11 text-swiss-mint mr-2.5" />
+              <SquaresPlusIcon className="h-[55px] w-[55px] text-swiss-mint mr-2.5" />
             )}
         </div>
       )}

--- a/frontend/pages/LoginPage.tsx
+++ b/frontend/pages/LoginPage.tsx
@@ -200,10 +200,10 @@ const LoginPage: React.FC = () => {
               <img 
                 src={settings.logoAsset.publicUrl} 
                 alt={settings.siteName || APP_NAME} 
-                className="h-20 w-auto mx-auto mb-3" 
+                className="h-[92px] w-auto mx-auto mb-3" 
               />
             ) : (
-              <SquaresPlusIcon className="h-14 w-14 text-swiss-mint mx-auto mb-3" />
+              <SquaresPlusIcon className="h-16 w-16 text-swiss-mint mx-auto mb-3" />
             )}
             <h1 className="text-2xl font-bold text-swiss-charcoal">
               {t('common:loginPage.title', { appName: settings?.siteName || APP_NAME })}
@@ -287,10 +287,10 @@ const LoginPage: React.FC = () => {
               <img 
                 src={settings.logoAsset.publicUrl} 
                 alt={settings.siteName || APP_NAME} 
-                className="h-20 w-auto mx-auto mb-3" 
+                className="h-[92px] w-auto mx-auto mb-3" 
               />
             ) : (
-              <SquaresPlusIcon className="h-14 w-14 text-swiss-mint mx-auto mb-3" />
+              <SquaresPlusIcon className="h-16 w-16 text-swiss-mint mx-auto mb-3" />
             )}
             <h1 className="text-2xl font-bold text-swiss-charcoal">
               {t('common:loginPage.title', { appName: settings?.siteName || APP_NAME })}
@@ -340,10 +340,10 @@ const LoginPage: React.FC = () => {
             <img 
               src={settings.logoAsset.publicUrl} 
               alt={settings.siteName || APP_NAME} 
-              className="h-20 w-auto mx-auto mb-3" 
+              className="h-[92px] w-auto mx-auto mb-3" 
             />
           ) : (
-            <SquaresPlusIcon className="h-14 w-14 text-swiss-mint mx-auto mb-3" />
+            <SquaresPlusIcon className="h-16 w-16 text-swiss-mint mx-auto mb-3" />
           )}
           <h1 className="text-2xl font-bold text-swiss-charcoal">
             {t('common:loginPage.title', { appName: settings?.siteName || APP_NAME })}


### PR DESCRIPTION
Increase login page logos by 15% and side navbar logos by 25% as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-7cc66bb0-0e20-4095-aaa3-b768f917b635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7cc66bb0-0e20-4095-aaa3-b768f917b635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

