### PR TITLE
Settings subscription modal status

### DIFF
--- a/frontend/components/settings/sections/BillingSubscriptionSettings.tsx
+++ b/frontend/components/settings/sections/BillingSubscriptionSettings.tsx
@@ -198,7 +198,8 @@ const BillingSubscriptionSettings: React.FC<BillingSubscriptionSettingsProps> = 
               </p>
             </div>
             <div className="text-sm text-gray-600">
-              <span className="font-medium">{t('common:status')}:</span> {subscriptionLoading ? t('common:loading') : statusLabel}
+              <span className="font-medium">{t('common:labels.status', 'Status')}:</span>{' '}
+              {subscriptionLoading ? t('common:loading') : statusLabel}
             </div>
           </div>
 

--- a/frontend/i18n/types.ts
+++ b/frontend/i18n/types.ts
@@ -2595,6 +2595,7 @@ export type I18nKey =
   | 'common:labels.decreaseQuantity'
   | 'common:labels.increaseQuantity'
   | 'common:labels.region'
+  | 'common:labels.status'
   | 'common:labels.sortBy'
   | 'common:labels.supplierTags'
   | 'common:labels.verificationCode'

--- a/packages/translations/locales/de/common.json
+++ b/packages/translations/locales/de/common.json
@@ -941,6 +941,7 @@
     "decreaseQuantity": "Menge verringern",
     "increaseQuantity": "Menge erhöhen",
     "region": "Region",
+    "status": "Status",
     "sortBy": "Sortieren nach",
     "supplierTags": "Lieferanten-Tags",
     "verificationCode": "Bestätigungscode"

--- a/packages/translations/locales/en/common.json
+++ b/packages/translations/locales/en/common.json
@@ -963,6 +963,7 @@
     "decreaseQuantity": "decrease Quantity",
     "increaseQuantity": "increase Quantity",
     "region": "Region",
+    "status": "Status",
     "sortBy": "sort By",
     "supplierTags": "supplier Tags",
     "verificationCode": "Verification Code"

--- a/packages/translations/locales/fr/common.json
+++ b/packages/translations/locales/fr/common.json
@@ -930,6 +930,7 @@
     "decreaseQuantity": "decrease Quantity",
     "increaseQuantity": "increase Quantity",
     "region": "Région",
+    "status": "Statut",
     "sortBy": "sort By",
     "supplierTags": "supplier Tags",
     "verificationCode": "Code de vérification"


### PR DESCRIPTION
Fixes i18n warning "key 'status (en)' returned an object instead of string" in the Settings subscription modal.

The `BillingSubscriptionSettings` component was attempting to translate `common:status`, which is an object containing status mappings, instead of a direct string label. This PR introduces a dedicated string key `common:labels.status` and updates the component to use it, resolving the warning across all locales.

---
<a href="https://cursor.com/background-agent?bcId=bc-174b6882-cef6-433a-9dad-0cd3664de3ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-174b6882-cef6-433a-9dad-0cd3664de3ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

