### PR TITLE
Render backend build failure

### DIFF
--- a/api/src/static-translation/static-translation.service.ts
+++ b/api/src/static-translation/static-translation.service.ts
@@ -207,7 +207,7 @@ export class StaticTranslationService {
         );
       }
 
-      const whereSql = Prisma.join(conditions, Prisma.sql` AND `);
+      const whereSql = Prisma.join(conditions, ' AND ');
 
       const countRows = await this.prisma.$queryRaw<{ count: bigint }[]>(
         Prisma.sql`
@@ -283,7 +283,7 @@ export class StaticTranslationService {
         Prisma.sql`(st.key ILIKE ${like} OR st.value ILIKE ${like} OR st.namespace ILIKE ${like} OR en.value ILIKE ${like})`,
       );
     }
-    const whereSql = Prisma.join(conditions, Prisma.sql` AND `);
+    const whereSql = Prisma.join(conditions, ' AND ');
 
     const countRows = await this.prisma.$queryRaw<{ count: bigint }[]>(
       Prisma.sql`


### PR DESCRIPTION
Fix TypeScript build error by providing a string separator to `Prisma.join()` instead of a `Prisma.Sql` object.

---
<a href="https://cursor.com/background-agent?bcId=bc-94966479-586f-4f62-b634-0d086991a243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-94966479-586f-4f62-b634-0d086991a243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

