### PR TITLE
Fix missing inquiries table

### DIFF
--- a/api/prisma/migrations/20251208000000_add_inquiries_table/migration.sql
+++ b/api/prisma/migrations/20251208000000_add_inquiries_table/migration.sql
@@ -1,0 +1,55 @@
+-- CreateEnum (if not exists)
+DO $$ BEGIN
+    CREATE TYPE "InquiryStatus" AS ENUM ('NEW', 'PENDING', 'CONTACTED', 'QUOTED', 'FULFILLED', 'DECLINED', 'CANCELLED');
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "inquiries" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "supplierId" TEXT NOT NULL,
+    "subject" TEXT,
+    "message" TEXT NOT NULL,
+    "productInterest" TEXT,
+    "quantity" INTEGER,
+    "budget" TEXT,
+    "urgency" TEXT,
+    "contactName" TEXT,
+    "contactEmail" TEXT,
+    "contactPhone" TEXT,
+    "preferredContactMethod" TEXT,
+    "status" "InquiryStatus" NOT NULL DEFAULT 'NEW',
+    "supplierNotes" TEXT,
+    "responseMessage" TEXT,
+    "quotedAmount" DOUBLE PRECISION,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "respondedAt" TIMESTAMP(3),
+    "fulfilledAt" TIMESTAMP(3),
+
+    CONSTRAINT "inquiries_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "inquiries_supplierId_status_idx" ON "inquiries"("supplierId", "status");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "inquiries_organizationId_idx" ON "inquiries"("organizationId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "inquiries_createdAt_idx" ON "inquiries"("createdAt");
+
+-- AddForeignKey (if not exists)
+DO $$ BEGIN
+    ALTER TABLE "inquiries" ADD CONSTRAINT "inquiries_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+    ALTER TABLE "inquiries" ADD CONSTRAINT "inquiries_supplierId_fkey" FOREIGN KEY ("supplierId") REFERENCES "organizations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;

--- a/api/prisma/migrations/20251208000000_add_inquiries_table/migration.sql
+++ b/api/prisma/migrations/20251208000000_add_inquiries_table/migration.sql
@@ -1,12 +1,16 @@
 -- CreateEnum (if not exists)
-DO $$ BEGIN
-    CREATE TYPE "InquiryStatus" AS ENUM ('NEW', 'PENDING', 'CONTACTED', 'QUOTED', 'FULFILLED', 'DECLINED', 'CANCELLED');
-EXCEPTION
-    WHEN duplicate_object THEN null;
-END $$;
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_type WHERE typname = 'InquiryStatus'
+    ) THEN
+        CREATE TYPE "public"."InquiryStatus" AS ENUM ('NEW', 'PENDING', 'CONTACTED', 'QUOTED', 'FULFILLED', 'DECLINED', 'CANCELLED');
+    END IF;
+END
+$$;
 
 -- CreateTable
-CREATE TABLE IF NOT EXISTS "inquiries" (
+CREATE TABLE IF NOT EXISTS "public"."inquiries" (
     "id" TEXT NOT NULL,
     "organizationId" TEXT NOT NULL,
     "supplierId" TEXT NOT NULL,
@@ -20,7 +24,7 @@ CREATE TABLE IF NOT EXISTS "inquiries" (
     "contactEmail" TEXT,
     "contactPhone" TEXT,
     "preferredContactMethod" TEXT,
-    "status" "InquiryStatus" NOT NULL DEFAULT 'NEW',
+    "status" "public"."InquiryStatus" NOT NULL DEFAULT 'NEW',
     "supplierNotes" TEXT,
     "responseMessage" TEXT,
     "quotedAmount" DOUBLE PRECISION,
@@ -33,23 +37,61 @@ CREATE TABLE IF NOT EXISTS "inquiries" (
 );
 
 -- CreateIndex
-CREATE INDEX IF NOT EXISTS "inquiries_supplierId_status_idx" ON "inquiries"("supplierId", "status");
-
--- CreateIndex
-CREATE INDEX IF NOT EXISTS "inquiries_organizationId_idx" ON "inquiries"("organizationId");
-
--- CreateIndex
-CREATE INDEX IF NOT EXISTS "inquiries_createdAt_idx" ON "inquiries"("createdAt");
-
--- AddForeignKey (if not exists)
-DO $$ BEGIN
-    ALTER TABLE "inquiries" ADD CONSTRAINT "inquiries_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-EXCEPTION
-    WHEN duplicate_object THEN null;
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes 
+        WHERE indexname = 'inquiries_supplierId_status_idx'
+    ) THEN
+        CREATE INDEX "inquiries_supplierId_status_idx" ON "public"."inquiries"("supplierId", "status");
+    END IF;
 END $$;
 
-DO $$ BEGIN
-    ALTER TABLE "inquiries" ADD CONSTRAINT "inquiries_supplierId_fkey" FOREIGN KEY ("supplierId") REFERENCES "organizations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-EXCEPTION
-    WHEN duplicate_object THEN null;
+-- CreateIndex
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes 
+        WHERE indexname = 'inquiries_organizationId_idx'
+    ) THEN
+        CREATE INDEX "inquiries_organizationId_idx" ON "public"."inquiries"("organizationId");
+    END IF;
+END $$;
+
+-- CreateIndex
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes 
+        WHERE indexname = 'inquiries_createdAt_idx'
+    ) THEN
+        CREATE INDEX "inquiries_createdAt_idx" ON "public"."inquiries"("createdAt");
+    END IF;
+END $$;
+
+-- AddForeignKey (if not exists)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint 
+        WHERE conname = 'inquiries_organizationId_fkey'
+    ) THEN
+        ALTER TABLE "public"."inquiries" 
+        ADD CONSTRAINT "inquiries_organizationId_fkey" 
+        FOREIGN KEY ("organizationId") REFERENCES "public"."organizations"("id") 
+        ON DELETE RESTRICT ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint 
+        WHERE conname = 'inquiries_supplierId_fkey'
+    ) THEN
+        ALTER TABLE "public"."inquiries" 
+        ADD CONSTRAINT "inquiries_supplierId_fkey" 
+        FOREIGN KEY ("supplierId") REFERENCES "public"."organizations"("id") 
+        ON DELETE RESTRICT ON UPDATE CASCADE;
+    END IF;
 END $$;

