### PR TITLE
Fix render migration deployment failure

### DIFF
--- a/api/scripts/prebuild-db-setup.mjs
+++ b/api/scripts/prebuild-db-setup.mjs
@@ -370,6 +370,57 @@ END $$;
   );
 };
 
+const ensureParentLeadsTable = () => {
+  const sql = `
+-- Create the parent_leads table if it doesn't exist
+CREATE TABLE IF NOT EXISTS "public"."parent_leads" (
+    "id" TEXT NOT NULL,
+    "parentName" TEXT NOT NULL,
+    "parentEmail" TEXT NOT NULL,
+    "parentPhone" TEXT,
+    "childName" TEXT NOT NULL,
+    "childAge" INTEGER NOT NULL,
+    "message" TEXT,
+    "foundationId" TEXT,
+    "preferredLocation" TEXT,
+    "preferredLanguages" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "specialRequirements" TEXT,
+    "source" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'NEW',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "parent_leads_pkey" PRIMARY KEY ("id")
+);
+
+-- Create indexes on parent_leads (if they don't exist)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes 
+        WHERE indexname = 'parent_leads_status_idx'
+    ) THEN
+        CREATE INDEX "parent_leads_status_idx" ON "public"."parent_leads"("status");
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes 
+        WHERE indexname = 'parent_leads_foundationId_idx'
+    ) THEN
+        CREATE INDEX "parent_leads_foundationId_idx" ON "public"."parent_leads"("foundationId");
+    END IF;
+END $$;
+`;
+
+  runPrisma(
+    ['db', 'execute', '--schema', SCHEMA_PATH, '--stdin'],
+    { silent: true, input: sql },
+  );
+};
+
 const ensureJobApplicationsTable = () => {
   const sql = `
 -- Ensure ApplicationStatus enum exists
@@ -445,6 +496,210 @@ BEGIN
         ADD CONSTRAINT "job_applications_candidateId_fkey" 
         FOREIGN KEY ("candidateId") REFERENCES "public"."users"("id") 
         ON DELETE RESTRICT ON UPDATE CASCADE;
+    END IF;
+END $$;
+`;
+
+  runPrisma(
+    ['db', 'execute', '--schema', SCHEMA_PATH, '--stdin'],
+    { silent: true, input: sql },
+  );
+};
+
+const ensureFoundationPagesEnhancements = () => {
+  // First ensure parent_leads exists (prerequisite)
+  ensureParentLeadsTable();
+  
+  const sql = `
+-- Create foundation_lead_responses table
+CREATE TABLE IF NOT EXISTS "foundation_lead_responses" (
+    "id" TEXT NOT NULL,
+    "leadId" TEXT NOT NULL,
+    "foundationId" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "message" TEXT,
+    "respondedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "foundation_lead_responses_pkey" PRIMARY KEY ("id")
+);
+
+-- Create support_tickets table
+CREATE TABLE IF NOT EXISTS "support_tickets" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "subject" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "category" TEXT NOT NULL DEFAULT 'GENERAL',
+    "priority" TEXT NOT NULL DEFAULT 'MEDIUM',
+    "status" TEXT NOT NULL DEFAULT 'OPEN',
+    "assignedTo" TEXT,
+    "resolvedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "support_tickets_pkey" PRIMARY KEY ("id")
+);
+
+-- Create ticket_responses table
+CREATE TABLE IF NOT EXISTS "ticket_responses" (
+    "id" TEXT NOT NULL,
+    "ticketId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "isStaff" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ticket_responses_pkey" PRIMARY KEY ("id")
+);
+
+-- Create calendar_events table
+CREATE TABLE IF NOT EXISTS "calendar_events" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "eventType" TEXT NOT NULL,
+    "startTime" TIMESTAMP(3) NOT NULL,
+    "endTime" TIMESTAMP(3),
+    "allDay" BOOLEAN NOT NULL DEFAULT false,
+    "location" TEXT,
+    "relatedEntityType" TEXT,
+    "relatedEntityId" TEXT,
+    "createdBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "calendar_events_pkey" PRIMARY KEY ("id")
+);
+
+-- Create indexes for foundation_lead_responses
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'foundation_lead_responses_leadId_foundationId_key') THEN
+        CREATE UNIQUE INDEX "foundation_lead_responses_leadId_foundationId_key" ON "foundation_lead_responses"("leadId", "foundationId");
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'foundation_lead_responses_foundationId_idx') THEN
+        CREATE INDEX "foundation_lead_responses_foundationId_idx" ON "foundation_lead_responses"("foundationId");
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'foundation_lead_responses_status_idx') THEN
+        CREATE INDEX "foundation_lead_responses_status_idx" ON "foundation_lead_responses"("status");
+    END IF;
+END $$;
+
+-- Create indexes for support_tickets
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'support_tickets_userId_idx') THEN
+        CREATE INDEX "support_tickets_userId_idx" ON "support_tickets"("userId");
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'support_tickets_status_idx') THEN
+        CREATE INDEX "support_tickets_status_idx" ON "support_tickets"("status");
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'support_tickets_priority_idx') THEN
+        CREATE INDEX "support_tickets_priority_idx" ON "support_tickets"("priority");
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'support_tickets_assignedTo_idx') THEN
+        CREATE INDEX "support_tickets_assignedTo_idx" ON "support_tickets"("assignedTo");
+    END IF;
+END $$;
+
+-- Create indexes for ticket_responses
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'ticket_responses_ticketId_idx') THEN
+        CREATE INDEX "ticket_responses_ticketId_idx" ON "ticket_responses"("ticketId");
+    END IF;
+END $$;
+
+-- Create indexes for calendar_events
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'calendar_events_organizationId_idx') THEN
+        CREATE INDEX "calendar_events_organizationId_idx" ON "calendar_events"("organizationId");
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'calendar_events_startTime_idx') THEN
+        CREATE INDEX "calendar_events_startTime_idx" ON "calendar_events"("startTime");
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'calendar_events_eventType_idx') THEN
+        CREATE INDEX "calendar_events_eventType_idx" ON "calendar_events"("eventType");
+    END IF;
+END $$;
+
+-- Add foreign keys for foundation_lead_responses
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'foundation_lead_responses_leadId_fkey') THEN
+        ALTER TABLE "foundation_lead_responses" ADD CONSTRAINT "foundation_lead_responses_leadId_fkey" 
+        FOREIGN KEY ("leadId") REFERENCES "parent_leads"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'foundation_lead_responses_foundationId_fkey') THEN
+        ALTER TABLE "foundation_lead_responses" ADD CONSTRAINT "foundation_lead_responses_foundationId_fkey" 
+        FOREIGN KEY ("foundationId") REFERENCES "organizations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+-- Add foreign keys for support_tickets
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'support_tickets_userId_fkey') THEN
+        ALTER TABLE "support_tickets" ADD CONSTRAINT "support_tickets_userId_fkey" 
+        FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'support_tickets_assignedTo_fkey') THEN
+        ALTER TABLE "support_tickets" ADD CONSTRAINT "support_tickets_assignedTo_fkey" 
+        FOREIGN KEY ("assignedTo") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+-- Add foreign keys for ticket_responses
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'ticket_responses_ticketId_fkey') THEN
+        ALTER TABLE "ticket_responses" ADD CONSTRAINT "ticket_responses_ticketId_fkey" 
+        FOREIGN KEY ("ticketId") REFERENCES "support_tickets"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'ticket_responses_userId_fkey') THEN
+        ALTER TABLE "ticket_responses" ADD CONSTRAINT "ticket_responses_userId_fkey" 
+        FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+-- Add foreign keys for calendar_events
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'calendar_events_organizationId_fkey') THEN
+        ALTER TABLE "calendar_events" ADD CONSTRAINT "calendar_events_organizationId_fkey" 
+        FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'calendar_events_createdBy_fkey') THEN
+        ALTER TABLE "calendar_events" ADD CONSTRAINT "calendar_events_createdBy_fkey" 
+        FOREIGN KEY ("createdBy") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
     END IF;
 END $$;
 `;
@@ -552,6 +807,11 @@ const handleFailedMigration = (migration) => {
       ensureProductMetadataColumns();
       resolveMigration('applied', migration);
       break;
+    case '20251202_foundation_pages_enhancements':
+      log(`   • Resolving ${migration} (foundation pages enhancements)`);
+      ensureFoundationPagesEnhancements();
+      resolveMigration('applied', migration);
+      break;
     default:
       log(`   • Rolling back failed migration ${migration}`);
       resolveMigration('rolled-back', migration);
@@ -578,6 +838,14 @@ try {
   log('✅ job_applications table check complete');
 } catch (error) {
   warn(`⚠️  Could not ensure job_applications table: ${error.message}`);
+}
+
+log('🔁 Ensuring parent_leads table exists...');
+try {
+  ensureParentLeadsTable();
+  log('✅ parent_leads table check complete');
+} catch (error) {
+  warn(`⚠️  Could not ensure parent_leads table: ${error.message}`);
 }
 
 // log('🔁 Ensuring translation infrastructure is present...');

--- a/api/scripts/render-build-with-recovery.sh
+++ b/api/scripts/render-build-with-recovery.sh
@@ -160,6 +160,63 @@ EOSQL
     #         npx prisma migrate status --schema "$PRISMA_SCHEMA_PATH" || true
     #         exit 1
     #     fi
+    elif echo "$MIGRATION_STATUS" | grep -q "20251202_foundation_pages_enhancements"; then
+        echo "🔧 Detected failed foundation pages migration, ensuring parent_leads table exists..."
+        
+        # Run the fix using prebuild script
+        if node ./scripts/prebuild-db-setup.mjs; then
+            echo "✅ Prerequisite tables created"
+        else
+            echo "⚠️  Prerequisite fix had issues, but continuing..."
+        fi
+        
+        # Mark migration as rolled back and retry
+        echo "🔄 Rolling back failed migration and retrying..."
+        npx prisma migrate resolve --rolled-back "20251202_foundation_pages_enhancements" --schema "$PRISMA_SCHEMA_PATH" || true
+        
+        # Retry migration deployment
+        echo "🔄 Retrying migration deployment after fix..."
+        if run_prisma_migrate_deploy; then
+            echo "✅ Migrations deployed successfully after foundation pages fix"
+        else
+            echo "⚠️  Migration still failing, applying schema manually..."
+            
+            # Apply the schema manually and mark as applied
+            FORCE_RESOLVE_MIGRATIONS="20251202_foundation_pages_enhancements" node ./scripts/prebuild-db-setup.mjs || true
+            
+            # Verify the tables exist
+            echo "🔍 Verifying foundation pages tables..."
+            VERIFY_TMP=$(mktemp)
+            if ! npx prisma db execute --schema "$PRISMA_SCHEMA_PATH" --stdin >"$VERIFY_TMP" 2>&1 <<'EOSQL'
+SELECT 
+    CASE WHEN EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'parent_leads') 
+        THEN 'parent_leads EXISTS' ELSE 'parent_leads MISSING' END as parent_leads_check,
+    CASE WHEN EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'foundation_lead_responses') 
+        THEN 'foundation_lead_responses EXISTS' ELSE 'foundation_lead_responses MISSING' END as flr_check,
+    CASE WHEN EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'support_tickets') 
+        THEN 'support_tickets EXISTS' ELSE 'support_tickets MISSING' END as st_check,
+    CASE WHEN EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'calendar_events') 
+        THEN 'calendar_events EXISTS' ELSE 'calendar_events MISSING' END as ce_check;
+EOSQL
+            then
+                :
+            fi
+            VERIFY_RESULT=$(cat "$VERIFY_TMP")
+            rm -f "$VERIFY_TMP"
+            
+            echo "$VERIFY_RESULT"
+            
+            if echo "$VERIFY_RESULT" | grep -q "EXISTS" && ! echo "$VERIFY_RESULT" | grep -q "MISSING"; then
+                echo "✅ All tables exist, marking migration as applied..."
+                npx prisma migrate resolve --applied "20251202_foundation_pages_enhancements" --schema "$PRISMA_SCHEMA_PATH" || true
+                echo "✅ Build can continue - schema is correct"
+            else
+                echo "❌ Some tables are missing"
+                echo "📋 Final migration status:"
+                npx prisma migrate status --schema "$PRISMA_SCHEMA_PATH" || true
+                exit 1
+            fi
+        fi
     elif echo "$MIGRATION_STATUS" | grep -q "$CONTENT_CATEGORY_MIGRATION_ID"; then
         echo "🔧 Detected pending content category migration, attempting automatic fix..."
         CONTENT_STATUS=$(check_content_category_column)


### PR DESCRIPTION
Fixes Render backend build failure by ensuring prerequisite tables exist before Prisma migrations.

The `20251202_foundation_pages_enhancements` migration failed because the `parent_leads` table (and other related tables) did not exist in the production database, resulting in a `relation "parent_leads" does not exist` error. This PR introduces logic in `prebuild-db-setup.mjs` to explicitly create these tables if they are missing and enhances `render-build-with-recovery.sh` to detect and resolve this specific migration failure by running the prebuild script and marking the migration as applied.

---
<a href="https://cursor.com/background-agent?bcId=bc-7dd46a31-e69c-4308-87f9-429e0dbed70a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7dd46a31-e69c-4308-87f9-429e0dbed70a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

