### PR TITLE
Render backend deployment investigation

### DIFF
--- a/api/scripts/prebuild-db-setup.mjs
+++ b/api/scripts/prebuild-db-setup.mjs
@@ -719,35 +719,10 @@ WHERE NOT EXISTS (
   log('✅ Foundation subscription tiers schema verified.');
 };
 
-/**
- * Ensure email grace period system setting exists.
- * Matches migration `20251221000002_add_email_grace_period_setting`.
- * This setting controls how many days to wait before deleting old email addresses
- * after a user's email is changed (allows users to recover if needed).
- */
-const ensureEmailGracePeriodSetting = () => {
-  const sql = `
--- Add email grace period setting for admin dashboard configuration
-INSERT INTO "SystemSettings" ("id", "key", "value", "description", "category", "isEncrypted", "isPublic", "createdAt", "updatedAt")
-SELECT 
-    gen_random_uuid(),
-    'email.grace_period_days',
-    '7',
-    'Number of days to keep old email addresses before automatic deletion after an email change. This grace period allows users to recover access if needed.',
-    'email',
-    false,
-    false,
-    NOW(),
-    NOW()
-WHERE NOT EXISTS (
-    SELECT 1 FROM "SystemSettings" WHERE "key" = 'email.grace_period_days'
-);
-`;
-
-  log('Ensuring email.grace_period_days system setting exists...');
-  runSql(sql);
-  log('✅ Email grace period setting verified.');
-};
+// NOTE:
+// An earlier version of this script inserted into `"SystemSettings"` using `gen_random_uuid()`.
+// The Prisma model is `SystemSettings` but the mapped Postgres table is `system_settings` (see schema.prisma),
+// and `gen_random_uuid()` also requires pgcrypto. We use the safer `system_settings` variant below.
 
 /**
  * Ensure job contract type enum has new values.

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -61,19 +61,41 @@ import {
   UPLOAD_TTL_SECONDS,
 } from './common/decorators/throttle.decorator';
 
+function isRedisEnabled(): boolean {
+  // In production (Render), only enable Redis-dependent modules if configured.
+  // In dev/test, default to localhost to keep existing behavior.
+  if (process.env.NODE_ENV !== 'production') return true;
+  return Boolean(process.env.REDIS_URL || process.env.REDIS_HOST);
+}
+
+function getBullRedisConfig():
+  | string
+  | {
+      host: string;
+      port: number;
+      password?: string;
+    } {
+  if (process.env.REDIS_URL) return process.env.REDIS_URL;
+  return {
+    host: process.env.REDIS_HOST || 'localhost',
+    port: parseInt(process.env.REDIS_PORT || '6379', 10),
+    password: process.env.REDIS_PASSWORD,
+  };
+}
+
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
     }),
     ScheduleModule.forRoot(),
-    BullModule.forRoot({
-      redis: {
-        host: process.env.REDIS_HOST || 'localhost',
-        port: parseInt(process.env.REDIS_PORT || '6379'),
-        password: process.env.REDIS_PASSWORD,
-      },
-    }),
+    ...(isRedisEnabled()
+      ? [
+          BullModule.forRoot({
+            redis: getBullRedisConfig(),
+          }),
+        ]
+      : []),
     ThrottlerModule.forRoot([
       {
         name: 'short',

--- a/api/src/translation/translation-queue.module.ts
+++ b/api/src/translation/translation-queue.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, DynamicModule } from '@nestjs/common';
 import { BullModule } from '@nestjs/bull';
 import { TranslationQueueProcessor } from './translation-queue.processor';
 import { DeepLService } from './deepl.service';
@@ -6,34 +6,66 @@ import { TranslationMemoryService } from './translation-memory.service';
 import { CostTrackingService } from './cost-tracking.service';
 import { PrismaModule } from '../prisma/prisma.module';
 
-@Module({
-  imports: [
-    BullModule.registerQueue({
-      name: 'translation',
-      redis: {
-        host: process.env.REDIS_HOST || 'localhost',
-        port: parseInt(process.env.REDIS_PORT || '6379'),
-        password: process.env.REDIS_PASSWORD,
-      },
-      defaultJobOptions: {
-        attempts: 3,
-        backoff: {
-          type: 'exponential',
-          delay: 2000,
-        },
-        removeOnComplete: true,
-        removeOnFail: false, // Keep failed jobs for debugging
-      },
-    }),
-    PrismaModule,
-  ],
-  providers: [
-    TranslationQueueProcessor,
-    DeepLService,
-    TranslationMemoryService,
-    CostTrackingService,
-  ],
-  exports: [BullModule, DeepLService, TranslationMemoryService, CostTrackingService],
-})
-export class TranslationQueueModule {}
+function isRedisEnabled(): boolean {
+  // In production (Render), we disable Redis/Bull unless explicitly configured.
+  // In non-production, default to localhost for developer convenience.
+  if (process.env.NODE_ENV !== 'production') return true;
+  return Boolean(process.env.REDIS_URL || process.env.REDIS_HOST);
+}
+
+function getBullRedisConfig():
+  | string
+  | {
+      host: string;
+      port: number;
+      password?: string;
+    } {
+  if (process.env.REDIS_URL) return process.env.REDIS_URL;
+  return {
+    host: process.env.REDIS_HOST || 'localhost',
+    port: parseInt(process.env.REDIS_PORT || '6379', 10),
+    password: process.env.REDIS_PASSWORD,
+  };
+}
+
+@Module({})
+export class TranslationQueueModule {
+  static register(): DynamicModule {
+    const redisEnabled = isRedisEnabled();
+
+    // Always provide these services so TranslationService can fall back to inline translation.
+    const base = {
+      module: TranslationQueueModule,
+      imports: [PrismaModule],
+      providers: [DeepLService, TranslationMemoryService, CostTrackingService],
+      exports: [DeepLService, TranslationMemoryService, CostTrackingService],
+    } as DynamicModule;
+
+    if (!redisEnabled) {
+      return base;
+    }
+
+    return {
+      ...base,
+      imports: [
+        ...(base.imports || []),
+        BullModule.registerQueue({
+          name: 'translation',
+          redis: getBullRedisConfig(),
+          defaultJobOptions: {
+            attempts: 3,
+            backoff: {
+              type: 'exponential',
+              delay: 2000,
+            },
+            removeOnComplete: true,
+            removeOnFail: false, // Keep failed jobs for debugging
+          },
+        }),
+      ],
+      providers: [...(base.providers || []), TranslationQueueProcessor],
+      exports: [...(base.exports || []), BullModule],
+    };
+  }
+}
 

--- a/api/src/translation/translation.module.ts
+++ b/api/src/translation/translation.module.ts
@@ -9,7 +9,7 @@ import { TranslationQueueModule } from './translation-queue.module';
   imports: [
     PrismaModule,
     AuthModule,
-    TranslationQueueModule,
+    TranslationQueueModule.register(),
   ],
   controllers: [TranslationController],
   providers: [TranslationService],

--- a/api/src/translation/translation.service.ts
+++ b/api/src/translation/translation.service.ts
@@ -27,7 +27,7 @@ export class TranslationService {
   constructor(
     private prisma: PrismaService,
     private configService: ConfigService,
-    @InjectQueue('translation') private translationQueue?: Queue,
+    @Optional() @InjectQueue('translation') private translationQueue?: Queue,
     @Optional() private deepLService?: DeepLService,
   ) {
     if (this.translationQueue) {


### PR DESCRIPTION
Fix `SyntaxError` in prebuild script and make Redis/Bull optional to prevent deploy stalls.

The Render deploy was stalling at the "Deploying..." phase because the API was attempting to connect to a non-existent Redis instance (`localhost:6379`) during startup when `REDIS_URL` or `REDIS_HOST` were not configured. This change allows the API to boot successfully without Redis in production if it's not explicitly configured. Additionally, a `SyntaxError` in `prebuild-db-setup.mjs` was fixed, which was preventing the pre-build database recovery steps from executing.

---
<a href="https://cursor.com/background-agent?bcId=bc-b06f9b5d-a717-4472-8416-a6855e74b746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b06f9b5d-a717-4472-8416-a6855e74b746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

