### PR TITLE
Gate entire dashboard behind subscription paywall

### DIFF
--- a/SUBSCRIPTION_SYSTEM_VERIFICATION.md
+++ b/SUBSCRIPTION_SYSTEM_VERIFICATION.md
@@ -1,0 +1,279 @@
+# Subscription System Verification
+
+## Summary
+
+The subscription system has been thoroughly verified to be **UNIFIED** and operates **identically** for all three subscription-required roles:
+
+- ✅ **FOUNDATION** (Daycares)
+- ✅ **PRODUCT_SUPPLIER** (Product Suppliers)
+- ✅ **SERVICE_PROVIDER** (Service Providers)
+
+---
+
+## 1. Role Configuration
+
+### Backend (`api/src/subscription-management/subscription-management.controller.ts`)
+```typescript
+const SUBSCRIPTION_REQUIRED_ROLES: UserRole[] = [
+  UserRole.FOUNDATION,
+  UserRole.PRODUCT_SUPPLIER,
+  UserRole.SERVICE_PROVIDER,
+];
+```
+
+### Frontend (`frontend/contexts/SubscriptionContext.tsx`)
+```typescript
+const SUBSCRIPTION_REQUIRED_ROLES: UserRole[] = [
+  UserRole.FOUNDATION,
+  UserRole.PRODUCT_SUPPLIER,
+  UserRole.SERVICE_PROVIDER,
+];
+```
+
+**Status**: ✅ IDENTICAL - Both frontend and backend use the exact same list
+
+---
+
+## 2. Authentication Context
+
+### Auth Guard (`api/src/auth/guards/clerk-auth.guard.ts`)
+
+The auth guard is **completely role-agnostic**:
+- Fetches `profileUserId` (User.id) for ALL users
+- Fetches `organizationId` for ALL users (via UserOrganization table)
+- Sets the same context structure for all roles
+
+```typescript
+request.context = {
+  userId: payload.sub,
+  role: appUser.role,           // Any role
+  appUserId: appUser.id,
+  profileUserId: userProfile?.id || null,
+  organizationId: primaryOrganizationId,  // Fetched for ALL users
+  clerkUserId: payload.sub,
+};
+```
+
+**Status**: ✅ UNIFIED - No role-specific logic in auth
+
+---
+
+## 3. Subscription Lookup
+
+### Unified Method (`api/src/subscription-management/subscription-management.service.ts`)
+
+```typescript
+async getActiveSubscriptionForUser(
+  userId?: string,
+  organizationId?: string,
+): Promise<Subscription | null>
+```
+
+This method is the **single source of truth** for all subscription checks:
+
+1. First checks by `organizationId` (for organization-based subscriptions)
+2. Then checks by `userId` (for user-based subscriptions)
+3. Falls back to looking up user's organization if `organizationId` not provided
+
+**Status**: ✅ UNIFIED - Same logic for all roles
+
+---
+
+## 4. API Endpoints
+
+All subscription endpoints consistently include all three roles:
+
+| Endpoint | Roles |
+|----------|-------|
+| `GET /subscriptions/me` | FOUNDATION, PRODUCT_SUPPLIER, SERVICE_PROVIDER + others |
+| `POST /subscriptions/request` | FOUNDATION, PRODUCT_SUPPLIER, SERVICE_PROVIDER |
+| `POST /subscriptions/cancel-request` | FOUNDATION, PRODUCT_SUPPLIER, SERVICE_PROVIDER |
+| `GET /subscriptions/requests` | FOUNDATION, PRODUCT_SUPPLIER, SERVICE_PROVIDER |
+| `DELETE /subscriptions/requests/:id` | FOUNDATION, PRODUCT_SUPPLIER, SERVICE_PROVIDER |
+| `GET /subscriptions/feature/:featureKey` | FOUNDATION, PRODUCT_SUPPLIER, SERVICE_PROVIDER + others |
+| `POST /billing/checkout/*` | FOUNDATION, PRODUCT_SUPPLIER, SERVICE_PROVIDER |
+| `GET /billing/subscription` | FOUNDATION, PRODUCT_SUPPLIER, SERVICE_PROVIDER |
+| `GET /billing/portal` | FOUNDATION, PRODUCT_SUPPLIER, SERVICE_PROVIDER |
+
+**Status**: ✅ UNIFIED - All endpoints include all three roles
+
+---
+
+## 5. Subscription Plans
+
+Each role has dedicated plans with role-specific features:
+
+| Plan | Role | Price | Trial |
+|------|------|-------|-------|
+| Basic | FOUNDATION | CHF 69/mo | 14 days |
+| Essential | FOUNDATION | CHF 129/mo | 14 days |
+| Professional | FOUNDATION | CHF 259/mo | 14 days |
+| Suppliers | PRODUCT_SUPPLIER | Enquiry-based | 0 days |
+| Service Providers | SERVICE_PROVIDER | Enquiry-based | 0 days |
+
+**Status**: ✅ CORRECT - Each role has its own plans with appropriate features
+
+---
+
+## 6. Admin Dashboard
+
+### User Grouping (`admin/src/pages/Subscriptions.tsx`)
+```typescript
+const subscribableRoles = [
+  UserRole.FOUNDATION, 
+  UserRole.PRODUCT_SUPPLIER, 
+  UserRole.SERVICE_PROVIDER, 
+  UserRole.EDUCATOR, 
+  UserRole.PARENT
+];
+```
+
+### Subscription Creation
+```typescript
+const subscription = await subscriptionService.createSubscription(apiClient, {
+  userId: subscriptionUserId,        // profileUserId (User.id)
+  organizationId: subscriptionOrgId, // From user's orgId
+  planId: data.planId,
+  tier: data.tier,
+  durationMonths: duration,
+  notes: data.notes,
+});
+```
+
+**Status**: ✅ UNIFIED - Same creation logic for all roles
+
+### Subscription Lookup Helper
+```typescript
+const getSubscriptionForUser = (user: User): Subscription | undefined => {
+  // Check profileUserId first
+  // Then check id (AppUser.id) for backwards compatibility
+  // Finally check orgId (organization-based subscription)
+};
+```
+
+**Status**: ✅ UNIFIED - Same lookup logic for all roles
+
+---
+
+## 7. Frontend Paywall
+
+### SubscriptionPaywall Component (`frontend/components/shared/SubscriptionPaywall.tsx`)
+
+```typescript
+// Role-agnostic check
+if (!requiresSubscription) {
+  return <>{children}</>;
+}
+
+if (hasActiveSubscription) {
+  return <>{children}</>;
+}
+
+// Show paywall
+return <PaywallContent ... />;
+```
+
+**Status**: ✅ UNIFIED - No role-specific logic in paywall
+
+---
+
+## 8. Billing Controller
+
+All billing endpoints use the same roles:
+```typescript
+@Roles(UserRole.FOUNDATION, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER)
+```
+
+**Status**: ✅ UNIFIED - All three roles have identical billing access
+
+---
+
+## Key Fixes Applied
+
+### Issue 1: Missing `organizationId` in Auth Context
+**Fix**: Auth guard now fetches user's primary organization for ALL users
+
+### Issue 2: ID Mismatch (AppUser.id vs User.id)
+**Fix**: 
+- API now returns `profileUserId` in users endpoint
+- Admin now uses `profileUserId` + `orgId` when creating subscriptions
+
+### Issue 3: Fragmented Subscription Lookup
+**Fix**: New unified `getActiveSubscriptionForUser()` method that checks:
+1. Organization-based subscription first
+2. User-based subscription second
+3. User's organization fallback third
+
+---
+
+## Verification Checklist
+
+| Component | Foundation | Product Supplier | Service Provider |
+|-----------|------------|------------------|------------------|
+| Auth context populated | ✅ | ✅ | ✅ |
+| organizationId in context | ✅ | ✅ | ✅ |
+| profileUserId in context | ✅ | ✅ | ✅ |
+| Unified subscription lookup | ✅ | ✅ | ✅ |
+| /subscriptions/me endpoint | ✅ | ✅ | ✅ |
+| Subscription request flow | ✅ | ✅ | ✅ |
+| Admin subscription creation | ✅ | ✅ | ✅ |
+| Frontend paywall | ✅ | ✅ | ✅ |
+| Billing endpoints | ✅ | ✅ | ✅ |
+
+---
+
+---
+
+## 9. Dashboard Gating
+
+The entire dashboard is now gated. Users without an active subscription can ONLY access:
+
+### Always Allowed Routes (no subscription required):
+| Route | Description |
+|-------|-------------|
+| `/profile` | View/edit personal profile |
+| `/settings/*` | All settings pages including billing |
+| `/pricing` | View subscription plans |
+| `/foundation/organisation-profile` | Foundation org profile |
+| `/foundation/support` | Foundation support |
+| `/supplier/organisation-profile` | Supplier org profile |
+| `/supplier/support` | Supplier support |
+| `/supplier/company-profile` | Supplier company profile → settings |
+| `/service-provider/organisation-profile` | Service Provider org profile |
+| `/service-provider/support` | Service Provider support |
+| `/service-provider/company-profile` | Service Provider settings |
+
+### Subscription-Gated Routes (require active subscription):
+| Route Category | Foundation | Product Supplier | Service Provider |
+|---------------|------------|------------------|------------------|
+| Dashboard | ✅ | ✅ | ✅ |
+| Orders/Requests | ✅ | ✅ | ✅ |
+| Product/Service Listings | - | ✅ | ✅ |
+| Leads | ✅ | - | - |
+| Analytics | ✅ | ✅ | ✅ |
+| Marketplace | ✅ | - | - |
+| Recruitment | ✅ | - | - |
+| HR Procedures | ✅ | - | - |
+| State Policies | ✅ | - | - |
+| E-Learning | ✅ | - | - |
+| Partners Directory | ✅ | ✅ | ✅ |
+| Messages | ✅ | ✅ | ✅ |
+| Notifications | ✅ | ✅ | ✅ |
+
+---
+
+## Conclusion
+
+The subscription system is now **fully unified** across all three business roles. There is:
+
+- **NO role-specific logic** in the core subscription flow
+- **SAME authentication context** for all roles
+- **SAME subscription lookup method** for all roles
+- **SAME admin creation flow** for all roles
+- **SAME frontend paywall behavior** for all roles
+- **CONSISTENT route gating** - only profile, settings, and support are allowed without subscription
+
+The only role-specific elements are:
+1. Plan availability (each role has its own plans)
+2. Foundation-specific "tier" selector in admin UI (cosmetic, for Foundation pricing tiers)
+3. Role-specific feature routes (e.g., Foundation has recruitment, suppliers have product listings)

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -285,44 +285,85 @@ const ProtectedLayout: React.FC = () => {
         <Routes>
           <Route path="/" element={<Navigate to="/dashboard" replace />} />
           <Route path="/dashboard" element={<RoleBasedDashboardRedirect />} />
-          <Route path="/dashboard/details/:detailType" element={<DashboardDetailPage />} />
+          {/* Dashboard details - Gated for subscription-required roles */}
+          <Route path="/dashboard/details/:detailType" element={
+            <SubscriptionGatedRoute roles={[UserRole.FOUNDATION, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER, UserRole.EDUCATOR, UserRole.PARENT, UserRole.ADMIN, UserRole.SUPER_ADMIN]}>
+              <DashboardDetailPage />
+            </SubscriptionGatedRoute>
+          } />
         
+        {/* Marketplace - Gated for Foundation users */}
         <Route path="/marketplace" element={<Navigate to="/marketplace/products" replace />} />
-        <Route path="/marketplace/products" element={<MarketplacePage />} />
-        <Route path="/marketplace/services" element={<MarketplacePage />} />
-        
-        <Route path="/recruitment" element={<Navigate to="/recruitment/job-listings" replace />} />
-        <Route path="/recruitment/job-listings" element={<RecruitmentPage />} />
-        <Route path="/recruitment/candidate-pool" element={<RecruitmentPage />} />
-        <Route path="/candidate/:candidateId" element={
-          <ProtectedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN]}>
-            <CandidateProfilePage />
-          </ProtectedRoute>
+        <Route path="/marketplace/products" element={
+          <SubscriptionGatedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN]}>
+            <MarketplacePage />
+          </SubscriptionGatedRoute>
+        } />
+        <Route path="/marketplace/services" element={
+          <SubscriptionGatedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN]}>
+            <MarketplacePage />
+          </SubscriptionGatedRoute>
         } />
         
