### PR TITLE
Investigate and build educator profile page

### DIFF
--- a/api/src/recruitment/recruitment.controller.ts
+++ b/api/src/recruitment/recruitment.controller.ts
@@ -180,8 +180,12 @@ export class RecruitmentController {
   }
 
   @Get('candidates/:id')
-  findCandidateById(@Param('id') id: string) {
-    return this.recruitmentService.findCandidateById(id);
+  async findCandidateById(@Param('id') id: string) {
+    const candidate = await this.recruitmentService.findCandidateById(id);
+    if (!candidate) {
+      throw new NotFoundException('Candidate not found');
+    }
+    return candidate;
   }
 
   // Matching endpoints

--- a/api/src/recruitment/recruitment.service.ts
+++ b/api/src/recruitment/recruitment.service.ts
@@ -341,6 +341,7 @@ export class RecruitmentService {
         role: 'EDUCATOR',
       },
       include: {
+        avatarAsset: true,
         applications: {
           include: {
             jobListing: {
@@ -359,6 +360,7 @@ export class RecruitmentService {
     return this.prisma.user.findUnique({
       where: { id },
       include: {
+        avatarAsset: true,
         applications: {
           include: {
             jobListing: {

--- a/frontend/hooks/useRecruitmentApi.ts
+++ b/frontend/hooks/useRecruitmentApi.ts
@@ -78,28 +78,34 @@ const safeParseJSON = <T>(value?: string | null): T | undefined => {
   }
 };
 
-const transformCandidate = (data: any): CandidateProfile => ({
-  id: data.id,
-  name: `${data.firstName ?? ''} ${data.lastName ?? ''}`.trim() || data.email,
-  email: data.email,
-  phone: data.phoneNumber ?? undefined,
-  avatarUrl: data.avatarUrl ?? undefined,
-  currentRoleOrTitle: safeParseJSON<any[]>(data.workExperience)?.[0]?.jobTitle ?? data.role,
-  location: data.region ?? undefined,
-  availabilityStatus: data.availability ?? undefined,
-  shortBio: data.bio ?? data.shortBio ?? undefined,
-  skills: data.skills ?? [],
-  workExperience: safeParseJSON(data.workExperience),
-  education: safeParseJSON(data.education),
-  certifications: data.certifications ?? [],
-  availabilityPreferences: data.availabilityPreferences ?? undefined,
-  documents: data.documents ?? [],
-  role: data.role,
-  availability: data.availability ?? undefined,
-  preferredRegion: data.region ?? undefined,
-  experience: data.experience ?? undefined,
-  languages: data.languages ?? [],
-});
+const transformCandidate = (data: any): CandidateProfile => {
+  if (!data || typeof data !== 'object') {
+    throw new Error('Invalid candidate data received');
+  }
+  
+  return {
+    id: data.id,
+    name: `${data.firstName ?? ''} ${data.lastName ?? ''}`.trim() || data.email || 'Unknown',
+    email: data.email ?? '',
+    phone: data.phoneNumber ?? undefined,
+    avatarUrl: data.avatarAsset?.publicUrl ?? data.avatarUrl ?? undefined,
+    currentRoleOrTitle: safeParseJSON<any[]>(data.workExperience)?.[0]?.jobTitle ?? data.role,
+    location: data.region ?? undefined,
+    availabilityStatus: data.availability ?? undefined,
+    shortBio: data.bio ?? data.shortBio ?? undefined,
+    skills: data.skills ?? [],
+    workExperience: safeParseJSON(data.workExperience),
+    education: safeParseJSON(data.education),
+    certifications: data.certifications ?? [],
+    availabilityPreferences: data.availabilityPreferences ?? undefined,
+    documents: data.documents ?? [],
+    role: data.role,
+    availability: data.availability ?? undefined,
+    preferredRegion: data.region ?? undefined,
+    experience: data.experience ?? undefined,
+    languages: data.languages ?? [],
+  };
+};
 
 export const useRecruitmentApi = () => {
   const { request } = useAuthenticatedApi();

--- a/frontend/providers/AuthProvider.tsx
+++ b/frontend/providers/AuthProvider.tsx
@@ -118,6 +118,7 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
           : user.firstName || user.lastName || user.name || user.email || 'Unknown User';
 
       const resolvedAvatar =
+        user.avatarAsset?.publicUrl ??
         user.avatarUrl ??
         primaryOrganization?.logoUrl ??
         `https://ui-avatars.com/api/?name=${encodeURIComponent(derivedName)}&background=48CFAE&color=ffffff&size=128&rounded=true`;


### PR DESCRIPTION
Fixes the educator profile page internal server error by correctly fetching and transforming avatar URLs and adding robust error handling.

The internal server error on the educator profile page was due to the backend not including the `avatarAsset` relation for user profiles, causing the frontend to fail when trying to display the avatar. Additionally, the backend was not returning a 404 for missing candidates, and the frontend lacked proper null/invalid data validation, leading to crashes.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a10eec9-0899-4ffc-b309-94f9047e35e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6a10eec9-0899-4ffc-b309-94f9047e35e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

