### PR TITLE
Investigate profile upload asset creation error

### DIFF
--- a/api/src/settings/settings.controller.ts
+++ b/api/src/settings/settings.controller.ts
@@ -150,17 +150,18 @@ export class SettingsController {
 
     await this.prisma.$transaction(async (tx) => {
       // Validate asset ownership and kind before updating
+      // Use accountId (AppUser.id) since Asset.uploadedById references AppUser
       await this.validateAssetForUsage(
         tx,
         settings.logoAssetId,
-        profileId,
+        accountId,
         [AssetKind.LOGO],
         'Logo',
       );
       await this.validateAssetForUsage(
         tx,
         settings.coverAssetId,
-        profileId,
+        accountId,
         [AssetKind.COVER_IMAGE],
         'Cover image',
       );
@@ -283,10 +284,11 @@ export class SettingsController {
 
     await this.prisma.$transaction(async (tx) => {
       // Validate asset ownership and kind before updating
+      // Use accountId (AppUser.id) since Asset.uploadedById references AppUser
       await this.validateAssetForUsage(
         tx,
         settings.avatarAssetId,
-        profileId,
+        accountId,
         [AssetKind.AVATAR],
         'Avatar',
       );
@@ -390,17 +392,18 @@ export class SettingsController {
 
     await this.prisma.$transaction(async (tx) => {
       // Validate asset ownership and kind before updating
+      // Use accountId (AppUser.id) since Asset.uploadedById references AppUser
       await this.validateAssetForUsage(
         tx,
         settings.logoAssetId,
-        profileId,
+        accountId,
         [AssetKind.LOGO],
         'Logo',
       );
       await this.validateAssetForUsage(
         tx,
         settings.coverAssetId,
-        profileId,
+        accountId,
         [AssetKind.COVER_IMAGE],
         'Cover image',
       );
@@ -601,17 +604,18 @@ export class SettingsController {
 
         try {
           // Validate asset ownership and kind before updating
+          // Use accountId (AppUser.id) since Asset.uploadedById references AppUser
           await this.validateAssetForUsage(
             tx,
             settings.logoAssetId,
-            profileId,
+            accountId,
             [AssetKind.LOGO],
             'Logo',
           );
           await this.validateAssetForUsage(
             tx,
             settings.coverAssetId,
-            profileId,
+            accountId,
             [AssetKind.COVER_IMAGE],
             'Cover image',
           );
@@ -905,10 +909,11 @@ export class SettingsController {
 
     await this.prisma.$transaction(async (tx) => {
       // Validate asset ownership and kind before updating
+      // Use accountId (AppUser.id) since Asset.uploadedById references AppUser
       await this.validateAssetForUsage(
         tx,
         settings.avatarAssetId,
-        profileId,
+        accountId,
         [AssetKind.AVATAR],
         'Avatar',
       );

--- a/api/src/upload/upload.controller.ts
+++ b/api/src/upload/upload.controller.ts
@@ -39,12 +39,12 @@ export class UploadController {
     try {
       const context = (req as any).context;
       
-      // Use profileId (User.id) for asset ownership to match settings validation
-      // profileId is set by EnsureProfileInterceptor from the User table
-      const userId = context?.profileId;
+      // Use accountId (AppUser.id) for asset ownership since Asset.uploader relation references AppUser
+      // accountId is set by EnsureProfileInterceptor from the AppUser table
+      const userId = context?.accountId;
       
       if (!userId) {
-        this.logger.warn('User profile not found in request context for file upload');
+        this.logger.warn('User account not found in request context for file upload');
         throw new BadRequestException('User context not found');
       }
 
@@ -108,10 +108,10 @@ export class UploadController {
   ) {
     try {
       const context = (req as any).context;
-      const userId = context?.profileId;
+      const userId = context?.accountId;
       
       if (!userId) {
-        this.logger.warn('User profile not found in request context for file delete');
+        this.logger.warn('User account not found in request context for file delete');
         throw new BadRequestException('User context not found');
       }
 
@@ -196,10 +196,10 @@ export class UploadController {
   ) {
     try {
       const context = (req as any).context;
-      const userId = context?.profileId;
+      const userId = context?.accountId;
       
       if (!userId) {
-        this.logger.warn('User profile not found in request context for my-files');
+        this.logger.warn('User account not found in request context for my-files');
         throw new BadRequestException('User context not found');
       }
 


### PR DESCRIPTION
Fix profile logo and banner uploads by using `AppUser.id` for asset ownership.

The `Asset` model's `uploader` relation points to `AppUser`. Previously, asset creation and validation incorrectly used `User.id` (`context.profileId`) instead of `AppUser.id` (`context.accountId`), leading to a Prisma error (`Field uploader is required to return data, got null instead`) when trying to link assets to the `AppUser` table. This PR corrects the ID used for asset operations and validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f50a045-6112-4881-afb4-37638f1293ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f50a045-6112-4881-afb4-37638f1293ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* Updated asset ownership tracking to reference account context instead of profile context across settings updates and file operations
* Adjusted system logging and messages to reflect the updated ownership identification model

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->