+        {/* Recruitment - Gated for Foundation users */}
+        <Route path="/recruitment" element={<Navigate to="/recruitment/job-listings" replace />} />
+        <Route path="/recruitment/job-listings" element={
+          <SubscriptionGatedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN]}>
+            <RecruitmentPage />
+          </SubscriptionGatedRoute>
+        } />
+        <Route path="/recruitment/candidate-pool" element={
+          <SubscriptionGatedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN]}>
+            <RecruitmentPage />
+          </SubscriptionGatedRoute>
+        } />
+        <Route path="/candidate/:candidateId" element={
+          <SubscriptionGatedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN]}>
+            <CandidateProfilePage />
+          </SubscriptionGatedRoute>
+        } />
+        
+        {/* Messages - Gated for subscription-required roles */}
         <Route path="/messages" element={
-          <ProtectedRoute roles={[UserRole.FOUNDATION, UserRole.EDUCATOR, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER, UserRole.PARENT, UserRole.ADMIN, UserRole.SUPER_ADMIN]}>
+          <SubscriptionGatedRoute roles={[UserRole.FOUNDATION, UserRole.EDUCATOR, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER, UserRole.PARENT, UserRole.ADMIN, UserRole.SUPER_ADMIN]}>
             <MessagesPage />
-          </ProtectedRoute>
+          </SubscriptionGatedRoute>
         } />
         <Route path="/messages/:conversationId" element={
-            <ProtectedRoute roles={[UserRole.FOUNDATION, UserRole.EDUCATOR, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER, UserRole.PARENT, UserRole.ADMIN, UserRole.SUPER_ADMIN]}>
+          <SubscriptionGatedRoute roles={[UserRole.FOUNDATION, UserRole.EDUCATOR, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER, UserRole.PARENT, UserRole.ADMIN, UserRole.SUPER_ADMIN]}>
             <MessagesPage />
-          </ProtectedRoute>
+          </SubscriptionGatedRoute>
         } />
 
