### PR TITLE
Admin profile link issue

### DIFF
--- a/admin/.env.example
+++ b/admin/.env.example
@@ -1,4 +1,6 @@
 VITE_CLERK_PUBLISHABLE_KEY=pk_test_dXByaWdodC1zYWxtb24tOTUuY2xlcmsuYWNjb3VudHMuZGV2JA
 VITE_API_URL=http://localhost:3000/api
+# Base URL for the main (frontend) app used by "View Profile" links.
+# Example production: https://app.procrechesolutions.com
 VITE_FRONTEND_URL=http://localhost:3000
 VITE_NODE_ENV=development

--- a/admin/src/pages/Users.tsx
+++ b/admin/src/pages/Users.tsx
@@ -753,6 +753,7 @@ const Users: React.FC = () => {
     // - admin.domain.com -> domain.com
     // - admin-staging.domain.com -> staging.domain.com
     // - staging-admin.domain.com -> staging.domain.com
+    // - domain.com -> app.domain.com (common SPA deployment)
     // - localhost:3001 -> localhost:3000
     const currentUrl = new URL(window.location.href)
     const { protocol, hostname, port } = currentUrl
@@ -764,6 +765,15 @@ const Users: React.FC = () => {
       derivedHostname = hostname.replace(/^admin-/, '')
     } else if (hostname.endsWith('-admin')) {
       derivedHostname = hostname.replace(/-admin$/, '')
+    }
+
+    // If admin is hosted on the apex domain but the frontend lives on app.<domain>,
+    // prefer that convention (e.g. procrechesolutions.com -> app.procrechesolutions.com).
+    // This is only applied when we couldn't derive a different hostname via admin-* patterns.
+    const hostnameLabels = derivedHostname.split('.')
+    const isLocalhostLike = derivedHostname === 'localhost' || derivedHostname.endsWith('.localhost')
+    if (!isLocalhostLike && derivedHostname === hostname && hostnameLabels.length === 2) {
+      derivedHostname = `app.${derivedHostname}`
     }
 
     const derivedPort = port === '3001' ? '3000' : port


### PR DESCRIPTION
Improve admin "View Profile" link fallback logic to correctly target `app.<domain>` when `VITE_FRONTEND_URL` is unset and admin is on the apex domain.

The previous attempt to fix this issue likely failed because the `VITE_FRONTEND_URL` environment variable was not configured in the production admin build. This change hardens the fallback logic to correctly guess the frontend host in such scenarios, preventing the "View Profile" link from pointing to the wrong domain.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d0edc80-1209-4f57-926a-c72d7c79a6e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4d0edc80-1209-4f57-926a-c72d7c79a6e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

