### PR TITLE
Ensure husky installs during production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,12 @@
     "check:i18n-keys": "ts-node scripts/check-i18n-keys.ts",
     "check:untranslated": "node scripts/check-untranslated-strings.mjs",
     "i18n:full-check": "npm run extract:i18n-keys && npm run check:i18n-keys && npm run generate:i18n-types",
-    "prepare": "husky"
+    "prepare": "node scripts/run-husky.js"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",
     "eslint-plugin-i18next": "^6.1.0",
     "glob": "^11.0.0",
-    "husky": "^9.1.7",
     "prettier": "^3.6.2",
     "ts-node": "^10.9.2",
     "turbo": "^2.5.6",
@@ -66,6 +65,7 @@
     "compression": "^1.8.1",
     "express": "^5.1.0",
     "helmet": "^8.1.0",
+    "husky": "^9.1.7",
     "lucide-react": "^0.544.0",
     "multer": "^2.0.2",
     "react": "^19.1.1",

--- a/scripts/run-husky.js
+++ b/scripts/run-husky.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('child_process');
+
+if (process.env.HUSKY === '0' || process.env.HUSKY_SKIP_INSTALL === '1') {
+  console.log('Husky install disabled by environment.');
+  process.exit(0);
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, { stdio: 'inherit' });
+  if (result.error) {
+    console.warn(`Failed to run ${command}:`, result.error.message);
+  }
+  return result.status ?? 0;
+}
+
+let huskyBin;
+try {
+  huskyBin = require.resolve('husky/lib/bin');
+} catch (error) {
+  console.log('Husky not found in node_modules, bootstrapping with npx...');
+  const status = run('npx', ['--yes', 'husky@9.1.7', 'install']);
+  process.exit(status);
+}
+
+const status = run('node', [huskyBin, 'install']);
+process.exit(status);

--- a/scripts/run-husky.js
+++ b/scripts/run-husky.js
@@ -2,7 +2,7 @@
 
 const { spawnSync } = require('child_process');
 
-if (process.env.HUSKY === '0' || process.env.HUSKY_SKIP_INSTALL === '1') {
+if (process.env.HUSKY === '0' || process.env.HUSKY_SKIP_INSTALL === '1' || process.env.CI === 'true') {
   console.log('Husky install disabled by environment.');
   process.exit(0);
 }
@@ -17,11 +17,10 @@ function run(command, args) {
 
 let huskyBin;
 try {
-  huskyBin = require.resolve('husky/lib/bin');
+  huskyBin = require.resolve('husky/bin.js');
 } catch (error) {
-  console.log('Husky not found in node_modules, bootstrapping with npx...');
-  const status = run('npx', ['--yes', 'husky@9.1.7', 'install']);
-  process.exit(status);
+  console.error('Husky not found. Please ensure dependencies are installed (e.g., run pnpm install).');
+  process.exit(1);
 }
 
 const status = run('node', [huskyBin, 'install']);


### PR DESCRIPTION
## Summary
- move husky into runtime dependencies so it is available in production installs
- update the prepare helper to always install husky and bootstrap via npx when missing

## Testing
- NODE_ENV=production node scripts/run-husky.js *(fails here due to registry 403 when fetching husky via npx)*
- pnpm install --ignore-scripts *(fails here due to registry 403 for @playwright/test)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938440ee4348325a28fd7ea335d8a6f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pre-commit hook installation process during project setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->