### PR TITLE
Subscription source of truth

### DIFF
--- a/FOUNDATION_SUBSCRIPTION_SOURCE_OF_TRUTH_INVESTIGATION.md
+++ b/FOUNDATION_SUBSCRIPTION_SOURCE_OF_TRUTH_INVESTIGATION.md
@@ -1,0 +1,361 @@
+# Foundation Tier Subscription - Source of Truth Investigation
+
+## Executive Summary
+
+**CRITICAL ISSUE IDENTIFIED**: The subscription system has two different concepts that are causing confusion and preventing daycares from accessing the platform even after activation:
+
+1. **SubscriptionPlan Table** (Backend - `subscription_plans` table) - Used for actual subscription management
+2. **PricingTier Table** (Backend - `pricing_tiers` table) - Used for the admin pricing tier modal (Foundation-specific tier configuration)
+
+**ROOT CAUSE**: The `getUserSubscription()` and `getOrganizationSubscription()` methods do NOT filter by subscription status, so they return ANY subscription (including PENDING, INACTIVE, CANCELLED) instead of only ACTIVE ones.
+
+---
+
+## System Architecture Analysis
+
+### 1. Backend Subscription Plans (Source of Truth for Subscriptions)
+
+**Location**: `subscription_plans` table in database  
+**Service**: `SubscriptionManagementService` (`api/src/subscription-management/subscription-management.service.ts`)
+
+**Schema**:
+```typescript
+model SubscriptionPlan {
+  id            String   @id @default(uuid())
+  name          String
+  code          String?  @unique  // BASIC, ESSENTIAL, PROFESSIONAL, etc.
+  description   String   @db.Text
+  price         Float
+  currency      String   @default("CHF")
+  billingPeriod String   @default("monthly")
+  features      String[]
+  limits        Json
+  allowedRoles  String[] @default([])
+  trialDays     Int      @default(0)
+  isActive      Boolean  @default(true)
+  isPopular     Boolean  @default(false)
+  displayOrder  Int      @default(0)
+  stripePriceId   String?
+  stripeProductId String?
+  
+  subscriptions          Subscription[]
+  subscriptionRequests   SubscriptionRequest[]
+}
+```
+
+**Default Plans** (Auto-seeded):
+- Basic (FOUNDATION) - CHF 69/month
+- Essential (FOUNDATION) - CHF 129/month  
+- Professional (FOUNDATION) - CHF 259/month
+- Suppliers (PRODUCT_SUPPLIER) - Enquiry-based
+- Service Providers (SERVICE_PROVIDER) - Enquiry-based
+
+**Purpose**: This is the ACTUAL subscription system. When users subscribe, records are created in the `subscriptions` table linking to these plans.
+
+---
+
+### 2. Pricing Tier Table (Admin Configuration - NOT Used for Subscription Logic)
+
+**Location**: `pricing_tiers` table in database  
+**Service**: `PricingService` (`api/src/subscription-management/pricing.service.ts`)
+
+**Schema**:
+```typescript
+model PricingTier {
+  id               String           @id @default(uuid())
+  role             UserRole         @default(FOUNDATION)
+  subscriptionTier SubscriptionTier @default(BASIC)  // BASIC, ESSENTIAL, PROFESSIONAL, ENTERPRISE
+  name             String
+  basePrice        Float
+  currency         String           @default("CHF")
+  billingPeriod    String           @default("monthly")
+  discounts        Json
+  isActive         Boolean          @default(true)
+  displayOrder     Int              @default(0)
+  
+  @@unique([role, subscriptionTier, billingPeriod])
+}
+```
+
+**Purpose**: This table exists for:
+- Dynamic pricing configuration by role and tier
+- Volume discounts and yearly billing discounts
+- Foundation-specific tier pricing customization
+
+**Admin UI**: Located in `admin/src/pages/Subscriptions.tsx` - "Foundation Subscription Tier Configuration" modal (lines 662-933)
+
+**IMPORTANT**: This table is NOT currently being used in the subscription status checking logic. It's a future-ready pricing configuration system.
+
+---
+
+### 3. Subscription Status Checking Logic (THE BUG)
+
+**File**: `api/src/subscription-management/subscription-management.service.ts`
+
+**Current Implementation (BUGGY)**:
+
+```typescript
+async getUserSubscription(userId: string): Promise<Subscription | null> {
+  try {
+    const subscription = await this.prisma.subscription.findFirst({
+      where: { userId },  // ❌ NO STATUS FILTER!
+      include: {
+        user: true,
+        organization: true,
+        plan: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return subscription as unknown as Subscription | null;
+  } catch (error) {
+    this.logger.error(`Failed to get user subscription: ${(error as Error).message}`);
+    throw error;
+  }
+}
+
+async getOrganizationSubscription(organizationId: string): Promise<Subscription | null> {
+  try {
+    const subscription = await this.prisma.subscription.findFirst({
+      where: { organizationId },  // ❌ NO STATUS FILTER!
+      include: {
+        user: true,
+        organization: true,
+        plan: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return subscription as unknown as Subscription | null;
+  } catch (error) {
+    this.logger.error(`Failed to get organization subscription: ${(error as Error).message}`);
+    throw error;
+  }
+}
+```
+
+**The Problem**:
+- These methods return the MOST RECENT subscription regardless of status
+- If a daycare has subscriptions: [PENDING (newest), CANCELLED (old), ACTIVE (older)]
+- The query returns the PENDING one instead of the ACTIVE one
+- The frontend checks `hasActiveSubscription` which evaluates `subscription?.status === 'ACTIVE' || subscription?.status === 'TRIAL'`
+- Since the returned subscription is PENDING, `hasActiveSubscription` becomes `false`
+- User sees the subscription paywall even though they have an ACTIVE subscription
+
+---
+
+### 4. Frontend Subscription Context
+
+**File**: `frontend/contexts/SubscriptionContext.tsx`
+
+**Status Check** (Line 964 in controller):
+```typescript
+const isActive = subscription?.status === 'ACTIVE' || subscription?.status === 'TRIAL';
+```
+
+**This is correct**, but it receives the WRONG subscription from the backend.
+
+---
+
+## The Two Data Flows
+
+### Flow 1: Pricing Page → Subscription Request → Activation
+
+1. **Pricing Page** (`frontend/pages/PricingPage.tsx`)
+   - Fetches plans from `/subscriptions/plans` (SubscriptionPlan table)
+   - Displays pricing to users
+   - Creates subscription request
+
+2. **Subscription Request** (`subscription_requests` table)
+   - Status: PENDING → UNDER_REVIEW → INVOICE_SENT → PAYMENT_RECEIVED → ACTIVATED
+   - Links to SubscriptionPlan via `planId`
+
+3. **Admin Activates** (`admin/src/pages/Subscriptions.tsx`)
+   - Admin reviews request in "Subscription Requests" tab
+   - Admin activates → creates record in `subscriptions` table
+   - Status set to ACTIVE
+
+### Flow 2: Admin Foundation Tier Configuration (Separate System)
+
+1. **Tier Management** (`admin/src/pages/Subscriptions.tsx` - lines 662-933)
+   - "Edit Foundation Subscription Tiers" modal
+   - Manages `pricing_tiers` table
+   - Configures pricing by tier (BASIC, ESSENTIAL, PROFESSIONAL, ENTERPRISE)
+   - **NOT connected to actual subscription status checking**
+
+---
+
+## Root Cause Analysis
+
+### Why Daycares See Paywall After Activation
+
+**Scenario**:
+1. Daycare requests a subscription → Creates `subscription_requests` record (status: PENDING)
+2. Admin activates request → Creates `subscriptions` record (status: ACTIVE)
+3. System might create multiple subscription records during testing/troubleshooting
+4. When frontend calls `/subscriptions/me`, backend calls `getUserSubscription(userId)` or `getOrganizationSubscription(organizationId)`
+5. Query returns most recent subscription by `createdAt DESC` **without filtering by status**
+6. If the most recent subscription is PENDING/INACTIVE, it's returned instead of the ACTIVE one
+7. Frontend evaluates `isActive = subscription?.status === 'ACTIVE' || subscription?.status === 'TRIAL'` → false
+8. User sees paywall
+
+---
+
+## Solution
+
+### Fix 1: Filter Subscriptions by Status (CRITICAL)
+
+**File**: `api/src/subscription-management/subscription-management.service.ts`
+
+**Update `getUserSubscription`**:
+```typescript
+async getUserSubscription(userId: string): Promise<Subscription | null> {
+  try {
+    const subscription = await this.prisma.subscription.findFirst({
+      where: { 
+        userId,
+        status: { in: ['ACTIVE', 'TRIAL'] }  // ✅ Only return active subscriptions
+      },
+      include: {
+        user: true,
+        organization: true,
+        plan: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return subscription as unknown as Subscription | null;
+  } catch (error) {
+    this.logger.error(`Failed to get user subscription: ${(error as Error).message}`);
+    throw error;
+  }
+}
+```
+
+**Update `getOrganizationSubscription`**:
+```typescript
+async getOrganizationSubscription(organizationId: string): Promise<Subscription | null> {
+  try {
+    const subscription = await this.prisma.subscription.findFirst({
+      where: { 
+        organizationId,
+        status: { in: ['ACTIVE', 'TRIAL'] }  // ✅ Only return active subscriptions
+      },
+      include: {
+        user: true,
+        organization: true,
+        plan: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return subscription as unknown as Subscription | null;
+  } catch (error) {
+    this.logger.error(`Failed to get organization subscription: ${(error as Error).message}`);
+    throw error;
+  }
+}
+```
+
+### Fix 2: Data Cleanup
+
+Check for orphaned/duplicate subscriptions:
+```sql
+-- Find organizations with multiple subscriptions
+SELECT organizationId, status, COUNT(*) as count
+FROM subscriptions
+WHERE organizationId IS NOT NULL
+GROUP BY organizationId, status
+HAVING COUNT(*) > 1;
+
+-- Find users with multiple subscriptions
+SELECT userId, status, COUNT(*) as count
+FROM subscriptions
+WHERE userId IS NOT NULL
+GROUP BY userId, status
+HAVING COUNT(*) > 1;
+```
+
+---
+
+## Source of Truth Clarification
+
+### For Subscription Status (Current Active Subscription)
+**Source of Truth**: `subscriptions` table
+- Linked to `subscription_plans` table via `planId`
+- Status field determines access: `ACTIVE` or `TRIAL` = has access
+- Retrieved via `getUserSubscription()` or `getOrganizationSubscription()` (after fix)
+
+### For Pricing Display (Pricing Page)
+**Source of Truth**: `subscription_plans` table
+- Contains plan names, features, prices
+- Displayed on `/pricing` page
+- Used for subscription requests
+
+### For Foundation Tier Pricing Configuration (Admin)
+**Data Source**: `pricing_tiers` table
+- Future-ready for dynamic pricing
+- Currently NOT integrated with subscription status checking
+- Admin can configure but it doesn't affect current subscription logic
+- **Recommendation**: Either integrate this with billing or remove the confusing UI
+
+---
+
+## Recommendations
+
+### Immediate Actions (High Priority)
+
+1. **Apply Fix 1** - Add status filter to `getUserSubscription()` and `getOrganizationSubscription()`
+2. **Data Audit** - Check production database for multiple subscription records per user/organization
+3. **Testing** - Verify daycares can access platform after fix
+
+### Short-term Actions (Medium Priority)
+
+4. **Clarify Admin UI** - Update "Foundation Subscription Tier Configuration" modal with clear explanation that it's for future pricing configuration, not current subscriptions
+5. **Add Logging** - Log which subscription is being returned and why (for debugging)
+6. **Status Transitions** - Ensure old subscriptions are properly marked as CANCELLED/EXPIRED when new ones are activated
+
+### Long-term Actions (Low Priority)
+
+7. **Integrate Pricing Tiers** - Connect `pricing_tiers` table to actual billing logic if needed
+8. **Consolidate Systems** - Decide if `pricing_tiers` should be merged into `subscription_plans` or used separately
+9. **Add Admin Warnings** - Show warning in admin if organization has multiple active subscriptions
+
+---
+
+## Testing Checklist
+
+After applying fixes:
+
+- [ ] Daycare with ACTIVE subscription can access platform (no paywall)
+- [ ] Daycare with TRIAL subscription can access platform
+- [ ] Daycare with PENDING subscription sees paywall
+- [ ] Daycare with CANCELLED subscription sees paywall
+- [ ] Daycare with EXPIRED subscription sees paywall
+- [ ] Organization-based subscription works correctly
+- [ ] User-based subscription works correctly
+- [ ] Subscription request flow still works end-to-end
+- [ ] Admin can view subscription status correctly
+- [ ] No duplicate subscriptions created during activation
+
+---
+
+## Files to Modify
+
+### Critical (Must Fix)
+- `api/src/subscription-management/subscription-management.service.ts` (lines 1550-1586)
+
+### Documentation (Should Update)
+- `admin/src/pages/Subscriptions.tsx` (add comments explaining pricing tiers)
+- This investigation document
+
+---
+
+## Conclusion
+
+The issue is NOT a conflict between two sources of truth, but rather:
+
+1. **Bug in subscription query**: Not filtering by status when fetching user/organization subscriptions
+2. **Confusing UI**: Admin tier configuration modal suggests it affects active subscriptions when it doesn't
+
+The fix is straightforward: Add status filtering to the subscription retrieval methods. This will ensure only ACTIVE or TRIAL subscriptions are returned, allowing daycares to access the platform after activation.