-        <Route path="/hr-procedures" element={<ProtectedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN]}><HRProceduresPage /></ProtectedRoute>} />
-        <Route path="/state-policies" element={<ProtectedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN]}><StatePoliciesPage /></ProtectedRoute>} />
-        <Route path="/e-learning" element={<ProtectedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN]}><ELearningPage /></ProtectedRoute>} />
-          <Route path="/partners-directory" element={<PartnersPage />} />
-          <Route
-            path="/partner/:partnerId"
-            element={
-              <ProtectedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER]}>
-                <PartnerDetailPage />
-              </ProtectedRoute>
-            }
-          />
+        {/* HR Procedures - Gated for Foundation users */}
+        <Route path="/hr-procedures" element={
+          <SubscriptionGatedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN]}>
+            <HRProceduresPage />
+          </SubscriptionGatedRoute>
+        } />
+        {/* State Policies - Gated for Foundation users */}
+        <Route path="/state-policies" element={
+          <SubscriptionGatedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN]}>
+            <StatePoliciesPage />
+          </SubscriptionGatedRoute>
+        } />
+        {/* E-Learning - Gated for Foundation users */}
+        <Route path="/e-learning" element={
+          <SubscriptionGatedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN]}>
+            <ELearningPage />
+          </SubscriptionGatedRoute>
+        } />
+        {/* Partners directory - Gated for subscription-required roles */}
+        <Route path="/partners-directory" element={
+          <SubscriptionGatedRoute roles={[UserRole.FOUNDATION, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER, UserRole.ADMIN, UserRole.SUPER_ADMIN]}>
+            <PartnersPage />
+          </SubscriptionGatedRoute>
+        } />
+        <Route path="/partner/:partnerId" element={
+          <SubscriptionGatedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER]}>
+            <PartnerDetailPage />
+          </SubscriptionGatedRoute>
+        } />
           <Route path="/users/*" element={<ProtectedRoute roles={[UserRole.ADMIN, UserRole.SUPER_ADMIN]}><UsersPage /></ProtectedRoute>} />
           <Route
             path="/profile"
