### PR TITLE
Promo code settings missing

### DIFF
--- a/frontend/pages/ServiceProviderSettingsPage.tsx
+++ b/frontend/pages/ServiceProviderSettingsPage.tsx
@@ -16,6 +16,7 @@ import {
     WalletIcon,
     BuildingOfficeIcon,
     PhoneIcon,
+    TagIcon,
     AdjustmentsHorizontalIcon,
     PencilSquareIcon,
 } from '@heroicons/react/24/outline';
@@ -27,6 +28,7 @@ import PrivacyDataSettings from '../components/settings/sections/PrivacyDataSett
 import ContactBookingSettings from '../components/settings/sections/ContactBookingSettings';
 import DefaultsSettings from '../components/settings/sections/DefaultsSettings';
 import NotificationPreferencesSettings from '../components/settings/sections/NotificationPreferencesSettings';
+import PromoCodeManagerSettings from '../components/settings/sections/PromoCodeManagerSettings';
 
 interface ProviderSectionConfig {
   id: string;
@@ -161,6 +163,7 @@ const ServiceProviderSettingsPage: React.FC = () => {
     { id: 'privacyData', nameKey: 'common:settingsPage.privacyData', icon: LockClosedIcon, component: PrivacyDataSettings },
     { id: 'notifications', nameKey: 'common:settingsPage.notificationPreferences', icon: BellAlertIcon, component: NotificationPreferencesSettings },
     { id: 'contactBooking', nameKey: 'common:settingsPage.contactBooking', icon: PhoneIcon, component: ContactBookingSettings },
+    { id: 'promoCodes', nameKey: 'common:settingsPage.promoCodeManager', icon: TagIcon, component: PromoCodeManagerSettings },
     { id: 'defaults', nameKey: 'settings:page.defaults', icon: AdjustmentsHorizontalIcon, component: DefaultsSettings },
   ];
 


### PR DESCRIPTION
Add PromoCodeManagerSettings to ServiceProviderSettingsPage to allow service providers to manage promo codes.

Service providers were prompted to create promo codes in their settings, but the `ServiceProviderSettingsPage` was missing the `PromoCodeManagerSettings` component, preventing them from actually doing so.

---
<a href="https://cursor.com/background-agent?bcId=bc-6647c9e8-dd2c-4f20-999b-3b60d91521bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6647c9e8-dd2c-4f20-999b-3b60d91521bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Promo Code Manager to Service Provider Settings, enabling providers to manage and configure promotional codes from their settings dashboard.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->