--- a/SUBSCRIPTION_FIX_QUICK_REFERENCE.md
+++ b/SUBSCRIPTION_FIX_QUICK_REFERENCE.md
@@ -1,0 +1,130 @@
+# Subscription Paywall Fix - Quick Reference
+
+## TL;DR
+
+**Problem**: Daycares see paywall despite having active subscriptions.
+
+**Root Cause**: Backend returns most recent subscription regardless of status (could be PENDING instead of ACTIVE).
+
+**Fix**: Filter subscription queries to only return ACTIVE or TRIAL subscriptions.
+
+**Files Changed**: 
+- `api/src/subscription-management/subscription-management.service.ts` (2 methods, 6 lines)
+
+**Status**: ✅ Fixed and ready to deploy
+
+---
+
+## What Was Changed
+
+```typescript
+// Before (BUGGY)
+where: { userId }
+
+// After (FIXED)
+where: { 
+  userId,
+  status: { in: ['ACTIVE', 'TRIAL'] }
+}
+```
+
+Applied to both:
+- `getUserSubscription(userId)`
+- `getOrganizationSubscription(organizationId)`
+
+---
+
+## Quick Deploy
+
+```bash
+# 1. Check data integrity (optional but recommended)
+psql $DATABASE_URL -f api/scripts/check-subscription-data-integrity.sql
+
+# 2. Deploy the fix
+cd api
+npm run build
+# Deploy to production
+
+# 3. Test
+curl -H "Authorization: Bearer $TOKEN" https://your-api.com/subscriptions/me
+```
+
+---
+
+## Quick Test
+
+1. **Login as daycare with active subscription**
+2. **Check dashboard** - Should NOT see paywall
+3. **Check API response**: `GET /subscriptions/me`
+   - Should return `hasActiveSubscription: true`
+   - Should return subscription with `status: "ACTIVE"`
+
+---
+
+## If Still Seeing Issues
+
+1. **Check subscription in database**:
+   ```sql
+   SELECT id, status, "organizationId", "currentPeriodEnd" 
+   FROM subscriptions 
+   WHERE "organizationId" = 'YOUR_ORG_ID'
+   ORDER BY "createdAt" DESC;
+   ```
+
+2. **Look for multiple subscriptions**:
+   ```sql
+   SELECT "organizationId", status, COUNT(*) 
+   FROM subscriptions 
+   GROUP BY "organizationId", status 
+   HAVING COUNT(*) > 1;
+   ```
+
+3. **Run data cleanup** (if needed):
+   ```bash
+   psql $DATABASE_URL -f api/scripts/fix-duplicate-subscriptions.sql
+   ```
+
+---
+
+## Documentation
+
+- **Full Investigation**: `FOUNDATION_SUBSCRIPTION_SOURCE_OF_TRUTH_INVESTIGATION.md`
+- **Deployment Guide**: `SUBSCRIPTION_PAYWALL_FIX_SUMMARY.md`
+- **Data Check Script**: `api/scripts/check-subscription-data-integrity.sql`
+- **Data Fix Script**: `api/scripts/fix-duplicate-subscriptions.sql`
+
+---
+
+## Key Insights
+
+### There Are TWO Subscription-Related Tables
+
+1. **`subscription_plans`** - The actual subscription plans (Basic, Essential, Professional)
+   - Used by pricing page
+   - Used for subscription requests
+   - ✅ This is the source of truth for subscriptions
+
+2. **`pricing_tiers`** - Foundation tier pricing configuration
+   - Used by admin "Edit Foundation Subscription Tiers" modal
+   - For future dynamic pricing features
+   - ❌ NOT currently used in subscription status checking
+   - Can be confusing but doesn't affect the bug
+
+### The Real Issue
+
+The bug was NOT about which table to use. Both tables are correct for their purposes.
+
+The bug was that the subscription query didn't filter by status, so it could return:
+- PENDING subscriptions (not yet activated)
+- CANCELLED subscriptions (expired)
+- INACTIVE subscriptions (not started)
+
+Instead of only:
+- ACTIVE subscriptions (currently valid)
+- TRIAL subscriptions (in trial period)
+
+---
+
+## Contact
+
+For questions, review the full investigation document or check the application logs.

