### PR TITLE
Promo code table missing

### DIFF
--- a/api/prisma/migrations/20251220000009_create_promo_codes_table/migration.sql
+++ b/api/prisma/migrations/20251220000009_create_promo_codes_table/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable: promo_codes for Product Suppliers and Service Providers
+CREATE TABLE "promo_codes" (
+    "id" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "discountType" TEXT NOT NULL,
+    "value" DOUBLE PRECISION NOT NULL,
+    "expiryDate" TIMESTAMP(3) NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'Active',
+    "description" TEXT,
+    "usageCount" INTEGER NOT NULL DEFAULT 0,
+    "maxUsage" INTEGER,
+    "organizationId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "promo_codes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex: unique constraint on code + organizationId
+CREATE UNIQUE INDEX "promo_codes_code_organizationId_key" ON "promo_codes"("code", "organizationId");
+
+-- CreateIndex: index on organizationId
+CREATE INDEX "promo_codes_organizationId_idx" ON "promo_codes"("organizationId");
+
+-- CreateIndex: index on status
+CREATE INDEX "promo_codes_status_idx" ON "promo_codes"("status");
+
+-- AddForeignKey: organization relationship with cascade delete
+ALTER TABLE "promo_codes" ADD CONSTRAINT "promo_codes_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
Create a new Prisma migration to add the `promo_codes` table to the database.

The promo code manager was failing with a `PrismaClientKnownRequestError: P2021` because the `promo_codes` table did not exist in the database, despite the `PromoCode` model being defined in the Prisma schema. This PR adds the missing migration to create the table.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f1caa51-4af3-440a-b56c-47a39618e358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f1caa51-4af3-440a-b56c-47a39618e358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added database infrastructure supporting promo code and discount management functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->