### PR TITLE
Fix pnpm lockfile issue

### DIFF
--- a/BUILD_STATUS.md
+++ b/BUILD_STATUS.md
@@ -1,5 +1,31 @@
 # Build Status & Troubleshooting
 
+## Current Issue: Render install fails before build (Resolved)
+
+### Error Message
+```
+pnpm install --frozen-lockfile
+ERR_PNPM_OUTDATED_LOCKFILE: Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with package.json
+```
+
+### Root Cause
+- Husky (`"husky": "^9.1.7"`) was added to the root `package.json` but the workspace lockfile was never regenerated.
+- Render’s build command (`pnpm install --frozen-lockfile && cd api && pnpm run build:render`) runs a frozen install before any scripts, so the deployment dies before it can even attempt the API build.
+
+### Fix
+1. Run `pnpm install` locally and commit the refreshed `pnpm-lock.yaml`.
+2. Add `scripts/prebuild-lock-check.mjs` plus the `pnpm run prebuild:render` npm script to guard the lockfile before any Render build starts.
+3. Ensure every Render service executes the guard (see `render.yaml` – each `buildCommand` now starts with `pnpm run prebuild:render`).
+
+### Local Verification
+```bash
+pnpm run prebuild:render        # Fails fast if pnpm-lock.yaml is stale
+pnpm install --frozen-lockfile  # Succeeds locally after the fix
+cd api && pnpm run build:render # Optional – mirrors Render’s build
+```
+
+---
+
 ## Current Issue: Frontend Build Failing
 
 ### Error Message

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:watch": "turbo run test:watch",
     "clean": "turbo run clean",
     "precommit:guard": "node scripts/check-no-raw-imports.mjs",
+    "prebuild:render": "node scripts/prebuild-lock-check.mjs",
     "i18n:check": "node scripts/i18n-check.js",
     "translate": "node scripts/translate-i18n-free.js",
     "translate:ai": "node scripts/translate-i18n.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       helmet:
         specifier: ^8.1.0
         version: 8.1.0
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       lucide-react:
         specifier: ^0.544.0
         version: 0.544.0(react@19.1.1)
@@ -138,9 +141,6 @@ importers:
       glob:
         specifier: ^11.0.0
         version: 11.0.3
-      husky:
-        specifier: ^9.1.7
-        version: 9.1.7
       prettier:
         specifier: ^3.6.2
         version: 3.6.2

--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,7 @@ services:
     env: node
     plan: starter
     branch: merge/pcs-development-integration
-    buildCommand: cd frontend && pnpm install --frozen-lockfile=false && pnpm run build:render
+    buildCommand: pnpm run prebuild:render && cd frontend && pnpm install --frozen-lockfile=false && pnpm run build:render
     startCommand: cd frontend && pnpm run start
     envVars:
       - key: NODE_ENV
@@ -24,7 +24,7 @@ services:
     name: pc-solutions-api
     env: node
     plan: starter
-    buildCommand: cd api && pnpm install && pnpm run build:render
+    buildCommand: pnpm run prebuild:render && cd api && pnpm install --frozen-lockfile && pnpm run build:render
     startCommand: cd api && pnpm run start:prod
     envVars:
       - key: NODE_ENV
@@ -46,7 +46,7 @@ services:
     env: node
     plan: starter
     branch: merge/pcs-development-integration
-    buildCommand: cd admin && pnpm install --frozen-lockfile=false && pnpm run build
+    buildCommand: pnpm run prebuild:render && cd admin && pnpm install --frozen-lockfile=false && pnpm run build
     startCommand: cd admin && pnpm run start
     envVars:
       - key: NODE_ENV

