### PR TITLE
Service provider dashboard loading

### DIFF
--- a/frontend/pages/service-provider/ServiceProviderDashboardPage.tsx
+++ b/frontend/pages/service-provider/ServiceProviderDashboardPage.tsx
@@ -52,7 +52,10 @@ const ServiceProviderDashboardPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {
-    if (!currentUser?.orgId) return;
+    if (!currentUser?.orgId) {
+      setLoading(false);
+      return;
+    }
 
     setLoading(true);
     setError(null);

--- a/frontend/pages/service-provider/ServiceProviderListingsPage.tsx
+++ b/frontend/pages/service-provider/ServiceProviderListingsPage.tsx
@@ -58,7 +58,10 @@ const ServiceProviderListingsPage: React.FC = () => {
   const [filterCategory, setFilterCategory] = useState<ServiceCategory | 'All'>('All');
 
   const fetchServices = useCallback(async () => {
-    if (!currentUser?.orgId) return;
+    if (!currentUser?.orgId) {
+      setLoading(false);
+      return;
+    }
 
     setLoading(true);
     setError(null);

--- a/frontend/pages/service-provider/ServiceProviderOrganisationProfilePage.tsx
+++ b/frontend/pages/service-provider/ServiceProviderOrganisationProfilePage.tsx
@@ -178,15 +178,15 @@ const ServiceProviderOrganisationProfilePage: React.FC = () => {
           request<ProfileResponse>('/profiles/me'),
         ]);
 
-        if (!serviceProviderRes.success || !serviceProviderRes.data) {
-          throw new Error(serviceProviderRes.message || 'Failed to load service provider settings');
-        }
-
         if (isCancelled) {
           return;
         }
 
-        const data = serviceProviderRes.data;
+        // Handle case where organization doesn't exist yet - use defaults instead of erroring
+        const data = serviceProviderRes.success && serviceProviderRes.data 
+          ? serviceProviderRes.data 
+          : {} as ServiceProviderSettingsData;
+        
         setServiceProviderSettings({
           companyName: data.companyName || currentUser.orgName || '',
           contactEmail: data.contactEmail || currentUser.email || '',

--- a/frontend/pages/supplier/SupplierDashboardPage.tsx
+++ b/frontend/pages/supplier/SupplierDashboardPage.tsx
@@ -31,7 +31,10 @@ const SupplierDashboardPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {
-    if (!currentUser?.orgId) return;
+    if (!currentUser?.orgId) {
+      setLoading(false);
+      return;
+    }
 
     setLoading(true);
     setError(null);

--- a/frontend/pages/supplier/SupplierOrdersPage.tsx
+++ b/frontend/pages/supplier/SupplierOrdersPage.tsx
@@ -35,7 +35,10 @@ const SupplierOrdersPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {
-    if (!currentUser?.orgId) return;
+    if (!currentUser?.orgId) {
+      setLoading(false);
+      return;
+    }
 
     setLoading(true);
     setError(null);

--- a/frontend/pages/supplier/SupplierProductListingsPage.tsx
+++ b/frontend/pages/supplier/SupplierProductListingsPage.tsx
@@ -37,6 +37,7 @@ const SupplierProductListingsPage: React.FC = () => {
 
   const loadProducts = useCallback(async () => {
     if (!currentUser?.orgId) {
+      setIsLoading(false);
       return;
     }
 


### PR DESCRIPTION
Fixes infinite loading on several dashboard/listing pages and the "Retry" error on the Service Provider Organisation Profile page.

The `fetchData` functions on various dashboard and listing pages were returning early when `currentUser?.orgId` was undefined, without setting the loading state to `false`, causing the UI to be stuck in a loading state. Additionally, the `ServiceProviderOrganisationProfilePage` was throwing an error when the `/settings/service-provider` API indicated no organization was set up, instead of gracefully displaying default values.

---
<a href="https://cursor.com/background-agent?bcId=bc-93403a68-3623-45d8-86af-3d10d39c5dfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-93403a68-3623-45d8-86af-3d10d39c5dfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed loading state remaining active on dashboard and listing pages when organization ID is unavailable, ensuring pages no longer appear stuck.
  * Improved handling of missing service provider settings to gracefully use default values instead of causing errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->