### PR TITLE
Debug email signup message

### DIFF
--- a/frontend/pages/SignupPage.tsx
+++ b/frontend/pages/SignupPage.tsx
@@ -34,7 +34,10 @@ const SignupPage: React.FC = () => {
 
   // Detect if this is an OAuth user completing their profile (signed in but no backend user)
   // Important: Also check !isAuthLoading to avoid false positive while user data is being fetched
-  const isOAuthCompletion = isSignedIn && !currentUser && !isAuthLoading;
+  // CRITICAL: Must also verify user actually used OAuth (has externalAccounts) - otherwise this
+  // incorrectly triggers for email/password users who are waiting for webhook to create backend profile
+  const hasOAuthAccount = clerkUser?.externalAccounts && clerkUser.externalAccounts.length > 0;
+  const isOAuthCompletion = isSignedIn && !currentUser && !isAuthLoading && hasOAuthAccount;
 
   useEffect(() => {
     if (settingsError) {


### PR DESCRIPTION
Correct `isOAuthCompletion` logic to prevent "signed in with Google" message for email/password signups.

The previous condition `isSignedIn && !currentUser && !isAuthLoading` was too broad, incorrectly triggering the OAuth completion flow for email/password users who were simply waiting for their backend profile to be created. The fix adds a check for `clerkUser?.externalAccounts` to accurately identify users who signed up via OAuth.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c3f25cf-470e-4e84-bb9d-22f60d477188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0c3f25cf-470e-4e84-bb9d-22f60d477188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

