### PR TITLE
fix: Remove organizationId from subscription request payload

### DIFF
--- a/frontend/components/shared/SubscriptionRequestModal.tsx
+++ b/frontend/components/shared/SubscriptionRequestModal.tsx
@@ -29,7 +29,7 @@ export interface SubscriptionRequestFormData {
   contactPhone?: string;
   preferredContact: 'email' | 'phone';
   message?: string;
-  organizationId?: string;
+  // Note: organizationId is obtained from auth context on the backend
 }
 
 const SubscriptionRequestModal: React.FC<SubscriptionRequestModalProps> = ({
@@ -138,7 +138,7 @@ const SubscriptionRequestModal: React.FC<SubscriptionRequestModalProps> = ({
         contactPhone: contactPhone.trim() || undefined,
         preferredContact,
         message: composedMessage,
-        organizationId: currentUser?.orgId,
+        // Note: organizationId is obtained from auth context on the backend
       });
       setSubmitted(true);
     } catch (err) {

--- a/frontend/contexts/SubscriptionContext.tsx
+++ b/frontend/contexts/SubscriptionContext.tsx
@@ -148,7 +148,7 @@ export interface SubscriptionRequestPayload {
   contactPhone?: string;
   preferredContact?: 'email' | 'phone';
   message?: string;
-  organizationId?: string;
+  // Note: organizationId is obtained from auth context on the backend, not sent by frontend
   notes?: string;
 }
 

--- a/frontend/pages/PricingPage.tsx
+++ b/frontend/pages/PricingPage.tsx
@@ -84,7 +84,7 @@ const PricingPage: React.FC = () => {
         contactPhone: data.contactPhone,
         preferredContact: data.preferredContact,
         message: data.message,
-        organizationId: data.organizationId,
+        // Note: organizationId is obtained from auth context on the backend
       });
     } catch (error) {
       // Re-throw to let the modal handle and display the error


### PR DESCRIPTION
The backend DTO uses whitelist validation and rejects organizationId. The backend already obtains organizationId from the auth context, so the frontend doesn't need to send it.