### PR TITLE
Subscription form amount issue

### DIFF
--- a/frontend/components/shared/SubscriptionRequestModal.tsx
+++ b/frontend/components/shared/SubscriptionRequestModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { XMarkIcon, CheckCircleIcon, ClockIcon, EnvelopeIcon, PhoneIcon } from '@heroicons/react/24/outline';
-import { PricingPlan, SubscriptionTier } from '../../types';
+import { PricingPlan, SubscriptionTier, UserRole } from '../../types';
 import Button from '../ui/Button';
 import { useAppContext } from '../../contexts/AppContext';
 
@@ -212,10 +212,18 @@ const SubscriptionRequestModal: React.FC<SubscriptionRequestModalProps> = ({
               </p>
             </div>
             <div className="text-right">
-              <p className="text-2xl font-bold text-swiss-teal">{formatPrice()}</p>
-              <p className="text-sm text-gray-500">
-                /{billingPeriod === 'yearly' ? t('subscription:requestForm.year', 'year') : t('subscription:requestForm.month', 'month')}
-              </p>
+              {plan.role === UserRole.FOUNDATION ? (
+                <>
+                  <p className="text-2xl font-bold text-swiss-teal">{formatPrice()}</p>
+                  <p className="text-sm text-gray-500">
+                    /{billingPeriod === 'yearly' ? t('subscription:requestForm.year', 'year') : t('subscription:requestForm.month', 'month')}
+                  </p>
+                </>
+              ) : (
+                <p className="text-lg font-semibold text-swiss-teal">
+                  {t('subscription:requestForm.priceOnRequest', 'Price on request')}
+                </p>
+              )}
             </div>
           </div>
         </div>

--- a/frontend/components/shared/SubscriptionRequestModal.tsx
+++ b/frontend/components/shared/SubscriptionRequestModal.tsx
@@ -100,7 +100,20 @@ const SubscriptionRequestModal: React.FC<SubscriptionRequestModalProps> = ({
     }
 
     if (isFoundation && (!tier || !billingPeriod)) {
-      setError(t('subscription:requestForm.validation.required', 'Please fill in all required fields'));
+      // This should not happen in normal usage (tier/billingPeriod are provided by the caller for foundation plans)
+      // If it does, it indicates a wiring/config issue rather than missing user input.
+      console.error('SubscriptionRequestModal: tier and billingPeriod are required for foundation plans', {
+        tier,
+        billingPeriod,
+        planName: plan?.name,
+        subscriptionPlanId,
+      });
+      setError(
+        t(
+          'subscription:requestForm.validation.planNotConfigured',
+          'This plan is not configured yet. Please contact support.'
+        )
+      );
       return;
     }
 

--- a/frontend/components/shared/SubscriptionRequestModal.tsx
+++ b/frontend/components/shared/SubscriptionRequestModal.tsx
@@ -9,8 +9,8 @@ interface SubscriptionRequestModalProps {
   isOpen: boolean;
   onClose: () => void;
   plan: PricingPlan;
-  billingPeriod: 'monthly' | 'yearly';
-  tier: SubscriptionTier;
+  billingPeriod?: 'monthly' | 'yearly';
+  tier?: SubscriptionTier;
   /**
    * Backend `SubscriptionPlan.id` used by /subscriptions/request.
    * Pricing cards use static `PRICING_PLANS`, so we pass the real plan id separately.
@@ -22,8 +22,8 @@ interface SubscriptionRequestModalProps {
 
 export interface SubscriptionRequestFormData {
   planId: string;
-  tier: SubscriptionTier;
-  billingPeriod: string;
+  tier?: SubscriptionTier;
+  billingPeriod?: string;
   contactName: string;
   contactEmail: string;
   contactPhone?: string;
@@ -44,11 +44,16 @@ const SubscriptionRequestModal: React.FC<SubscriptionRequestModalProps> = ({
 }) => {
   const { t } = useTranslation(['subscription', 'common']);
   const { currentUser } = useAppContext();
+  const isFoundation = plan.role === UserRole.FOUNDATION;
+  const isSupplier = plan.role === UserRole.PRODUCT_SUPPLIER;
+  const isServiceProvider = plan.role === UserRole.SERVICE_PROVIDER;
   
   const [contactName, setContactName] = useState('');
   const [contactEmail, setContactEmail] = useState('');
   const [contactPhone, setContactPhone] = useState('');
   const [preferredContact, setPreferredContact] = useState<'email' | 'phone'>('email');
+  const [organizationName, setOrganizationName] = useState('');
+  const [website, setWebsite] = useState('');
   const [message, setMessage] = useState('');
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -58,6 +63,7 @@ const SubscriptionRequestModal: React.FC<SubscriptionRequestModalProps> = ({
     if (currentUser) {
       setContactName(`${currentUser.firstName || ''} ${currentUser.lastName || ''}`.trim() || '');
       setContactEmail(currentUser.email || '');
+      setOrganizationName(currentUser.orgName || '');
     }
   }, [currentUser]);
 
@@ -78,7 +84,7 @@ const SubscriptionRequestModal: React.FC<SubscriptionRequestModalProps> = ({
     e.preventDefault();
     setError(null);
 
-    if (!contactName.trim() || !contactEmail.trim()) {
+    if (!contactName.trim() || !contactEmail.trim() || (!isFoundation && !organizationName.trim())) {
       setError(t('subscription:requestForm.validation.required', 'Please fill in all required fields'));
       return;
     }
@@ -93,16 +99,32 @@ const SubscriptionRequestModal: React.FC<SubscriptionRequestModalProps> = ({
       return;
     }
 
+    if (isFoundation && (!tier || !billingPeriod)) {
+      setError(t('subscription:requestForm.validation.required', 'Please fill in all required fields'));
+      return;
+    }
+
+    const composedMessage = (() => {
+      if (isFoundation) {
+        return message.trim() || undefined;
+      }
+      const parts: string[] = [];
+      if (organizationName.trim()) parts.push(`Organization: ${organizationName.trim()}`);
+      if (website.trim()) parts.push(`Website: ${website.trim()}`);
+      if (message.trim()) parts.push(`Message: ${message.trim()}`);
+      return parts.length ? parts.join('\n') : undefined;
+    })();
+
     try {
       await onSubmit({
         planId: subscriptionPlanId,
-        tier,
-        billingPeriod,
+        tier: isFoundation ? tier : undefined,
+        billingPeriod: isFoundation ? billingPeriod : undefined,
         contactName: contactName.trim(),
         contactEmail: contactEmail.trim(),
         contactPhone: contactPhone.trim() || undefined,
         preferredContact,
-        message: message.trim() || undefined,
+        message: composedMessage,
         organizationId: currentUser?.orgId,
       });
       setSubmitted(true);
@@ -182,10 +204,27 @@ const SubscriptionRequestModal: React.FC<SubscriptionRequestModalProps> = ({
           <div className="flex justify-between items-start">
             <div>
               <h2 id="subscription-modal-title" className="text-xl font-bold text-gray-900">
-                {t('subscription:requestForm.title', 'Request Subscription')}
+            {isSupplier
+              ? t('subscription:requestForm.titles.supplier', 'Supplier enquiry')
+              : isServiceProvider
+                ? t('subscription:requestForm.titles.serviceProvider', 'Service provider enquiry')
+                : t('subscription:requestForm.titles.foundation', t('subscription:requestForm.title', 'Request Subscription'))}
               </h2>
               <p className="text-sm text-gray-500 mt-1">
-                {t('subscription:requestForm.subtitle', 'Complete the form below to request your subscription')}
+            {isSupplier
+              ? t(
+                  'subscription:requestForm.subtitles.supplier',
+                  'Tell us about your company and products. We will contact you with pricing and next steps.'
+                )
+              : isServiceProvider
+                ? t(
+                    'subscription:requestForm.subtitles.serviceProvider',
+                    'Tell us about your company and services. We will contact you with pricing and next steps.'
+                  )
+                : t(
+                    'subscription:requestForm.subtitles.foundation',
+                    t('subscription:requestForm.subtitle', 'Complete the form below to request your subscription')
+                  )}
               </p>
             </div>
             <button
@@ -205,14 +244,24 @@ const SubscriptionRequestModal: React.FC<SubscriptionRequestModalProps> = ({
               <p className="text-sm text-gray-500">{t('subscription:requestForm.selectedPlan', 'Selected Plan')}</p>
               <p className="text-lg font-semibold text-gray-900">{plan.emoji} {plan.name}</p>
               <p className="text-sm text-gray-500 capitalize">
-                {t(`subscription:tier.${tier.toLowerCase()}`, tier)} • {billingPeriod === 'yearly' 
-                  ? t('subscription:requestForm.billedAnnually', 'Billed annually') 
-                  : t('subscription:requestForm.billedMonthly', 'Billed monthly')
-                }
+                {isFoundation && tier && billingPeriod ? (
+                  <>
+                    {t(`subscription:tier.${tier.toLowerCase()}`, tier)} •{' '}
+                    {billingPeriod === 'yearly'
+                      ? t('subscription:requestForm.billedAnnually', 'Billed annually')
+                      : t('subscription:requestForm.billedMonthly', 'Billed monthly')}
+                  </>
+                ) : (
+                  <span>
+                    {isSupplier
+                      ? t('subscription:requestForm.roleLabel.supplier', 'Supplier')
+                      : t('subscription:requestForm.roleLabel.serviceProvider', 'Service provider')}
+                  </span>
+                )}
               </p>
             </div>
             <div className="text-right">
-              {plan.role === UserRole.FOUNDATION ? (
+              {isFoundation ? (
                 <>
                   <p className="text-2xl font-bold text-swiss-teal">{formatPrice()}</p>
                   <p className="text-sm text-gray-500">
@@ -233,6 +282,22 @@ const SubscriptionRequestModal: React.FC<SubscriptionRequestModalProps> = ({
           {error && (
             <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
               {error}
+            </div>
+          )}
+
+          {!isFoundation && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                {t('subscription:requestForm.organizationName', 'Organization / Company')} *
+              </label>
+              <input
+                type="text"
+                value={organizationName}
+                onChange={(e) => setOrganizationName(e.target.value)}
+                className="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-swiss-teal focus:border-transparent"
+                placeholder={t('subscription:requestForm.organizationNamePlaceholder', 'Your organization name')}
+                required
+              />
             </div>
           )}
 
@@ -283,6 +348,21 @@ const SubscriptionRequestModal: React.FC<SubscriptionRequestModalProps> = ({
             </div>
           </div>
 
+          {!isFoundation && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                {t('subscription:requestForm.website', 'Website')} ({t('common:optional', 'Optional')})
+              </label>
+              <input
+                type="url"
+                value={website}
+                onChange={(e) => setWebsite(e.target.value)}
+                className="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-swiss-teal focus:border-transparent"
+                placeholder={t('subscription:requestForm.websitePlaceholder', 'https://example.com')}
+              />
+            </div>
+          )}
+
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">
               {t('subscription:requestForm.preferredContact', 'Preferred Contact Method')}
@@ -315,14 +395,25 @@ const SubscriptionRequestModal: React.FC<SubscriptionRequestModalProps> = ({
 
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
-              {t('subscription:requestForm.message', 'Additional Message')} ({t('common:optional', 'Optional')})
+              {isFoundation
+                ? t('subscription:requestForm.message', 'Additional Message')
+                : (isSupplier
+                    ? t('subscription:requestForm.messageSupplier', 'Tell us about your products')
+                    : t('subscription:requestForm.messageServiceProvider', 'Tell us about your services'))}{' '}
+              ({t('common:optional', 'Optional')})
             </label>
             <textarea
               value={message}
               onChange={(e) => setMessage(e.target.value)}
               rows={3}
               className="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-swiss-teal focus:border-transparent resize-none"
-              placeholder={t('subscription:requestForm.messagePlaceholder', 'Any questions or special requirements...')}
+              placeholder={
+                isFoundation
+                  ? t('subscription:requestForm.messagePlaceholder', 'Any questions or special requirements...')
+                  : (isSupplier
+                      ? t('subscription:requestForm.messageSupplierPlaceholder', 'What do you sell? Any focus categories, MOQ, regions served, etc.')
+                      : t('subscription:requestForm.messageServiceProviderPlaceholder', 'What services do you offer? Coverage region, pricing model, availability, etc.'))
+              }
             />
           </div>
 
@@ -331,10 +422,20 @@ const SubscriptionRequestModal: React.FC<SubscriptionRequestModalProps> = ({
               {t('subscription:requestForm.howItWorks.title', 'How it works:')}
             </p>
             <ol className="list-decimal list-inside space-y-1 text-blue-700">
-              <li>{t('subscription:requestForm.howItWorks.step1', 'Submit your request')}</li>
-              <li>{t('subscription:requestForm.howItWorks.step2', 'Receive an invoice via email')}</li>
-              <li>{t('subscription:requestForm.howItWorks.step3', 'Pay the invoice')}</li>
-              <li>{t('subscription:requestForm.howItWorks.step4', 'Your subscription is activated')}</li>
+              {isFoundation ? (
+                <>
+                  <li>{t('subscription:requestForm.howItWorks.step1', 'Submit your request')}</li>
+                  <li>{t('subscription:requestForm.howItWorks.step2', 'Receive an invoice via email')}</li>
+                  <li>{t('subscription:requestForm.howItWorks.step3', 'Pay the invoice')}</li>
+                  <li>{t('subscription:requestForm.howItWorks.step4', 'Your subscription is activated')}</li>
+                </>
+              ) : (
+                <>
+                  <li>{t('subscription:requestForm.howItWorksVendor.step1', 'Submit your enquiry')}</li>
+                  <li>{t('subscription:requestForm.howItWorksVendor.step2', 'We contact you with pricing')}</li>
+                  <li>{t('subscription:requestForm.howItWorksVendor.step3', 'You receive next steps to get listed')}</li>
+                </>
+              )}
             </ol>
           </div>
 

--- a/frontend/components/shared/SubscriptionRequestModal.tsx
+++ b/frontend/components/shared/SubscriptionRequestModal.tsx
@@ -11,6 +11,11 @@ interface SubscriptionRequestModalProps {
   plan: PricingPlan;
   billingPeriod: 'monthly' | 'yearly';
   tier: SubscriptionTier;
+  /**
+   * Backend `SubscriptionPlan.id` used by /subscriptions/request.
+   * Pricing cards use static `PRICING_PLANS`, so we pass the real plan id separately.
+   */
+  subscriptionPlanId?: string;
   onSubmit: (data: SubscriptionRequestFormData) => Promise<void>;
   isLoading?: boolean;
 }
@@ -33,6 +38,7 @@ const SubscriptionRequestModal: React.FC<SubscriptionRequestModalProps> = ({
   plan,
   billingPeriod,
   tier,
+  subscriptionPlanId,
   onSubmit,
   isLoading = false,
 }) => {
@@ -77,9 +83,19 @@ const SubscriptionRequestModal: React.FC<SubscriptionRequestModalProps> = ({
       return;
     }
 
+    if (!subscriptionPlanId) {
+      setError(
+        t(
+          'subscription:requestForm.validation.planNotConfigured',
+          'This plan is not configured yet. Please contact support.'
+        )
+      );
+      return;
+    }
+
     try {
       await onSubmit({
-        planId: plan.id || '',
+        planId: subscriptionPlanId,
         tier,
         billingPeriod,
         contactName: contactName.trim(),
@@ -96,11 +112,15 @@ const SubscriptionRequestModal: React.FC<SubscriptionRequestModalProps> = ({
   };
 
   const formatPrice = () => {
-    const price = billingPeriod === 'yearly' && plan.annualPrice ? plan.annualPrice : plan.price;
+    const price =
+      billingPeriod === 'yearly'
+        ? plan.price?.annually
+        : plan.price?.monthly;
+    const numericPrice = typeof price === 'number' && Number.isFinite(price) ? price : 0;
     return new Intl.NumberFormat('de-CH', {
       style: 'currency',
-      currency: plan.currency || 'CHF',
-    }).format(price || 0);
+      currency: 'CHF',
+    }).format(numericPrice);
   };
 
   // Success view after submission

--- a/frontend/pages/PricingPage.tsx
+++ b/frontend/pages/PricingPage.tsx
@@ -123,6 +123,13 @@ const PricingPage: React.FC = () => {
     );
     if (byName?.id) return byName.id;
 
+    // Fallback: match by allowed role (for vendor plans that might be named differently)
+    const roleMatch = activeSubscriptionPlans.find((p) => {
+      const allowed = (p?.allowedRoles || []).map((r) => String(r).toUpperCase());
+      return allowed.includes(String(plan.role).toUpperCase());
+    });
+    if (roleMatch?.id) return roleMatch.id;
+
     // Fallback for foundation plans that follow tier codes.
     const tier = getPlanTier(plan);
     return activePlanIdByCode.get(String(tier).toUpperCase());
@@ -247,8 +254,8 @@ const PricingPage: React.FC = () => {
             setSelectedPlan(null);
           }}
           plan={selectedPlan}
-          billingPeriod={isAnnual ? 'yearly' : 'monthly'}
-          tier={getPlanTier(selectedPlan)}
+          billingPeriod={selectedPlan.role === UserRole.FOUNDATION ? (isAnnual ? 'yearly' : 'monthly') : undefined}
+          tier={selectedPlan.role === UserRole.FOUNDATION ? getPlanTier(selectedPlan) : undefined}
           subscriptionPlanId={resolveSubscriptionPlanId(selectedPlan)}
           onSubmit={handleSubmitRequest}
           isLoading={isSubmitting}

--- a/frontend/pages/PricingPage.tsx
+++ b/frontend/pages/PricingPage.tsx
@@ -115,11 +115,22 @@ const PricingPage: React.FC = () => {
     return map;
   }, [activeSubscriptionPlans]);
 
+  const resolveSubscriptionPlanId = (plan: PricingPlan): string | undefined => {
+    // Prefer matching by backend plan name (works for Suppliers/Service Providers too).
+    const normalized = (plan.name || '').trim().toLowerCase();
+    const byName = activeSubscriptionPlans.find(
+      (p) => (p?.name || '').trim().toLowerCase() === normalized
+    );
+    if (byName?.id) return byName.id;
+
+    // Fallback for foundation plans that follow tier codes.
+    const tier = getPlanTier(plan);
+    return activePlanIdByCode.get(String(tier).toUpperCase());
+  };
+
 
   const PlanCard: React.FC<{ plan: PricingPlan }> = ({ plan }) => {
     const translatedPlan = translatePlan(plan, isAnnual);
-    const isSupplierOrProvider =
-      plan.role === UserRole.PRODUCT_SUPPLIER || plan.role === UserRole.SERVICE_PROVIDER;
     
     return (
       <Card className={`flex flex-col p-6 border-2 ${plan.isPopular ? 'border-swiss-mint' : 'border-gray-200'} relative`} hoverEffect>
@@ -130,7 +141,7 @@ const PricingPage: React.FC = () => {
         )}
         <h3 className="text-2xl font-bold text-swiss-charcoal text-center mt-3">{plan.emoji} {translatedPlan.name}</h3>
         
-        {!isSupplierOrProvider && (translatedPlan.monthlyPriceText || translatedPlan.annualPlanText) && (
+        {(translatedPlan.monthlyPriceText || translatedPlan.annualPlanText) && (
           <div className="my-4 text-center space-y-1">
             {translatedPlan.monthlyPriceText && (
               <p className="text-xl font-semibold text-gray-800">{translatedPlan.monthlyPriceText}</p>
@@ -155,27 +166,16 @@ const PricingPage: React.FC = () => {
             </li>
           ))}
         </ul>
-        {isSupplierOrProvider ? (
-          <Button
-            variant="primary"
-            size="lg"
-            className="w-full mt-6"
-            onClick={() => {
-              window.location.href = 'mailto:hello@procrechesolutions.com';
-            }}
-          >
-            {t('pricingPage.enquireButton')}
-          </Button>
-        ) : (
-          <Button
-            variant={plan.isPopular ? 'primary' : 'outline'}
-            size="lg"
-            className="w-full mt-6"
-            onClick={() => handleChoosePlan(plan)}
-          >
-            {fromSignup ? t('pricingPage.selectAndContinue') : t('pricingPage.choosePlan')}
-          </Button>
-        )}
+        <Button
+          variant={plan.isPopular ? 'primary' : 'outline'}
+          size="lg"
+          className="w-full mt-6"
+          onClick={() => handleChoosePlan(plan)}
+        >
+          {plan.role === UserRole.PRODUCT_SUPPLIER || plan.role === UserRole.SERVICE_PROVIDER
+            ? t('pricingPage.enquireButton')
+            : (fromSignup ? t('pricingPage.selectAndContinue') : t('pricingPage.choosePlan'))}
+        </Button>
       </Card>
     );
   };
@@ -249,7 +249,7 @@ const PricingPage: React.FC = () => {
           plan={selectedPlan}
           billingPeriod={isAnnual ? 'yearly' : 'monthly'}
           tier={getPlanTier(selectedPlan)}
-          subscriptionPlanId={activePlanIdByCode.get(getPlanTier(selectedPlan))}
+          subscriptionPlanId={resolveSubscriptionPlanId(selectedPlan)}
           onSubmit={handleSubmitRequest}
           isLoading={isSubmitting}
         />

--- a/frontend/pages/PricingPage.tsx
+++ b/frontend/pages/PricingPage.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, Link } from 'react-router-dom';
 import { PricingPlan, UserRole, SubscriptionTier } from '../types';
@@ -15,6 +15,8 @@ import { useFrontendSettings } from '../hooks/useFrontendSettings';
 import { APP_NAME } from '../constants';
 import SubscriptionRequestModal, { SubscriptionRequestFormData } from '../components/shared/SubscriptionRequestModal';
 import { useSubscription } from '../contexts/SubscriptionContext';
+import { apiService } from '../services/api';
+import type { SubscriptionPlan } from '../contexts/SubscriptionContext';
 
 const PricingPage: React.FC = () => {
   const { t } = useTranslation(['pricing', 'common']);
@@ -28,11 +30,32 @@ const PricingPage: React.FC = () => {
   const [selectedPlan, setSelectedPlan] = useState<PricingPlan | null>(null);
   const [isRequestModalOpen, setIsRequestModalOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [activeSubscriptionPlans, setActiveSubscriptionPlans] = useState<SubscriptionPlan[]>([]);
 
   const fromSignup = location.state?.fromSignup || false;
   const userRoleFromSignup = location.state?.role as UserRole | undefined;
 
   const { foundation: daycarePlans, supplier: supplierPlan, serviceProvider: serviceProviderPlan } = pricingService.getPlansByRole();
+
+  // Fetch backend subscription plans so the request payload has a real `planId`
+  useEffect(() => {
+    let isMounted = true;
+    apiService
+      .get<SubscriptionPlan[]>('/subscriptions/plans')
+      .then((res) => {
+        if (!isMounted) return;
+        if (res?.success && Array.isArray(res.data)) {
+          setActiveSubscriptionPlans(res.data);
+        }
+      })
+      .catch(() => {
+        // Best-effort only: UI can still render prices from PRICING_PLANS.
+        // Submission will show a friendly error if planId is missing.
+      });
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   const handleChoosePlan = (plan: PricingPlan) => {
     // If user is logged in, show the request modal
@@ -81,6 +104,16 @@ const PricingPage: React.FC = () => {
     };
     return tierMap[plan.name] || SubscriptionTier.BASIC;
   };
+
+  const activePlanIdByCode = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of activeSubscriptionPlans) {
+      if (p?.code && p?.id) {
+        map.set(String(p.code).toUpperCase(), p.id);
+      }
+    }
+    return map;
+  }, [activeSubscriptionPlans]);
 
 
   const PlanCard: React.FC<{ plan: PricingPlan }> = ({ plan }) => {
@@ -216,6 +249,7 @@ const PricingPage: React.FC = () => {
           plan={selectedPlan}
           billingPeriod={isAnnual ? 'yearly' : 'monthly'}
           tier={getPlanTier(selectedPlan)}
+          subscriptionPlanId={activePlanIdByCode.get(getPlanTier(selectedPlan))}
           onSubmit={handleSubmitRequest}
           isLoading={isSubmitting}
         />

--- a/packages/translations/locales/de/subscription.json
+++ b/packages/translations/locales/de/subscription.json
@@ -33,21 +33,43 @@
   "requestForm": {
     "title": "Abonnement anfordern",
     "subtitle": "Füllen Sie das untenstehende Formular aus, um Ihr Abonnement anzufordern",
+    "titles": {
+      "foundation": "Abonnement anfordern",
+      "supplier": "Anfrage (Lieferant)",
+      "serviceProvider": "Anfrage (Dienstleister)"
+    },
+    "subtitles": {
+      "foundation": "Füllen Sie das untenstehende Formular aus, um Ihr Abonnement anzufordern",
+      "supplier": "Erzählen Sie uns von Ihrem Unternehmen und Ihren Produkten. Wir melden uns mit Preisen und den nächsten Schritten.",
+      "serviceProvider": "Erzählen Sie uns von Ihrem Unternehmen und Ihren Dienstleistungen. Wir melden uns mit Preisen und den nächsten Schritten."
+    },
     "selectedPlan": "Ausgewählter Plan",
     "priceOnRequest": "Preis auf Anfrage",
     "billedMonthly": "Monatlich abgerechnet",
     "billedAnnually": "Jährlich abgerechnet",
     "year": "Jahr",
     "month": "Monat",
+    "roleLabel": {
+      "supplier": "Lieferant",
+      "serviceProvider": "Dienstleister"
+    },
+    "organizationName": "Organisation / Unternehmen",
+    "organizationNamePlaceholder": "Name Ihrer Organisation",
     "contactName": "Kontaktname",
     "contactNamePlaceholder": "Ihr vollständiger Name",
     "contactEmail": "E-Mail-Adresse",
     "contactEmailPlaceholder": "ihre@email.com",
     "contactPhone": "Telefonnummer",
     "contactPhonePlaceholder": "+41 XX XXX XX XX",
+    "website": "Website",
+    "websitePlaceholder": "https://beispiel.de",
     "preferredContact": "Bevorzugte Kontaktmethode",
     "message": "Zusätzliche Nachricht",
     "messagePlaceholder": "Fragen oder besondere Anforderungen...",
+    "messageSupplier": "Erzählen Sie uns von Ihren Produkten",
+    "messageSupplierPlaceholder": "Was verkaufen Sie? Kategorien, MOQ, Regionen, usw.",
+    "messageServiceProvider": "Erzählen Sie uns von Ihren Dienstleistungen",
+    "messageServiceProviderPlaceholder": "Welche Dienstleistungen bieten Sie an? Region, Preismodell, Verfügbarkeit, usw.",
     "submitButton": "Anfrage senden",
     "submitting": "Wird gesendet...",
     "validation": {
@@ -66,6 +88,11 @@
       "step2": "Erhalten Sie eine Rechnung per E-Mail",
       "step3": "Zahlen Sie die Rechnung",
       "step4": "Ihr Abonnement wird aktiviert"
+    },
+    "howItWorksVendor": {
+      "step1": "Senden Sie Ihre Anfrage",
+      "step2": "Wir melden uns mit Preisen",
+      "step3": "Sie erhalten die nächsten Schritte für die Listung"
     }
   },
   "featureGate": {

--- a/packages/translations/locales/de/subscription.json
+++ b/packages/translations/locales/de/subscription.json
@@ -34,6 +34,7 @@
     "title": "Abonnement anfordern",
     "subtitle": "Füllen Sie das untenstehende Formular aus, um Ihr Abonnement anzufordern",
     "selectedPlan": "Ausgewählter Plan",
+    "priceOnRequest": "Preis auf Anfrage",
     "billedMonthly": "Monatlich abgerechnet",
     "billedAnnually": "Jährlich abgerechnet",
     "year": "Jahr",

--- a/packages/translations/locales/de/subscription.json
+++ b/packages/translations/locales/de/subscription.json
@@ -50,7 +50,8 @@
     "submitButton": "Anfrage senden",
     "submitting": "Wird gesendet...",
     "validation": {
-      "required": "Bitte füllen Sie alle Pflichtfelder aus"
+      "required": "Bitte füllen Sie alle Pflichtfelder aus",
+      "planNotConfigured": "Dieser Plan ist noch nicht konfiguriert. Bitte kontaktieren Sie den Support."
     },
     "success": {
       "title": "Anfrage gesendet!",

--- a/packages/translations/locales/en/subscription.json
+++ b/packages/translations/locales/en/subscription.json
@@ -34,6 +34,7 @@
     "title": "Request Subscription",
     "subtitle": "Complete the form below to request your subscription",
     "selectedPlan": "Selected Plan",
+    "priceOnRequest": "Price on request",
     "billedMonthly": "Billed monthly",
     "billedAnnually": "Billed annually",
     "year": "year",

--- a/packages/translations/locales/en/subscription.json
+++ b/packages/translations/locales/en/subscription.json
@@ -50,7 +50,8 @@
     "submitButton": "Submit Request",
     "submitting": "Submitting...",
     "validation": {
-      "required": "Please fill in all required fields"
+      "required": "Please fill in all required fields",
+      "planNotConfigured": "This plan is not configured yet. Please contact support."
     },
     "success": {
       "title": "Request Submitted!",

--- a/packages/translations/locales/en/subscription.json
+++ b/packages/translations/locales/en/subscription.json
@@ -33,21 +33,43 @@
   "requestForm": {
     "title": "Request Subscription",
     "subtitle": "Complete the form below to request your subscription",
+    "titles": {
+      "foundation": "Request Subscription",
+      "supplier": "Supplier enquiry",
+      "serviceProvider": "Service provider enquiry"
+    },
+    "subtitles": {
+      "foundation": "Complete the form below to request your subscription",
+      "supplier": "Tell us about your company and products. We will contact you with pricing and next steps.",
+      "serviceProvider": "Tell us about your company and services. We will contact you with pricing and next steps."
+    },
     "selectedPlan": "Selected Plan",
     "priceOnRequest": "Price on request",
     "billedMonthly": "Billed monthly",
     "billedAnnually": "Billed annually",
     "year": "year",
     "month": "month",
+    "roleLabel": {
+      "supplier": "Supplier",
+      "serviceProvider": "Service provider"
+    },
+    "organizationName": "Organization / Company",
+    "organizationNamePlaceholder": "Your organization name",
     "contactName": "Contact Name",
     "contactNamePlaceholder": "Your full name",
     "contactEmail": "Email Address",
     "contactEmailPlaceholder": "your@email.com",
     "contactPhone": "Phone Number",
     "contactPhonePlaceholder": "+41 XX XXX XX XX",
+    "website": "Website",
+    "websitePlaceholder": "https://example.com",
     "preferredContact": "Preferred Contact Method",
     "message": "Additional Message",
     "messagePlaceholder": "Any questions or special requirements...",
+    "messageSupplier": "Tell us about your products",
+    "messageSupplierPlaceholder": "What do you sell? Any focus categories, MOQ, regions served, etc.",
+    "messageServiceProvider": "Tell us about your services",
+    "messageServiceProviderPlaceholder": "What services do you offer? Coverage region, pricing model, availability, etc.",
     "submitButton": "Submit Request",
     "submitting": "Submitting...",
     "validation": {
@@ -66,6 +88,11 @@
       "step2": "Receive an invoice via email",
       "step3": "Pay the invoice",
       "step4": "Your subscription is activated"
+    },
+    "howItWorksVendor": {
+      "step1": "Submit your enquiry",
+      "step2": "We contact you with pricing",
+      "step3": "You receive next steps to get listed"
     }
   },
   "featureGate": {

--- a/packages/translations/locales/fr/subscription.json
+++ b/packages/translations/locales/fr/subscription.json
@@ -33,21 +33,43 @@
   "requestForm": {
     "title": "Demander un abonnement",
     "subtitle": "Complétez le formulaire ci-dessous pour demander votre abonnement",
+    "titles": {
+      "foundation": "Demander un abonnement",
+      "supplier": "Demande d’information (fournisseur)",
+      "serviceProvider": "Demande d’information (prestataire)"
+    },
+    "subtitles": {
+      "foundation": "Complétez le formulaire ci-dessous pour demander votre abonnement",
+      "supplier": "Parlez-nous de votre entreprise et de vos produits. Nous vous contacterons avec le tarif et les prochaines étapes.",
+      "serviceProvider": "Parlez-nous de votre entreprise et de vos services. Nous vous contacterons avec le tarif et les prochaines étapes."
+    },
     "selectedPlan": "Plan sélectionné",
     "priceOnRequest": "Prix sur demande",
     "billedMonthly": "Facturé mensuellement",
     "billedAnnually": "Facturé annuellement",
     "year": "année",
     "month": "mois",
+    "roleLabel": {
+      "supplier": "Fournisseur",
+      "serviceProvider": "Prestataire"
+    },
+    "organizationName": "Organisation / entreprise",
+    "organizationNamePlaceholder": "Nom de votre organisation",
     "contactName": "Nom du contact",
     "contactNamePlaceholder": "Votre nom complet",
     "contactEmail": "Adresse e-mail",
     "contactEmailPlaceholder": "votre@email.com",
     "contactPhone": "Numéro de téléphone",
     "contactPhonePlaceholder": "+41 XX XXX XX XX",
+    "website": "Site web",
+    "websitePlaceholder": "https://exemple.com",
     "preferredContact": "Méthode de contact préférée",
     "message": "Message supplémentaire",
     "messagePlaceholder": "Questions ou exigences particulières...",
+    "messageSupplier": "Parlez-nous de vos produits",
+    "messageSupplierPlaceholder": "Que vendez-vous ? Catégories, MOQ, zones desservies, etc.",
+    "messageServiceProvider": "Parlez-nous de vos services",
+    "messageServiceProviderPlaceholder": "Quels services proposez-vous ? Zone, modèle tarifaire, disponibilités, etc.",
     "submitButton": "Soumettre la demande",
     "submitting": "Envoi en cours...",
     "validation": {
@@ -66,6 +88,11 @@
       "step2": "Recevez une facture par e-mail",
       "step3": "Payez la facture",
       "step4": "Votre abonnement est activé"
+    },
+    "howItWorksVendor": {
+      "step1": "Soumettez votre demande d’information",
+      "step2": "Nous vous contactons avec le tarif",
+      "step3": "Vous recevez les prochaines étapes pour être référencé"
     }
   },
   "featureGate": {

--- a/packages/translations/locales/fr/subscription.json
+++ b/packages/translations/locales/fr/subscription.json
@@ -34,6 +34,7 @@
     "title": "Demander un abonnement",
     "subtitle": "Complétez le formulaire ci-dessous pour demander votre abonnement",
     "selectedPlan": "Plan sélectionné",
+    "priceOnRequest": "Prix sur demande",
     "billedMonthly": "Facturé mensuellement",
     "billedAnnually": "Facturé annuellement",
     "year": "année",

--- a/packages/translations/locales/fr/subscription.json
+++ b/packages/translations/locales/fr/subscription.json
@@ -50,7 +50,8 @@
     "submitButton": "Soumettre la demande",
     "submitting": "Envoi en cours...",
     "validation": {
-      "required": "Veuillez remplir tous les champs obligatoires"
+      "required": "Veuillez remplir tous les champs obligatoires",
+      "planNotConfigured": "Ce plan n'est pas encore configuré. Veuillez contacter le support."
     },
     "success": {
       "title": "Demande soumise !",


### PR DESCRIPTION
Fixes `NaN` price display and ensures correct plan ID submission for foundation plans in the subscription request modal.

The modal was attempting to format `plan.price` (which is an object for foundation plans) as a number, resulting in `NaN`. Additionally, the `planId` submitted was a static frontend ID, not the actual backend `SubscriptionPlan.id` required for the `/subscriptions/request` endpoint.

---
<a href="https://cursor.com/background-agent?bcId=bc-b7161aa4-aa5b-42d1-9926-5de39982d1ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b7161aa4-aa5b-42d1-9926-5de39982d1ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription request flow now adapts based on user role (Foundation, Supplier, Service Provider) with tailored titles, messaging, and pricing display.
  * Added organization name and website fields for vendor onboarding.
  * Introduced role-specific "How it works" guidance for suppliers and service providers.
  * Enhanced plan pricing display with backend-backed subscription plans.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->