--- a/SUBSCRIPTION_PAYWALL_FIX_SUMMARY.md
+++ b/SUBSCRIPTION_PAYWALL_FIX_SUMMARY.md
@@ -1,0 +1,216 @@
+# Subscription Paywall Fix - Summary
+
+## Problem Statement
+
+Daycares were seeing the subscription paywall even after their subscriptions were activated by admins. This prevented them from accessing the platform despite having valid, active subscriptions.
+
+## Root Cause
+
+The `getUserSubscription()` and `getOrganizationSubscription()` methods in `SubscriptionManagementService` were not filtering by subscription status. They returned the **most recent** subscription regardless of status (PENDING, CANCELLED, ACTIVE, etc.).
+
+**Example Scenario**:
+```
+Organization has subscriptions:
+1. PENDING (created 2024-12-28) ← Returned by query
+2. ACTIVE (created 2024-12-20)   ← Should be returned
+3. CANCELLED (created 2024-12-15)
+
+Query: SELECT * FROM subscriptions WHERE organizationId = 'xxx' ORDER BY createdAt DESC LIMIT 1
+Result: Returns PENDING subscription
+Frontend checks: subscription.status === 'ACTIVE' || subscription.status === 'TRIAL'
+Result: false → Shows paywall
+```
+
+## Solution Applied
+
+### Code Changes
+
+**File**: `api/src/subscription-management/subscription-management.service.ts`
+
+**Before**:
+```typescript
+async getUserSubscription(userId: string): Promise<Subscription | null> {
+  const subscription = await this.prisma.subscription.findFirst({
+    where: { userId },  // ❌ No status filter
+    orderBy: { createdAt: 'desc' },
+  });
+  return subscription;
+}
+```
+
+**After**:
+```typescript
+async getUserSubscription(userId: string): Promise<Subscription | null> {
+  const subscription = await this.prisma.subscription.findFirst({
+    where: { 
+      userId,
+      status: { in: ['ACTIVE', 'TRIAL'] }  // ✅ Only active subscriptions
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+  return subscription;
+}
+```
+
+Same fix applied to `getOrganizationSubscription()`.
+
+### Impact
+
+- ✅ Daycares with ACTIVE subscriptions will now properly access the platform
+- ✅ Daycares with TRIAL subscriptions will continue to work
+- ✅ Daycares with PENDING/CANCELLED/EXPIRED subscriptions will correctly see the paywall
+- ✅ No changes needed to frontend code
+- ✅ No database schema changes required
+
+## Additional Tools Created
+
+### 1. Data Integrity Check Script
+**File**: `api/scripts/check-subscription-data-integrity.sql`
+
+Run this to diagnose subscription data issues:
+```bash
+psql $DATABASE_URL -f api/scripts/check-subscription-data-integrity.sql
+```
+
+Checks for:
+- Organizations with multiple subscriptions
+- Duplicate active subscriptions
+- Expired active subscriptions
+- Orphaned subscription requests
+- Overall subscription health
+
+### 2. Duplicate Subscription Fix Script
+**File**: `api/scripts/fix-duplicate-subscriptions.sql`
+
+Run this to clean up duplicate subscriptions:
+```bash
+psql $DATABASE_URL -f api/scripts/fix-duplicate-subscriptions.sql
+```
+
+**WARNING**: Review the output first before uncommenting the UPDATE statement!
+
+### 3. Investigation Document
+**File**: `FOUNDATION_SUBSCRIPTION_SOURCE_OF_TRUTH_INVESTIGATION.md`
+
+Comprehensive analysis of:
+- System architecture
+- Data flow
+- Source of truth clarification
+- PricingTier vs SubscriptionPlan tables
+
+## Testing Checklist
+
+After deploying this fix:
+
+### Functional Testing
+- [ ] Daycare with ACTIVE subscription can access dashboard (no paywall)
+- [ ] Daycare with TRIAL subscription can access dashboard
+- [ ] Daycare with PENDING subscription sees paywall
+- [ ] Daycare with CANCELLED subscription sees paywall
+- [ ] Daycare with EXPIRED subscription sees paywall
+
+### Edge Cases
+- [ ] Organization with multiple subscriptions (one ACTIVE, others not) → should access platform
+- [ ] User-based subscription works correctly
+- [ ] Organization-based subscription works correctly
+- [ ] Subscription request → activation flow still works
+
+### API Endpoints
+- [ ] `GET /subscriptions/me` returns correct subscription
+- [ ] `GET /subscriptions/plans` still works (pricing page)
+- [ ] Subscription request submission still works
+
+### Admin Panel
+- [ ] Can view subscription status correctly
+- [ ] Can activate subscription requests
+- [ ] Can manage subscriptions (pause, cancel, etc.)
+
+## Deployment Steps
+
+1. **Backup Database** (recommended)
+   ```bash
+   pg_dump $DATABASE_URL > backup_$(date +%Y%m%d_%H%M%S).sql
+   ```
+
+2. **Run Data Integrity Check**
+   ```bash
+   psql $DATABASE_URL -f api/scripts/check-subscription-data-integrity.sql > integrity_report.txt
+   ```
+   Review the output for any anomalies.
+
+3. **Deploy Code Changes**
+   ```bash
+   cd api
+   npm run build
+   # Deploy to production
+   ```
+
+4. **Clean Up Duplicate Subscriptions** (if needed)
+   ```bash
+   # Review the script first!
+   psql $DATABASE_URL -f api/scripts/fix-duplicate-subscriptions.sql
+   ```
+
+5. **Verify Fix**
+   - Test with a known affected daycare account
+   - Check logs for any errors
+   - Monitor subscription status API calls
+
+## Monitoring
+
+After deployment, monitor:
+
+1. **Error Logs**: Check for any new errors in subscription checking
+2. **Subscription API**: Monitor `/subscriptions/me` endpoint response times
+3. **User Reports**: Track if daycares still report paywall issues
+4. **Database**: Run integrity check weekly for first month
+
+## Rollback Plan
+
+If issues occur:
+
+1. **Code Rollback**: Revert the changes to `subscription-management.service.ts`
+2. **Database Rollback**: Restore from backup if data cleanup was performed
+3. **Notify Users**: Inform affected daycares of temporary issue
+
+The code change is minimal and safe, so rollback should be straightforward.
+
+## Related Issues
+
+This fix addresses:
+- Subscription paywall showing despite active subscription
+- Incorrect subscription status detection
+- Multiple subscription records causing confusion
+
+This does NOT address (separate issues):
+- PricingTier table integration (future feature)
+- Stripe payment integration (future feature)
+- Subscription renewal automation (separate feature)
+
+## Questions & Answers
+
+**Q: Why were there multiple subscriptions per organization?**
+A: Likely from testing, troubleshooting, or the subscription request flow creating PENDING records before activation.
+
+**Q: Will this affect existing subscriptions?**
+A: No, this only changes how subscriptions are queried. Existing data is unchanged.
+
+**Q: Do we need to update the frontend?**
+A: No, the frontend already checks for ACTIVE/TRIAL status correctly. The issue was the backend returning the wrong subscription.
+
+**Q: What about the PricingTier table?**
+A: That's a separate system for future dynamic pricing. It's not currently integrated with subscription status checking. See the investigation document for details.
+
+## Success Metrics
+
+After 1 week:
+- Zero reports of "paywall showing despite active subscription"
+- All ACTIVE subscriptions properly grant access
+- No increase in subscription-related support tickets
+
+## Contact
+
+For issues or questions about this fix:
+- Review: `FOUNDATION_SUBSCRIPTION_SOURCE_OF_TRUTH_INVESTIGATION.md`
+- Check data: `api/scripts/check-subscription-data-integrity.sql`
+- Support: Check application logs and database state

