### PR TITLE
Skills and specialties comma input

### DIFF
--- a/frontend/components/profile/edit/EducatorProfileForm.tsx
+++ b/frontend/components/profile/edit/EducatorProfileForm.tsx
@@ -29,13 +29,19 @@ const EducatorProfileForm: React.FC<EducatorProfileFormProps> = ({ formData, onC
   const { currentUser } = useAppContext();
 
   const handleSkillsChange = (value: string) => {
-    const skillsArray = value.split(',').map(s => s.trim()).filter(s => s.length > 0);
-    onChange('skills', skillsArray);
+    // Split by comma, trim each part, but keep empty strings to preserve commas during typing
+    const skillsArray = value.split(',').map(s => s.trim());
+    // Only filter out empty strings if the value doesn't end with a comma (user is still typing)
+    const filteredSkills = value.endsWith(',') ? skillsArray : skillsArray.filter(s => s.length > 0);
+    onChange('skills', filteredSkills);
   };
 
   const handleCertificationsChange = (value: string) => {
-    const certsArray = value.split(',').map(s => s.trim()).filter(s => s.length > 0);
-    onChange('certifications', certsArray);
+    // Split by comma, trim each part, but keep empty strings to preserve commas during typing
+    const certsArray = value.split(',').map(s => s.trim());
+    // Only filter out empty strings if the value doesn't end with a comma (user is still typing)
+    const filteredCerts = value.endsWith(',') ? certsArray : certsArray.filter(s => s.length > 0);
+    onChange('certifications', filteredCerts);
   };
 
   const handleAvatarChange = (url: string, assetId?: string) => {

--- a/frontend/components/settings/sections/EducatorProfileSettings.tsx
+++ b/frontend/components/settings/sections/EducatorProfileSettings.tsx
@@ -81,13 +81,19 @@ const EducatorProfileSettings: React.FC<EducatorProfileSettingsProps> = ({ setti
   };
 
   const handleSkillsChange = (value: string) => {
-    const skillsArray = value.split(',').map(s => s.trim()).filter(s => s.length > 0);
-    handleFieldChange('skills', skillsArray);
+    // Split by comma, trim each part, but keep empty strings to preserve commas during typing
+    const skillsArray = value.split(',').map(s => s.trim());
+    // Only filter out empty strings if the value doesn't end with a comma (user is still typing)
+    const filteredSkills = value.endsWith(',') ? skillsArray : skillsArray.filter(s => s.length > 0);
+    handleFieldChange('skills', filteredSkills);
   };
 
   const handleCertificationsChange = (value: string) => {
-    const certsArray = value.split(',').map(s => s.trim()).filter(s => s.length > 0);
-    handleFieldChange('certifications', certsArray);
+    // Split by comma, trim each part, but keep empty strings to preserve commas during typing
+    const certsArray = value.split(',').map(s => s.trim());
+    // Only filter out empty strings if the value doesn't end with a comma (user is still typing)
+    const filteredCerts = value.endsWith(',') ? certsArray : certsArray.filter(s => s.length > 0);
+    handleFieldChange('certifications', filteredCerts);
   };
 
   // Avatar handlers


### PR DESCRIPTION
Preserve trailing commas in skills and certifications input fields to allow natural comma-separated input.

Previously, typing a comma (e.g., "skill1,") would cause the input value to be processed as `["skill1", ""]`, which was then filtered to `["skill1"]` and rejoined as `"skill1"`, making the comma disappear instantly. The fix now conditionally filters empty strings, preserving them if the input ends with a comma, thus allowing the comma to remain visible while the user is typing.

---
<a href="https://cursor.com/background-agent?bcId=bc-b748655e-f88e-4433-a617-af10630169df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b748655e-f88e-4433-a617-af10630169df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

