### PR TITLE
Subscription edit database error

### DIFF
--- a/api/prisma/migrations/20251220000010_fix_subscription_plans_column_names/migration.sql
+++ b/api/prisma/migrations/20251220000010_fix_subscription_plans_column_names/migration.sql
@@ -1,0 +1,37 @@
+-- Fix subscription_plans column names to match Prisma schema @map directives
+-- The initial migration created camelCase columns, but the schema expects snake_case
+
+-- Rename billingPeriod to billing_period
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'subscription_plans' AND column_name = 'billingPeriod') THEN
+        ALTER TABLE "subscription_plans" RENAME COLUMN "billingPeriod" TO "billing_period";
+    END IF;
+END$$;
+
+-- Rename isActive to is_active
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'subscription_plans' AND column_name = 'isActive') THEN
+        ALTER TABLE "subscription_plans" RENAME COLUMN "isActive" TO "is_active";
+    END IF;
+END$$;
+
+-- Rename isPopular to is_popular
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'subscription_plans' AND column_name = 'isPopular') THEN
+        ALTER TABLE "subscription_plans" RENAME COLUMN "isPopular" TO "is_popular";
+    END IF;
+END$$;
+
+-- Rename stripePriceId to stripe_price_id
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'subscription_plans' AND column_name = 'stripePriceId') THEN
+        ALTER TABLE "subscription_plans" RENAME COLUMN "stripePriceId" TO "stripe_price_id";
+    END IF;
+END$$;
+
+-- Note: code, allowed_roles, trial_days, display_order, stripe_product_id were already added
+-- with correct snake_case names in the 20251218000000_subscription_management_system migration

--- a/api/scripts/prebuild-db-setup.mjs
+++ b/api/scripts/prebuild-db-setup.mjs
@@ -385,22 +385,52 @@ CREATE INDEX IF NOT EXISTS "subscriptions_organizationId_idx" ON "subscriptions"
 CREATE UNIQUE INDEX IF NOT EXISTS "subscriptions_stripeSubscriptionId_key" ON "subscriptions"("stripeSubscriptionId");
 
 -- Ensure base subscription_plans table exists (from init migration)
+-- Use snake_case column names to match Prisma schema @map directives
 CREATE TABLE IF NOT EXISTS "subscription_plans" (
     "id" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "description" TEXT NOT NULL,
     "price" DOUBLE PRECISION NOT NULL,
     "currency" TEXT NOT NULL DEFAULT 'CHF',
-    "billingPeriod" TEXT NOT NULL DEFAULT 'monthly',
+    "billing_period" TEXT NOT NULL DEFAULT 'monthly',
     "features" TEXT[],
     "limits" JSONB NOT NULL,
-    "isActive" BOOLEAN NOT NULL DEFAULT true,
-    "isPopular" BOOLEAN NOT NULL DEFAULT false,
-    "stripePriceId" TEXT,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "is_popular" BOOLEAN NOT NULL DEFAULT false,
+    "stripe_price_id" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
     CONSTRAINT "subscription_plans_pkey" PRIMARY KEY ("id")
 );
+
+-- Fix column names from camelCase to snake_case for existing databases
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'subscription_plans' AND column_name = 'billingPeriod') THEN
+        ALTER TABLE "subscription_plans" RENAME COLUMN "billingPeriod" TO "billing_period";
+    END IF;
+END$$;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'subscription_plans' AND column_name = 'isActive') THEN
+        ALTER TABLE "subscription_plans" RENAME COLUMN "isActive" TO "is_active";
+    END IF;
+END$$;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'subscription_plans' AND column_name = 'isPopular') THEN
+        ALTER TABLE "subscription_plans" RENAME COLUMN "isPopular" TO "is_popular";
+    END IF;
+END$$;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'subscription_plans' AND column_name = 'stripePriceId') THEN
+        ALTER TABLE "subscription_plans" RENAME COLUMN "stripePriceId" TO "stripe_price_id";
+    END IF;
+END$$;
 
 -- Add new enum values to SubscriptionStatus
 DO $$


### PR DESCRIPTION
Rename `subscription_plans` table columns to snake_case to resolve a Prisma schema mismatch and fix the blank edit subscription page.

The initial database migration created `subscription_plans` columns (e.g., `billingPeriod`) in camelCase. However, the Prisma schema was later updated with `@map` directives expecting snake_case columns (e.g., `billing_period`). This mismatch led to a `PrismaClientKnownRequestError` when fetching subscription plans, causing the frontend to display a blank page. This PR introduces a migration to rename these columns in existing databases and updates the `prebuild-db-setup.mjs` script for new deployments.

---
<a href="https://cursor.com/background-agent?bcId=bc-9259f6b0-df6f-43c2-9f67-f9acf646edf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9259f6b0-df6f-43c2-9f67-f9acf646edf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Standardized database naming conventions to improve internal consistency and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->