--- a/api/scripts/check-subscription-data-integrity.sql
+++ b/api/scripts/check-subscription-data-integrity.sql
@@ -1,0 +1,162 @@
+-- Subscription Data Integrity Check
+-- This script helps identify potential issues with subscription data
+-- Run this to diagnose subscription paywall issues
+
+-- 1. Organizations with multiple subscriptions (potential issue)
+SELECT 
+    o.id as org_id,
+    o.name as org_name,
+    o.type as org_type,
+    COUNT(s.id) as subscription_count,
+    STRING_AGG(DISTINCT s.status::text, ', ') as statuses
+FROM organizations o
+LEFT JOIN subscriptions s ON s."organizationId" = o.id
+WHERE o.type = 'FOUNDATION'
+GROUP BY o.id, o.name, o.type
+HAVING COUNT(s.id) > 1
+ORDER BY subscription_count DESC;
+
+-- 2. Organizations with ACTIVE subscriptions but also other statuses
+SELECT 
+    o.id as org_id,
+    o.name as org_name,
+    s.id as subscription_id,
+    s.status,
+    s."createdAt",
+    s."currentPeriodStart",
+    s."currentPeriodEnd",
+    sp.name as plan_name,
+    sp.code as plan_code
+FROM organizations o
+JOIN subscriptions s ON s."organizationId" = o.id
+JOIN subscription_plans sp ON sp.id = s."planId"
+WHERE o.id IN (
+    SELECT "organizationId" 
+    FROM subscriptions 
+    WHERE status IN ('ACTIVE', 'TRIAL')
+    GROUP BY "organizationId"
+)
+ORDER BY o.name, s."createdAt" DESC;
+
+-- 3. Find organizations that should have access but might be seeing paywall
+-- (Have ACTIVE subscription but also newer PENDING/INACTIVE subscriptions)
+WITH org_subscriptions AS (
+    SELECT 
+        o.id as org_id,
+        o.name as org_name,
+        s.id as subscription_id,
+        s.status,
+        s."createdAt",
+        ROW_NUMBER() OVER (PARTITION BY o.id ORDER BY s."createdAt" DESC) as recency_rank,
+        (s.status IN ('ACTIVE', 'TRIAL')) as is_active
+    FROM organizations o
+    JOIN subscriptions s ON s."organizationId" = o.id
+    WHERE o.type = 'FOUNDATION'
+)
+SELECT 
+    org_id,
+    org_name,
+    MAX(CASE WHEN recency_rank = 1 THEN status END) as most_recent_status,
+    MAX(CASE WHEN recency_rank = 1 THEN is_active END) as most_recent_is_active,
+    MAX(CASE WHEN is_active THEN 'YES' ELSE 'NO' END) as has_active_subscription,
+    COUNT(*) as total_subscriptions
+FROM org_subscriptions
+GROUP BY org_id, org_name
+HAVING 
+    MAX(CASE WHEN recency_rank = 1 THEN is_active END) = false
+    AND MAX(CASE WHEN is_active THEN 'YES' ELSE 'NO' END) = 'YES'
+ORDER BY org_name;
+
+-- 4. Subscription status distribution
+SELECT 
+    status,
+    COUNT(*) as count,
+    ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER (), 2) as percentage
+FROM subscriptions
+GROUP BY status
+ORDER BY count DESC;
+
+-- 5. Organizations without any subscription
+SELECT 
+    o.id,
+    o.name,
+    o.type,
+    o."createdAt"
+FROM organizations o
+LEFT JOIN subscriptions s ON s."organizationId" = o.id
+WHERE o.type = 'FOUNDATION'
+    AND s.id IS NULL
+ORDER BY o."createdAt" DESC;
+
+-- 6. Subscription requests that were activated but subscription status is not ACTIVE
+SELECT 
+    sr.id as request_id,
+    sr.status as request_status,
+    sr."contactEmail",
+    sr."subscriptionId",
+    s.status as subscription_status,
+    s."currentPeriodEnd",
+    o.name as org_name
+FROM subscription_requests sr
+LEFT JOIN subscriptions s ON s.id = sr."subscriptionId"
+LEFT JOIN organizations o ON o.id = sr."organizationId"
+WHERE sr.status = 'ACTIVATED'
+    AND (s.status IS NULL OR s.status NOT IN ('ACTIVE', 'TRIAL'))
+ORDER BY sr."createdAt" DESC;
+
+-- 7. Active subscriptions with expired periods
+SELECT 
+    s.id,
+    o.name as org_name,
+    s.status,
+    s."currentPeriodEnd",
+    sp.name as plan_name,
+    EXTRACT(DAY FROM NOW() - s."currentPeriodEnd") as days_expired
+FROM subscriptions s
+LEFT JOIN organizations o ON o.id = s."organizationId"
+JOIN subscription_plans sp ON sp.id = s."planId"
+WHERE s.status IN ('ACTIVE', 'TRIAL')
+    AND s."currentPeriodEnd" < NOW()
+ORDER BY s."currentPeriodEnd" DESC;
+
+-- 8. Summary report
+SELECT 
+    'Total Foundations' as metric,
+    COUNT(*) as value
+FROM organizations WHERE type = 'FOUNDATION'
+UNION ALL
+SELECT 
+    'Foundations with Subscriptions',
+    COUNT(DISTINCT "organizationId")
+FROM subscriptions WHERE "organizationId" IS NOT NULL
+UNION ALL
+SELECT 
+    'Active Subscriptions',
+    COUNT(*)
+FROM subscriptions WHERE status = 'ACTIVE'
+UNION ALL
+SELECT 
+    'Trial Subscriptions',
+    COUNT(*)
+FROM subscriptions WHERE status = 'TRIAL'
+UNION ALL
+SELECT 
+    'Pending Subscriptions',
+    COUNT(*)
+FROM subscriptions WHERE status = 'PENDING'
+UNION ALL
+SELECT 
+    'Cancelled Subscriptions',
+    COUNT(*)
+FROM subscriptions WHERE status = 'CANCELLED'
+UNION ALL
+SELECT 
+    'Foundations with Multiple Subscriptions',
+    COUNT(*)
+FROM (
+    SELECT "organizationId"
+    FROM subscriptions
+    WHERE "organizationId" IS NOT NULL
+    GROUP BY "organizationId"
+    HAVING COUNT(*) > 1
+) multi;

