### PR TITLE
Fix missing table error

### DIFF
--- a/api/prisma/migrations/20251220000007_add_organization_documents_table/migration.sql
+++ b/api/prisma/migrations/20251220000007_add_organization_documents_table/migration.sql
@@ -1,0 +1,45 @@
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "organization_documents" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "assetId" TEXT NOT NULL,
+    "documentType" TEXT NOT NULL DEFAULT 'CATALOG',
+    "title" TEXT,
+    "description" TEXT,
+    "displayOrder" INTEGER NOT NULL DEFAULT 0,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "organization_documents_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "organization_documents_organizationId_idx" ON "organization_documents"("organizationId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "organization_documents_documentType_idx" ON "organization_documents"("documentType");
+
+-- AddForeignKey (only if not exists)
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints 
+        WHERE constraint_name = 'organization_documents_organizationId_fkey'
+    ) THEN
+        ALTER TABLE "organization_documents" ADD CONSTRAINT "organization_documents_organizationId_fkey" 
+        FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+-- AddForeignKey (only if not exists)
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints 
+        WHERE constraint_name = 'organization_documents_assetId_fkey'
+    ) THEN
+        ALTER TABLE "organization_documents" ADD CONSTRAINT "organization_documents_assetId_fkey" 
+        FOREIGN KEY ("assetId") REFERENCES "assets"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;

--- a/api/scripts/prebuild-db-setup.mjs
+++ b/api/scripts/prebuild-db-setup.mjs
@@ -506,6 +506,80 @@ END $$;
   );
 };
 
+const ensureOrganizationDocumentsTable = () => {
+  const sql = `
+-- Create the organization_documents table if it doesn't exist
+CREATE TABLE IF NOT EXISTS "public"."organization_documents" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "assetId" TEXT NOT NULL,
+    "documentType" TEXT NOT NULL DEFAULT 'CATALOG',
+    "title" TEXT,
+    "description" TEXT,
+    "displayOrder" INTEGER NOT NULL DEFAULT 0,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "organization_documents_pkey" PRIMARY KEY ("id")
+);
+
+-- Create indexes for organization_documents (if they don't exist)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes 
+        WHERE indexname = 'organization_documents_organizationId_idx'
+    ) THEN
+        CREATE INDEX "organization_documents_organizationId_idx" ON "public"."organization_documents"("organizationId");
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes 
+        WHERE indexname = 'organization_documents_documentType_idx'
+    ) THEN
+        CREATE INDEX "organization_documents_documentType_idx" ON "public"."organization_documents"("documentType");
+    END IF;
+END $$;
+
+-- Add foreign key for organizationId (only if it doesn't exist)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint 
+        WHERE conname = 'organization_documents_organizationId_fkey'
+    ) THEN
+        ALTER TABLE "public"."organization_documents" 
+        ADD CONSTRAINT "organization_documents_organizationId_fkey" 
+        FOREIGN KEY ("organizationId") REFERENCES "public"."organizations"("id") 
+        ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+-- Add foreign key for assetId (only if it doesn't exist)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint 
+        WHERE conname = 'organization_documents_assetId_fkey'
+    ) THEN
+        ALTER TABLE "public"."organization_documents" 
+        ADD CONSTRAINT "organization_documents_assetId_fkey" 
+        FOREIGN KEY ("assetId") REFERENCES "public"."assets"("id") 
+        ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;
+`;
+
+  runPrisma(
+    ['db', 'execute', '--schema', SCHEMA_PATH, '--stdin'],
+    { silent: true, input: sql },
+  );
+};
+
 const ensureFoundationPagesEnhancements = () => {
   // First ensure parent_leads exists (prerequisite)
   ensureParentLeadsTable();
@@ -846,6 +920,14 @@ try {
   log('✅ parent_leads table check complete');
 } catch (error) {
   warn(`⚠️  Could not ensure parent_leads table: ${error.message}`);
+}
+
+log('🔁 Ensuring organization_documents table exists...');
+try {
+  ensureOrganizationDocumentsTable();
+  log('✅ organization_documents table check complete');
+} catch (error) {
+  warn(`⚠️  Could not ensure organization_documents table: ${error.message}`);
 }
 
 // log('🔁 Ensuring translation infrastructure is present...');


### PR DESCRIPTION
Add missing database migration to create the `organization_documents` table, resolving a `P2021` error that prevented dashboard and orders pages from loading.

The `OrganizationDocument` model was defined in the Prisma schema and actively used by the API, but the corresponding `organization_documents` table was never created in the database. This led to a `PrismaClientKnownRequestError` (P2021) when attempting to query the non-existent table, causing critical pages to fail. This PR introduces the necessary migration to rectify the database schema.

---
<a href="https://cursor.com/background-agent?bcId=bc-36267a15-9c65-409e-a6f0-386811b233c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-36267a15-9c65-409e-a6f0-386811b233c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

