### PR TITLE
Add sidebar logo setting

### DIFF
--- a/admin/src/components/settings/BrandingSettings.tsx
+++ b/admin/src/components/settings/BrandingSettings.tsx
@@ -49,6 +49,9 @@ const BrandingSettings: React.FC = () => {
         case 'adminFavicon':
           response = await apiService.uploadAdminFavicon(apiClient, formData)
           break
+        case 'sidebarLogo':
+          response = await apiService.uploadSidebarLogo(apiClient, formData)
+          break
         default:
           throw new Error(`Unknown asset type: ${assetType}`)
       }
@@ -304,6 +307,9 @@ const BrandingSettings: React.FC = () => {
               <label className="block text-sm font-medium text-swiss-charcoal mb-2">
                 {t('admin:settings.branding.logosAssets.mainLogo')}
               </label>
+              <p className="text-xs text-gray-500 mb-2">
+                {t('admin:settings.branding.logosAssets.mainLogoDescription')}
+              </p>
               <SimpleAssetUploader
                 currentAssetId={settings?.logoAssetId}
                 onUpload={(file: File) => handleUploadAndUpdate('logo', file)}
@@ -331,6 +337,46 @@ const BrandingSettings: React.FC = () => {
                       disabled={saving}
                     >
                       {saving ? t('admin:settings.branding.saving') : t('admin:settings.branding.saveLogo')}
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-swiss-charcoal mb-2">
+                {t('admin:settings.branding.logosAssets.sidebarLogo')}
+              </label>
+              <p className="text-xs text-gray-500 mb-2">
+                {t('admin:settings.branding.logosAssets.sidebarLogoDescription')}
+              </p>
+              <SimpleAssetUploader
+                currentAssetId={settings?.sidebarLogoAssetId}
+                onUpload={(file: File) => handleUploadAndUpdate('sidebarLogo', file)}
+                accept="image/*"
+                maxSize={5 * 1024 * 1024}
+                fetchDelay={200}
+              />
+              {uploadingAssets.sidebarLogo && (
+                <div className="mt-2 p-3 bg-blue-50 border border-blue-200 rounded-md">
+                  <div className="flex items-center">
+                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600 mr-2"></div>
+                    <span className="text-sm text-blue-700">{t('admin:settings.branding.uploading.sidebarLogo')}</span>
+                  </div>
+                </div>
+              )}
+              {uploadedAssets.sidebarLogo && (
+                <div className="mt-2 space-y-2">
+                  <div className="p-3 bg-green-50 border border-green-200 rounded-md">
+                    <span className="text-sm text-green-700">{t('admin:settings.branding.uploaded.sidebarLogo')}</span>
+                  </div>
+                  <div className="flex justify-end">
+                    <Button
+                      onClick={() => handleSaveAsset('sidebarLogo')}
+                      variant="primary"
+                      disabled={saving}
+                    >
+                      {saving ? t('admin:settings.branding.saving') : t('admin:settings.branding.saveSidebarLogo')}
                     </Button>
                   </div>
                 </div>

--- a/admin/src/components/settings/BrandingSettings.tsx
+++ b/admin/src/components/settings/BrandingSettings.tsx
@@ -12,16 +12,19 @@ import logger from '../../utils/logger'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
 
+// Define supported asset types for type safety
+type BrandingAssetType = 'logo' | 'sidebarLogo' | 'adminLogo' | 'favicon' | 'adminFavicon';
+
 const BrandingSettings: React.FC = () => {
   const { t } = useTranslation(['admin', 'common'])
   const { settings, updateSettings, refreshSettings, loading, error, saving } = useSettings()
   const apiClient = useApiClient()
   const { user } = useUser()
-  const [uploadingAssets, setUploadingAssets] = useState<Record<string, boolean>>({})
-  const [uploadedAssets, setUploadedAssets] = useState<Record<string, string>>({})
+  const [uploadingAssets, setUploadingAssets] = useState<Record<BrandingAssetType, boolean>>({} as Record<BrandingAssetType, boolean>)
+  const [uploadedAssets, setUploadedAssets] = useState<Record<BrandingAssetType, string>>({} as Record<BrandingAssetType, string>)
 
 
-  const handleUploadAndUpdate = async (assetType: string, file: File) => {
+  const handleUploadAndUpdate = async (assetType: BrandingAssetType, file: File) => {
     setUploadingAssets(prev => ({ ...prev, [assetType]: true }))
     
     try {
@@ -77,7 +80,7 @@ const BrandingSettings: React.FC = () => {
     }
   }
 
-  const handleSaveAsset = async (assetType: string) => {
+  const handleSaveAsset = async (assetType: BrandingAssetType) => {
     const assetId = uploadedAssets[assetType]
     if (!assetId) {
       toast.error(t('admin:settings.branding.noAssetToSave'))

--- a/admin/src/services/api.ts
+++ b/admin/src/services/api.ts
@@ -531,6 +531,22 @@ export const apiService = {
     })
   },
 
+  uploadSidebarLogo: (apiClient: AxiosInstance, formData: FormData, onProgress?: (progress: number) => void) => {
+    const fullUrl = `${apiClient.defaults.baseURL}/admin/frontend-settings/sidebar-logo`
+    console.log('🔄 API: uploadSidebarLogo called with full URL:', fullUrl)
+    return apiClient.post<ApiResponse<UploadedAsset>>('/admin/frontend-settings/sidebar-logo', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+      onUploadProgress: (progressEvent) => {
+        if (onProgress && progressEvent.total) {
+          const progress = Math.round((progressEvent.loaded * 100) / progressEvent.total);
+          onProgress(progress);
+        }
+      },
+    })
+  },
+
   // Health Check
   getSettingsHealth: (apiClient: AxiosInstance) => apiClient.get<ApiResponse<SettingsHealth>>('/admin/settings/health'),
   getSystemHealth: (apiClient: AxiosInstance) => apiClient.get<ApiResponse<SystemHealth>>('/health'),

--- a/admin/src/types/api.ts
+++ b/admin/src/types/api.ts
@@ -23,6 +23,7 @@ export interface FrontendSettings {
   secondaryColor: string;
   accentColor?: string;
   adminLogoAssetId?: string;
+  sidebarLogoAssetId?: string;
   adminPrimaryColor: string;
   adminSecondaryColor: string;
   adminAccentColor: string;
@@ -79,6 +80,16 @@ export interface FrontendSettings {
     height?: number;
   };
   adminFaviconAsset?: {
+    id: string;
+    publicUrl: string;
+    filename: string;
+    originalName: string;
+    size: number;
+    mimeType: string;
+    width?: number;
+    height?: number;
+  };
+  sidebarLogoAsset?: {
     id: string;
     publicUrl: string;
     filename: string;

--- a/api/prisma/migrations/20251220000006_add_sidebar_logo_to_frontend_settings/migration.sql
+++ b/api/prisma/migrations/20251220000006_add_sidebar_logo_to_frontend_settings/migration.sql
@@ -1,0 +1,8 @@
+-- AlterEnum
+ALTER TYPE "AssetKind" ADD VALUE 'SIDEBAR_LOGO';
+
+-- AlterTable
+ALTER TABLE "frontend_settings" ADD COLUMN "sidebarLogoAssetId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "frontend_settings" ADD CONSTRAINT "frontend_settings_sidebarLogoAssetId_fkey" FOREIGN KEY ("sidebarLogoAssetId") REFERENCES "assets"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -41,6 +41,7 @@ enum AssetKind {
   FRONTEND_OG_IMAGE
   ADMIN_LOGO
   ADMIN_FAVICON
+  SIDEBAR_LOGO
   ELEARNING
 }
 
@@ -345,6 +346,7 @@ model Asset {
   frontendOgImages FrontendSettings[] @relation("FrontendOgImage")
   adminLogos       FrontendSettings[] @relation("AdminLogo")
   adminFavicons    FrontendSettings[] @relation("AdminFavicon")
+  sidebarLogos     FrontendSettings[] @relation("SidebarLogo")
 
   @@index([storageKey])
   @@index([etag])
@@ -1126,6 +1128,9 @@ model FrontendSettings {
   adminSecondaryColor String  @default("#374151")
   adminAccentColor    String  @default("#3B82F6")
 
+  // Sidebar Logo (for main app sidebar menu)
+  sidebarLogoAssetId  String?
+
   // Contact Information
   contactEmail   String?
   contactPhone   String?
@@ -1170,6 +1175,7 @@ model FrontendSettings {
   ogImageAsset      Asset? @relation("FrontendOgImage", fields: [ogImageAssetId], references: [id])
   adminLogoAsset    Asset? @relation("AdminLogo", fields: [adminLogoAssetId], references: [id])
   adminFaviconAsset Asset? @relation("AdminFavicon", fields: [adminFaviconAssetId], references: [id])
+  sidebarLogoAsset  Asset? @relation("SidebarLogo", fields: [sidebarLogoAssetId], references: [id])
 
   @@map("frontend_settings")
 }

--- a/api/src/frontend-settings/dto/update-frontend-settings.dto.ts
+++ b/api/src/frontend-settings/dto/update-frontend-settings.dto.ts
@@ -34,6 +34,10 @@ export class UpdateFrontendSettingsDto {
   @IsUUID()
   adminFaviconAssetId?: string;
 
+  @IsOptional()
+  @IsUUID()
+  sidebarLogoAssetId?: string;
+
   // Branding Colors
   @IsOptional()
   @IsHexColor()

--- a/api/src/frontend-settings/frontend-settings.controller.ts
+++ b/api/src/frontend-settings/frontend-settings.controller.ts
@@ -253,4 +253,43 @@ export class FrontendSettingsController {
       throw error;
     }
   }
+
+  @Post('sidebar-logo')
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadSidebarLogo(@UploadedFile() file: Express.Multer.File, @Request() req) {
+    try {
+      if (!file) {
+        throw new Error('No file provided');
+      }
+      
+      // Development mode bypass
+      const isDevelopment = process.env.NODE_ENV !== 'production';
+      let appUserId = req.context?.appUserId;
+      
+      if (!appUserId && isDevelopment) {
+        appUserId = 'dev-user-123';
+        console.log('🔧 Development mode: Using mock user ID for sidebar logo upload');
+      } else if (!appUserId) {
+        throw new BadRequestException('Missing authenticated user');
+      }
+      
+      const result = await this.frontendSettingsService.uploadSidebarLogo(file, appUserId);
+      
+      return {
+        success: true,
+        message: 'Sidebar logo uploaded',
+        data: {
+          id: result.asset.id,
+          url: result.publicUrl,
+          filename: result.asset.filename,
+          size: result.asset.size,
+          mimeType: result.asset.mimeType,
+        },
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      console.error('Sidebar logo upload error:', error);
+      throw error;
+    }
+  }
 }

--- a/api/src/frontend-settings/frontend-settings.service.ts
+++ b/api/src/frontend-settings/frontend-settings.service.ts
@@ -40,6 +40,7 @@ export class FrontendSettingsService {
       logoAsset: settings.logoAsset,
       faviconAsset: settings.faviconAsset,
       ogImageAsset: settings.ogImageAsset,
+      sidebarLogoAsset: settings.sidebarLogoAsset,
     };
   }
 
@@ -51,6 +52,7 @@ export class FrontendSettingsService {
         ogImageAsset: true,
         adminLogoAsset: true,
         adminFaviconAsset: true,
+        sidebarLogoAsset: true,
       },
     });
     
@@ -76,6 +78,7 @@ export class FrontendSettingsService {
           ogImageAsset: true,
           adminLogoAsset: true,
           adminFaviconAsset: true,
+          sidebarLogoAsset: true,
         },
       });
     }
@@ -96,6 +99,7 @@ export class FrontendSettingsService {
           ogImageAsset: true,
           adminLogoAsset: true,
           adminFaviconAsset: true,
+          sidebarLogoAsset: true,
         },
       });
     } else {
@@ -109,6 +113,7 @@ export class FrontendSettingsService {
           ogImageAsset: true,
           adminLogoAsset: true,
           adminFaviconAsset: true,
+          sidebarLogoAsset: true,
         },
       });
     }