--- a/api/scripts/fix-duplicate-subscriptions.sql
+++ b/api/scripts/fix-duplicate-subscriptions.sql
@@ -1,0 +1,86 @@
+-- Fix Duplicate Subscriptions Script
+-- WARNING: Review the output of check-subscription-data-integrity.sql before running this!
+-- This script will cancel duplicate subscriptions, keeping only the most recent ACTIVE or TRIAL one
+
+-- Step 1: Identify organizations with problematic duplicates
+-- (Run this first to see what will be affected)
+WITH ranked_subscriptions AS (
+    SELECT 
+        s.id,
+        s."organizationId",
+        s.status,
+        s."createdAt",
+        o.name as org_name,
+        ROW_NUMBER() OVER (
+            PARTITION BY s."organizationId" 
+            ORDER BY 
+                CASE 
+                    WHEN s.status IN ('ACTIVE', 'TRIAL') THEN 0
+                    ELSE 1
+                END,
+                s."createdAt" DESC
+        ) as priority_rank
+    FROM subscriptions s
+    JOIN organizations o ON o.id = s."organizationId"
+    WHERE s."organizationId" IS NOT NULL
+)
+SELECT 
+    org_name,
+    "organizationId",
+    COUNT(*) as total_subscriptions,
+    COUNT(*) FILTER (WHERE priority_rank = 1) as subscriptions_to_keep,
+    COUNT(*) FILTER (WHERE priority_rank > 1) as subscriptions_to_cancel
+FROM ranked_subscriptions
+GROUP BY org_name, "organizationId"
+HAVING COUNT(*) > 1
+ORDER BY total_subscriptions DESC;
+
+-- Step 2: Cancel duplicate subscriptions (UNCOMMENT TO RUN)
+-- This keeps the most recent ACTIVE/TRIAL subscription, or the most recent one if none are active
+/*
+WITH ranked_subscriptions AS (
+    SELECT 
+        s.id,
+        s."organizationId",
+        s.status,
+        ROW_NUMBER() OVER (
+            PARTITION BY s."organizationId" 
+            ORDER BY 
+                CASE 
+                    WHEN s.status IN ('ACTIVE', 'TRIAL') THEN 0
+                    ELSE 1
+                END,
+                s."createdAt" DESC
+        ) as priority_rank
+    FROM subscriptions s
+    WHERE s."organizationId" IS NOT NULL
+        AND s.status NOT IN ('CANCELLED', 'EXPIRED')
+)
+UPDATE subscriptions
+SET 
+    status = 'CANCELLED',
+    "canceledAt" = NOW(),
+    "cancellationReason" = 'Duplicate subscription - auto-cancelled by data integrity script',
+    "updatedAt" = NOW()
+WHERE id IN (
+    SELECT id 
+    FROM ranked_subscriptions 
+    WHERE priority_rank > 1
+)
+RETURNING id, "organizationId", status;
+*/
+
+-- Step 3: Verify the fix (run after Step 2)
+/*
+SELECT 
+    o.name as org_name,
+    s.status,
+    s."currentPeriodStart",
+    s."currentPeriodEnd",
+    sp.name as plan_name
+FROM subscriptions s
+JOIN organizations o ON o.id = s."organizationId"
+JOIN subscription_plans sp ON sp.id = s."planId"
+WHERE s.status IN ('ACTIVE', 'TRIAL')
+ORDER BY o.name;
+*/

