### PR TITLE
Supplier provider documents display

### DIFF
--- a/frontend/pages/partner/PartnerDetailPage.tsx
+++ b/frontend/pages/partner/PartnerDetailPage.tsx
@@ -29,6 +29,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useOrganizationMessaging } from '../../hooks/useOrganizationMessaging';
 import ActiveClientToggle from '../../components/shared/ActiveClientToggle';
+import OrganizationDocumentsList from '../../components/profile/OrganizationDocumentsList';
 import { formatServiceCategory, formatServiceDeliveryType, formatCategory } from '../../utils/serviceFormatting';
 import { organizationService } from '../../services/organizationService';
 
@@ -533,6 +534,11 @@ const PartnerDetailPage: React.FC = () => {
               </Card>
             )}
           </Card>
+
+          {/* Documents Section - For Suppliers and Service Providers */}
+          {(isSupplier || isServiceProvider) && (
+            <OrganizationDocumentsList organizationId={partner.id} />
+          )}
         </div>
       </div>
       


### PR DESCRIPTION
Add the documents section to the `PartnerDetailPage` to display supplier and service provider documents.

Users navigating to supplier/service provider profiles from the marketplace were directed to `PartnerDetailPage`, which lacked the `OrganizationDocumentsList` component present in `OrganizationProfileViewPage`. This PR integrates the documents list into `PartnerDetailPage` to ensure documents are visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7adb34a-74c8-44c3-b4ec-0767d122d52a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e7adb34a-74c8-44c3-b4ec-0767d122d52a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

