### PR TITLE
Subscription controller argument error

### DIFF
--- a/api/src/common/utils/response.util.ts
+++ b/api/src/common/utils/response.util.ts
@@ -19,6 +19,7 @@ export interface ApiResponseEnvelope<T> {
  * Standard API response wrapper for successful operations.
  * @param data The response payload
  * @param message Optional success message (defaults to 'OK')
+ * @param success Optional success flag (defaults to true)
  * @returns Standardized response object with success flag, message, data, and timestamp
  * 
  * @example
@@ -32,9 +33,13 @@ export interface ApiResponseEnvelope<T> {
  * return wrapResponse(plan, 'Subscription plan created successfully');
  * ```
  */
-export function wrapResponse<T>(data: T, message = 'OK'): ApiResponseEnvelope<T> {
+export function wrapResponse<T>(
+  data: T,
+  message = 'OK',
+  success = true
+): ApiResponseEnvelope<T> {
   return {
-    success: true,
+    success,
     message,
     data,
     timestamp: new Date().toISOString(),

--- a/api/src/subscription-management/pricing.service.ts
+++ b/api/src/subscription-management/pricing.service.ts
@@ -11,8 +11,12 @@ export interface PricingTier {
   currency: string;
   billingPeriod: 'monthly' | 'yearly';
   discounts: {
-    yearlyDiscount: number; // Percentage discount for yearly billing
-    volumeDiscounts: Array<{
+    /**
+     * Percentage discount for yearly billing.
+     * Optional to allow partial updates / DTO input; defaults are applied at write-time.
+     */
+    yearlyDiscount?: number;
+    volumeDiscounts?: Array<{
       minQuantity: number;
       discountPercentage: number;
     }>;


### PR DESCRIPTION
Extend `wrapResponse` to accept a `success` flag and make `PricingTier.discounts.yearlyDiscount` optional to resolve TypeScript build errors.

The initial Render build failure was due to `wrapResponse` being called with three arguments (including a `success` boolean) but only expecting two. After fixing this, a subsequent TypeScript error emerged because `yearlyDiscount` was optional in DTOs but required in the `PricingTier` interface used by the pricing service, preventing DTOs from being passed directly.

---
<a href="https://cursor.com/background-agent?bcId=bc-2deb2f1a-9860-4c65-9bed-49e502e7587c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2deb2f1a-9860-4c65-9bed-49e502e7587c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

