### PR TITLE
Admin system maintenance integration

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -52,6 +52,8 @@ import { PromoCodesModule } from './promo-codes/promo-codes.module';
 import { VendorClientsModule } from './vendor-clients/vendor-clients.module';
 import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
 import { RequestLoggerMiddleware } from './common/middleware/request-logger.middleware';
+import { MaintenanceModeMiddleware } from './common/middleware/maintenance-mode.middleware';
+import { MaintenanceModule } from './maintenance/maintenance.module';
 
 import {
   AUTH_REQUESTS_LIMIT,
@@ -144,6 +146,7 @@ import {
     OrganizationDocumentsModule,
     PromoCodesModule,
     VendorClientsModule,
+    MaintenanceModule,
   ],
   controllers: [AppController],
   providers: [
@@ -152,6 +155,7 @@ import {
       provide: APP_GUARD,
       useClass: CustomThrottlerGuard,
     },
+    MaintenanceModeMiddleware,
   ],
 })
 export class AppModule implements NestModule {
@@ -170,6 +174,11 @@ export class AppModule implements NestModule {
         'api/health/*rest',
         'api/webhooks/*rest',
       )
+      .forRoutes('*');
+
+    // Global maintenance mode gate (platform-settings is the source of truth)
+    consumer
+      .apply(MaintenanceModeMiddleware)
       .forRoutes('*');
   }
 }

--- a/api/src/common/middleware/maintenance-mode.middleware.ts
+++ b/api/src/common/middleware/maintenance-mode.middleware.ts
@@ -25,7 +25,7 @@ export class MaintenanceModeMiddleware {
 
     if (allowList.some((re) => re.test(url))) return next();
 
-    // Admin bypass (role is populated by ClerkAuthGuard / RoleContextMiddleware)
+    // Admin bypass (role is populated by RoleContextMiddleware)
     const role = (req as any)?.context?.role;
     if (role === 'ADMIN' || role === 'SUPER_ADMIN') return next();
 

--- a/api/src/common/middleware/maintenance-mode.middleware.ts
+++ b/api/src/common/middleware/maintenance-mode.middleware.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { PlatformSettingsService } from '../../platform-settings/platform-settings.service';
+
+@Injectable()
+export class MaintenanceModeMiddleware {
+  constructor(private readonly platformSettingsService: PlatformSettingsService) {}
+
+  async use(req: Request, res: Response, next: NextFunction) {
+    // Always allow CORS preflight
+    if (req.method === 'OPTIONS') return next();
+
+    const url = req.originalUrl || req.url || '';
+
+    // Always-allowed paths (must work even during maintenance)
+    const allowList = [
+      /^\/api\/health(\/|$)/,
+      /^\/api\/maintenance(\/|$)/,
+      /^\/api\/auth(\/|$)/,
+      /^\/api\/webhooks(\/|$)/,
+      /^\/api\/static-translations\/public(\/|$)/,
+      /^\/api\/static-translations\/admin\/full-sync(\/|$)/,
+      /^\/api\/docs(\/|$)/,
+    ];
+
+    if (allowList.some((re) => re.test(url))) return next();
+
+    // Admin bypass (role is populated by ClerkAuthGuard / RoleContextMiddleware)
+    const role = (req as any)?.context?.role;
+    if (role === 'ADMIN' || role === 'SUPER_ADMIN') return next();
+
+    try {
+      const { enabled, message } = await this.platformSettingsService.getMaintenanceMode();
+      if (!enabled) return next();
+
+      res.setHeader('Retry-After', '60');
+      return res.status(503).json({
+        success: false,
+        code: 'MAINTENANCE_MODE',
+        message: message || 'System is under maintenance',
+      });
+    } catch {
+      // If we cannot determine maintenance mode, fail open to avoid taking the API down accidentally.
+      return next();
+    }
+  }
+}
+

--- a/api/src/maintenance/maintenance.controller.ts
+++ b/api/src/maintenance/maintenance.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get } from '@nestjs/common';
+import { Public } from '../auth/decorators/public.decorator';
+import { PlatformSettingsService } from '../platform-settings/platform-settings.service';
+
+@Controller('maintenance')
+export class MaintenanceController {
+  constructor(private readonly platformSettingsService: PlatformSettingsService) {}
+
+  /**
+   * Public endpoint for clients to check maintenance status.
+   * This remains available even when maintenance mode is enabled.
+   */
+  @Get()
+  @Public()
+  async getMaintenanceStatus() {
+    const status = await this.platformSettingsService.getMaintenanceMode();
+    return {
+      success: true,
+      data: {
+        enabled: status.enabled,
+        message: status.message,
+      },
+    };
+  }
+}
+

--- a/api/src/maintenance/maintenance.module.ts
+++ b/api/src/maintenance/maintenance.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { MaintenanceController } from './maintenance.controller';
+import { PlatformSettingsModule } from '../platform-settings/platform-settings.module';
+
+@Module({
+  imports: [PlatformSettingsModule],
+  controllers: [MaintenanceController],
+})
+export class MaintenanceModule {}
+

