### PR TITLE
Educator cover image issue

### DIFF
--- a/api/prisma/migrations/20251220103000_add_user_cover_asset/migration.sql
+++ b/api/prisma/migrations/20251220103000_add_user_cover_asset/migration.sql
@@ -1,0 +1,22 @@
+-- AlterTable: Add coverAssetId to users table
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "coverAssetId" TEXT;
+
+-- AddForeignKey: Add foreign key constraint for coverAssetId
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'users_coverAssetId_fkey'
+    ) THEN
+        ALTER TABLE "users"
+        ADD CONSTRAINT "users_coverAssetId_fkey"
+        FOREIGN KEY ("coverAssetId")
+        REFERENCES "assets"("id")
+        ON DELETE SET NULL
+        ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+-- CreateIndex: Add index for coverAssetId if it doesn't exist
+CREATE INDEX IF NOT EXISTS "users_coverAssetId_idx" ON "users"("coverAssetId");
+

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -180,6 +180,10 @@ model User {
   avatarAssetId String?
   avatarAsset   Asset?  @relation("UserAvatar", fields: [avatarAssetId], references: [id])
 
+  // Cover image asset relation (educator profile cover)
+  coverAssetId String?
+  coverAsset   Asset?  @relation("UserCover", fields: [coverAssetId], references: [id])
+
   // Stripe integration
   stripeCustomerId String? @unique
 
@@ -418,6 +422,7 @@ model Asset {
 
   // User asset relations
   userAvatars User[] @relation("UserAvatar")
+  userCovers  User[] @relation("UserCover")
 
   // Product relations
   products Product[]

--- a/api/src/settings/dto/educator-settings.dto.ts
+++ b/api/src/settings/dto/educator-settings.dto.ts
@@ -56,4 +56,8 @@ export class UpdateEducatorSettingsDto {
   @IsOptional()
   @IsString()
   avatarAssetId?: string;
+
+  @IsOptional()
+  @IsString()
+  coverAssetId?: string;
 }

--- a/api/src/settings/settings.controller.ts
+++ b/api/src/settings/settings.controller.ts
@@ -282,6 +282,7 @@ export class SettingsController {
     const { clerkUserId } = this.getContext(req);
     const { user } = await this.principal.getOrBootstrapAccountAndProfile(clerkUserId, {
       avatarAsset: true, // Include avatar asset relation
+      coverAsset: true, // Include cover asset relation
     });
 
     return {
@@ -300,6 +301,8 @@ export class SettingsController {
         shortBio: user.shortBio ?? '',
         avatarAssetId: user.avatarAssetId ?? '',
         avatarUrl: (user as any).avatarAsset?.publicUrl ?? '', // Compute from asset relation
+        coverAssetId: (user as any).coverAssetId ?? '',
+        coverImageUrl: (user as any).coverAsset?.publicUrl ?? null,
       },
     };
   }
@@ -321,6 +324,13 @@ export class SettingsController {
         [AssetKind.AVATAR],
         'Avatar',
       );
+      await this.validateAssetForUsage(
+        tx,
+        settings.coverAssetId,
+        accountId,
+        [AssetKind.COVER_IMAGE],
+        'Cover image',
+      );
 
       await tx.user.update({
         where: { id: profileId },
@@ -337,6 +347,7 @@ export class SettingsController {
         cvUrl: settings.cvUrl,
         shortBio: settings.shortBio,
         ...(settings.avatarAssetId !== undefined && { avatarAssetId: settings.avatarAssetId || null }),
+        ...(settings.coverAssetId !== undefined && { coverAssetId: settings.coverAssetId || null }),
       },
       });
 

--- a/frontend/pages/ProfileEditPage.tsx
+++ b/frontend/pages/ProfileEditPage.tsx
@@ -160,6 +160,8 @@ const ProfileEditPage: React.FC = () => {
           shortBio: data.shortBio || '',
           avatarAssetId: data.avatarAssetId || '',
           avatarUrl: data.avatarUrl || '', // Computed from asset relation on backend
+          coverAssetId: data.coverAssetId || '',
+          coverImageUrl: data.coverImageUrl || null,
         } as Partial<SettingsFormData>;
       }
 
@@ -271,6 +273,9 @@ const ProfileEditPage: React.FC = () => {
 
         if (payload.availabilitySettings !== undefined) {
           educatorPayload.availabilitySettings = payload.availabilitySettings;
+        }
+        if (payload.coverAssetId !== undefined) {
+          educatorPayload.coverAssetId = payload.coverAssetId || null;
         }
 
         saveRequest = request('/settings/educator', {


### PR DESCRIPTION
Add persistence for educator cover images, which were previously not saved to the database.

The educator UI allowed users to select a cover image, but the `PATCH /api/settings/educator` endpoint did not accept or save the `coverAssetId`, and the `users` table lacked a `coverAssetId` column. This resulted in the image not persisting across page refreshes, and the API returning `304 Not Modified` because the underlying data never actually changed.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc36c73b-298a-4c60-afc4-1b0abc1b2ae4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fc36c73b-298a-4c60-afc4-1b0abc1b2ae4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

