### PR TITLE
Admin org settings access

### DIFF
--- a/frontend/components/settings/sections/AccountSecuritySettings.tsx
+++ b/frontend/components/settings/sections/AccountSecuritySettings.tsx
@@ -509,8 +509,14 @@ const AccountSecuritySettings: React.FC<AccountSecuritySettingsProps> = ({ setti
 
           {/* Error Message */}
           {emailError && (
-            <div className="mt-4">
-              <p className="text-sm text-swiss-coral font-medium">{emailError}</p>
+            <div className="mt-4 p-4 bg-red-50 border border-red-200 rounded-lg">
+              <p className="text-sm text-red-700 font-medium">{emailError}</p>
+              {emailError.includes('sign out and sign back in') && (
+                <p className="text-xs text-red-600 mt-2">
+                  {t('common:settingsAccountSecurity.changeEmail.reAuthTip', 
+                    'After signing back in, return to this page to change your email address.')}
+                </p>
+              )}
             </div>
           )}
         </div>

--- a/frontend/providers/AuthProvider.tsx
+++ b/frontend/providers/AuthProvider.tsx
@@ -451,21 +451,36 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
         // Prepare data for backend (remove frontend-only fields)
         const backendData: any = { ...updatedInfo };
         
+        // Map orgName to organizationName for the profiles endpoint
+        if (backendData.orgName !== undefined) {
+          backendData.organizationName = backendData.orgName;
+          delete backendData.orgName;
+        }
+        
         // Remove frontend-only fields that backend doesn't accept
         delete backendData.name; // We use firstName/lastName separately
-        delete backendData.orgName; // Backend uses orgId (UUID), not orgName (string)
         delete backendData.status; // Transformed field, not raw backend field
         delete backendData.lastLogin; // Transformed field
         delete backendData.memberSince; // Transformed field
         delete backendData.organizations; // Many-to-many relation, not direct field
         
-
+        // Determine which endpoint to use based on what's being updated
+        // Use profiles endpoint if updating organization-related fields
+        const hasOrgFields = backendData.organizationName !== undefined || 
+                           backendData.description !== undefined ||
+                           backendData.contactPerson !== undefined ||
+                           backendData.canton !== undefined ||
+                           backendData.languages !== undefined;
+        
         const apiBaseUrl = apiService.apiBaseUrl;
-        const url = `${apiBaseUrl}${API_ENDPOINTS.users.update}`;
+        const url = hasOrgFields 
+          ? `${apiBaseUrl}${API_ENDPOINTS.profiles.update}`
+          : `${apiBaseUrl}${API_ENDPOINTS.users.update}`;
+        const method = hasOrgFields ? 'PUT' : 'PATCH';
 
 
         const response = await fetch(url, {
-          method: 'PATCH',
+          method,
           headers: {
             'Content-Type': 'application/json',
             Accept: 'application/json',
@@ -619,14 +634,37 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
         // Handle Clerk-specific errors
         const clerkErrors = error?.errors;
         if (Array.isArray(clerkErrors) && clerkErrors.length > 0) {
+          const firstError = clerkErrors[0];
+          const errorCode = firstError?.code || '';
           const message = clerkErrors
             .map((e: any) => e?.longMessage || e?.message)
             .filter(Boolean)
             .join(' ');
+          
+          // Handle verification_strategy_requires_reverification error
+          if (errorCode === 'verification_strategy_requires_reverification' ||
+              message.includes('additional verification')) {
+            throw new Error(
+              'For security reasons, you need to sign out and sign back in before changing your email address. ' +
+              'This helps us verify your identity for sensitive account changes.'
+            );
+          }
+          
           throw new Error(message || 'Email change failed');
         }
 
         const errorMessage = error?.message || '';
+        const errorStatus = error?.status || error?.code;
+        
+        // Handle 403 additional verification requirement
+        if (errorStatus === 403 || 
+            errorMessage.includes('additional verification') ||
+            errorMessage.includes('verification')) {
+          throw new Error(
+            'For security reasons, you need to sign out and sign back in before changing your email address. ' +
+            'This helps us verify your identity for sensitive account changes.'
+          );
+        }
         
         // Handle duplicate email
         if (errorMessage.includes('already exists') || errorMessage.includes('taken')) {


### PR DESCRIPTION
Fixes organization name updates and improves error handling for email changes requiring additional verification.

The organization name update failed because the frontend was incorrectly deleting the `orgName` field before sending it to the backend's `/profiles/me` endpoint, which actually accepts `organizationName`. For email changes, a 403 error indicated that Clerk's security features required additional verification, which is now handled by providing a clear user message to re-authenticate.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8295ea4-61cc-4cb7-8d41-6fbd23d52f35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e8295ea4-61cc-4cb7-8d41-6fbd23d52f35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

