### PR TITLE
feat: Add 7-day grace period for email changes with admin-configurabl…

### DIFF
--- a/admin/src/pages/SystemConfigurationPage.tsx
+++ b/admin/src/pages/SystemConfigurationPage.tsx
@@ -96,6 +96,8 @@ export default function SystemConfigurationPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showCreateSetting, setShowCreateSetting] = useState(false);
+  const [showEditSetting, setShowEditSetting] = useState(false);
+  const [editingSetting, setEditingSetting] = useState<SystemSetting | null>(null);
   const [showCreateIntegration, setShowCreateIntegration] = useState(false);
   const [showCreateSchedule, setShowCreateSchedule] = useState(false);
   const [newSetting, setNewSetting] = useState({
@@ -256,6 +258,41 @@ export default function SystemConfigurationPage() {
       fetchSettings();
     } catch (err: any) {
       alert(t('admin:settings.systemConfig.systemSettings.alerts.createFailed', { message: err.message }));
+    }
+  };
+
+  const handleEditSetting = (setting: SystemSetting) => {
+    setEditingSetting(setting);
+    setShowEditSetting(true);
+  };
+
+  const handleUpdateSetting = async () => {
+    if (!editingSetting) return;
+    
+    try {
+      const token = await getToken();
+      const response = await fetch(`/api/admin/system-configuration/settings/${editingSetting.key}`, {
+        method: 'PUT',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          value: editingSetting.value,
+          description: editingSetting.description,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to update system setting');
+      }
+
+      alert(t('admin:settings.systemConfig.systemSettings.alerts.updated', 'Setting updated successfully'));
+      setShowEditSetting(false);
+      setEditingSetting(null);
+      fetchSettings();
+    } catch (err: any) {
+      alert(t('admin:settings.systemConfig.systemSettings.alerts.updateFailed', { message: err.message }));
     }
   };
 
@@ -527,7 +564,11 @@ export default function SystemConfigurationPage() {
                     </AdminTableCell>
                     <AdminTableCell>
                       <div className="flex gap-2">
-                        <AdminButton variant="outline" size="sm">
+                        <AdminButton 
+                          variant="outline" 
+                          size="sm"
+                          onClick={() => handleEditSetting(setting)}
+                        >
                           {t('admin:settings.systemConfig.systemSettings.buttons.edit')}
                         </AdminButton>
                         <AdminButton variant="secondary" size="sm">
@@ -539,6 +580,82 @@ export default function SystemConfigurationPage() {
                 ))}
               </AdminTableBody>
             </AdminTable>
+
+            {/* Edit Setting Modal */}
+            {showEditSetting && editingSetting && (
+              <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+                <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-md">
+                  <h3 className="text-lg font-semibold text-gray-900 mb-4">
+                    {t('admin:settings.systemConfig.systemSettings.editTitle', 'Edit Setting')}
+                  </h3>
+                  
+                  <div className="space-y-4">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                        {t('admin:settings.systemConfig.systemSettings.tableHeaders.key')}
+                      </label>
+                      <input
+                        type="text"
+                        value={editingSetting.key}
+                        disabled
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md bg-gray-100 text-gray-500"
+                      />
+                    </div>
+                    
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                        {t('admin:settings.systemConfig.systemSettings.tableHeaders.value')}
+                      </label>
+                      <input
+                        type="text"
+                        value={typeof editingSetting.value === 'string' ? editingSetting.value : JSON.stringify(editingSetting.value)}
+                        onChange={(e) => setEditingSetting({ ...editingSetting, value: e.target.value })}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      />
+                      {editingSetting.key === 'email.grace_period_days' && (
+                        <p className="mt-1 text-sm text-gray-500">
+                          {t('admin:settings.systemConfig.systemSettings.gracePeriodHint', 'Enter the number of days (e.g., 7)')}
+                        </p>
+                      )}
+                    </div>
+                    
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                        {t('admin:settings.systemConfig.systemSettings.description', 'Description')}
+                      </label>
+                      <textarea
+                        value={editingSetting.description}
+                        onChange={(e) => setEditingSetting({ ...editingSetting, description: e.target.value })}
+                        rows={3}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      />
+                    </div>
+                    
+                    <div className="text-sm text-gray-500">
+                      <p><strong>{t('admin:settings.systemConfig.systemSettings.tableHeaders.category')}:</strong> {editingSetting.category}</p>
+                    </div>
+                  </div>
+                  
+                  <div className="mt-6 flex justify-end gap-3">
+                    <AdminButton
+                      variant="secondary"
+                      onClick={() => {
+                        setShowEditSetting(false);
+                        setEditingSetting(null);
+                      }}
+                    >
+                      {t('common:cancel', 'Cancel')}
+                    </AdminButton>
+                    <AdminButton
+                      variant="primary"
+                      onClick={handleUpdateSetting}
+                    >
+                      {t('common:save', 'Save')}
+                    </AdminButton>
+                  </div>
+                </div>
+              </div>
+            )}
           </AdminCard>
         )}
 

