### PR TITLE
fix: Prevent empty orgName from triggering profiles endpoint

### DIFF
--- a/frontend/providers/AuthProvider.tsx
+++ b/frontend/providers/AuthProvider.tsx
@@ -452,10 +452,14 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
         const backendData: any = { ...updatedInfo };
         
         // Map orgName to organizationName for the profiles endpoint
-        if (backendData.orgName !== undefined) {
+        // Only include organizationName if it's a non-empty value
+        const hasOrgNameUpdate = backendData.orgName !== undefined && 
+                                 backendData.orgName !== null && 
+                                 String(backendData.orgName).trim() !== '';
+        if (hasOrgNameUpdate) {
           backendData.organizationName = backendData.orgName;
-          delete backendData.orgName;
         }
+        delete backendData.orgName; // Always remove orgName (backend expects organizationName)
         
         // Remove frontend-only fields that backend doesn't accept
         delete backendData.name; // We use firstName/lastName separately
@@ -465,10 +469,10 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
         delete backendData.organizations; // Many-to-many relation, not direct field
         
         // Determine which endpoint to use based on what's being updated
-        // Use profiles endpoint if updating organization-related fields
-        const hasOrgFields = backendData.organizationName !== undefined || 
-                           backendData.description !== undefined ||
-                           backendData.contactPerson !== undefined ||
+        // Use profiles endpoint if updating organization-related fields with actual values
+        const hasOrgFields = hasOrgNameUpdate || 
+                           (backendData.description !== undefined && backendData.description !== '') ||
+                           (backendData.contactPerson !== undefined && backendData.contactPerson !== '') ||
                            backendData.canton !== undefined ||
                            backendData.languages !== undefined;
         


### PR DESCRIPTION
When updating user info (firstName, lastName), the form always sends orgName even when empty. This was incorrectly triggering the profiles endpoint instead of the users endpoint.

Now the logic only routes to /profiles/me when there's actually a meaningful organization field being updated (non-empty value).

This fixes the issue where firstName and lastName updates were not being saved for users without organization names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of organization profile updates to ensure empty values are not sent to the backend, enhancing data consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->