### PR TITLE
Pricing page loading issue

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -538,7 +538,7 @@ const App: React.FC = () => {
             <Routes>
               <Route path="/login" element={<LoginPage />} />
               <Route path="/signup" element={<SignupPage />} />
-              <Route path="/pricing" element={<PricingPage />} />
+              <Route path="/pricing" element={<SubscriptionProvider><PricingPage /></SubscriptionProvider>} />
               <Route path="/partners" element={<PublicPartnersPage />} />
               <Route path="/parent-lead-form" element={<ParentLeadFormPage />} />
               <Route path="/*" element={<ProtectedLayout />} />

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -278,7 +278,6 @@ const ProtectedLayout: React.FC = () => {
   }
 
   return (
-    <SubscriptionProvider>
       <MainLayout>
         <Routes>
           <Route path="/" element={<Navigate to="/dashboard" replace />} />
@@ -497,7 +496,6 @@ const ProtectedLayout: React.FC = () => {
         <Route path="*" element={<Navigate to="/dashboard" replace />} />
         </Routes>
       </MainLayout>
-    </SubscriptionProvider>
   );
 };
 
@@ -535,14 +533,16 @@ const App: React.FC = () => {
       <CartProvider>
         <NotificationProvider>
           <MessagingProvider>
-            <Routes>
-              <Route path="/login" element={<LoginPage />} />
-              <Route path="/signup" element={<SignupPage />} />
-              <Route path="/pricing" element={<SubscriptionProvider><PricingPage /></SubscriptionProvider>} />
-              <Route path="/partners" element={<PublicPartnersPage />} />
-              <Route path="/parent-lead-form" element={<ParentLeadFormPage />} />
-              <Route path="/*" element={<ProtectedLayout />} />
-            </Routes>
+            <SubscriptionProvider>
+              <Routes>
+                <Route path="/login" element={<LoginPage />} />
+                <Route path="/signup" element={<SignupPage />} />
+                <Route path="/pricing" element={<PricingPage />} />
+                <Route path="/partners" element={<PublicPartnersPage />} />
+                <Route path="/parent-lead-form" element={<ParentLeadFormPage />} />
+                <Route path="/*" element={<ProtectedLayout />} />
+              </Routes>
+            </SubscriptionProvider>
           </MessagingProvider>
         </NotificationProvider>
       </CartProvider>


### PR DESCRIPTION
Wrap `PricingPage` with `SubscriptionProvider` to fix the "useSubscription must be used within a SubscriptionProvider" error on the public pricing route.

The `PricingPage` component uses the `useSubscription()` hook, but it was rendered as a public route (`/pricing`) outside of the `ProtectedLayout`, which is where the `SubscriptionProvider` was previously located. This caused the page to fail loading because the necessary context was missing. Wrapping the `PricingPage` directly with `SubscriptionProvider` ensures the context is available for both authenticated and unauthenticated users.

---
<a href="https://cursor.com/background-agent?bcId=bc-72971998-5b6d-4649-a531-f82b3f91febf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-72971998-5b6d-4649-a531-f82b3f91febf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pricing page now enforces subscription-based access restrictions to control visibility and availability for different user types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->