### PR TITLE
User subscription edit blank

### DIFF
--- a/admin/src/pages/Subscriptions.tsx
+++ b/admin/src/pages/Subscriptions.tsx
@@ -131,14 +131,7 @@ const EditSubscriptionModal: React.FC<EditSubscriptionModalProps> = ({
     }
   }, [subscription]);
 
-  if (!isOpen || !user) return null;
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    await onSave({ status, planId: selectedPlanId || undefined, notes: notes || undefined });
-  };
-
-  // Handle Escape key to close modal
+  // Handle Escape key to close modal - must be before any early returns to comply with Rules of Hooks
   React.useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && isOpen) {
@@ -148,6 +141,14 @@ const EditSubscriptionModal: React.FC<EditSubscriptionModalProps> = ({
     document.addEventListener('keydown', handleEscape);
     return () => document.removeEventListener('keydown', handleEscape);
   }, [isOpen, onClose]);
+
+  // Early return AFTER all hooks to comply with React's Rules of Hooks
+  if (!isOpen || !user) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await onSave({ status, planId: selectedPlanId || undefined, notes: notes || undefined });
+  };
 
   return (
     <div 


### PR DESCRIPTION
Fixes a React error in `EditSubscriptionModal` by ensuring all hooks are called unconditionally.

The previous implementation conditionally rendered a `useEffect` hook after an early return, leading to React error #310 ("Rendered more hooks than during the previous render") when the modal state changed. Moving the early return after all hooks ensures consistent hook calls.

---
<a href="https://cursor.com/background-agent?bcId=bc-d816cd6c-f31f-4812-9c7d-ec5f7be8ca5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d816cd6c-f31f-4812-9c7d-ec5f7be8ca5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

