### PR TITLE
User profile banner display

### DIFF
--- a/frontend/components/profile/edit/shared/CoverImageSection.tsx
+++ b/frontend/components/profile/edit/shared/CoverImageSection.tsx
@@ -40,6 +40,7 @@ const CoverImageSection: React.FC<CoverImageSectionProps> = ({
   };
 
   const presetConfig = IMAGE_CROP_PRESETS[cropPreset];
+  const usePresetAspectRatio = cropPreset === 'COVER' || cropPreset === 'BANNER';
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -114,7 +115,10 @@ const CoverImageSection: React.FC<CoverImageSectionProps> = ({
 
   return (
     <>
-      <div className={`relative w-full ${heightClasses[height]} bg-gray-200 rounded-lg overflow-hidden group`}>
+      <div
+        className={`relative w-full bg-gray-200 rounded-lg overflow-hidden group ${usePresetAspectRatio ? '' : heightClasses[height]}`}
+        style={usePresetAspectRatio ? { aspectRatio: `${presetConfig.width} / ${presetConfig.height}` } : undefined}
+      >
         <img
           src={displayUrl}
           alt="Cover"

--- a/frontend/components/profile/edit/shared/CoverImageSection.tsx
+++ b/frontend/components/profile/edit/shared/CoverImageSection.tsx
@@ -40,7 +40,7 @@ const CoverImageSection: React.FC<CoverImageSectionProps> = ({
   };
 
   const presetConfig = IMAGE_CROP_PRESETS[cropPreset];
-  const usePresetAspectRatio = cropPreset === 'COVER' || cropPreset === 'BANNER';
+  const usePresetAspectRatio = presetConfig.useAspectRatio;
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];

--- a/frontend/components/shared/ImageCropperModal.tsx
+++ b/frontend/components/shared/ImageCropperModal.tsx
@@ -10,24 +10,28 @@ export const IMAGE_CROP_PRESETS = {
     width: 256,
     height: 256,
     aspectRatio: 1,
+    useAspectRatio: false,
     labelKey: 'settings:imageCropper.presets.profilePhoto',
   },
   LOGO: {
     width: 256,
     height: 256,
     aspectRatio: 1,
+    useAspectRatio: false,
     labelKey: 'settings:imageCropper.presets.logo',
   },
   COVER: {
     width: 1600,
     height: 400,
     aspectRatio: 4,
+    useAspectRatio: true,
     labelKey: 'settings:imageCropper.presets.coverImage',
   },
   BANNER: {
     width: 1200,
     height: 400,
     aspectRatio: 3,
+    useAspectRatio: true,
     labelKey: 'settings:imageCropper.presets.banner',
   },
 } as const;

--- a/frontend/pages/partner/PartnerDetailPage.tsx
+++ b/frontend/pages/partner/PartnerDetailPage.tsx
@@ -348,7 +348,7 @@ const PartnerDetailPage: React.FC = () => {
         </Button>
         
         <Card className="overflow-hidden animate-pulse">
-          <div className="aspect-[4/1] bg-gray-200" />
+          <div className="w-full aspect-[4/1] bg-gray-200" />
           <div className="p-6 pt-28 sm:pt-6 sm:pl-36">
             <div className="h-8 bg-gray-200 rounded w-1/3 mb-2" />
             <div className="h-4 bg-gray-200 rounded w-1/4 mb-4" />
@@ -426,7 +426,7 @@ const PartnerDetailPage: React.FC = () => {
 
       {/* Header Section */}
       <Card className="overflow-hidden">
-        <div className="aspect-[4/1] bg-gray-200 relative">
+        <div className="w-full aspect-[4/1] bg-gray-200 relative">
           <img 
             src={coverImageUrl} 
             alt={`${partner.name} cover`} 

--- a/frontend/pages/partner/PartnerDetailPage.tsx
+++ b/frontend/pages/partner/PartnerDetailPage.tsx
@@ -348,7 +348,7 @@ const PartnerDetailPage: React.FC = () => {
         </Button>
         
         <Card className="overflow-hidden animate-pulse">
-          <div className="h-48 bg-gray-200" />
+          <div className="aspect-[4/1] bg-gray-200" />
           <div className="p-6 pt-28 sm:pt-6 sm:pl-36">
             <div className="h-8 bg-gray-200 rounded w-1/3 mb-2" />
             <div className="h-4 bg-gray-200 rounded w-1/4 mb-4" />
@@ -426,7 +426,7 @@ const PartnerDetailPage: React.FC = () => {
 
       {/* Header Section */}
       <Card className="overflow-hidden">
-        <div className="h-48 bg-gray-200 relative">
+        <div className="aspect-[4/1] bg-gray-200 relative">
           <img 
             src={coverImageUrl} 
             alt={`${partner.name} cover`} 

--- a/frontend/pages/profile/EducatorProfileViewPage.tsx
+++ b/frontend/pages/profile/EducatorProfileViewPage.tsx
@@ -172,7 +172,7 @@ const EducatorProfileViewPage: React.FC = () => {
       {/* Social Media Style Header with Cover Image and Avatar */}
       <Card className="overflow-hidden p-0">
         {/* Cover Image Section */}
-        <div className="aspect-[4/1] bg-gradient-to-r from-swiss-mint/20 to-swiss-teal/20 relative">
+        <div className="w-full aspect-[4/1] bg-gradient-to-r from-swiss-mint/20 to-swiss-teal/20 relative">
           <div className="w-full h-full bg-gradient-to-br from-swiss-mint/30 via-swiss-teal/20 to-swiss-mint/30" />
           <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent" />
           

--- a/frontend/pages/profile/EducatorProfileViewPage.tsx
+++ b/frontend/pages/profile/EducatorProfileViewPage.tsx
@@ -172,7 +172,7 @@ const EducatorProfileViewPage: React.FC = () => {
       {/* Social Media Style Header with Cover Image and Avatar */}
       <Card className="overflow-hidden p-0">
         {/* Cover Image Section */}
-        <div className="h-64 bg-gradient-to-r from-swiss-mint/20 to-swiss-teal/20 relative">
+        <div className="aspect-[4/1] bg-gradient-to-r from-swiss-mint/20 to-swiss-teal/20 relative">
           <div className="w-full h-full bg-gradient-to-br from-swiss-mint/30 via-swiss-teal/20 to-swiss-mint/30" />
           <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent" />
           

--- a/frontend/pages/profile/OrganizationProfileViewPage.tsx
+++ b/frontend/pages/profile/OrganizationProfileViewPage.tsx
@@ -167,7 +167,7 @@ const OrganizationProfileViewPage: React.FC = () => {
       {/* Social Media Style Header with Cover Image and Avatar */}
       <Card className="overflow-hidden p-0">
         {/* Cover Image Section */}
-        <div className="h-64 bg-gradient-to-r from-swiss-mint/20 to-swiss-teal/20 relative">
+        <div className="aspect-[4/1] bg-gradient-to-r from-swiss-mint/20 to-swiss-teal/20 relative">
           {organization.coverImageUrl ? (
             <img
               src={organization.coverImageUrl}

--- a/frontend/pages/profile/OrganizationProfileViewPage.tsx
+++ b/frontend/pages/profile/OrganizationProfileViewPage.tsx
@@ -167,7 +167,7 @@ const OrganizationProfileViewPage: React.FC = () => {
       {/* Social Media Style Header with Cover Image and Avatar */}
       <Card className="overflow-hidden p-0">
         {/* Cover Image Section */}
-        <div className="aspect-[4/1] bg-gradient-to-r from-swiss-mint/20 to-swiss-teal/20 relative">
+        <div className="w-full aspect-[4/1] bg-gradient-to-r from-swiss-mint/20 to-swiss-teal/20 relative">
           {organization.coverImageUrl ? (
             <img
               src={organization.coverImageUrl}

--- a/frontend/pages/service-provider/ServiceProviderOrganisationProfilePage.tsx
+++ b/frontend/pages/service-provider/ServiceProviderOrganisationProfilePage.tsx
@@ -371,7 +371,7 @@ const ServiceProviderOrganisationProfilePage: React.FC = () => {
           {/* Cover Image and Logo Section */}
           <Card className="overflow-hidden">
             <div 
-              className="h-48 bg-cover bg-center"
+              className="w-full aspect-[4/1] bg-cover bg-center"
               style={{ backgroundImage: `url(${coverImageUrl})` }}
             />
             <div className="relative px-6 pb-6">

--- a/frontend/pages/supplier/SupplierOrganisationProfilePage.tsx
+++ b/frontend/pages/supplier/SupplierOrganisationProfilePage.tsx
@@ -364,7 +364,7 @@ const SupplierOrganisationProfilePage: React.FC = () => {
           {/* Cover Image and Logo Section */}
           <Card className="overflow-hidden">
             <div 
-              className="h-48 bg-cover bg-center"
+              className="w-full aspect-[4/1] bg-cover bg-center"
               style={{ backgroundImage: `url(${coverImageUrl})` }}
             />
             <div className="relative px-6 pb-6">


### PR DESCRIPTION
Update profile banner containers to a 4:1 aspect ratio to prevent cropping of 1600x400 images.

Previously, banner images were rendered in fixed-height containers with `object-cover` or `bg-cover`, which caused images to be cropped or "zoomed in" if their aspect ratio didn't exactly match the container's. This change ensures that banners with a 4:1 aspect ratio (like 1600x400) display correctly without being cut off.

---
<a href="https://cursor.com/background-agent?bcId=bc-100abb5a-4ebe-4ada-874a-3a36331ac4ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-100abb5a-4ebe-4ada-874a-3a36331ac4ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated cover image containers across profile pages to use responsive aspect-ratio sizing (4:1) instead of fixed heights, improving layout responsiveness and consistency.
  * Changed loading placeholders to aspect-ratio-based containers for more proportional visual representation.
  * Affected pages: Educator, Organization, Service Provider, and Supplier profiles, plus Partner detail page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->