--- a/api/prisma/migrations/20251221000002_add_email_grace_period_setting/migration.sql
+++ b/api/prisma/migrations/20251221000002_add_email_grace_period_setting/migration.sql
@@ -1,0 +1,19 @@
+-- Add email grace period setting for admin dashboard configuration
+-- This setting controls how many days to wait before deleting old email addresses
+-- after a user's email is changed (allows users to recover if needed)
+
+-- Only insert if the setting doesn't already exist
+INSERT INTO "SystemSettings" ("id", "key", "value", "description", "category", "isEncrypted", "isPublic", "createdAt", "updatedAt")
+SELECT 
+    gen_random_uuid(),
+    'email.grace_period_days',
+    '7',
+    'Number of days to keep old email addresses before automatic deletion after an email change. This grace period allows users to recover access if needed.',
+    'email',
+    false,
+    false,
+    NOW(),
+    NOW()
+WHERE NOT EXISTS (
+    SELECT 1 FROM "SystemSettings" WHERE "key" = 'email.grace_period_days'
+);

--- a/api/src/sync/outbox.worker.ts
+++ b/api/src/sync/outbox.worker.ts
@@ -16,6 +16,14 @@ interface EmailSyncPayload {
   attemptedAt?: string;
 }
 
+interface EmailDeletePayload {
+  clerkId: string;
+  emailAddressId: string;
+  emailAddress?: string;
+  reason?: string;
+  scheduledAt?: string;
+}
+
 @Injectable()
 export class OutboxWorker {
   private readonly logger = new Logger(OutboxWorker.name);
@@ -69,6 +77,8 @@ export class OutboxWorker {
       await this.mirrorRoleToClerk(job.payload as MirrorRolePayload);
     } else if (job.topic === 'clerk.email.sync') {
       await this.syncEmailToClerk(job.payload as EmailSyncPayload);
+    } else if (job.topic === 'clerk.email.delete') {
+      await this.deleteOldEmailFromClerk(job.payload as EmailDeletePayload);
     } else {
       this.logger.warn(`Unknown outbox topic: ${job.topic}`);
     }
@@ -143,6 +153,73 @@ export class OutboxWorker {
       if (error?.status === 404) {
         this.logger.warn(`User ${clerkId} not found in Clerk, skipping email sync`);
         return; // Don't throw error for non-existent users
+      }
+      throw error; // Re-throw other errors for retry
+    }
+  }
+
+  /**
+   * Delete old email from Clerk after grace period has expired.
+   * This is scheduled when a user's email is changed to clean up the old address.
+   */
+  private async deleteOldEmailFromClerk(payload: EmailDeletePayload) {
+    const { clerkId, emailAddressId, emailAddress, reason } = payload;
+    
+    this.logger.log(
+      `🗑️ [OUTBOX] Deleting old email ${emailAddress || emailAddressId} for user ${clerkId}. ` +
+      `Reason: ${reason || 'Grace period expired'}`
+    );
+    
+    try {
+      // First check if user still exists in Clerk
+      const clerkUser = await this.clerk.users.getUser(clerkId);
+      
+      // Check if the email address still exists and is not the primary
+      const emailToDelete = clerkUser.emailAddresses?.find(
+        (ea: any) => ea.id === emailAddressId
+      );
+      
+      if (!emailToDelete) {
+        this.logger.log(
+          `ℹ️ [OUTBOX] Email ${emailAddressId} no longer exists for user ${clerkId}, ` +
+          `skipping deletion (may have been manually deleted)`
+        );
+        return;
+      }
+      
+      // Safety check: Don't delete the primary email
+      if (clerkUser.primaryEmailAddressId === emailAddressId) {
+        this.logger.warn(
+          `⚠️ [OUTBOX] Cannot delete email ${emailAddressId} - it is now the primary email ` +
+          `for user ${clerkId}. The user may have reverted the change.`
+        );
+        return;
+      }
+      
+      // Safety check: Don't delete if it's the only email left
+      const emailCount = clerkUser.emailAddresses?.length || 0;
+      if (emailCount <= 1) {
+        this.logger.warn(
+          `⚠️ [OUTBOX] Cannot delete email ${emailAddressId} - it is the only email ` +
+          `for user ${clerkId}. Skipping to prevent account lockout.`
+        );
+        return;
+      }
+      
+      // Delete the old email address
+      await this.clerk.emailAddresses.deleteEmailAddress(emailAddressId);
+      
+      this.logger.log(
+        `✅ [OUTBOX] Successfully deleted old email ${emailAddress || emailAddressId} ` +
+        `for user ${clerkId}`
+      );
+    } catch (error: any) {
+      if (error?.status === 404) {
+        this.logger.warn(
+          `User or email ${clerkId}/${emailAddressId} not found in Clerk, ` +
+          `skipping deletion (may have been already deleted)`
+        );
+        return; // Don't throw error for non-existent resources
       }
       throw error; // Re-throw other errors for retry
     }

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -74,7 +74,7 @@ export class UsersService {
    * To update the primary email, we need to:
    * 1. Create a new email address for the user
    * 2. Set it as primary
-   * 3. Keep old email as secondary (for grace period / recovery)
+   * 3. Schedule old email for deletion after grace period
    * 
    * @param clerkId - The Clerk user ID
    * @param newEmail - The new email address to set
@@ -91,6 +91,10 @@ export class UsersService {
     
     // Get the current user from Clerk to find existing email addresses
     const clerkUser = await this.clerk.users.getUser(clerkId);
+    const oldPrimaryEmailId = clerkUser.primaryEmailAddressId;
+    const oldPrimaryEmail = clerkUser.emailAddresses?.find(
+      (ea: any) => ea.id === oldPrimaryEmailId
+    )?.emailAddress;
     
     // Check if the new email already exists for this user
     const existingEmailAddress = clerkUser.emailAddresses?.find(
@@ -119,11 +123,71 @@ export class UsersService {
       primary: true, // Set as primary immediately
     });
     
-    // Keep old email as a secondary address for a grace period
-    // This allows users to still recover access if needed
-    // Admins can manually delete it later via Clerk dashboard if needed
-    this.logger.log(`ℹ️ [EMAIL SYNC] Old email retained as secondary address for ${clerkId}`);
+    // Schedule old email for deletion after grace period
+    // This allows users time to verify the new email works and recover if needed
+    if (oldPrimaryEmailId) {
+      await this.scheduleOldEmailDeletion(clerkId, oldPrimaryEmailId, oldPrimaryEmail);
+    }
+    
     this.logger.log(`✅ [EMAIL SYNC] Email sync completed for ${clerkId}`);
+  }
+
+  /**
+   * Schedule the old email address for deletion after a grace period.
+   * Default grace period is 7 days, configurable via System Settings in admin dashboard.
+   * Setting key: email.grace_period_days (category: email)
+   */
+  private async scheduleOldEmailDeletion(
+    clerkId: string, 
+    emailAddressId: string, 
+    emailAddress?: string
+  ): Promise<void> {
+    // Get grace period from system settings, fallback to env var, then default to 7 days
+    let gracePeriodDays = 7;
+    
+    try {
+      const setting = await this.prisma.systemSettings.findUnique({
+        where: { key: 'email.grace_period_days' },
+      });
+      if (setting?.value) {
+        gracePeriodDays = Number(setting.value) || 7;
+      } else {
+        // Fallback to env var for backwards compatibility
+        gracePeriodDays = this.configService.get<number>('EMAIL_GRACE_PERIOD_DAYS') || 7;
+      }
+    } catch {
+      // If system settings table doesn't exist yet, use env var fallback
+      gracePeriodDays = this.configService.get<number>('EMAIL_GRACE_PERIOD_DAYS') || 7;
+    }
+    
+    const deletionDate = new Date(Date.now() + gracePeriodDays * 24 * 60 * 60 * 1000);
+    
+    try {
+      await this.prisma.outbox.create({
+        data: {
+          topic: 'clerk.email.delete',
+          payload: { 
+            clerkId, 
+            emailAddressId,
+            emailAddress: emailAddress || 'unknown',
+            reason: 'Grace period expired after email change',
+            scheduledAt: new Date().toISOString(),
+          },
+          nextRunAt: deletionDate, // Won't be processed until this date
+        },
+      });
+      
+      this.logger.log(
+        `📅 [EMAIL SYNC] Old email ${emailAddress || emailAddressId} scheduled for deletion ` +
+        `after ${gracePeriodDays} days (${deletionDate.toISOString()}) for user ${clerkId}`
+      );
+    } catch (error: any) {
+      // Non-critical error - the new email is already working
+      this.logger.warn(
+        `⚠️ [EMAIL SYNC] Could not schedule old email deletion: ${error.message}. ` +
+        `Manual cleanup may be needed for user ${clerkId}`
+      );
+    }
   }
 
   /**

--- a/packages/translations/locales/de/admin.json
+++ b/packages/translations/locales/de/admin.json
@@ -149,8 +149,13 @@
         },
         "alerts": {
           "createFailed": "Fehler beim Erstellen der Einstellung: {{message}}",
-          "created": "Systemeinstellung erfolgreich erstellt!"
+          "created": "Systemeinstellung erfolgreich erstellt!",
+          "updated": "Einstellung erfolgreich aktualisiert!",
+          "updateFailed": "Fehler beim Aktualisieren der Einstellung: {{message}}"
         },
+        "editTitle": "Einstellung bearbeiten",
+        "description": "Beschreibung",
+        "gracePeriodHint": "Geben Sie die Anzahl der Tage ein (z.B. 7)",
         "badges": {
           "encrypted": "Verschlüsselt",
           "public": "Öffentlich"

--- a/packages/translations/locales/en/admin.json
+++ b/packages/translations/locales/en/admin.json
@@ -149,8 +149,13 @@
         },
         "alerts": {
           "createFailed": "Failed to create setting: {{message}}",
-          "created": "System setting created successfully!"
+          "created": "System setting created successfully!",
+          "updated": "Setting updated successfully!",
+          "updateFailed": "Failed to update setting: {{message}}"
         },
+        "editTitle": "Edit Setting",
+        "description": "Description",
+        "gracePeriodHint": "Enter the number of days (e.g., 7)",
         "badges": {
           "encrypted": "Encrypted",
           "public": "Public"

--- a/packages/translations/locales/fr/admin.json
+++ b/packages/translations/locales/fr/admin.json
@@ -149,8 +149,13 @@
         },
         "alerts": {
           "createFailed": "Échec de la création du paramètre : {{message}}",
-          "created": "Paramètre système créé avec succès !"
+          "created": "Paramètre système créé avec succès !",
+          "updated": "Paramètre mis à jour avec succès !",
+          "updateFailed": "Échec de la mise à jour du paramètre : {{message}}"
         },
+        "editTitle": "Modifier le paramètre",
+        "description": "Description",
+        "gracePeriodHint": "Entrez le nombre de jours (par ex. 7)",
         "badges": {
           "encrypted": "Chiffré",
           "public": "Public"


### PR DESCRIPTION
…e setting

- Schedule old email deletion after user email change (7 days default)
- Add email.grace_period_days system setting for admin configuration
- Add edit settings modal to System Configuration page
- Add safety checks to prevent accidental email lockout
- Add translations for new UI elements (EN/FR/DE)

This enhancement ensures old emails are retained as secondary for a configurable grace period, allowing users time to verify new email works before old is deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System settings can now be edited directly in the admin interface with a dedicated modal.
  * Added email grace period setting to manage email address transitions (default: 7 days).
  * Settings updates now provide success and error feedback.

* **Chores**
  * Updated translations for admin interface across multiple languages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->