--- a/api/scripts/prebuild-db-setup.mjs
+++ b/api/scripts/prebuild-db-setup.mjs
@@ -905,6 +905,112 @@ END $$;
   );
 };
 
+const ensureInquiriesTable = () => {
+  const sql = `
+-- Ensure InquiryStatus enum exists
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_type WHERE typname = 'InquiryStatus'
+    ) THEN
+        CREATE TYPE "public"."InquiryStatus" AS ENUM ('NEW', 'PENDING', 'CONTACTED', 'QUOTED', 'FULFILLED', 'DECLINED', 'CANCELLED');
+    END IF;
+END
+$$;
+
+-- Create the inquiries table if it doesn't exist
+CREATE TABLE IF NOT EXISTS "public"."inquiries" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "supplierId" TEXT NOT NULL,
+    "subject" TEXT,
+    "message" TEXT NOT NULL,
+    "productInterest" TEXT,
+    "quantity" INTEGER,
+    "budget" TEXT,
+    "urgency" TEXT,
+    "contactName" TEXT,
+    "contactEmail" TEXT,
+    "contactPhone" TEXT,
+    "preferredContactMethod" TEXT,
+    "status" "public"."InquiryStatus" NOT NULL DEFAULT 'NEW',
+    "supplierNotes" TEXT,
+    "responseMessage" TEXT,
+    "quotedAmount" DOUBLE PRECISION,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "respondedAt" TIMESTAMP(3),
+    "fulfilledAt" TIMESTAMP(3),
+
+    CONSTRAINT "inquiries_pkey" PRIMARY KEY ("id")
+);
+
+-- Create indexes for inquiries (if they don't exist)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes 
+        WHERE indexname = 'inquiries_supplierId_status_idx'
+    ) THEN
+        CREATE INDEX "inquiries_supplierId_status_idx" ON "public"."inquiries"("supplierId", "status");
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes 
+        WHERE indexname = 'inquiries_organizationId_idx'
+    ) THEN
+        CREATE INDEX "inquiries_organizationId_idx" ON "public"."inquiries"("organizationId");
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes 
+        WHERE indexname = 'inquiries_createdAt_idx'
+    ) THEN
+        CREATE INDEX "inquiries_createdAt_idx" ON "public"."inquiries"("createdAt");
+    END IF;
+END $$;
+
+-- Add foreign key for organizationId (only if it doesn't exist)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint 
+        WHERE conname = 'inquiries_organizationId_fkey'
+    ) THEN
+        ALTER TABLE "public"."inquiries" 
+        ADD CONSTRAINT "inquiries_organizationId_fkey" 
+        FOREIGN KEY ("organizationId") REFERENCES "public"."organizations"("id") 
+        ON DELETE RESTRICT ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+-- Add foreign key for supplierId (only if it doesn't exist)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint 
+        WHERE conname = 'inquiries_supplierId_fkey'
+    ) THEN
+        ALTER TABLE "public"."inquiries" 
+        ADD CONSTRAINT "inquiries_supplierId_fkey" 
+        FOREIGN KEY ("supplierId") REFERENCES "public"."organizations"("id") 
+        ON DELETE RESTRICT ON UPDATE CASCADE;
+    END IF;
+END $$;
+`;
+
+  runPrisma(
+    ['db', 'execute', '--schema', SCHEMA_PATH, '--stdin'],
+    { silent: true, input: sql },
+  );
+};
+
 const ensureFoundationPagesEnhancements = () => {
   // First ensure parent_leads exists (prerequisite)
   ensureParentLeadsTable();
@@ -1211,6 +1317,11 @@ const handleFailedMigration = (migration) => {
       ensureFoundationPagesEnhancements();
       resolveMigration('applied', migration);
       break;
+    case '20251208000000_add_inquiries_table':
+      log(`   • Resolving ${migration} (inquiries table)`);
+      ensureInquiriesTable();
+      resolveMigration('applied', migration);
+      break;
     default:
       log(`   • Rolling back failed migration ${migration}`);
       resolveMigration('rolled-back', migration);
@@ -1301,6 +1412,14 @@ try {
   log('✅ messages table check complete');
 } catch (error) {
   warn(`⚠️  Could not ensure messages table: ${error.message}`);
+}
+
+log('🔁 Ensuring inquiries table exists...');
+try {
+  ensureInquiriesTable();
+  log('✅ inquiries table check complete');
+} catch (error) {
+  warn(`⚠️  Could not ensure inquiries table: ${error.message}`);
 }
 
 // log('🔁 Ensuring translation infrastructure is present...');

--- a/api/scripts/render-build-with-recovery.sh
+++ b/api/scripts/render-build-with-recovery.sh
@@ -217,6 +217,49 @@ EOSQL
                 exit 1
             fi
         fi
+    elif echo "$MIGRATION_STATUS" | grep -q "20251208000000_add_inquiries_table"; then
+        echo "🔧 Detected failed inquiries table migration, ensuring table exists..."
+        
+        # Run the fix using prebuild script
+        if node ./scripts/prebuild-db-setup.mjs; then
+            echo "✅ Inquiries table created"
+        else
+            echo "⚠️  Inquiries table fix had issues, but continuing..."
+        fi
+        
+        # Retry migration deployment
+        echo "🔄 Retrying migration deployment after fix..."
+        if run_prisma_migrate_deploy; then
+            echo "✅ Migrations deployed successfully after inquiries fix"
+        else
+            echo "⚠️  Migration still failing, verifying schema state..."
+            
+            # Verify the table exists
+            VERIFY_TMP=$(mktemp)
+            if ! npx prisma db execute --schema "$PRISMA_SCHEMA_PATH" --stdin >"$VERIFY_TMP" 2>&1 <<'EOSQL'
+SELECT 
+    CASE WHEN EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'inquiries') 
+        THEN 'inquiries EXISTS' ELSE 'inquiries MISSING' END as inquiries_check;
+EOSQL
+            then
+                :
+            fi
+            VERIFY_RESULT=$(cat "$VERIFY_TMP")
+            rm -f "$VERIFY_TMP"
+            
+            echo "$VERIFY_RESULT"
+            
+            if echo "$VERIFY_RESULT" | grep -q "EXISTS" && ! echo "$VERIFY_RESULT" | grep -q "MISSING"; then
+                echo "✅ Inquiries table exists, marking migration as applied..."
+                npx prisma migrate resolve --applied "20251208000000_add_inquiries_table" --schema "$PRISMA_SCHEMA_PATH" || true
+                echo "✅ Build can continue - schema is correct"
+            else
+                echo "❌ Inquiries table is missing"
+                echo "📋 Final migration status:"
+                npx prisma migrate status --schema "$PRISMA_SCHEMA_PATH" || true
+                exit 1
+            fi
+        fi
     elif echo "$MIGRATION_STATUS" | grep -q "$CONTENT_CATEGORY_MIGRATION_ID"; then
         echo "🔧 Detected pending content category migration, attempting automatic fix..."
         CONTENT_STATUS=$(check_content_category_column)


### PR DESCRIPTION
Add Prisma migration to create the `inquiries` table and `InquiryStatus` enum.

This fixes the supplier dashboard pages failing to load due to a `PrismaClientKnownRequestError` (P2021) caused by the `public.inquiries` table not existing in the database. The `Inquiry` model was defined in the schema, but a migration to create its corresponding table was missing.

---
<a href="https://cursor.com/background-agent?bcId=bc-38f664e2-0bd7-48dc-b0ee-45b8e8fc9dbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-38f664e2-0bd7-48dc-b0ee-45b8e8fc9dbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database infrastructure and migration recovery processes for improved system reliability and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->