--- a/api/src/subscription-management/subscription-management.service.ts
+++ b/api/src/subscription-management/subscription-management.service.ts
@@ -1550,7 +1550,10 @@ export class SubscriptionManagementService {
   async getUserSubscription(userId: string): Promise<Subscription | null> {
     try {
       const subscription = await this.prisma.subscription.findFirst({
-        where: { userId },
+        where: { 
+          userId,
+          status: { in: ['ACTIVE', 'TRIAL'] } // Only return active or trial subscriptions
+        },
         include: {
           user: true,
           organization: true,
@@ -1569,7 +1572,10 @@ export class SubscriptionManagementService {
   async getOrganizationSubscription(organizationId: string): Promise<Subscription | null> {
     try {
       const subscription = await this.prisma.subscription.findFirst({
-        where: { organizationId },
+        where: { 
+          organizationId,
+          status: { in: ['ACTIVE', 'TRIAL'] } // Only return active or trial subscriptions
+        },
         include: {
           user: true,
           organization: true,


### PR DESCRIPTION
Filter user and organization subscription queries to only return ACTIVE or TRIAL subscriptions to fix daycares seeing paywalls despite having active subscriptions.

Previously, `getUserSubscription` and `getOrganizationSubscription` methods would return the most recent subscription by creation date, even if it was PENDING or INACTIVE. This caused the frontend to incorrectly determine that a user lacked an active subscription, leading to the paywall being displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec357dcd-6039-409b-afe7-4efed1859de4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec357dcd-6039-409b-afe7-4efed1859de4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed paywall incorrectly appearing for users after subscription plan activation
  * Improved subscription status filtering to ensure accurate access control for active subscriptions

* **Documentation**
  * Added investigation guides and reference documentation for subscription system architecture and troubleshooting

* **Chores**
  * Added subscription data integrity diagnostic and cleanup utilities

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->