### PR TITLE
Build fail compat controller

### DIFF
--- a/api/src/compat/compat.controller.ts
+++ b/api/src/compat/compat.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Post, Put, Delete, Body, Param, Query, UseGuards, Requ
 import { Public } from '../auth/decorators/public.decorator';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
-import { UserRole, JobStatus, JobContractType, OrganizationType, SubscriptionStatus } from '@prisma/client';
+import { Prisma, UserRole, JobStatus, JobContractType, OrganizationType, SubscriptionStatus } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateCandidateDto } from './dto/create-candidate.dto';
 import { CreateJobListingDto } from '../recruitment/dto/create-job-listing.dto';
@@ -22,7 +22,7 @@ type RequestWithUser = {
 export class CompatController {
   constructor(private prisma: PrismaService) {}
 
-  private marketplaceActiveSubscriptionWhere(now: Date) {
+  private marketplaceActiveSubscriptionWhere(now: Date): Prisma.SubscriptionWhereInput {
     return {
       OR: [
         {
@@ -38,7 +38,7 @@ export class CompatController {
           OR: [{ gracePeriodEnd: null }, { gracePeriodEnd: { gt: now } }],
         },
       ],
-    } as const;
+    };
   }
 
   private canBypassMarketplaceSubscriptionGate(user: RequestUser | undefined, organizationId: string): boolean {


### PR DESCRIPTION
Fixes TypeScript build errors in `compat.controller.ts` by adjusting Prisma query types and includes.

The `as const` on a Prisma `where` clause caused a `TS2322` error due to readonly array incompatibility, which then cascaded to "property does not exist" errors because Prisma's type inference for included relations failed. Explicitly typing the `where` clause and including necessary relations resolves these issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-de209f25-f6bc-47eb-8b58-07e734d49fcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-de209f25-f6bc-47eb-8b58-07e734d49fcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type safety and code consistency with enhanced method signature definitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->