--- a/api/src/platform-settings/platform-settings.controller.ts
+++ b/api/src/platform-settings/platform-settings.controller.ts
@@ -10,6 +10,7 @@ import {
   UseGuards,
   HttpStatus,
   HttpException,
+  Request,
 } from '@nestjs/common';
 import { PlatformSettingsService } from './platform-settings.service';
 import { CreatePlatformSettingsDto, UpdatePlatformSettingsDto } from './dto/platform-settings.dto';
@@ -134,11 +135,16 @@ export class PlatformSettingsController {
 
   @Put('maintenance-mode')
   @Roles(UserRole.SUPER_ADMIN)
-  async toggleMaintenanceMode(@Body() body: { enabled: boolean; message?: string }) {
+  async toggleMaintenanceMode(
+    @Request() req: any,
+    @Body() body: { enabled: boolean; message?: string },
+  ) {
     try {
+      const actorId: string | undefined = req?.context?.profileUserId || req?.user?.id || undefined;
       const result = await this.platformSettingsService.toggleMaintenanceMode(
         body.enabled,
         body.message,
+        actorId,
       );
       return {
         success: true,

--- a/api/src/platform-settings/platform-settings.controller.ts
+++ b/api/src/platform-settings/platform-settings.controller.ts
@@ -140,11 +140,13 @@ export class PlatformSettingsController {
     @Body() body: { enabled: boolean; message?: string },
   ) {
     try {
-      const actorId: string | undefined = req?.context?.profileUserId || req?.user?.id || undefined;
+      // AuditLog.actorId references the `User` table, so prefer the profile user ID if available.
+      const profileUserId: string | undefined = req?.context?.profileUserId || req?.user?.id || undefined;
+      const clerkUserId: string | undefined = req?.context?.clerkUserId || req?.context?.userId || req?.clerk?.userId || undefined;
       const result = await this.platformSettingsService.toggleMaintenanceMode(
         body.enabled,
         body.message,
-        actorId,
+        { profileUserId, clerkUserId },
       );
       return {
         success: true,

--- a/api/src/platform-settings/platform-settings.service.ts
+++ b/api/src/platform-settings/platform-settings.service.ts
@@ -10,6 +10,8 @@ import { Cache } from 'cache-manager';
 export class PlatformSettingsService {
   private readonly CACHE_KEY_PREFIX = 'platform:settings:';
   private readonly CACHE_TTL = 60; // 60 seconds
+  private readonly MAINTENANCE_CACHE_KEY = 'platform:settings:maintenance';
+  private readonly MAINTENANCE_CACHE_TTL = 5; // seconds (short TTL for faster propagation)
 
   constructor(
     private prisma: PrismaService,
@@ -129,17 +131,26 @@ export class PlatformSettingsService {
   }
 
   async getMaintenanceMode(): Promise<{ enabled: boolean; message?: string }> {
+    // Short-lived cache specifically for maintenance checks (middleware hits this frequently)
+    const cached = await this.cacheManager.get<{ enabled: boolean; message?: string }>(
+      this.MAINTENANCE_CACHE_KEY,
+    );
+    if (cached) return cached;
+
     const settings = await this.getPlatformSettings();
-    return {
+    const value = {
       enabled: settings?.maintenanceMode || false,
       message: settings?.maintenanceMessage || 'System is under maintenance',
     };
+
+    await this.cacheManager.set(this.MAINTENANCE_CACHE_KEY, value, this.MAINTENANCE_CACHE_TTL * 1000);
+    return value;
   }
 
   async toggleMaintenanceMode(
     enabled: boolean,
     message?: string,
-    actorId?: string,
+    actor: { profileUserId?: string; clerkUserId?: string } = {},
   ): Promise<PlatformSettings> {
     const previous = await this.getPlatformSettings();
     let settings = previous;
@@ -159,8 +170,19 @@ export class PlatformSettingsService {
           maintenanceMode: enabled,
           maintenanceMessage: message,
         },
-        actorId,
+        actor.profileUserId,
       );
+    }
+
+    // Resolve a stable audit actorId (AuditLog.actorId references the `User` table)
+    let auditActorId: string | null = actor.profileUserId || null;
+    if (!auditActorId && actor.clerkUserId) {
+      try {
+        const user = await this.prisma.user.findUnique({ where: { clerkId: actor.clerkUserId } });
+        auditActorId = user?.id || null;
+      } catch {
+        auditActorId = null;
+      }
     }
 
     // Write audit log entry (System Config uses this for auditing)
@@ -170,7 +192,7 @@ export class PlatformSettingsService {
           entity: 'PlatformSettings',
           entityId: settings.id,
           action: enabled ? 'maintenance.enable' : 'maintenance.disable',
-          actorId: actorId || null,
+          actorId: auditActorId,
           diff: {
             before: {
               maintenanceMode: previous?.maintenanceMode ?? false,
@@ -184,12 +206,16 @@ export class PlatformSettingsService {
           metadata: {
             source: 'platform-settings',
             timestamp: new Date().toISOString(),
+            actorClerkId: actor.clerkUserId || null,
           },
         },
       });
     } catch {
       // Audit logging should not block maintenance toggling.
     }
+
+    // Invalidate maintenance cache
+    await this.cacheManager.del(this.MAINTENANCE_CACHE_KEY);
 
     // Emit specific event for maintenance mode changes
     this.eventEmitter.emit('platform.maintenance.changed', {

--- a/api/src/platform-settings/platform-settings.service.ts
+++ b/api/src/platform-settings/platform-settings.service.ts
@@ -132,7 +132,7 @@ export class PlatformSettingsService {
     const settings = await this.getPlatformSettings();
     return {
       enabled: settings?.maintenanceMode || false,
-      message: settings?.platformDescription || 'System is under maintenance',
+      message: settings?.maintenanceMessage || 'System is under maintenance',
     };
   }
 
@@ -141,7 +141,8 @@ export class PlatformSettingsService {
     message?: string,
     actorId?: string,
   ): Promise<PlatformSettings> {
-    let settings = await this.getPlatformSettings();
+    const previous = await this.getPlatformSettings();
+    let settings = previous;
 
     if (!settings) {
       // Create default settings if none exist
@@ -160,6 +161,34 @@ export class PlatformSettingsService {
         },
         actorId,
       );
+    }
+
+    // Write audit log entry (System Config uses this for auditing)
+    try {
+      await this.prisma.auditLog.create({
+        data: {
+          entity: 'PlatformSettings',
+          entityId: settings.id,
+          action: enabled ? 'maintenance.enable' : 'maintenance.disable',
+          actorId: actorId || null,
+          diff: {
+            before: {
+              maintenanceMode: previous?.maintenanceMode ?? false,
+              maintenanceMessage: previous?.maintenanceMessage ?? null,
+            },
+            after: {
+              maintenanceMode: enabled,
+              maintenanceMessage: message ?? null,
+            },
+          },
+          metadata: {
+            source: 'platform-settings',
+            timestamp: new Date().toISOString(),
+          },
+        },
+      });
+    } catch {
+      // Audit logging should not block maintenance toggling.
     }
 
     // Emit specific event for maintenance mode changes

--- a/api/test/maintenance-mode.e2e-spec.ts
+++ b/api/test/maintenance-mode.e2e-spec.ts
@@ -1,0 +1,67 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { PrismaService } from '../src/prisma/prisma.service';
+
+describe('Maintenance Mode (e2e)', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    prisma = moduleFixture.get(PrismaService);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  afterEach(async () => {
+    // Ensure maintenance is disabled after each test (best effort).
+    const existing = await prisma.platformSettings.findFirst({ orderBy: { createdAt: 'desc' } });
+    if (existing) {
+      await prisma.platformSettings.update({
+        where: { id: existing.id },
+        data: { maintenanceMode: false, maintenanceMessage: null },
+      });
+    }
+  });
+
+  it('GET /api/maintenance is always accessible', async () => {
+    const res = await request(app.getHttpServer()).get('/api/maintenance').expect(200);
+    expect(res.body).toHaveProperty('success', true);
+    expect(res.body).toHaveProperty('data');
+    expect(res.body.data).toHaveProperty('enabled');
+  });
+
+  it('returns 503 for non-admin requests when maintenance is enabled', async () => {
+    // Enable maintenance in DB directly (no auth in tests)
+    const existing = await prisma.platformSettings.findFirst({ orderBy: { createdAt: 'desc' } });
+    if (!existing) {
+      await prisma.platformSettings.create({
+        data: {
+          platformName: 'Test',
+          maintenanceMode: true,
+          maintenanceMessage: 'Down for maintenance',
+        },
+      });
+    } else {
+      await prisma.platformSettings.update({
+        where: { id: existing.id },
+        data: { maintenanceMode: true, maintenanceMessage: 'Down for maintenance' },
+      });
+    }
+
+    const res = await request(app.getHttpServer()).get('/api/partners/active').expect(503);
+    expect(res.body).toHaveProperty('code', 'MAINTENANCE_MODE');
+    expect(res.body).toHaveProperty('message');
+  });
+});
+


### PR DESCRIPTION
Implement end-to-end maintenance mode enforcement using `PlatformSettings` as the source of truth, with audit logging and a global 503 gate.

The previous implementation had two parallel maintenance mechanisms and lacked global enforcement. This PR consolidates activation to `PlatformSettings`, adds audit logging for toggles, and introduces a global middleware to return 503 for non-admin users when maintenance is active, ensuring the feature is fully functional and consistent with the user's specified architecture (Platform Settings for activation, System Config for auditing).

---
<a href="https://cursor.com/background-agent?bcId=bc-fe43594d-060c-41dc-8a8c-0e012365e708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe43594d-060c-41dc-8a8c-0e012365e708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