@@ -497,7 +538,12 @@ const ProtectedLayout: React.FC = () => {
         
         {/* Misc Protected Routes */}
         <Route path="/file-gallery" element={<ProtectedRoute roles={[UserRole.EDUCATOR]}><FileGalleryPage /></ProtectedRoute>} />
-        <Route path="/notifications" element={<ProtectedRoute roles={[UserRole.FOUNDATION, UserRole.EDUCATOR, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER, UserRole.PARENT, UserRole.ADMIN, UserRole.SUPER_ADMIN]}><NotificationsPage /></ProtectedRoute>} />
+        {/* Notifications - Gated for subscription-required roles */}
+        <Route path="/notifications" element={
+          <SubscriptionGatedRoute roles={[UserRole.FOUNDATION, UserRole.EDUCATOR, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER, UserRole.PARENT, UserRole.ADMIN, UserRole.SUPER_ADMIN]}>
+            <NotificationsPage />
+          </SubscriptionGatedRoute>
+        } />
 
         <Route path="*" element={<Navigate to="/dashboard" replace />} />
         </Routes>

--- a/frontend/components/shared/SubscriptionPaywall.tsx
+++ b/frontend/components/shared/SubscriptionPaywall.tsx
@@ -70,6 +70,12 @@ export interface SubscriptionPaywallProps {
 /**
  * Routes that are always accessible without subscription
  * These allow users to manage their account/subscription even without active sub
+ * 
+ * Users should always be able to:
+ * - View/edit their profile and organisation profile
+ * - Access settings
+ * - Access support
+ * - View pricing
  */
 const ALWAYS_ALLOWED_ROUTES = [
   '/pricing',
@@ -77,6 +83,15 @@ const ALWAYS_ALLOWED_ROUTES = [
   '/profile',
   '/settings',
   '/support',
+  // Role-specific profile/support routes
+  '/foundation/organisation-profile',
+  '/foundation/support',
+  '/supplier/organisation-profile',
+  '/supplier/support',
+  '/supplier/company-profile',
+  '/service-provider/organisation-profile',
+  '/service-provider/support',
+  '/service-provider/company-profile',
 ];
 
 /**
@@ -86,7 +101,6 @@ const ALWAYS_ALLOWED_PREFIXES = [
   '/pricing',
   '/settings',
   '/profile',
-  '/support',
 ];
 
 // =====================================


### PR DESCRIPTION
- Update SubscriptionPaywall to allow role-specific profile/support routes
- Convert all Foundation feature routes to use SubscriptionGatedRoute:
  - Marketplace, Recruitment, HR Procedures, State Policies, E-Learning
- Gate Messages and Notifications for subscription-required roles
- Gate Partners Directory and Dashboard Details
- Add comprehensive verification documentation

Users without active subscription can now only access:
- Profile (personal and organization)
- Settings (including billing)
- Support
- Pricing page

All other dashboard features require an active subscription.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive subscription system verification documentation covering unified role configurations, access control, and subscription enforcement.

* **Improvements**
  * Enhanced subscription enforcement across dashboard, marketplace, recruitment, messaging, and HR features.
  * Refined route-based access control to ensure consistent subscription requirements across user roles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->