### PR TITLE
Email template display issue

### DIFF
--- a/admin/src/components/settings/SettingsLayout.tsx
+++ b/admin/src/components/settings/SettingsLayout.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Tab } from '@headlessui/react'
 import { Settings as SettingsIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { useLocation, useNavigate } from 'react-router-dom'
 import GeneralSettings from './GeneralSettings'
 import BrandingSettings from './BrandingSettings'
 import ContentSettings from './ContentSettings'
@@ -12,6 +13,8 @@ import SystemConfigurationPage from '../../pages/SystemConfigurationPage'
 
 const SettingsLayout: React.FC = () => {
   const { t } = useTranslation(['admin', 'common'])
+  const location = useLocation()
+  const navigate = useNavigate()
   
   const tabs = [
     { name: t('admin:settings.tabs.general'), key: 'general', component: GeneralSettings },
@@ -26,6 +29,21 @@ const SettingsLayout: React.FC = () => {
 function classNames(...classes: string[]) {
   return classes.filter(Boolean).join(' ')
 }
+
+  const selectedIndex = React.useMemo(() => {
+    const params = new URLSearchParams(location.search)
+    const tabKey = params.get('tab')
+    if (!tabKey) return 0
+    const idx = tabs.findIndex((t) => t.key === tabKey)
+    return idx >= 0 ? idx : 0
+  }, [location.search, tabs])
+
+  const handleTabChange = (idx: number) => {
+    const tabKey = tabs[idx]?.key
+    const params = new URLSearchParams(location.search)
+    if (tabKey) params.set('tab', tabKey)
+    navigate({ pathname: location.pathname, search: params.toString() ? `?${params.toString()}` : '' }, { replace: true })
+  }
 
   return (
     <div className="space-y-8">
@@ -42,7 +60,7 @@ function classNames(...classes: string[]) {
 
       {/* Settings Tabs */}
       <div className="bg-white rounded-card shadow-soft border border-gray-200">
-        <Tab.Group>
+        <Tab.Group selectedIndex={selectedIndex} onChange={handleTabChange}>
           <div className="border-b border-gray-200">
             <Tab.List className="flex space-x-8 px-6">
               {tabs.map((tab) => (

--- a/admin/src/pages/SystemConfigurationPage.tsx
+++ b/admin/src/pages/SystemConfigurationPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useAuth } from '@clerk/clerk-react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import { 
   AdminCard, 
   AdminButton, 
@@ -87,6 +88,7 @@ interface SystemHealth {
 export default function SystemConfigurationPage() {
   const { t } = useTranslation(['admin', 'common']);
   const { getToken } = useAuth();
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<'settings' | 'integrations' | 'maintenance' | 'health' | 'templates'>('settings');
   const [settings, setSettings] = useState<SystemSetting[]>([]);
   const [integrations, setIntegrations] = useState<IntegrationConfig[]>([]);
@@ -904,16 +906,24 @@ export default function SystemConfigurationPage() {
           <AdminCard className="p-6">
             <div className="flex items-center justify-between mb-6">
               <h3 className="text-lg font-semibold text-admin-text">{t('admin:settings.systemConfig.emailTemplates.title')}</h3>
-              <AdminButton variant="primary" size="sm">
-                {t('admin:settings.systemConfig.emailTemplates.createTemplate')}
+              <AdminButton
+                variant="primary"
+                size="sm"
+                onClick={() => navigate({ search: '?tab=emailTemplates' })}
+              >
+                {t('admin:settings.systemConfig.emailTemplates.goToTemplates')}
               </AdminButton>
             </div>
             
             <div className="text-center py-8">
               <div className="text-4xl mb-4">📧</div>
-              <h4 className="text-lg font-medium text-admin-text mb-2">{t('admin:settings.systemConfig.emailTemplates.title')}</h4>
-              <p className="text-admin-muted mb-4">{t('admin:settings.systemConfig.emailTemplates.description')}</p>
-              <AdminButton variant="primary">
+              <h4 className="text-lg font-medium text-admin-text mb-2">
+                {t('admin:settings.systemConfig.emailTemplates.title')}
+              </h4>
+              <p className="text-admin-muted mb-4">
+                Email templates are managed in the main <strong>Settings → Email Templates</strong> tab.
+              </p>
+              <AdminButton variant="primary" onClick={() => navigate({ search: '?tab=emailTemplates' })}>
                 {t('admin:settings.systemConfig.emailTemplates.goToTemplates')}
               </AdminButton>
             </div>


### PR DESCRIPTION
Enable URL-driven tab selection for Settings and redirect the System Config Email Templates placeholder to the actual Email Templates manager.

The "System Config → Email Templates" sub-tab was a static placeholder that always appeared empty, causing confusion. The actual email template management UI is located under the top-level "Settings → Email Templates" tab. This PR wires the placeholder to navigate to the correct, functional UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-e920537f-ed45-4ac9-a010-5c8d3d0eb7dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e920537f-ed45-4ac9-a010-5c8d3d0eb7dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

