### PR TITLE
Translation admin issues column

### DIFF
--- a/api/src/static-translation/static-translation.service.ts
+++ b/api/src/static-translation/static-translation.service.ts
@@ -270,7 +270,7 @@ export class StaticTranslationService {
     }
 
     // needsReview
-    const conditions: Prisma.Sql[] = [Prisma.sql`st.needs_review = true`];
+    const conditions: Prisma.Sql[] = [Prisma.sql`st."needsReview" = true`];
     if (lang) {
       conditions.push(Prisma.sql`st.lang = ${lang}`);
     }
@@ -316,9 +316,9 @@ export class StaticTranslationService {
           st.key AS key,
           st.lang AS lang,
           st.value AS value,
-          st.updated_at AS "updatedAt",
-          st.updated_by AS "updatedBy",
-          st.needs_review AS "needsReview",
+          st."updatedAt" AS "updatedAt",
+          st."updatedBy" AS "updatedBy",
+          st."needsReview" AS "needsReview",
           en.value AS "enValue"
         FROM static_translations st
         JOIN static_translations en
@@ -326,7 +326,7 @@ export class StaticTranslationService {
          AND en.key = st.key
          AND en.lang = 'en'
         WHERE ${whereSql}
-        ORDER BY st.updated_at DESC
+        ORDER BY st."updatedAt" DESC
         LIMIT ${limit} OFFSET ${offset}
       `,
     );


### PR DESCRIPTION
Fixes the "Issues" tab on the translation admin page by correcting SQL column names.

The raw SQL queries in `StaticTranslationService.listIssues` were using snake_case column names (e.g., `st.needs_review`, `st.updated_at`, `st.updated_by`), but the corresponding columns in the PostgreSQL database, as managed by Prisma, are in camelCase (e.g., `st."needsReview"`, `st."updatedAt"`, `st."updatedBy"`). This mismatch caused a `PrismaClientKnownRequestError` with the message `column st.needs_review does not exist`. The fix updates the raw SQL to use the correct, quoted camelCase column names.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1c2d6a3-85c9-47ac-9a6b-1a466e88e5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e1c2d6a3-85c9-47ac-9a6b-1a466e88e5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

