### PR TITLE
User email constraint issue

### DIFF
--- a/api/src/auth/_old/auth.service.ts
+++ b/api/src/auth/_old/auth.service.ts
@@ -105,9 +105,9 @@ export class AuthService {
       await this.prisma.user.create({
         data: {
           clerkId: clerkUser.id,
-          email: clerkUser.email_addresses[0]?.email_address || '',
-          firstName: clerkUser.first_name || '',
-          lastName: clerkUser.last_name || '',
+          email: clerkUser.email_addresses[0]?.email_address || null, // Allow NULL - do not use empty string
+          firstName: clerkUser.first_name || null,
+          lastName: clerkUser.last_name || null,
           role: role,
           phoneNumber: clerkUser.public_metadata?.phoneNumber || null,
         },

--- a/api/src/principal/principal.service.spec.ts
+++ b/api/src/principal/principal.service.spec.ts
@@ -20,6 +20,7 @@ describe('PrincipalService', () => {
               upsert: jest.fn(),
             },
             user: {
+              findUnique: jest.fn(),
               upsert: jest.fn(),
             },
             userNotificationPreferences: {
@@ -122,7 +123,7 @@ describe('PrincipalService', () => {
       expect(prisma.user.upsert).toHaveBeenCalledTimes(5);
     });
 
-    it('passes null email to create when appUser.email is null (not empty string)', async () => {
+    it('passes null email to create when appUser.email is null and no existing User (not empty string)', async () => {
       const mockAppUser = {
         id: 'app-1',
         clerkId: 'clerk_null_email',
@@ -143,6 +144,7 @@ describe('PrincipalService', () => {
       };
 
       prisma.appUser.findUnique.mockResolvedValue(mockAppUser as any);
+      prisma.user.findUnique.mockResolvedValue(null); // No existing User
       prisma.user.upsert.mockResolvedValue(mockUser as any);
 
       await service.getOrBootstrapAccountAndProfile('clerk_null_email');
@@ -159,6 +161,50 @@ describe('PrincipalService', () => {
         create: {
           clerkId: 'clerk_null_email',
           email: null, // Must be null, NOT ''
+          role: UserRole.SUPER_ADMIN,
+          isActive: true,
+        },
+      });
+    });
+
+    it('uses existing User email when appUser.email is null', async () => {
+      const mockAppUser = {
+        id: 'app-1',
+        clerkId: 'clerk_existing_email',
+        email: null, // AppUser has no email
+        role: UserRole.SUPER_ADMIN,
+      };
+
+      const existingUserEmail = { email: 'existing@example.com' };
+
+      const mockUser = {
+        id: 'user-1',
+        clerkId: 'clerk_existing_email',
+        email: 'existing@example.com',
+        firstName: null,
+        lastName: null,
+        role: UserRole.SUPER_ADMIN,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      prisma.appUser.findUnique.mockResolvedValue(mockAppUser as any);
+      prisma.user.findUnique.mockResolvedValue(existingUserEmail as any); // Existing User has email
+      prisma.user.upsert.mockResolvedValue(mockUser as any);
+
+      await service.getOrBootstrapAccountAndProfile('clerk_existing_email');
+
+      // Verify that the existing User email is used for create
+      expect(prisma.user.upsert).toHaveBeenCalledWith({
+        where: { clerkId: 'clerk_existing_email' },
+        update: {
+          email: undefined,
+          role: UserRole.SUPER_ADMIN,
+        },
+        create: {
+          clerkId: 'clerk_existing_email',
+          email: 'existing@example.com', // Uses existing User's email
           role: UserRole.SUPER_ADMIN,
           isActive: true,
         },

--- a/api/src/principal/principal.service.spec.ts
+++ b/api/src/principal/principal.service.spec.ts
@@ -121,6 +121,49 @@ describe('PrincipalService', () => {
       expect(results).toHaveLength(5);
       expect(prisma.user.upsert).toHaveBeenCalledTimes(5);
     });
+
+    it('passes null email to create when appUser.email is null (not empty string)', async () => {
+      const mockAppUser = {
+        id: 'app-1',
+        clerkId: 'clerk_null_email',
+        email: null, // AppUser has no email
+        role: UserRole.SUPER_ADMIN,
+      };
+
+      const mockUser = {
+        id: 'user-1',
+        clerkId: 'clerk_null_email',
+        email: null,
+        firstName: null,
+        lastName: null,
+        role: UserRole.SUPER_ADMIN,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      prisma.appUser.findUnique.mockResolvedValue(mockAppUser as any);
+      prisma.user.upsert.mockResolvedValue(mockUser as any);
+
+      await service.getOrBootstrapAccountAndProfile('clerk_null_email');
+
+      // Verify that email is passed as null, not as empty string ''
+      // This is critical because the DB has a constraint: users_email_not_empty
+      // which allows NULL but rejects empty strings
+      expect(prisma.user.upsert).toHaveBeenCalledWith({
+        where: { clerkId: 'clerk_null_email' },
+        update: {
+          email: undefined, // null ?? undefined = undefined
+          role: UserRole.SUPER_ADMIN,
+        },
+        create: {
+          clerkId: 'clerk_null_email',
+          email: null, // Must be null, NOT ''
+          role: UserRole.SUPER_ADMIN,
+          isActive: true,
+        },
+      });
+    });
   });
 
   describe('getOrDefaultNotificationPrefs', () => {

--- a/api/src/principal/principal.service.ts
+++ b/api/src/principal/principal.service.ts
@@ -60,7 +60,7 @@ export class PrincipalService {
       },
       create: {
         clerkId,
-        email: appUser.email ?? '',
+        email: appUser.email, // Allow NULL - do not fall back to empty string
         role: appUser.role,
         isActive: true,
       },

--- a/api/src/principal/principal.service.ts
+++ b/api/src/principal/principal.service.ts
@@ -52,6 +52,17 @@ export class PrincipalService {
       throw new NotFoundException('User not found in system');
     }
 
+    // If appUser.email is null, check if the User record already has an email
+    // This handles the case where User was created before AppUser got its email synced
+    let emailForCreate: string | null = appUser.email;
+    if (!emailForCreate) {
+      const existingUser = await this.prisma.user.findUnique({
+        where: { clerkId },
+        select: { email: true },
+      });
+      emailForCreate = existingUser?.email ?? null;
+    }
+
     const user = await this.prisma.user.upsert({
       where: { clerkId },
       update: {
@@ -60,7 +71,7 @@ export class PrincipalService {
       },
       create: {
         clerkId,
-        email: appUser.email, // Allow NULL - do not fall back to empty string
+        email: emailForCreate, // Use existing User email if AppUser email is null
         role: appUser.role,
         isActive: true,
       },

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -266,6 +266,20 @@ export class UsersService {
           reason: 'Profile completion role update',
         });
       }
+      
+      // Sync email to both AppUser and User if provided and AppUser email is missing
+      if (email && !existingUser.email) {
+        this.logger.log(`📧 [COMPLETE PROFILE] Syncing email to existing user...`);
+        await this.prisma.appUser.update({
+          where: { id: existingUser.id },
+          data: { email },
+        });
+        // Also update User table if it exists
+        await this.prisma.user.updateMany({
+          where: { clerkId },
+          data: { email },
+        });
+      }
     } else {
       // Check if an account with this email already exists (for a DIFFERENT clerkId)
       // This can happen when:

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -676,7 +676,7 @@ export class UsersService {
         user = await this.prisma.user.create({
           data: {
             clerkId,
-            email: appUser.email || updateUserDto.email || '',
+            email: appUser.email || updateUserDto.email || null, // Allow NULL - do not use empty string
             firstName: updateUserDto.firstName || null,
             lastName: updateUserDto.lastName || null,
             role: appUser.role,


### PR DESCRIPTION
Fixes `users_email_not_empty` constraint violation by ensuring `null` emails are passed as `null` to the database, not empty strings.

The `users_email_not_empty` database constraint allows `NULL` emails but rejects empty strings (`''`). Previously, several code paths would convert `null` email values to empty strings (e.g., `appUser.email ?? ''`), leading to `PrismaClientUnknownRequestError` during user creation or upsert operations. This PR updates these paths to correctly pass `null` values and also improves the logic for syncing emails from Clerk to `AppUser` and `User` tables during profile completion and bootstrapping.

---
<a href="https://cursor.com/background-agent?bcId=bc-29767832-0b71-4a35-9cae-8acbdbf7129d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-29767832-0b71-4a35-9cae-8acbdbf7129d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing user profile data (email, first name, last name) by properly supporting null values instead of empty strings.
  * Enhanced email synchronization to ensure consistency across user data tables when email information is incomplete.

* **Tests**
  * Added test coverage for null email handling scenarios during user creation and updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->