--- a/scripts/prebuild-lock-check.mjs
+++ b/scripts/prebuild-lock-check.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+/**
+ * Minimal prebuild guard that ensures `pnpm-lock.yaml` stays in sync with
+ * root-level dependencies. Render now runs this script before attempting a
+ * frozen install so we can fail fast with an actionable message instead of
+ * letting the install blow up mid-build.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const packageJsonPath = path.join(repoRoot, 'package.json');
+const lockfilePath = path.join(repoRoot, 'pnpm-lock.yaml');
+
+function assertFileExists(filePath) {
+  if (!fs.existsSync(filePath)) {
+    console.error(`Required file missing: ${filePath}`);
+    process.exit(1);
+  }
+}
+
+assertFileExists(packageJsonPath);
+assertFileExists(lockfilePath);
+
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+const lockfileContent = fs.readFileSync(lockfilePath, 'utf8');
+
+function extractRootImporterBlock(content) {
+  const lines = content.split(/\r?\n/);
+  let capturing = false;
+  const block = [];
+
+  for (const line of lines) {
+    if (!capturing) {
+      if (line.startsWith('  .:')) {
+        capturing = true;
+      }
+      continue;
+    }
+
+    if (line.startsWith('  ') && !line.startsWith('    ') && line.trim().length) {
+      break;
+    }
+
+    block.push(line);
+  }
+
+  if (!capturing || block.length === 0) {
+    console.error('Unable to locate root workspace importers inside pnpm-lock.yaml.');
+    process.exit(1);
+  }
+
+  return block.join('\n');
+}
+
+function stripQuotes(value) {
+  if (!value) return value;
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function collectSections(blockContent) {
+  const sections = {};
+  const lines = blockContent.split(/\r?\n/);
+  let currentSection = null;
+  let currentName = null;
+
+  for (const rawLine of lines) {
+    if (!rawLine.trim()) {
+      continue;
+    }
+
+    const indent = rawLine.match(/^(\s*)/)?.[1].length ?? 0;
+    const line = rawLine.trim();
+
+    if (indent === 4 && line.endsWith(':')) {
+      currentSection = line.slice(0, -1);
+      if (!sections[currentSection]) {
+        sections[currentSection] = {};
+      }
+      currentName = null;
+      continue;
+    }
+
+    if (indent === 6 && line.endsWith(':')) {
+      currentName = stripQuotes(line.slice(0, -1));
+      continue;
+    }
+
+    if (indent === 8 && line.startsWith('specifier:')) {
+      if (currentSection && currentName) {
+        const specifierValue = line.replace('specifier:', '').trim();
+        sections[currentSection][currentName] = specifierValue;
+      }
+      continue;
+    }
+
+    if (indent <= 4) {
+      currentName = null;
+    }
+  }
+
+  return sections;
+}
+
+const rootImporterBlock = extractRootImporterBlock(lockfileContent);
+const sections = collectSections(rootImporterBlock);
+
+function compareDeps(pkgDeps, sectionName) {
+  const lockSection = sections[sectionName] ?? {};
+  const mismatches = [];
+
+  if (!pkgDeps) {
+    return mismatches;
+  }
+
+  for (const [name, specifier] of Object.entries(pkgDeps)) {
+    const lockSpecifier = lockSection[name];
+    if (!lockSpecifier) {
+      mismatches.push(`[${sectionName}] Missing "${name}" in pnpm-lock.yaml (expected ${specifier}).`);
+      continue;
+    }
+    if (lockSpecifier !== specifier) {
+      mismatches.push(
+        `[${sectionName}] "${name}" specifier mismatch. pnpm-lock.yaml has "${lockSpecifier}" but package.json requires "${specifier}".`,
+      );
+    }
+  }
+
+  return mismatches;
+}
+
+const mismatches = [
+  ...compareDeps(packageJson.dependencies, 'dependencies'),
+  ...compareDeps(packageJson.devDependencies, 'devDependencies'),
+];
+
+if (mismatches.length > 0) {
+  console.error('❌ pnpm-lock.yaml is out of sync with package.json:');
+  for (const mismatch of mismatches) {
+    console.error(`  - ${mismatch}`);
+  }
+  console.error('\nFix it by running "pnpm install" at the repo root and committing the updated pnpm-lock.yaml.');
+  process.exit(1);
+}
+
+console.log('✅ pnpm-lock.yaml matches package.json. Safe to proceed with frozen installs.');


### PR DESCRIPTION
Fixes Render build failures by regenerating `pnpm-lock.yaml` and adding a prebuild script to validate lockfile consistency.

The `ERR_PNPM_OUTDATED_LOCKFILE` error occurred because `husky` was added to `package.json` but `pnpm-lock.yaml` was not updated. The new `prebuild:render` script now acts as a guard, ensuring the lockfile is in sync before any frozen `pnpm install` command is executed on Render, preventing build failures and providing clearer diagnostics.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5e41862-33eb-4493-8d7b-654e7d9fa26b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e5e41862-33eb-4493-8d7b-654e7d9fa26b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

