### PR TITLE
Login page pricing link

### DIFF
--- a/frontend/pages/LoginPage.tsx
+++ b/frontend/pages/LoginPage.tsx
@@ -444,6 +444,12 @@ const LoginPage: React.FC = () => {
               {t('common:buttons.signup')}
             </Link>
           </p>
+          <p>
+            {t('common:loginPage.viewPlansPrompt')}{' '}
+            <Link to="/pricing" className="font-medium text-swiss-mint hover:underline">
+              {t('common:loginPage.viewPlans')}
+            </Link>
+          </p>
           <div className="border-t border-gray-200 pt-2 sm:pt-3 mt-2 sm:mt-3">
             <p className="text-xs text-gray-600 text-center mb-1.5 sm:mb-2">
               {t('common:loginPage.parentLookingForCreche')}


### PR DESCRIPTION
Restore the pricing page link to the login page as it was accidentally removed in a previous commit.

---
<a href="https://cursor.com/background-agent?bcId=bc-a938ca16-9e3f-498a-bb3f-b47f3a1c1d2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a938ca16-9e3f-498a-bb3f-b47f3a1c1d2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

