### PR TITLE
Enlarge sidebar logo by 25 percent

### DIFF
--- a/admin/src/components/Sidebar.tsx
+++ b/admin/src/components/Sidebar.tsx
@@ -68,11 +68,11 @@ const Sidebar: React.FC<SidebarProps> = ({ sidebarOpen, setSidebarOpen }) => {
           <img
             src={getAdminLogo()}
             alt="Admin Logo"
-            className="h-[55px] w-[55px] object-contain mr-2.5"
+            className="h-[69px] w-[69px] object-contain mr-2.5"
           />
         ) : (
-          <div className="h-[55px] w-[55px] bg-swiss-mint mr-2.5 flex items-center justify-center rounded">
-            <Shield className="h-[30px] w-[30px] text-white" />
+          <div className="h-[69px] w-[69px] bg-swiss-mint mr-2.5 flex items-center justify-center rounded">
+            <Shield className="h-[38px] w-[38px] text-white" />
           </div>
         )}
         <h1 className="text-2xl font-bold text-swiss-charcoal">Admin</h1>

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -167,9 +167,9 @@ const Sidebar: React.FC<SidebarProps> = ({ onLinkClick, isMobileView }) => {
         <div className="flex justify-between items-center h-20 px-4 border-b border-gray-200/80">
             <div className="flex items-center">
                 {settings?.logoAsset?.publicUrl ? (
-                  <img src={settings.logoAsset.publicUrl} alt={settings.siteName || t('appName')} className="h-[50px] w-auto mr-2" />
+                  <img src={settings.logoAsset.publicUrl} alt={settings.siteName || t('appName')} className="h-[63px] w-auto mr-2" />
                 ) : (
-                  <SquaresPlusIcon className="h-[50px] w-[50px] text-swiss-mint mr-2" />
+                  <SquaresPlusIcon className="h-[63px] w-[63px] text-swiss-mint mr-2" />
                 )}
             </div>
           {/* Close button for mobile view - managed by MainLayout now */}
@@ -178,9 +178,9 @@ const Sidebar: React.FC<SidebarProps> = ({ onLinkClick, isMobileView }) => {
       {!isMobileView && (
         <div className="h-20 flex items-center justify-center px-6 border-b border-gray-200/80"> 
             {settings?.logoAsset?.publicUrl ? (
-              <img src={settings.logoAsset.publicUrl} alt={settings.siteName || t('appName')} className="h-[55px] w-auto mr-2.5" />
+              <img src={settings.logoAsset.publicUrl} alt={settings.siteName || t('appName')} className="h-[69px] w-auto mr-2.5" />
             ) : (
-              <SquaresPlusIcon className="h-[55px] w-[55px] text-swiss-mint mr-2.5" />
+              <SquaresPlusIcon className="h-[69px] w-[69px] text-swiss-mint mr-2.5" />
             )}
         </div>
       )}


### PR DESCRIPTION
Increase the logo size in the sidebar menus of both the admin and frontend applications by approximately 25%.

---
<a href="https://cursor.com/background-agent?bcId=bc-2237ebc8-9c99-4f75-a8a2-c921687490ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2237ebc8-9c99-4f75-a8a2-c921687490ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

