### PR TITLE
Fix admin dashboard counts and quick actions

### DIFF
--- a/admin/src/pages/Dashboard.tsx
+++ b/admin/src/pages/Dashboard.tsx
@@ -29,9 +29,6 @@ const Dashboard: React.FC = () => {
   const navigate = useNavigate()
   const apiClient = useApiClient()
   const { t } = useTranslation(['dashboard', 'common', 'admin'])
-  const user = {
-    fullName: 'Development User'
-  }
 
   // System health check
   const { data: healthData } = useQuery({
@@ -40,50 +37,10 @@ const Dashboard: React.FC = () => {
     refetchInterval: 120000, // Refresh every 2 minutes instead of 30 seconds
   })
 
-  // Fetch users count directly from users endpoint
-  const { data: usersResponse, isLoading: usersLoading } = useQuery({
-    queryKey: ['dashboard-users-count'],
-    queryFn: () => apiService.getUsers(apiClient, { page: 1, limit: 1 }),
-    enabled: !!apiClient,
-    staleTime: 60000, // Cache for 1 minute
-  })
-
-  // Fetch organizations count directly from organizations endpoint
-  const { data: orgsResponse, isLoading: orgsLoading } = useQuery({
-    queryKey: ['dashboard-orgs-count'],
-    queryFn: () => apiService.getOrganizations(apiClient),
-    enabled: !!apiClient,
-    staleTime: 60000,
-  })
-
-  // Fetch products count directly from products endpoint
-  const { data: productsResponse, isLoading: productsLoading } = useQuery({
-    queryKey: ['dashboard-products-count'],
-    queryFn: () => apiService.getProducts(apiClient),
-    enabled: !!apiClient,
-    staleTime: 60000,
-  })
-
-  // Fetch parent leads count directly from parent-leads endpoint
-  const { data: parentLeadsResponse, isLoading: parentLeadsLoading } = useQuery({
-    queryKey: ['dashboard-parent-leads-count'],
-    queryFn: () => apiService.getParentLeads(apiClient),
-    enabled: !!apiClient,
-    staleTime: 60000,
-  })
-
-  // Fetch job listings count directly from job-listings endpoint
-  const { data: jobListingsResponse, isLoading: jobListingsLoading } = useQuery({
-    queryKey: ['dashboard-job-listings-count'],
-    queryFn: () => apiService.getJobListings(apiClient),
-    enabled: !!apiClient,
-    staleTime: 60000,
-  })
-
-  // Fetch candidates/applications count directly from candidates endpoint
-  const { data: candidatesResponse, isLoading: candidatesLoading } = useQuery({
-    queryKey: ['dashboard-candidates-count'],
-    queryFn: () => apiService.getCandidates(apiClient),
+  // Fetch dashboard counts from analytics endpoint (accurate DB counts)
+  const { data: dashboardCountsResponse, isLoading: countsLoading } = useQuery({
+    queryKey: ['dashboard-counts'],
+    queryFn: () => apiService.getDashboardCounts(apiClient),
     enabled: !!apiClient,
     staleTime: 60000,
   })
@@ -96,46 +53,20 @@ const Dashboard: React.FC = () => {
   const [policiesCount, setPoliciesCount] = useState(0)
   const [contentLoading, setContentLoading] = useState(true)
 
-  const organizations = (() => {
-    const data = orgsResponse?.data?.data as any
-    if (!data) return []
-    if (Array.isArray(data)) return data
-    if (Array.isArray(data.organizations)) return data.organizations
-    return []
-  })()
-
-  // Extract counts directly from API responses - much simpler and more reliable
-  const usersData = (() => {
-    const raw: any = usersResponse?.data?.data
-    // Expected shape: { data: [...], meta: { total } }
-    if (raw && typeof raw === 'object' && raw.meta && typeof raw.meta.total === 'number') {
-      return raw.meta.total
-    }
-    // Fallbacks
-    if (raw && typeof raw === 'object' && typeof raw.total === 'number') {
-      return raw.total
-    }
-    if (Array.isArray(raw)) {
-      return raw.length
-    }
-    if (raw && typeof raw === 'object' && Array.isArray(raw.data)) {
-      return raw.data.length
-    }
-    return 0
-  })()
-  // Dashboard card is specifically "Foundations" (org.type === 'FOUNDATION')
-  const orgsData = organizations.filter((o: any) => o?.type === 'FOUNDATION').length
-  const productsData = productsResponse?.data?.data?.length ?? 0
-  const leadsData = parentLeadsResponse?.data?.data?.length ?? 0
-  const totalJobs = jobListingsResponse?.data?.data?.length ?? 0
-  const totalApplications = candidatesResponse?.data?.data?.length ?? 0
+  const dashboardCounts = dashboardCountsResponse?.data?.data
+  const usersData = dashboardCounts?.totalUsers ?? 0
+  const orgsData = dashboardCounts?.totalFoundations ?? 0
+  const productsData = dashboardCounts?.totalProducts ?? 0
+  const leadsData = dashboardCounts?.totalParentLeads ?? 0
+  const totalJobs = dashboardCounts?.totalJobs ?? 0
+  const totalApplications = dashboardCounts?.totalApplications ?? 0
 
   const stats = [
     {
       name: t('dashboard:sidebar.allUsersTitle', 'Total Users'),
       value: usersData,
       icon: Users,
-      loading: usersLoading,
+      loading: countsLoading,
       color: 'text-swiss-mint',
       bgColor: 'bg-swiss-mint/10',
       link: '/users',
@@ -144,7 +75,7 @@ const Dashboard: React.FC = () => {
       name: t('dashboard:sidebar.foundations', 'Foundations'),
       value: orgsData,
       icon: Building2,
-      loading: orgsLoading,
+      loading: countsLoading,
       color: 'text-swiss-sand',
       bgColor: 'bg-swiss-sand/20',
       link: '/organizations',
@@ -153,7 +84,7 @@ const Dashboard: React.FC = () => {
       name: t('dashboard:sidebar.products', 'Products'),
       value: productsData,
       icon: Package,
-      loading: productsLoading,
+      loading: countsLoading,
       color: 'text-swiss-teal',
       bgColor: 'bg-swiss-teal/10',
       link: '/products',
@@ -162,7 +93,7 @@ const Dashboard: React.FC = () => {
       name: t('dashboard:sidebar.parentLeads', 'Parent Leads'),
       value: leadsData,
       icon: Heart,
-      loading: parentLeadsLoading,
+      loading: countsLoading,
       color: 'text-swiss-coral',
       bgColor: 'bg-swiss-coral/10',
       link: '/parent-leads',
@@ -175,7 +106,7 @@ const Dashboard: React.FC = () => {
       name: t('dashboard:sidebar.jobListings', 'Job Listings'),
       value: totalJobs,
       icon: Briefcase,
-      loading: jobListingsLoading,
+      loading: countsLoading,
       color: 'text-indigo-600',
       bgColor: 'bg-indigo-100',
       link: '/job-listings',
@@ -184,7 +115,7 @@ const Dashboard: React.FC = () => {
       name: t('dashboard:sidebar.applications', 'Applications'),
       value: totalApplications,
       icon: FileText,
-      loading: candidatesLoading,
+      loading: countsLoading,
       color: 'text-purple-600',
       bgColor: 'bg-purple-100',
       link: '/candidates',
@@ -200,7 +131,7 @@ const Dashboard: React.FC = () => {
   })()
 
   // Overall loading state for summary section
-  const statsLoading = usersLoading || orgsLoading || productsLoading || jobListingsLoading
+  const statsLoading = countsLoading
 
   // Fetch content counts
   useEffect(() => {
@@ -485,25 +416,41 @@ const Dashboard: React.FC = () => {
       <Card className="p-6">
         <h2 className="text-lg font-semibold text-swiss-charcoal mb-4">{t('admin:dashboard.quickActions.title', 'Quick Actions')}</h2>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <Card className="p-4 text-left hover:bg-gray-50 transition-colors cursor-pointer" hoverEffect>
+          <Card
+            className="p-4 text-left hover:bg-gray-50 transition-colors cursor-pointer"
+            hoverEffect
+            onClick={() => navigate('/users')}
+          >
             <Users className="h-6 w-6 text-swiss-teal mb-2" />
             <h3 className="font-medium text-swiss-charcoal">{t('admin:dashboard.quickActions.manageUsers.title', 'Manage Users')}</h3>
             <p className="text-sm text-gray-600">{t('admin:dashboard.quickActions.manageUsers.description', 'Add, edit, or remove users')}</p>
           </Card>
 
-          <Card className="p-4 text-left hover:bg-gray-50 transition-colors cursor-pointer" hoverEffect>
+          <Card
+            className="p-4 text-left hover:bg-gray-50 transition-colors cursor-pointer"
+            hoverEffect
+            onClick={() => navigate('/organizations')}
+          >
             <Building2 className="h-6 w-6 text-swiss-mint mb-2" />
             <h3 className="font-medium text-swiss-charcoal">{t('admin:dashboard.quickActions.organizations.title', 'Organizations')}</h3>
             <p className="text-sm text-gray-600">{t('admin:dashboard.quickActions.organizations.description', 'Manage daycare centers')}</p>
           </Card>
 
-          <Card className="p-4 text-left hover:bg-gray-50 transition-colors cursor-pointer" hoverEffect>
+          <Card
+            className="p-4 text-left hover:bg-gray-50 transition-colors cursor-pointer"
+            hoverEffect
+            onClick={() => navigate('/orders')}
+          >
             <ShoppingCart className="h-6 w-6 text-swiss-coral mb-2" />
             <h3 className="font-medium text-swiss-charcoal">{t('admin:dashboard.quickActions.orders.title', 'Orders')}</h3>
             <p className="text-sm text-gray-600">{t('admin:dashboard.quickActions.orders.description', 'View recent orders')}</p>
           </Card>
 
-          <Card className="p-4 text-left hover:bg-gray-50 transition-colors cursor-pointer" hoverEffect>
+          <Card
+            className="p-4 text-left hover:bg-gray-50 transition-colors cursor-pointer"
+            hoverEffect
+            onClick={() => navigate('/system')}
+          >
             <TrendingUp className="h-6 w-6 text-swiss-sand mb-2" />
             <h3 className="font-medium text-swiss-charcoal">{t('admin:dashboard.quickActions.analytics.title', 'Analytics')}</h3>
             <p className="text-sm text-gray-600">{t('admin:dashboard.quickActions.analytics.description', 'View platform metrics')}</p>
@@ -522,28 +469,28 @@ const Dashboard: React.FC = () => {
               <span className="text-gray-400">• {t('dashboard:live', 'Live')}</span>
             </div>
           )}
-          {!usersLoading && usersData > 0 && (
+          {!countsLoading && usersData > 0 && (
             <div className="flex items-center space-x-3 text-sm">
               <div className="w-2 h-2 bg-swiss-mint rounded-full"></div>
               <span className="text-gray-600">{usersData} {t('dashboard:registeredUsers', 'registered users in the platform')}</span>
               <span className="text-gray-400">• {t('dashboard:total', 'Total')}</span>
             </div>
           )}
-          {!orgsLoading && orgsData > 0 && (
+          {!countsLoading && orgsData > 0 && (
             <div className="flex items-center space-x-3 text-sm">
               <div className="w-2 h-2 bg-swiss-sand rounded-full"></div>
               <span className="text-gray-600">{orgsData} {t('dashboard:activeOrganizations', 'active organizations')}</span>
               <span className="text-gray-400">• {t('dashboard:total', 'Total')}</span>
             </div>
           )}
-          {!jobListingsLoading && totalJobs > 0 && (
+          {!countsLoading && totalJobs > 0 && (
             <div className="flex items-center space-x-3 text-sm">
               <div className="w-2 h-2 bg-indigo-500 rounded-full"></div>
               <span className="text-gray-600">{totalJobs} {t('dashboard:jobsPosted', 'job listings posted')}</span>
               <span className="text-gray-400">• {totalApplications} {t('dashboard:sidebar.applications', 'applications')}</span>
             </div>
           )}
-          {!productsLoading && productsData > 0 && (
+          {!countsLoading && productsData > 0 && (
             <div className="flex items-center space-x-3 text-sm">
               <div className="w-2 h-2 bg-swiss-teal rounded-full"></div>
               <span className="text-gray-600">{productsData} {t('dashboard:productsAvailable', 'products in catalog')}</span>

--- a/admin/src/services/api.ts
+++ b/admin/src/services/api.ts
@@ -12,6 +12,7 @@ import {
   ApiResponse,
   InviteUserResponse,
   AnalyticsOverview,
+  AdminDashboardCounts,
   UserAnalytics,
   OrgAnalytics,
   ProductAnalytics,
@@ -664,6 +665,8 @@ export const apiService = {
   // Admin Analytics - Real-time dashboard statistics
   getAnalyticsOverview: (apiClient: AxiosInstance) => 
     apiClient.get<ApiResponse<AnalyticsOverview>>('/admin/analytics/overview'),
+  getDashboardCounts: (apiClient: AxiosInstance) =>
+    apiClient.get<ApiResponse<AdminDashboardCounts>>('/admin/analytics/counts'),
   getUserAnalytics: (apiClient: AxiosInstance, timeRange: '7d' | '30d' | '90d' | '1y' = '30d') => 
     apiClient.get<ApiResponse<UserAnalytics>>('/admin/analytics/users', { params: { timeRange } }),
   getOrganizationAnalytics: (apiClient: AxiosInstance, timeRange: '7d' | '30d' | '90d' | '1y' = '30d') => 

--- a/admin/src/types/api.ts
+++ b/admin/src/types/api.ts
@@ -441,6 +441,16 @@ export interface AnalyticsOverview {
   lastUpdated: string;
 }
 
+export interface AdminDashboardCounts {
+  totalUsers: number;
+  totalFoundations: number;
+  totalProducts: number;
+  totalParentLeads: number;
+  totalJobs: number;
+  totalApplications: number;
+  lastUpdated: string;
+}
+
 export interface LegacyUploadResult {
   id: string;
   url: string;

--- a/api/src/analytics/analytics.controller.ts
+++ b/api/src/analytics/analytics.controller.ts
@@ -18,6 +18,12 @@ export class AnalyticsController {
     return wrapResponse(data);
   }
 
+  @Get('counts')
+  async getDashboardCounts() {
+    const data = await this.analyticsService.getAdminDashboardCounts();
+    return wrapResponse(data);
+  }
+
   @Get('users')
   async getUserGrowthMetrics(@Query('timeRange') timeRange: '7d' | '30d' | '90d' | '1y' = '30d') {
     const data = await this.analyticsService.getUserGrowthMetrics(timeRange);

--- a/api/src/analytics/analytics.service.ts
+++ b/api/src/analytics/analytics.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { OrganizationType, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -318,6 +319,45 @@ export class AnalyticsService {
       jobs: jobMetrics,
       revenue: revenueMetrics,
       system: systemMetrics,
+      lastUpdated: new Date().toISOString(),
+    };
+  }
+
+  async getAdminDashboardCounts() {
+    const safeCount = async (query: Promise<number>): Promise<number> => {
+      try {
+        return await query;
+      } catch (error: unknown) {
+        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2021') {
+          return 0;
+        }
+        throw error;
+      }
+    };
+
+    const [
+      totalUsers,
+      totalFoundations,
+      totalProducts,
+      totalParentLeads,
+      totalJobs,
+      totalApplications,
+    ] = await Promise.all([
+      this.prisma.user.count(),
+      this.prisma.organization.count({ where: { type: OrganizationType.FOUNDATION } }),
+      this.prisma.product.count(),
+      safeCount(this.prisma.parentLead.count()),
+      this.prisma.jobListing.count(),
+      safeCount(this.prisma.jobApplication.count()),
+    ]);
+
+    return {
+      totalUsers,
+      totalFoundations,
+      totalProducts,
+      totalParentLeads,
+      totalJobs,
+      totalApplications,
       lastUpdated: new Date().toISOString(),
     };
   }


### PR DESCRIPTION
### Motivation
- The admin dashboard was showing inaccurate totals because it derived counts from list endpoints and array lengths rather than performing DB-level aggregates.
- Some compat/list endpoints return limited or transformed payloads (e.g. `take: 50`), which made frontend length-based counts unreliable.
- The dashboard needed a single, reliable source of truth for totals and resilient behavior if optional tables are missing.
- Quick action cards on the dashboard were not wired to navigate to the appropriate admin pages.

### Description
- Added a new server-side helper `getAdminDashboardCounts` in `api/src/analytics/analytics.service.ts` that runs Prisma `count()` queries (with safe handling for missing tables) and returns totals for users, foundations, products, parent leads, jobs, and applications.
- Exposed the new endpoint `GET /admin/analytics/counts` in `api/src/analytics/analytics.controller.ts` returning the aggregated counts.
- Updated the admin frontend by adding the `AdminDashboardCounts` type, `apiService.getDashboardCounts` in `admin/src/services/api.ts`, and switching `admin/src/pages/Dashboard.tsx` to call `useQuery(['dashboard-counts'])` and consume the precise counts instead of multiple list calls.
- Wired the Quick Actions cards to navigate to their routes (e.g. `navigate('/users')`, `navigate('/organizations')`, `navigate('/orders')`, `navigate('/system')`) and removed an unused development `user` object.

### Testing
- No automated tests were executed for these changes.
- The change is limited to adding a counts endpoint and updating frontend queries; please run the normal CI/type-check/build in your environment before deploying.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69517940340883258370852f4b93362b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized dashboard data loading by consolidating platform metrics (users, organizations, products, leads, jobs, applications) into a single query endpoint, improving page responsiveness and standardizing loading indicators across all dashboard cards and statistics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->