### PR TITLE
Investigate foundation dashboard loading error

### DIFF
--- a/api/src/analytics/foundation-analytics.service.ts
+++ b/api/src/analytics/foundation-analytics.service.ts
@@ -79,22 +79,40 @@ export class FoundationAnalyticsService {
     const startDate = new Date();
     startDate.setDate(startDate.getDate() - days);
 
-    // Get all orders for the organization in the time range
-    const orders = await this.prisma.order.findMany({
-      where: {
-        organizationId: { in: organizationIds },
-        createdAt: { gte: startDate },
-      },
-      include: {
-        items: {
-          include: {
-            product: {
-              select: { category: true, primaryCategory: true },
+    // Note: orders table may not exist in all environments
+    let orders: Array<{
+      items: Array<{
+        price: number;
+        quantity: number;
+        product: { category: string | null; primaryCategory: string | null } | null;
+      }>;
+    }> = [];
+
+    try {
+      // Get all orders for the organization in the time range
+      orders = await this.prisma.order.findMany({
+        where: {
+          organizationId: { in: organizationIds },
+          createdAt: { gte: startDate },
+        },
+        include: {
+          items: {
+            include: {
+              product: {
+                select: { category: true, primaryCategory: true },
+              },
             },
           },
         },
-      },
-    });
+      });
+    } catch (error: unknown) {
+      // Handle case where orders table doesn't exist (P2021)
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'P2021') {
+        console.warn('Order table does not exist, returning empty spending data');
+        return [];
+      }
+      throw error;
+    }
 
     // Aggregate spending by category
     const categorySpending: Record<string, { amount: number; count: number }> = {};

--- a/api/src/dashboard/dashboard.controller.ts
+++ b/api/src/dashboard/dashboard.controller.ts
@@ -387,40 +387,50 @@ export class DashboardController {
     const userId = req.context.userId;
     const organizationIds = await this.getUserOrganizationIds(userId);
 
-    const orders = await this.prisma.order.findMany({
-      where: {
-        items: {
-          some: { product: { supplierId: { in: organizationIds } } },
+    // Note: orders table may not exist in all environments
+    try {
+      const orders = await this.prisma.order.findMany({
+        where: {
+          items: {
+            some: { product: { supplierId: { in: organizationIds } } },
+          },
         },
-      },
-      include: {
-        organization: true,
-        items: { include: { product: true } },
-      },
-      orderBy: { createdAt: 'desc' },
-      take: 10,
-    });
+        include: {
+          organization: true,
+          items: { include: { product: true } },
+        },
+        orderBy: { createdAt: 'desc' },
+        take: 10,
+      });
 
-    const orderData = orders.map((order) => {
-      const supplierItems = order.items.filter((item) =>
-        organizationIds.includes(item.product.supplierId),
-      );
+      const orderData = orders.map((order) => {
+        const supplierItems = order.items.filter((item) =>
+          organizationIds.includes(item.product.supplierId),
+        );
 
-      return {
-        id: order.id,
-        customerName: order.organization.name,
-        productName:
-          supplierItems.length === 1
-            ? supplierItems[0].product.title
-            : `${supplierItems.length} products`,
-        quantity: supplierItems.reduce((sum, item) => sum + item.quantity, 0),
-        totalAmount: supplierItems.reduce((sum, item) => sum + item.price * item.quantity, 0),
-        orderDate: order.createdAt.toISOString(),
-        status: order.status.toLowerCase(),
-      };
-    });
+        return {
+          id: order.id,
+          customerName: order.organization.name,
+          productName:
+            supplierItems.length === 1
+              ? supplierItems[0].product.title
+              : `${supplierItems.length} products`,
+          quantity: supplierItems.reduce((sum, item) => sum + item.quantity, 0),
+          totalAmount: supplierItems.reduce((sum, item) => sum + item.price * item.quantity, 0),
+          orderDate: order.createdAt.toISOString(),
+          status: order.status.toLowerCase(),
+        };
+      });
 
-    return wrapResponse(orderData);
+      return wrapResponse(orderData);
+    } catch (error: unknown) {
+      // Handle case where orders table doesn't exist (P2021)
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'P2021') {
+        console.warn('Order table does not exist, returning empty orders list');
+        return wrapResponse([]);
+      }
+      throw error;
+    }
   }
 
   // ============================================

--- a/api/src/dashboard/dashboard.service.ts
+++ b/api/src/dashboard/dashboard.service.ts
@@ -179,29 +179,39 @@ export class DashboardService {
     }
 
     // Get recent orders
-    const recentOrders = await this.prisma.order.findMany({
-      where: { organizationId: { in: organizationIds } },
-      include: {
-        items: {
-          include: { product: { select: { title: true, supplier: { select: { name: true } } } } },
+    // Note: orders table may not exist in all environments
+    try {
+      const recentOrders = await this.prisma.order.findMany({
+        where: { organizationId: { in: organizationIds } },
+        include: {
+          items: {
+            include: { product: { select: { title: true, supplier: { select: { name: true } } } } },
+          },
         },
-      },
-      orderBy: { createdAt: 'desc' },
-      take: 5,
-    });
-
-    for (const order of recentOrders) {
-      const supplierName = order.items[0]?.product?.supplier?.name || 'Unknown Supplier';
-      const itemCount = order.items.length;
-      activities.push({
-        id: order.id,
-        type: 'order',
-        title: 'Order Confirmation',
-        description: `Order #${order.id.substring(0, 8)} from ${supplierName} (${itemCount} item${itemCount !== 1 ? 's' : ''})`,
-        timestamp: order.createdAt.toISOString(),
-        status: order.status.toLowerCase(),
-        metadata: { totalAmount: order.totalAmount },
+        orderBy: { createdAt: 'desc' },
+        take: 5,
       });
+
+      for (const order of recentOrders) {
+        const supplierName = order.items[0]?.product?.supplier?.name || 'Unknown Supplier';
+        const itemCount = order.items.length;
+        activities.push({
+          id: order.id,
+          type: 'order',
+          title: 'Order Confirmation',
+          description: `Order #${order.id.substring(0, 8)} from ${supplierName} (${itemCount} item${itemCount !== 1 ? 's' : ''})`,
+          timestamp: order.createdAt.toISOString(),
+          status: order.status.toLowerCase(),
+          metadata: { totalAmount: order.totalAmount },
+        });
+      }
+    } catch (error: unknown) {
+      // Handle case where orders table doesn't exist (P2021)
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'P2021') {
+        console.warn('Order table does not exist, skipping orders in activities');
+      } else {
+        throw error;
+      }
     }
 
     // Get recent service requests


### PR DESCRIPTION
Add try-catch blocks for `prisma.order.findMany()` calls to gracefully handle missing `orders` table, resolving dashboard page load failures.

The `orders` table does not exist in the production database, leading to `PrismaClientKnownRequestError: P2021` when `prisma.order.findMany()` is invoked. While a previous fix addressed similar issues for the `ServiceRequest` table, the `Order` queries were overlooked. This PR applies the same error handling pattern to `Order` queries in dashboard and analytics services, allowing pages to load successfully by returning empty data instead of a 500 error when the table is absent.

---
<a href="https://cursor.com/background-agent?bcId=bc-61818585-0436-4506-9e8e-ca8932c5a9ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-61818585-0436-4506-9e8e-ca8932c5a9ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

