### PR TITLE
Frontend loading MIME type

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Build frontend
         working-directory: frontend
         run: pnpm run build
+
+      - name: Guard: verify built index.html is production output
+        run: node scripts/verify-spa-build-output.mjs frontend
       
       - name: Run unit tests
         working-directory: frontend

--- a/Dockerfile.admin
+++ b/Dockerfile.admin
@@ -18,8 +18,8 @@ RUN pnpm install --frozen-lockfile
 # Copy source code
 COPY . .
 
-# Build the application
-RUN pnpm --filter admin build
+# Build the application (avoid relying on workspace package name / pnpm filters)
+RUN pnpm -C admin build
 
 # Production stage
 FROM nginx:alpine

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -18,8 +18,8 @@ RUN pnpm install --frozen-lockfile
 # Copy source code
 COPY . .
 
-# Build the application
-RUN pnpm --filter frontend build
+# Build the application (avoid relying on workspace package name / pnpm filters)
+RUN pnpm -C frontend build
 
 # Production stage
 FROM nginx:alpine

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "copy-of-pro-crèche-solutions-for-merge",
+  "name": "frontend",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "copy-of-pro-crèche-solutions-for-merge",
+      "name": "frontend",
       "version": "0.0.1",
       "dependencies": {
         "@clerk/clerk-react": "^5.53.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "copy-of-pro-crèche-solutions-for-merge",
+  "name": "frontend",
   "private": true,
   "version": "0.0.1",
   "type": "module",

--- a/scripts/verify-spa-build-output.mjs
+++ b/scripts/verify-spa-build-output.mjs
@@ -1,0 +1,35 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function fail(message) {
+  console.error(`❌ ${message}`);
+  process.exit(1);
+}
+
+const appDir = process.argv[2] || 'frontend';
+const repoRoot = process.cwd();
+const indexPath = path.join(repoRoot, appDir, 'dist', 'index.html');
+
+if (!fs.existsSync(indexPath)) {
+  fail(`Missing build output: ${indexPath}. Did the ${appDir} build run?`);
+}
+
+const html = fs.readFileSync(indexPath, 'utf8');
+
+// If we ever ship source entrypoints, the server will return HTML for them (SPA fallback),
+// and browsers will throw "Failed to load module script ... MIME type text/html".
+const hasTsModuleRefs = /\b(?:src|href)=["']\/[^"']+\.(?:ts|tsx)\b/i.test(html);
+if (hasTsModuleRefs) {
+  fail(
+    `${appDir}/dist/index.html references .ts/.tsx assets. This indicates the source index.html was shipped instead of a Vite-built output.`,
+  );
+}
+
+// Vite production output should reference hashed assets under /assets/
+const hasAssetsJs = /\/assets\/[^"']+\.(?:mjs|js)\b/i.test(html);
+if (!hasAssetsJs) {
+  fail(`${appDir}/dist/index.html does not reference /assets/*.js. Build output looks wrong.`);
+}
+
+console.log(`✅ ${appDir} build output looks OK (${indexPath})`);
+


### PR DESCRIPTION
Rename frontend package to `frontend` to enable correct build command execution and resolve module script loading errors.

The previous package name prevented `pnpm --filter frontend build` from running, resulting in the unbuilt `index.html` being served. This `index.html` referenced `/index.tsx`, which the server returned as `text/html` instead of a JavaScript module, causing the browser error "Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html"". Correcting the package name ensures the build process generates the proper `dist/index.html` with correct module paths.

---
<a href="https://cursor.com/background-agent?bcId=bc-4a27307d-2597-419c-8b48-262e228d09e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4a27307d-2597-419c-8b48-262e228d09e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

