### PR TITLE
Auth error investigation pending user

### DIFF
--- a/api/src/users/dto/complete-profile.dto.ts
+++ b/api/src/users/dto/complete-profile.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsEnum, IsNotEmpty, IsInt, Min } from 'class-validator';
+import { IsString, IsOptional, IsEnum, IsNotEmpty, IsInt, Min, IsEmail } from 'class-validator';
 import { UserRole } from '@prisma/client';
 import { Type } from 'class-transformer';
 
@@ -6,6 +6,10 @@ export class CompleteProfileDto {
   @IsEnum(UserRole)
   @IsNotEmpty()
   role: UserRole;
+
+  @IsEmail()
+  @IsOptional()
+  email?: string;
 
   @IsString()
   @IsOptional()

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -11,6 +11,7 @@ import {
   ParseUUIDPipe,
   Request,
   Logger,
+  BadRequestException,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
@@ -47,7 +48,7 @@ export class UsersController {
     const email = completeProfileDto.email || request.user?.email;
     
     if (!email) {
-      throw new Error('Email is required to complete profile');
+      throw new BadRequestException('Email is required to complete profile');
     }
     
     return this.usersService.completeProfile(clerkId, email, completeProfileDto);

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -39,9 +39,16 @@ export class UsersController {
   }
 
   @Post('complete-profile')
+  @AllowPending()  // Allow pending users (those whose webhook hasn't processed yet) to complete profile
   async completeProfile(@Request() request, @Body() completeProfileDto: CompleteProfileDto) {
     const clerkId = request.user.clerkId;
-    const email = request.user.email;
+    // Get email from DTO (preferred) or fall back to request.user.email
+    // For pending users, request.user.email may be undefined, so DTO email is essential
+    const email = completeProfileDto.email || request.user?.email;
+    
+    if (!email) {
+      throw new Error('Email is required to complete profile');
+    }
     
     return this.usersService.completeProfile(clerkId, email, completeProfileDto);
   }

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -213,8 +213,14 @@ const ProtectedLayout: React.FC = () => {
           <div className="flex flex-col sm:flex-row gap-3 justify-center text-sm">
             <button
               onClick={async () => {
-                await signOut();
-                navigate('/login', { replace: true });
+                try {
+                  await signOut();
+                  navigate('/login', { replace: true });
+                } catch (error) {
+                  console.error('Sign out failed:', error);
+                  // Force navigate to login even if sign-out fails
+                  navigate('/login', { replace: true });
+                }
               }}
               className="text-gray-500 hover:text-gray-700 underline"
             >

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,8 +1,8 @@
 
 
 import React from 'react';
-import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
-import { useAuth } from '@clerk/clerk-react';
+import { Routes, Route, Navigate, useLocation, useNavigate, Link } from 'react-router-dom';
+import { useAuth, useUser, useClerk } from '@clerk/clerk-react';
 import MainLayout from './components/layout/MainLayout';
 import DashboardPage from './pages/DashboardPage'; // This will be the Foundation default dashboard
 import MarketplacePage from './pages/MarketplacePage';
@@ -131,8 +131,11 @@ const RoleBasedDashboardRedirect: React.FC = () => {
 const ProtectedLayout: React.FC = () => {
   const { currentUser } = useAppContext();
   const { isLoaded, isSignedIn } = useAuth();
+  const { user: clerkUser } = useUser();
+  const { signOut } = useClerk();
   const { isLoading: isAuthLoading } = useAuthContext();
   const location = useLocation();
+  const navigate = useNavigate();
 
   // Wait for Clerk to load before checking authentication
   if (!isLoaded) {
@@ -162,9 +165,70 @@ const ProtectedLayout: React.FC = () => {
       );
     }
     
-    // Backend sync failed (not loading anymore, but no user) ? redirect to signup
-    // This handles the case where a user authenticated via OAuth but hasn't completed their profile
-    return <Navigate to="/signup" state={{ from: location, isPending: true }} replace />;
+    // Backend sync failed (not loading anymore, but no user)
+    // Show a manual "Complete Profile" page instead of auto-redirecting
+    // This handles OAuth users and email/password users whose webhook failed
+    const hasOAuthAccount = clerkUser?.externalAccounts && clerkUser.externalAccounts.length > 0;
+    const userEmail = clerkUser?.primaryEmailAddress?.emailAddress;
+    const userName = clerkUser?.firstName || userEmail?.split('@')[0] || 'there';
+    
+    return (
+      <div className="min-h-screen bg-page-bg flex items-center justify-center p-4">
+        <div className="max-w-md w-full bg-white rounded-xl shadow-lg p-8 text-center">
+          {/* Icon */}
+          <div className="w-16 h-16 bg-swiss-mint/10 rounded-full flex items-center justify-center mx-auto mb-6">
+            <svg className="w-8 h-8 text-swiss-mint" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+            </svg>
+          </div>
+          
+          {/* Title */}
+          <h1 className="text-2xl font-bold text-swiss-charcoal mb-2">
+            Welcome, {userName}!
+          </h1>
+          
+          {/* Message */}
+          <p className="text-gray-600 mb-6">
+            {hasOAuthAccount 
+              ? "You've signed in successfully. To get started, please complete your profile by selecting your role and providing a few details."
+              : "Your account was created but your profile setup wasn't completed. Please complete your profile to continue."}
+          </p>
+          
+          {/* Email display */}
+          {userEmail && (
+            <p className="text-sm text-gray-500 mb-6">
+              Signed in as <span className="font-medium text-swiss-charcoal">{userEmail}</span>
+            </p>
+          )}
+          
+          {/* Complete Profile Button */}
+          <button
+            onClick={() => navigate('/signup', { state: { from: location, isPending: true } })}
+            className="w-full bg-swiss-mint text-white font-semibold py-3 px-6 rounded-lg hover:bg-swiss-mint/90 transition-colors mb-4"
+          >
+            Complete Your Profile
+          </button>
+          
+          {/* Secondary actions */}
+          <div className="flex flex-col sm:flex-row gap-3 justify-center text-sm">
+            <button
+              onClick={async () => {
+                await signOut();
+                navigate('/login', { replace: true });
+              }}
+              className="text-gray-500 hover:text-gray-700 underline"
+            >
+              Sign out and use a different account
+            </button>
+          </div>
+          
+          {/* Help text */}
+          <p className="mt-6 text-xs text-gray-400">
+            Having trouble? <Link to="/support" className="text-swiss-mint hover:underline">Contact support</Link>
+          </p>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/frontend/pages/SignupPage.tsx
+++ b/frontend/pages/SignupPage.tsx
@@ -32,12 +32,19 @@ const SignupPage: React.FC = () => {
   const { currentUser, refreshCurrentUser, logout, isLoading: isAuthLoading } = useAuthContext();
   const { settings, loading: settingsLoading, error: settingsError } = useFrontendSettings();
 
-  // Detect if this is an OAuth user completing their profile (signed in but no backend user)
+  // Detect if this is a user who needs to complete their profile (signed in but no backend user)
+  // This can happen for:
+  // 1. OAuth users (Google) who signed in but haven't selected a role yet
+  // 2. Email/password users whose webhook failed to create their AppUser record
   // Important: Also check !isAuthLoading to avoid false positive while user data is being fetched
-  // CRITICAL: Must also verify user actually used OAuth (has externalAccounts) - otherwise this
-  // incorrectly triggers for email/password users who are waiting for webhook to create backend profile
   const hasOAuthAccount = clerkUser?.externalAccounts && clerkUser.externalAccounts.length > 0;
-  const isOAuthCompletion = isSignedIn && !currentUser && !isAuthLoading && hasOAuthAccount;
+  
+  // Check if user needs to complete profile (signed in to Clerk but no backend user)
+  // This applies to BOTH OAuth users AND email/password users with failed webhooks
+  const needsProfileCompletion = isSignedIn && !currentUser && !isAuthLoading;
+  
+  // For backwards compatibility, keep isOAuthCompletion for OAuth-specific UI
+  const isOAuthCompletion = needsProfileCompletion && hasOAuthAccount;
 
   useEffect(() => {
     if (settingsError) {
@@ -168,16 +175,16 @@ const SignupPage: React.FC = () => {
     }
   }, [isSignedIn, currentStep, navigate, successRedirect]);
 
-  // Pre-fill form data for OAuth users (e.g., Google Sign Up)
+  // Pre-fill form data for users completing their profile (OAuth or email/password with failed webhook)
   useEffect(() => {
-    if (isOAuthCompletion && clerkUser) {
+    if (needsProfileCompletion && clerkUser) {
       setFormData(prev => ({
         ...prev,
         email: clerkUser.primaryEmailAddress?.emailAddress || prev.email,
         contactPerson: `${clerkUser.firstName || ''} ${clerkUser.lastName || ''}`.trim() || prev.contactPerson,
       }));
     }
-  }, [isOAuthCompletion, clerkUser]);
+  }, [needsProfileCompletion, clerkUser]);
 
   const rolesConfig: { role: SignupRole; nameKey: string; icon: React.ElementType; subtitleKey?: string }[] = [
     { role: SignupRole.FOUNDATION, nameKey: 'role.foundation', icon: BuildingOffice2Icon },
@@ -364,6 +371,7 @@ const SignupPage: React.FC = () => {
 
        const payload = {
            role: SIGNUP_ROLE_TO_USER_ROLE[selectedRole!],
+           email: formData.email || clerkUser?.primaryEmailAddress?.emailAddress,  // Include email for pending users
            organisationName: formData.organisationName || undefined,
            contactPerson: formData.contactPerson || undefined,
            phone: formData.phone || undefined,
@@ -403,8 +411,8 @@ const SignupPage: React.FC = () => {
        }
     } catch (err: any) {
         console.error('Profile completion error:', err);
-        // For OAuth users, set error in a visible banner instead of on the read-only email field
-        if (isOAuthCompletion) {
+        // For users completing profile, set error in a visible banner instead of on the read-only email field
+        if (needsProfileCompletion) {
             setCompleteProfileError(err.message || t('signup:errors.profileCompletionFailed', 'An error occurred while completing your profile. Please try again.'));
         } else {
             setErrors({ email: err.message || 'An error occurred while completing your profile' });
@@ -418,15 +426,19 @@ const SignupPage: React.FC = () => {
     e.preventDefault();
     if (!selectedRole) return;
     
-    // If user is already authenticated (e.g. via Google OAuth) but missing backend profile
-    // we use OAuth-specific validation (no password required) and complete their profile
-    if (isOAuthCompletion) {
+    // If user is already authenticated but missing backend profile, complete their profile
+    // This handles both:
+    // 1. OAuth users (Google) who signed in but haven't selected a role
+    // 2. Email/password users whose webhook failed to create their AppUser record
+    if (needsProfileCompletion) {
+        // OAuth users don't need password validation
+        // Email/password users who are already signed in also don't need password (they already have a Clerk account)
         if (!validateOAuthProfile()) return;
         await handleCompleteProfile();
         return;
     }
 
-    // Regular email/password signup - use full validation including password
+    // Regular email/password signup for NEW users - use full validation including password
     if (!validateStep2()) return;
 
     if (!isLoaded || !signUp) return;
@@ -629,10 +641,10 @@ const SignupPage: React.FC = () => {
   );
 
   const progressText = currentStep === 1 
-    ? (isOAuthCompletion ? t('signup:progress.oauthStep1', 'Step 1: Select your role') : t('signup:progress.step1')) 
-    : (isOAuthCompletion ? t('signup:progress.oauthStep2', 'Step 2: Complete your profile') : t('signup:progress.step2'));
+    ? (needsProfileCompletion ? t('signup:progress.oauthStep1', 'Step 1: Select your role') : t('signup:progress.step1')) 
+    : (needsProfileCompletion ? t('signup:progress.oauthStep2', 'Step 2: Complete your profile') : t('signup:progress.step2'));
   const formTitle = currentStep === 1 
-    ? (isOAuthCompletion ? t('signup:selectRoleTitle.oauth', 'Complete Your Registration') : t('signup:selectRoleTitle')) 
+    ? (needsProfileCompletion ? t('signup:selectRoleTitle.oauth', 'Complete Your Registration') : t('signup:selectRoleTitle')) 
     : t('signup:detailsTitle', { role: selectedRole ? t(rolesConfig.find(rc => rc.role === selectedRole)!.nameKey) : '' });
 
   if (!isLoaded) {
@@ -756,14 +768,16 @@ const SignupPage: React.FC = () => {
                   </div>
                 )}
 
-                {/* OAuth completion notice */}
-                {isOAuthCompletion && !emailConflictError && (
+                {/* Profile completion notice - for users who are signed in but need to complete profile */}
+                {needsProfileCompletion && !emailConflictError && (
                   <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-md">
                     <p className="text-sm text-blue-800">
                       <strong>{t('signup:oauthCompletion.title', 'Almost there!')}</strong>
                     </p>
                     <p className="text-xs text-blue-700 mt-1">
-                      {t('signup:oauthCompletion.message', 'You\'re signed in with Google. Just complete your profile details below to finish setting up your account.')}
+                      {isOAuthCompletion 
+                        ? t('signup:oauthCompletion.message', 'You\'re signed in with Google. Just complete your profile details below to finish setting up your account.')
+                        : t('signup:profileCompletion.message', 'Your account was created but your profile setup wasn\'t completed. Please complete the details below to finish setting up your account.')}
                     </p>
                   </div>
                 )}
@@ -785,8 +799,8 @@ const SignupPage: React.FC = () => {
                       {requiresOrganizationDetails && renderField('organisationName', 'labels.organisationName', 'text', true, 'placeholders.organisationName')}
                     {renderField('contactPerson', selectedRole === SignupRole.PARENT ? 'labels.parentName' : 'labels.contactPerson', 'text', true, selectedRole === SignupRole.PARENT ? 'placeholders.parentName' : 'placeholders.contactPerson')}
                     
-                    {/* Email field - read-only for OAuth users */}
-                    {isOAuthCompletion ? (
+                    {/* Email field - read-only for users completing their profile (already have Clerk account) */}
+                    {needsProfileCompletion ? (
                       <div>
                         <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
                           {t('signup:labels.email')}<span className="text-swiss-coral">*</span>
@@ -799,14 +813,18 @@ const SignupPage: React.FC = () => {
                           readOnly
                           className={`${STANDARD_INPUT_FIELD} bg-gray-100 cursor-not-allowed`}
                         />
-                        <p className="text-xs text-gray-500 mt-1">{t('signup:oauthCompletion.emailFromProvider', 'Email provided by Google')}</p>
+                        <p className="text-xs text-gray-500 mt-1">
+                          {isOAuthCompletion 
+                            ? t('signup:oauthCompletion.emailFromProvider', 'Email provided by Google')
+                            : t('signup:profileCompletion.emailFromAccount', 'Email from your account')}
+                        </p>
                       </div>
                     ) : (
                       renderField('email', 'labels.email', 'email', true, 'placeholders.email')
                     )}
                     
-                    {/* Password fields - only for regular email/password signup, not OAuth */}
-                    {!isOAuthCompletion && (
+                    {/* Password fields - only for NEW email/password signup, not for users completing profile */}
+                    {!needsProfileCompletion && (
                       <>
                         {renderField('password', 'labels.password', 'password', true, 'placeholders.password')}
                         {renderField('confirmPassword', 'labels.confirmPassword', 'password', true, 'placeholders.confirmPassword')}
@@ -867,8 +885,8 @@ const SignupPage: React.FC = () => {
                       </Button>
                       <Button type="submit" variant="primary" size="lg" className="w-full sm:w-auto bg-swiss-mint hover:bg-opacity-90" disabled={isLoading}>
                         {isLoading 
-                          ? (isOAuthCompletion ? t('signup:completingProfile', 'Completing Profile...') : t('signup:creatingAccount', 'Creating Account...')) 
-                          : (isOAuthCompletion ? t('signup:completeProfile', 'Complete Profile') : t('common:buttons.createAccount'))}
+                          ? (needsProfileCompletion ? t('signup:completingProfile', 'Completing Profile...') : t('signup:creatingAccount', 'Creating Account...')) 
+                          : (needsProfileCompletion ? t('signup:completeProfile', 'Complete Profile') : t('common:buttons.createAccount'))}
                       </Button>
                     </div>
                   </form>
@@ -950,8 +968,8 @@ const SignupPage: React.FC = () => {
               </Link>
             </p>
 
-            {/* Sign out option for OAuth users who want to start fresh */}
-            {isOAuthCompletion && (
+            {/* Sign out option for users completing profile who want to start fresh */}
+            {needsProfileCompletion && (
               <div className="mt-4 pt-4 border-t border-gray-200 text-center">
                 <p className="text-xs text-gray-500 mb-2">
                   {t('signup:oauthCompletion.wrongAccount', 'Wrong account? Sign out and try again.')}

--- a/frontend/pages/SignupPage.tsx
+++ b/frontend/pages/SignupPage.tsx
@@ -286,7 +286,7 @@ const SignupPage: React.FC = () => {
     return Object.keys(newErrors).length === 0 && captchaToken !== null;
   };
 
-  // Validation for OAuth users (no password required, email already verified by OAuth provider)
+  // Validation for users completing their profile (no password required - they already have a Clerk account)
   const validateOAuthProfile = (): boolean => {
     const newErrors: Partial<Record<keyof SignupFormData, string>> = {};
     if (!selectedRole) return false;
@@ -299,8 +299,12 @@ const SignupPage: React.FC = () => {
     if (!formData.contactPerson) 
       newErrors.contactPerson = t(selectedRole === SignupRole.PARENT ? 'signup:errors.parentNameRequired' : 'signup:errors.contactPersonRequired');
     
-    // OAuth users don't need email validation - it's pre-filled from OAuth provider
-    // Password fields are not required for OAuth users
+    // Validate email is present (should be pre-filled from Clerk)
+    // This catches edge cases where Clerk user lacks primaryEmailAddress
+    if (!formData.email) {
+      newErrors.email = t('signup:errors.emailRequired');
+    }
+    // Password fields are not required for pending users (they already have Clerk accounts)
 
     if (requiresOrganizationDetails && !formData.phone) {
       newErrors.phone = t('signup:errors.phoneRequired');


### PR DESCRIPTION
Fixes a redirect loop and "account already exists" error for email/password users with incomplete backend profiles.

The frontend's `SignupPage` incorrectly assumed only OAuth users could be signed into Clerk without a corresponding backend `AppUser` record. This led to a broken flow for email/password users whose webhook-based profile creation failed, causing them to be redirected to the signup page and attempt to create a new Clerk account, resulting in an "account already exists" error. This PR generalizes the profile completion flow to correctly handle both OAuth and email/password users in this state.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec7e71aa-2e72-46ec-b327-3638524af416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec7e71aa-2e72-46ec-b327-3638524af416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced profile completion experience with custom UI modal instead of automatic redirect
  * Unified signup flow for OAuth and email/password users
  * Email field now pre-filled and read-only during profile completion with provider-specific messaging

* **Bug Fixes**
  * Fixed profile access permissions for pending user accounts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->