### PR TITLE
Database column error fix

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1546,7 +1546,7 @@ model SubscriptionSchedule {
   isProcessed     Boolean   @default(false) @map("is_processed")
   processedAt     DateTime? @map("processed_at")
   createdBy       String    @map("created_by")
-  createdAt       DateTime  @default(now())
+  createdAt       DateTime  @default(now()) @map("created_at")
   
   subscription    Subscription @relation(fields: [subscriptionId], references: [id], onDelete: Cascade)
   

--- a/api/src/subscription-management/subscription-management.service.ts
+++ b/api/src/subscription-management/subscription-management.service.ts
@@ -910,7 +910,7 @@ export class SubscriptionManagementService {
         throw new BadRequestException('New plan is not an upgrade - price must be higher than current plan');
       }
 
-      let updateData: any = {
+      const updateData: any = {
         planId: data.newPlanId,
       };
 
@@ -975,7 +975,7 @@ export class SubscriptionManagementService {
         throw new BadRequestException('New plan is not a downgrade - price must be lower than current plan');
       }
 
-      let updateData: any = {
+      const updateData: any = {
         planId: data.newPlanId,
       };
 


### PR DESCRIPTION
Fixes `subscription_schedules.createdAt` column not found error by adding `@map` directive to Prisma schema.

The `ScheduledActionsService` was failing due to a column name mismatch between the Prisma schema's `createdAt` field and the database's `created_at` column for the `SubscriptionSchedule` model. Adding `@map("created_at")` resolves this by explicitly mapping the field.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3620267-cea3-4435-867b-c77067f47dce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c3620267-cea3-4435-867b-c77067f47dce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

