### PR TITLE
Admin document message access

### DIFF
--- a/frontend/components/profile/OrganizationPublicProfile.tsx
+++ b/frontend/components/profile/OrganizationPublicProfile.tsx
@@ -23,6 +23,7 @@ type OrganizationPublicProfileProps = {
   user?: User;
   organization?: Organization;
   showActions?: boolean;
+  currentUser?: User; // The currently logged-in user (for admin/super admin access checks)
 };
 
 const SectionTitle: React.FC<{ icon: React.ElementType; title: string }> = ({ icon: Icon, title }) => (
@@ -35,7 +36,8 @@ const SectionTitle: React.FC<{ icon: React.ElementType; title: string }> = ({ ic
 const OrganizationPublicProfile: React.FC<OrganizationPublicProfileProps> = ({ 
   user, 
   organization: organizationProp, 
-  showActions = true 
+  showActions = true,
+  currentUser,
 }) => {
   const { t } = useTranslation(['profile', 'common']);
   
@@ -554,8 +556,11 @@ const OrganizationPublicProfile: React.FC<OrganizationPublicProfileProps> = ({
             </Card>
           )}
 
-          {/* Documents Section - For Suppliers and Service Providers */}
-          {(role === UserRole.PRODUCT_SUPPLIER || role === UserRole.SERVICE_PROVIDER) && (
+          {/* Documents Section - For Suppliers and Service Providers, or when viewed by Admin/Super Admin */}
+          {(role === UserRole.PRODUCT_SUPPLIER || 
+            role === UserRole.SERVICE_PROVIDER || 
+            currentUser?.role === UserRole.ADMIN || 
+            currentUser?.role === UserRole.SUPER_ADMIN) && (
             <OrganizationDocumentsList organizationId={organization.id} />
           )}
         </div>

--- a/frontend/pages/profile/EducatorProfileViewPage.tsx
+++ b/frontend/pages/profile/EducatorProfileViewPage.tsx
@@ -153,6 +153,7 @@ const EducatorProfileViewPage: React.FC = () => {
 
   const isOwnProfile = currentUser?.id === candidate.id;
   const isFoundationUser = currentUser?.role === UserRole.FOUNDATION;
+  const isAdminOrSuperAdmin = currentUser?.role === UserRole.ADMIN || currentUser?.role === UserRole.SUPER_ADMIN;
 
   return (
     <div className="space-y-6">
@@ -411,12 +412,14 @@ const EducatorProfileViewPage: React.FC = () => {
         </div>
       </div>
 
-      {!isOwnProfile && isFoundationUser && (
+      {!isOwnProfile && (isFoundationUser || isAdminOrSuperAdmin) && (
         <Card className="p-6">
           <div className="flex flex-col sm:flex-row justify-center items-center space-y-3 sm:space-y-0 sm:space-x-3">
-            <Button variant="primary" leftIcon={PlusCircleIcon} onClick={handleInviteToApply}>
-              {t('profile:educator.inviteToApply', 'Invite to Apply')}
-            </Button>
+            {isFoundationUser && (
+              <Button variant="primary" leftIcon={PlusCircleIcon} onClick={handleInviteToApply}>
+                {t('profile:educator.inviteToApply', 'Invite to Apply')}
+              </Button>
+            )}
             <Button variant="outline" leftIcon={EnvelopeIcon} onClick={handleSendMessage}>
               {t('common:buttons.sendMessage', 'Send Message')}
             </Button>

--- a/frontend/pages/profile/OrganizationProfileViewPage.tsx
+++ b/frontend/pages/profile/OrganizationProfileViewPage.tsx
@@ -218,7 +218,12 @@ const OrganizationProfileViewPage: React.FC = () => {
                 <p className="text-gray-600 mt-3 max-w-2xl">{organization.description}</p>
               )}
             </div>
-            {currentUser && !((organization as any).__rawData?.members || []).some((m: any) => m?.user?.id === currentUser.id) && (
+            {currentUser && (
+              // Show message button if: user is not a member of this org OR user is admin/super admin
+              !((organization as any).__rawData?.members || []).some((m: any) => m?.user?.id === currentUser.id) ||
+              currentUser.role === UserRole.ADMIN ||
+              currentUser.role === UserRole.SUPER_ADMIN
+            ) && (
               <div className="flex flex-wrap gap-2">
                 <Button
                   variant="primary"
@@ -236,7 +241,7 @@ const OrganizationProfileViewPage: React.FC = () => {
       {/* Organization Details - Always visible */}
       <div className="w-full">
         {organization ? (
-          <OrganizationPublicProfile organization={organization} showActions={true} />
+          <OrganizationPublicProfile organization={organization} showActions={true} currentUser={currentUser} />
         ) : (
           <Card className="p-6">
             <p className="text-gray-500 text-center">Loading organization details...</p>


### PR DESCRIPTION
Enable admin and super admin users to view documents and message other roles from profile pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-48eceec5-5d4d-44b6-9b9b-9690daa202f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-48eceec5-5d4d-44b6-9b9b-9690daa202f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Admin and super-admin users now have expanded access to view documents on organization profiles.
  * Admin and super-admin users can now see invite-to-apply actions on educator profiles.
  * Admin and super-admin users can now send messages when viewing organization profiles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->