@@ -181,6 +186,20 @@ export class FrontendSettingsService {
     await this.prisma.frontendSettings.update({
       where: { id: settings.id },
       data: { adminFaviconAssetId: uploadResult.asset.id },
+    });
+
+    return uploadResult;
+  }
+
+  async uploadSidebarLogo(file: Express.Multer.File, uploadedById: string) {
+    // Use the existing upload service
+    const uploadResult = await this.uploadService.uploadFile(file, uploadedById, AssetKind.SIDEBAR_LOGO);
+
+    // Update frontend settings with new sidebar logo
+    const settings = await this.getSettings();
+    await this.prisma.frontendSettings.update({
+      where: { id: settings.id },
+      data: { sidebarLogoAssetId: uploadResult.asset.id },
     });
 
     return uploadResult;

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -166,8 +166,8 @@ const Sidebar: React.FC<SidebarProps> = ({ onLinkClick, isMobileView }) => {
       {isMobileView && (
         <div className="flex justify-between items-center h-20 px-4 border-b border-gray-200/80">
             <div className="flex items-center">
-                {settings?.logoAsset?.publicUrl ? (
-                  <img src={settings.logoAsset.publicUrl} alt={settings.siteName || t('appName')} className="h-[63px] w-auto mr-2" />
+                {(settings?.sidebarLogoAsset?.publicUrl || settings?.logoAsset?.publicUrl) ? (
+                  <img src={settings.sidebarLogoAsset?.publicUrl || settings.logoAsset?.publicUrl} alt={settings.siteName || t('appName')} className="h-[63px] w-auto mr-2" />
                 ) : (
                   <SquaresPlusIcon className="h-[63px] w-[63px] text-swiss-mint mr-2" />
                 )}
@@ -177,8 +177,8 @@ const Sidebar: React.FC<SidebarProps> = ({ onLinkClick, isMobileView }) => {
       )}
       {!isMobileView && (
         <div className="h-20 flex items-center justify-center px-6 border-b border-gray-200/80"> 
-            {settings?.logoAsset?.publicUrl ? (
-              <img src={settings.logoAsset.publicUrl} alt={settings.siteName || t('appName')} className="h-[69px] w-auto mr-2.5" />
+            {(settings?.sidebarLogoAsset?.publicUrl || settings?.logoAsset?.publicUrl) ? (
+              <img src={settings.sidebarLogoAsset?.publicUrl || settings.logoAsset?.publicUrl} alt={settings.siteName || t('appName')} className="h-[69px] w-auto mr-2.5" />
             ) : (
               <SquaresPlusIcon className="h-[69px] w-[69px] text-swiss-mint mr-2.5" />
             )}

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -35,6 +35,10 @@ const Sidebar: React.FC<SidebarProps> = ({ onLinkClick, isMobileView }) => {
   const { currentUser } = useAppContext();
   const { settings, loading, error } = useFrontendSettings();
   const navigate = useNavigate();
+  
+  // Compute sidebar logo URL once - prefer sidebar logo, fall back to main logo
+  const sidebarLogoUrl = settings?.sidebarLogoAsset?.publicUrl || settings?.logoAsset?.publicUrl;
+  
   const [openMenus, setOpenMenus] = useState<Record<string, boolean>>({
     'sidebar.content': true, // Corrected key
     'sidebar.marketplace': true, // Corrected key
@@ -166,8 +170,8 @@ const Sidebar: React.FC<SidebarProps> = ({ onLinkClick, isMobileView }) => {
       {isMobileView && (
         <div className="flex justify-between items-center h-20 px-4 border-b border-gray-200/80">
             <div className="flex items-center">
-                {(settings?.sidebarLogoAsset?.publicUrl || settings?.logoAsset?.publicUrl) ? (
-                  <img src={settings.sidebarLogoAsset?.publicUrl || settings.logoAsset?.publicUrl} alt={settings.siteName || t('appName')} className="h-[63px] w-auto mr-2" />
+                {sidebarLogoUrl ? (
+                  <img src={sidebarLogoUrl} alt={settings?.siteName || t('appName')} className="h-[63px] w-auto mr-2" />
                 ) : (
                   <SquaresPlusIcon className="h-[63px] w-[63px] text-swiss-mint mr-2" />
                 )}
@@ -177,8 +181,8 @@ const Sidebar: React.FC<SidebarProps> = ({ onLinkClick, isMobileView }) => {
       )}
       {!isMobileView && (
         <div className="h-20 flex items-center justify-center px-6 border-b border-gray-200/80"> 
-            {(settings?.sidebarLogoAsset?.publicUrl || settings?.logoAsset?.publicUrl) ? (
-              <img src={settings.sidebarLogoAsset?.publicUrl || settings.logoAsset?.publicUrl} alt={settings.siteName || t('appName')} className="h-[69px] w-auto mr-2.5" />
+            {sidebarLogoUrl ? (
+              <img src={sidebarLogoUrl} alt={settings?.siteName || t('appName')} className="h-[69px] w-auto mr-2.5" />
             ) : (
               <SquaresPlusIcon className="h-[69px] w-[69px] text-swiss-mint mr-2.5" />
             )}

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -965,6 +965,7 @@ export interface FrontendSettings {
   logoAsset?: Asset;
   faviconAsset?: Asset;
   ogImageAsset?: Asset;
+  sidebarLogoAsset?: Asset;
 }
 
 // ACTIVE CLIENT FEATURE TYPES

--- a/packages/translations/locales/de/admin.json
+++ b/packages/translations/locales/de/admin.json
@@ -220,19 +220,24 @@
       },
       "logosAssets": {
         "title": "Logos & Assets",
-        "mainLogo": "Hauptlogo",
+        "mainLogo": "Hauptlogo (Öffentliche Seiten)",
+        "mainLogoDescription": "Wird auf Anmelde-, Registrierungs- und anderen öffentlichen Seiten verwendet",
+        "sidebarLogo": "Seitenleisten-Logo",
+        "sidebarLogoDescription": "Separates Logo für das Seitenleisten-Menü der Haupt-App (optional - verwendet Hauptlogo als Fallback)",
         "adminLogo": "Admin-Logo",
         "favicon": "Favicon",
         "adminFavicon": "Admin-Favicon"
       },
       "uploading": {
         "logo": "Logo wird hochgeladen...",
+        "sidebarLogo": "Seitenleisten-Logo wird hochgeladen...",
         "adminLogo": "Admin-Logo wird hochgeladen...",
         "favicon": "Favicon wird hochgeladen...",
         "adminFavicon": "Admin-Favicon wird hochgeladen..."
       },
       "uploaded": {
         "logo": "✓ Logo hochgeladen! Klicken Sie unten auf \"Logo speichern\", um die Änderungen zu übernehmen.",
+        "sidebarLogo": "✓ Seitenleisten-Logo hochgeladen! Klicken Sie unten auf \"Seitenleisten-Logo speichern\", um die Änderungen zu übernehmen.",
         "adminLogo": "✓ Admin-Logo hochgeladen! Klicken Sie unten auf \"Admin-Logo speichern\", um die Änderungen zu übernehmen.",
         "favicon": "✓ Favicon hochgeladen! Klicken Sie unten auf \"Favicon speichern\", um die Änderungen zu übernehmen.",
         "adminFavicon": "✓ Admin-Favicon hochgeladen! Klicken Sie unten auf \"Admin-Favicon speichern\", um die Änderungen zu übernehmen."
@@ -240,6 +245,7 @@
       "saveColors": "Farben speichern",
       "saveAdminColors": "Admin-Farben speichern",
       "saveLogo": "Logo speichern",
+      "saveSidebarLogo": "Seitenleisten-Logo speichern",
       "saveAdminLogo": "Admin-Logo speichern",
       "saveFavicon": "Favicon speichern",
       "saveAdminFavicon": "Admin-Favicon speichern",

--- a/packages/translations/locales/en/admin.json
+++ b/packages/translations/locales/en/admin.json
@@ -283,19 +283,24 @@
       },
       "logosAssets": {
         "title": "Logos & Assets",
-        "mainLogo": "Main Logo",
+        "mainLogo": "Main Logo (Public Pages)",
+        "mainLogoDescription": "Used on login, signup, and other public-facing pages",
+        "sidebarLogo": "Sidebar Logo",
+        "sidebarLogoDescription": "Separate logo for the main app sidebar menu (optional - falls back to Main Logo if not set)",
         "adminLogo": "Admin Logo",
         "favicon": "Favicon",
         "adminFavicon": "Admin Favicon"
       },
       "uploading": {
         "logo": "Uploading logo...",
+        "sidebarLogo": "Uploading sidebar logo...",
         "adminLogo": "Uploading admin logo...",
         "favicon": "Uploading favicon...",
         "adminFavicon": "Uploading admin favicon..."
       },
       "uploaded": {
         "logo": "✓ Logo uploaded! Click \"Save Logo\" below to apply changes.",
+        "sidebarLogo": "✓ Sidebar logo uploaded! Click \"Save Sidebar Logo\" below to apply changes.",
         "adminLogo": "✓ Admin logo uploaded! Click \"Save Admin Logo\" below to apply changes.",
         "favicon": "✓ Favicon uploaded! Click \"Save Favicon\" below to apply changes.",
         "adminFavicon": "✓ Admin favicon uploaded! Click \"Save Admin Favicon\" below to apply changes."
@@ -303,6 +308,7 @@
       "saveColors": "Save Colors",
       "saveAdminColors": "Save Admin Colors",
       "saveLogo": "Save Logo",
+      "saveSidebarLogo": "Save Sidebar Logo",
       "saveAdminLogo": "Save Admin Logo",
       "saveFavicon": "Save Favicon",
       "saveAdminFavicon": "Save Admin Favicon",

--- a/packages/translations/locales/fr/admin.json
+++ b/packages/translations/locales/fr/admin.json
@@ -220,19 +220,24 @@
       },
       "logosAssets": {
         "title": "Logos et ressources",
-        "mainLogo": "Logo principal",
+        "mainLogo": "Logo principal (Pages publiques)",
+        "mainLogoDescription": "Utilisé sur les pages de connexion, d'inscription et autres pages publiques",
+        "sidebarLogo": "Logo de la barre latérale",
+        "sidebarLogoDescription": "Logo séparé pour le menu de la barre latérale de l'application principale (optionnel - utilise le logo principal par défaut)",
         "adminLogo": "Logo admin",
         "favicon": "Favicon",
         "adminFavicon": "Favicon admin"
       },
       "uploading": {
         "logo": "Téléchargement du logo...",
+        "sidebarLogo": "Téléchargement du logo de la barre latérale...",
         "adminLogo": "Téléchargement du logo admin...",
         "favicon": "Téléchargement du favicon...",
         "adminFavicon": "Téléchargement du favicon admin..."
       },
       "uploaded": {
         "logo": "✓ Logo téléchargé ! Cliquez sur \"Enregistrer le logo\" ci-dessous pour appliquer les modifications.",
+        "sidebarLogo": "✓ Logo de la barre latérale téléchargé ! Cliquez sur \"Enregistrer le logo de la barre latérale\" ci-dessous pour appliquer les modifications.",
         "adminLogo": "✓ Logo admin téléchargé ! Cliquez sur \"Enregistrer le logo admin\" ci-dessous pour appliquer les modifications.",
         "favicon": "✓ Favicon téléchargé ! Cliquez sur \"Enregistrer le favicon\" ci-dessous pour appliquer les modifications.",
         "adminFavicon": "✓ Favicon admin téléchargé ! Cliquez sur \"Enregistrer le favicon admin\" ci-dessous pour appliquer les modifications."
@@ -240,6 +245,7 @@
       "saveColors": "Enregistrer les couleurs",
       "saveAdminColors": "Enregistrer les couleurs admin",
       "saveLogo": "Enregistrer le logo",
+      "saveSidebarLogo": "Enregistrer le logo de la barre latérale",
       "saveAdminLogo": "Enregistrer le logo admin",
       "saveFavicon": "Enregistrer le favicon",
       "saveAdminFavicon": "Enregistrer le favicon admin",

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -36,6 +36,7 @@ export declare const AssetKind: {
     readonly FRONTEND_OG_IMAGE: "FRONTEND_OG_IMAGE";
     readonly ADMIN_LOGO: "ADMIN_LOGO";
     readonly ADMIN_FAVICON: "ADMIN_FAVICON";
+    readonly SIDEBAR_LOGO: "SIDEBAR_LOGO";
 };
 export type AssetKind = (typeof AssetKind)[keyof typeof AssetKind];
 export declare const OrganizationType: {

--- a/packages/types/index.js
+++ b/packages/types/index.js
@@ -40,6 +40,7 @@ exports.AssetKind = {
     FRONTEND_OG_IMAGE: 'FRONTEND_OG_IMAGE',
     ADMIN_LOGO: 'ADMIN_LOGO',
     ADMIN_FAVICON: 'ADMIN_FAVICON',
+    SIDEBAR_LOGO: 'SIDEBAR_LOGO',
 };
 // Organization Types
 exports.OrganizationType = {


### PR DESCRIPTION
Add a new "Sidebar Logo" setting to the admin dashboard to allow a distinct logo for the main application's sidebar menu.

The existing "Main Logo" is used for public-facing pages (login, signup, etc.), while this new setting provides an option for a different logo specifically within the authenticated app's sidebar, falling back to the main logo if not set. This provides greater branding flexibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-632bc616-43b4-4159-b890-5b43e69ba505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-632bc616-43b4-4159-b890-5b43e69ba505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated sidebar logo management in branding settings with upload, progress tracking, and save functionality
  * Enhanced main logo labeling as "Main Logo (Public Pages)" with added descriptive guidance
  * Sidebar now displays custom sidebar logo when available, falling back to main logo
  * Added multi-language support for all sidebar logo features

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->