### PR TITLE
Signup password visibility

### DIFF
--- a/frontend/pages/SignupPage.tsx
+++ b/frontend/pages/SignupPage.tsx
@@ -664,7 +664,13 @@ const SignupPage: React.FC = () => {
       ) : (
         <div className="relative">
           <input 
-            type={(name === 'password' && !showPassword) || (name === 'confirmPassword' && !showConfirmPassword) ? 'password' : type}
+            type={
+              name === 'password'
+                ? (showPassword ? 'text' : 'password')
+                : name === 'confirmPassword'
+                  ? (showConfirmPassword ? 'text' : 'password')
+                  : type
+            }
             id={name} 
             name={name} 
             value={String(formData[name as keyof SignupFormData] ?? '')}


### PR DESCRIPTION
Fix the signup password fields to correctly toggle the input type between 'password' and 'text'.

The previous logic incorrectly fell back to the original 'password' type, preventing the field from ever switching to 'text' when the eye icon was clicked.

---
<a href="https://cursor.com/background-agent?bcId=bc-35c0d91c-915a-485f-bbde-c672d67c4aef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-35c0d91c-915a-485f-bbde-c672d67c4aef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

