### PR TITLE
Prevent mock logo flash and make platform logos link to home

### DIFF
--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -1,13 +1,14 @@
 
 
 import React, { useState } from 'react';
-import { NavLink, useNavigate } from 'react-router-dom';
+import { Link, NavLink, useNavigate } from 'react-router-dom';
 import { HomeIcon, ShoppingBagIcon, BriefcaseIcon, DocumentTextIcon, AcademicCapIcon, UsersIcon, CogIcon, BookOpenIcon, BuildingStorefrontIcon, UserGroupIcon, NewspaperIcon, PresentationChartLineIcon, BuildingOfficeIcon, TruckIcon, UserCircleIcon, ChevronDownIcon, ChevronUpIcon, PuzzlePieceIcon, InboxArrowDownIcon, ClipboardDocumentListIcon, SquaresPlusIcon, QuestionMarkCircleIcon, TagIcon, ListBulletIcon, ChatBubbleLeftEllipsisIcon, ChartBarIcon, WrenchScrewdriverIcon, IdentificationIcon, CalendarDaysIcon, XMarkIcon, PaperClipIcon, AdjustmentsHorizontalIcon, SwatchIcon, WalletIcon } from '@heroicons/react/24/outline';
 import { useAppContext } from '../../contexts/AppContext';
 import { useFrontendSettings } from '../../hooks/useFrontendSettings';
 import { UserRole } from '../../types';
 import { useTranslation } from 'react-i18next'; // Import useTranslation
 import { TFunction } from 'i18next'; // Import TFunction for typing
+import { getHomePath } from '../../utils/navigation';
 
 interface NavItem {
   path: string;
@@ -38,6 +39,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onLinkClick, isMobileView }) => {
   
   // Compute sidebar logo URL once - prefer sidebar logo, fall back to main logo
   const sidebarLogoUrl = settings?.sidebarLogoAsset?.publicUrl || settings?.logoAsset?.publicUrl;
+  const homePath = getHomePath(currentUser);
   
   const [openMenus, setOpenMenus] = useState<Record<string, boolean>>({
     'sidebar.content': true, // Corrected key
@@ -169,28 +171,42 @@ const Sidebar: React.FC<SidebarProps> = ({ onLinkClick, isMobileView }) => {
   const isFoundationUser = currentUser?.role === UserRole.FOUNDATION;
   const hasSubscription = currentUser && [UserRole.FOUNDATION, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER].includes(currentUser.role);
 
+  const renderLogo = (imageClassName: string, placeholderClassName: string) => {
+    if (sidebarLogoUrl) {
+      return (
+        <img
+          src={sidebarLogoUrl}
+          alt={settings?.siteName || t('appName')}
+          className={imageClassName}
+        />
+      );
+    }
+
+    if (loading) {
+      return <span className={placeholderClassName} aria-hidden="true" />;
+    }
+
+    return <SquaresPlusIcon className={placeholderClassName} />;
+  };
+
 
   return (
     <div className="w-full md:w-56 lg:w-64 bg-white border-r border-gray-200/80 flex flex-col shadow-sm h-full"> {/* Responsive width for desktop sidebar */}
       {isMobileView && (
         <div className="flex justify-between items-center h-16 sm:h-20 px-3 sm:px-4 border-b border-gray-200/80">
             <div className="flex items-center">
-                {sidebarLogoUrl ? (
-                  <img src={sidebarLogoUrl} alt={settings?.siteName || t('appName')} className="h-12 sm:h-[63px] w-auto mr-2" />
-                ) : (
-                  <SquaresPlusIcon className="h-12 w-12 sm:h-[63px] sm:w-[63px] text-swiss-mint mr-2" />
-                )}
+                <Link to={homePath} aria-label={t('common:buttons.goHome', 'Go to home')}>
+                  {renderLogo('h-12 sm:h-[63px] w-auto mr-2', 'h-12 w-12 sm:h-[63px] sm:w-[63px] text-swiss-mint mr-2')}
+                </Link>
             </div>
           {/* Close button for mobile view - managed by MainLayout now */}
         </div>
       )}
       {!isMobileView && (
         <div className="h-16 lg:h-20 flex items-center justify-center px-3 lg:px-6 border-b border-gray-200/80"> 
-            {sidebarLogoUrl ? (
-              <img src={sidebarLogoUrl} alt={settings?.siteName || t('appName')} className="h-12 lg:h-[69px] w-auto mr-2 lg:mr-2.5" />
-            ) : (
-              <SquaresPlusIcon className="h-12 w-12 lg:h-[69px] lg:w-[69px] text-swiss-mint mr-2 lg:mr-2.5" />
-            )}
+            <Link to={homePath} aria-label={t('common:buttons.goHome', 'Go to home')}>
+              {renderLogo('h-12 lg:h-[69px] w-auto mr-2 lg:mr-2.5', 'h-12 w-12 lg:h-[69px] lg:w-[69px] text-swiss-mint mr-2 lg:mr-2.5')}
+            </Link>
         </div>
       )}
       <nav className="flex-1 p-2 md:p-3 lg:p-4 space-y-1 lg:space-y-1.5 overflow-y-auto"> 

--- a/frontend/pages/LoginPage.tsx
+++ b/frontend/pages/LoginPage.tsx
@@ -10,6 +10,7 @@ import LanguageSwitcher from '../components/ui/LanguageSwitcher';
 import { useAppContext } from '../contexts/AppContext';
 import { useAuthContext } from '../providers/AuthProvider';
 import { useFrontendSettings } from '../hooks/useFrontendSettings';
+import { getHomePath } from '../utils/navigation';
 
 // Social icons
 const GoogleIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
@@ -30,6 +31,29 @@ const LoginPage: React.FC = () => {
   const { currentUser } = useAppContext();
   const { isLoading: isAuthLoading, authError, clearAuthError, logout, isSigningOut: isSigningOutGlobal } = useAuthContext();
   const { settings, loading: settingsLoading, error: settingsError } = useFrontendSettings();
+  const homePath = getHomePath(currentUser);
+  const logoUrl = settings?.logoAsset?.publicUrl;
+  const showLogoFallback = !settingsLoading && !logoUrl;
+
+  const renderLogo = (imageClassName: string, iconClassName: string) => {
+    if (logoUrl) {
+      return (
+        <Link to={homePath} aria-label={t('common:buttons.goHome', 'Go to home')}>
+          <img src={logoUrl} alt={settings?.siteName || APP_NAME} className={imageClassName} />
+        </Link>
+      );
+    }
+
+    if (showLogoFallback) {
+      return (
+        <Link to={homePath} aria-label={t('common:buttons.goHome', 'Go to home')}>
+          <SquaresPlusIcon className={iconClassName} />
+        </Link>
+      );
+    }
+
+    return <span className={imageClassName} aria-hidden="true" />;
+  };
   
   useEffect(() => {
     if (settingsError) {
@@ -190,14 +214,9 @@ const LoginPage: React.FC = () => {
       <div className="min-h-screen bg-page-bg flex flex-col items-center justify-center p-2 sm:p-3 md:p-4 lg:p-6">
         <Card className="w-full max-w-md p-3 sm:p-4 md:p-6 shadow-xl">
           <div className="text-center mb-3 sm:mb-4 md:mb-5">
-            {settings?.logoAsset?.publicUrl ? (
-              <img 
-                src={settings.logoAsset.publicUrl} 
-                alt={settings.siteName || APP_NAME} 
-                className="h-12 sm:h-14 md:h-[72px] w-auto mx-auto mb-1.5 sm:mb-2" 
-              />
-            ) : (
-              <SquaresPlusIcon className="h-10 w-10 sm:h-12 sm:w-12 md:h-14 md:w-14 text-swiss-mint mx-auto mb-1.5 sm:mb-2" />
+            {renderLogo(
+              'h-12 sm:h-14 md:h-[72px] w-auto mx-auto mb-1.5 sm:mb-2',
+              'h-10 w-10 sm:h-12 sm:w-12 md:h-14 md:w-14 text-swiss-mint mx-auto mb-1.5 sm:mb-2'
             )}
             <h1 className="text-base sm:text-lg md:text-xl font-bold text-swiss-charcoal">
               {t('common:loginPage.title', { appName: settings?.siteName || APP_NAME })}
@@ -278,14 +297,9 @@ const LoginPage: React.FC = () => {
       <div className="min-h-screen bg-page-bg flex flex-col items-center justify-center p-2 sm:p-3 md:p-4 lg:p-6">
         <Card className="w-full max-w-md p-3 sm:p-4 md:p-6 shadow-xl">
           <div className="text-center mb-3 sm:mb-4 md:mb-5">
-            {settings?.logoAsset?.publicUrl ? (
-              <img 
-                src={settings.logoAsset.publicUrl} 
-                alt={settings.siteName || APP_NAME} 
-                className="h-12 sm:h-14 md:h-[72px] w-auto mx-auto mb-1.5 sm:mb-2" 
-              />
-            ) : (
-              <SquaresPlusIcon className="h-10 w-10 sm:h-12 sm:w-12 md:h-14 md:w-14 text-swiss-mint mx-auto mb-1.5 sm:mb-2" />
+            {renderLogo(
+              'h-12 sm:h-14 md:h-[72px] w-auto mx-auto mb-1.5 sm:mb-2',
+              'h-10 w-10 sm:h-12 sm:w-12 md:h-14 md:w-14 text-swiss-mint mx-auto mb-1.5 sm:mb-2'
             )}
             <h1 className="text-base sm:text-lg md:text-xl font-bold text-swiss-charcoal">
               {t('common:loginPage.completeRegistration', 'Complete Your Registration')}
@@ -337,14 +351,9 @@ const LoginPage: React.FC = () => {
     <div className="min-h-screen bg-page-bg flex flex-col items-center justify-center p-2 sm:p-3 md:p-4 lg:p-6">
       <Card className="w-full max-w-md p-3 sm:p-4 md:p-6 shadow-xl">
         <div className="text-center mb-3 sm:mb-4 md:mb-5">
-          {settings?.logoAsset?.publicUrl ? (
-            <img 
-              src={settings.logoAsset.publicUrl} 
-              alt={settings.siteName || APP_NAME} 
-              className="h-12 sm:h-14 md:h-[72px] w-auto mx-auto mb-1.5 sm:mb-2" 
-            />
-          ) : (
-            <SquaresPlusIcon className="h-10 w-10 sm:h-12 sm:w-12 md:h-14 md:w-14 text-swiss-mint mx-auto mb-1.5 sm:mb-2" />
+          {renderLogo(
+            'h-12 sm:h-14 md:h-[72px] w-auto mx-auto mb-1.5 sm:mb-2',
+            'h-10 w-10 sm:h-12 sm:w-12 md:h-14 md:w-14 text-swiss-mint mx-auto mb-1.5 sm:mb-2'
           )}
           <h1 className="text-base sm:text-lg md:text-xl font-bold text-swiss-charcoal">
             {t('common:loginPage.title', { appName: settings?.siteName || APP_NAME })}

--- a/frontend/pages/ParentLeadFormPage.tsx
+++ b/frontend/pages/ParentLeadFormPage.tsx
@@ -9,13 +9,37 @@ import { useNavigate, Link } from 'react-router-dom'; // Import Link
 import { UserRole } from '../types'; 
 import { useTranslation } from 'react-i18next';
 import { useFrontendSettings } from '../hooks/useFrontendSettings';
+import { getHomePath } from '../utils/navigation';
 
 const ParentLeadFormPage: React.FC = () => {
   const { t } = useTranslation(['parentLeadForm', 'common']);
   const { submitParentLead, currentUser } = useAppContext(); 
   const navigate = useNavigate();
-  const { settings } = useFrontendSettings();
+  const { settings, loading: settingsLoading } = useFrontendSettings();
   const isParentUser = currentUser?.role === UserRole.PARENT;
+  const homePath = getHomePath(currentUser);
+  const logoUrl = settings?.logoAsset?.publicUrl;
+  const showLogoFallback = !settingsLoading && !logoUrl;
+
+  const renderLogo = (imageClassName: string, iconClassName: string) => {
+    if (logoUrl) {
+      return (
+        <Link to={homePath} aria-label={t('common:buttons.goHome', 'Go to home')}>
+          <img src={logoUrl} alt={settings?.siteName || APP_NAME} className={imageClassName} />
+        </Link>
+      );
+    }
+
+    if (showLogoFallback) {
+      return (
+        <Link to={homePath} aria-label={t('common:buttons.goHome', 'Go to home')}>
+          <SquaresPlusIcon className={iconClassName} />
+        </Link>
+      );
+    }
+
+    return <span className={imageClassName} aria-hidden="true" />;
+  };
   const [formData, setFormData] = useState({
     canton: '',
     municipality: '',
@@ -128,15 +152,7 @@ const ParentLeadFormPage: React.FC = () => {
       <div className="min-h-screen bg-swiss-light-gray flex flex-col items-center justify-center p-4">
         <BackButton maxWidthClass="max-w-lg" />
         <Card className="w-full max-w-lg p-8 text-center">
-            {settings?.logoAsset?.publicUrl ? (
-              <img 
-                src={settings.logoAsset.publicUrl} 
-                alt={settings.siteName || APP_NAME} 
-                className="h-16 w-auto mx-auto mb-4" 
-              />
-            ) : (
-              <SquaresPlusIcon className="h-16 w-16 text-swiss-mint mx-auto mb-4" />
-            )}
+            {renderLogo('h-16 w-auto mx-auto mb-4', 'h-16 w-16 text-swiss-mint mx-auto mb-4')}
           <h1 className="text-2xl font-bold text-swiss-charcoal mb-4">{t('parentLeadForm:messages.success')}</h1>
           {unauthenticatedSuccess ? (
             <>
@@ -162,15 +178,7 @@ const ParentLeadFormPage: React.FC = () => {
     <div className="min-h-screen bg-page-bg flex flex-col items-center justify-center p-6">
       <BackButton maxWidthClass="max-w-2xl" />
       <div className="text-center mb-8">
-        {settings?.logoAsset?.publicUrl ? (
-          <img 
-            src={settings.logoAsset.publicUrl} 
-            alt={settings.siteName || APP_NAME} 
-            className="h-16 w-auto mx-auto mb-2" 
-          />
-        ) : (
-          <SquaresPlusIcon className="h-12 w-12 text-swiss-mint mx-auto mb-2" />
-        )}
+        {renderLogo('h-16 w-auto mx-auto mb-2', 'h-12 w-12 text-swiss-mint mx-auto mb-2')}
         <h1 className="text-3xl font-bold text-swiss-charcoal">{t('parentLeadForm:title')}</h1>
         <p className="text-gray-600">{t('parentLeadForm:subtitle')}</p>
       </div>

--- a/frontend/pages/PricingPage.tsx
+++ b/frontend/pages/PricingPage.tsx
@@ -17,6 +17,7 @@ import SubscriptionRequestModal, { SubscriptionRequestFormData } from '../compon
 import { useSubscription } from '../contexts/SubscriptionContext';
 import { apiService } from '../services/api';
 import type { SubscriptionPlan } from '../contexts/SubscriptionContext';
+import { getHomePath } from '../utils/navigation';
 
 const PricingPage: React.FC = () => {
   const { t } = useTranslation(['pricing', 'common']);
@@ -25,7 +26,10 @@ const PricingPage: React.FC = () => {
   const { currentUser } = useAppContext();
   const { requestSubscription } = useSubscription();
   const { translatePlan } = usePricingTranslations();
-  const { settings } = useFrontendSettings();
+  const { settings, loading: settingsLoading } = useFrontendSettings();
+  const homePath = getHomePath(currentUser);
+  const logoUrl = settings?.logoAsset?.publicUrl;
+  const showLogoFallback = !settingsLoading && !logoUrl;
   const [isAnnual, setIsAnnual] = useState(false);
   const [selectedPlan, setSelectedPlan] = useState<PricingPlan | null>(null);
   const [isRequestModalOpen, setIsRequestModalOpen] = useState(false);
@@ -245,15 +249,17 @@ const PricingPage: React.FC = () => {
   return (
     <div className="bg-page-bg min-h-screen py-12 px-4 sm:px-6 lg:px-8 relative text-swiss-charcoal">
        <div className="absolute top-0 left-0 w-full p-4 sm:p-6 lg:p-8 flex justify-between items-center z-10">
-        <Link to="/login" className="flex items-center space-x-2 text-swiss-charcoal hover:text-swiss-teal transition-colors">
-            {(settings && settings.logoAsset && settings.logoAsset.publicUrl) ? (
+        <Link to={homePath} className="flex items-center space-x-2 text-swiss-charcoal hover:text-swiss-teal transition-colors" aria-label={t('common:buttons.goHome', 'Go to home')}>
+            {logoUrl ? (
               <img 
-                src={settings.logoAsset.publicUrl} 
-                alt={settings.siteName || APP_NAME} 
+                src={logoUrl} 
+                alt={settings?.siteName || APP_NAME} 
                 className="h-10 w-auto" 
               />
-            ) : (
+            ) : showLogoFallback ? (
               <SquaresPlusIcon className="h-8 w-8 text-swiss-mint" />
+            ) : (
+              <span className="h-10 w-10" aria-hidden="true" />
             )}
         </Link>
         <Button variant="light" onClick={() => navigate(-1)} leftIcon={ArrowLeftIcon}>

--- a/frontend/pages/PublicPartnersPage.tsx
+++ b/frontend/pages/PublicPartnersPage.tsx
@@ -5,6 +5,8 @@ import { apiService } from '../services/api';
 import { useTranslation } from 'react-i18next';
 import { useFrontendSettings } from '../hooks/useFrontendSettings';
 import { APP_NAME } from '../constants';
+import { useAppContext } from '../contexts/AppContext';
+import { getHomePath } from '../utils/navigation';
 import Button from '../components/ui/Button';
 import LanguageSwitcher from '../components/ui/LanguageSwitcher';
 import {
@@ -235,7 +237,11 @@ const StatCard: React.FC<{
 
 const PublicPartnersPage: React.FC = () => {
   const { t } = useTranslation(['admin', 'common']);
-  const { settings } = useFrontendSettings();
+  const { settings, loading: settingsLoading } = useFrontendSettings();
+  const { currentUser } = useAppContext();
+  const homePath = getHomePath(currentUser);
+  const logoUrl = settings?.logoAsset?.publicUrl;
+  const showLogoFallback = !settingsLoading && !logoUrl;
   
   const [partners, setPartners] = useState<Partner[]>([]);
   const [loading, setLoading] = useState(true);
@@ -321,20 +327,22 @@ const PublicPartnersPage: React.FC = () => {
       <nav className="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur-lg border-b border-gray-100">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
-            <Link to="/login" className="flex items-center space-x-3 group">
-              {settings?.logoAsset?.publicUrl ? (
+            <Link to={homePath} className="flex items-center space-x-3 group" aria-label={t('common:buttons.goHome', 'Go to home')}>
+              {logoUrl ? (
                 <img
-                  src={settings.logoAsset.publicUrl}
-                  alt={settings.siteName || APP_NAME}
+                  src={logoUrl}
+                  alt={settings?.siteName || APP_NAME}
                   className="h-10 w-auto"
                 />
-              ) : (
+              ) : showLogoFallback ? (
                 <div className="flex items-center gap-2">
                   <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-swiss-mint to-swiss-teal flex items-center justify-center">
                     <SwissFlagIcon className="w-6 h-6 text-white" />
                   </div>
                   <span className="text-xl font-bold text-swiss-charcoal">{APP_NAME}</span>
                 </div>
+              ) : (
+                <span className="h-10 w-10" aria-hidden="true" />
               )}
             </Link>
 
@@ -602,20 +610,24 @@ const PublicPartnersPage: React.FC = () => {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex flex-col md:flex-row items-center justify-between gap-6">
             <div className="flex items-center gap-3">
-              {settings?.logoAsset?.publicUrl ? (
-                <img
-                  src={settings.logoAsset.publicUrl}
-                  alt={settings.siteName || APP_NAME}
-                  className="h-8 w-auto brightness-0 invert"
-                />
-              ) : (
-                <div className="flex items-center gap-2">
-                  <div className="w-8 h-8 rounded-lg bg-swiss-mint flex items-center justify-center">
-                    <SwissFlagIcon className="w-5 h-5 text-white" />
+              <Link to={homePath} className="flex items-center gap-3" aria-label={t('common:buttons.goHome', 'Go to home')}>
+                {logoUrl ? (
+                  <img
+                    src={logoUrl}
+                    alt={settings?.siteName || APP_NAME}
+                    className="h-8 w-auto brightness-0 invert"
+                  />
+                ) : showLogoFallback ? (
+                  <div className="flex items-center gap-2">
+                    <div className="w-8 h-8 rounded-lg bg-swiss-mint flex items-center justify-center">
+                      <SwissFlagIcon className="w-5 h-5 text-white" />
+                    </div>
+                    <span className="text-lg font-bold">{APP_NAME}</span>
                   </div>
-                  <span className="text-lg font-bold">{APP_NAME}</span>
-                </div>
-              )}
+                ) : (
+                  <span className="h-8 w-8" aria-hidden="true" />
+                )}
+              </Link>
             </div>
             
             <div className="flex items-center gap-8 text-sm text-gray-400">

--- a/frontend/pages/SignupPage.tsx
+++ b/frontend/pages/SignupPage.tsx
@@ -14,6 +14,7 @@ import { useFrontendSettings } from '../hooks/useFrontendSettings';
 import { useAuthContext } from '../providers/AuthProvider';
 import { apiService } from '../services/api';
 import { API_ENDPOINTS } from '../services/api-endpoints';
+import { getHomePath } from '../utils/navigation';
 
 const SIGNUP_ROLE_TO_USER_ROLE: Record<SignupRole, UserRole> = {
   [SignupRole.FOUNDATION]: UserRole.FOUNDATION,
@@ -31,6 +32,29 @@ const SignupPage: React.FC = () => {
   const { user: clerkUser } = useUser();
   const { currentUser, refreshCurrentUser, logout, isLoading: isAuthLoading } = useAuthContext();
   const { settings, loading: settingsLoading, error: settingsError } = useFrontendSettings();
+  const homePath = getHomePath(currentUser);
+  const logoUrl = settings?.logoAsset?.publicUrl;
+  const showLogoFallback = !settingsLoading && !logoUrl;
+
+  const renderLogo = (imageClassName: string, iconClassName: string) => {
+    if (logoUrl) {
+      return (
+        <Link to={homePath} aria-label={t('common:buttons.goHome', 'Go to home')}>
+          <img src={logoUrl} alt={settings?.siteName || APP_NAME} className={imageClassName} />
+        </Link>
+      );
+    }
+
+    if (showLogoFallback) {
+      return (
+        <Link to={homePath} aria-label={t('common:buttons.goHome', 'Go to home')}>
+          <SquaresPlusIcon className={iconClassName} />
+        </Link>
+      );
+    }
+
+    return <span className={imageClassName} aria-hidden="true" />;
+  };
 
   // Detect if this is a user who needs to complete their profile (signed in but no backend user)
   // This can happen for:
@@ -746,14 +770,9 @@ const SignupPage: React.FC = () => {
         ) : (
           <>
             <div className="text-center mb-2">
-              {(settings && settings.logoAsset && settings.logoAsset.publicUrl) ? (
-                <img 
-                  src={settings.logoAsset.publicUrl} 
-                  alt={settings.siteName || APP_NAME} 
-                  className="h-14 sm:h-16 md:h-20 w-auto mx-auto mb-2" 
-                />
-              ) : (
-                <SquaresPlusIcon className="w-10 h-10 sm:w-12 sm:h-12 md:w-14 md:h-14 text-swiss-mint mx-auto mb-2" />
+              {renderLogo(
+                'h-14 sm:h-16 md:h-20 w-auto mx-auto mb-2',
+                'w-10 h-10 sm:w-12 sm:h-12 md:w-14 md:h-14 text-swiss-mint mx-auto mb-2'
               )}
               <h1 className="text-lg sm:text-xl md:text-2xl font-bold text-swiss-charcoal">{formTitle}</h1>
               <p className="text-xs sm:text-sm text-gray-500 mt-1">{progressText}</p>

--- a/frontend/utils/navigation.ts
+++ b/frontend/utils/navigation.ts
@@ -1,0 +1,5 @@
+import type { User } from '../types';
+
+export const getHomePath = (user?: User | null): string => {
+  return user ? '/dashboard' : '/login';
+};


### PR DESCRIPTION
### Motivation

- Users saw a brief flash of old/mock logo icons before the real platform logos loaded, which looks like a visual glitch that must be removed.  
- Logos should be clickable and take the user to the appropriate home route (dashboard when authenticated, login when not).  
- Centralize the home-route selection logic to keep navigation consistent across the app.  
- Ensure placeholders do not show while frontend settings are still loading to avoid layout/branding flash.

### Description

- Added a small navigation helper `getHomePath` in `frontend/utils/navigation.ts` to resolve the correct home URL based on `currentUser`.  
- Reworked logo rendering to use a `renderLogo` pattern and to read `loading` from `useFrontendSettings`, so the UI returns an empty placeholder while settings load and only shows the fallback icon after loading completes.  
- Wrapped platform logos in `Link` elements that point to `getHomePath(currentUser)` so logos are clickable and route to the correct home page.  
- Updated the sidebar and public/auth pages to use `useFrontendSettings` loading state and the new logo behavior, touching `frontend/components/layout/Sidebar.tsx`, `frontend/pages/LoginPage.tsx`, `frontend/pages/SignupPage.tsx`, `frontend/pages/ParentLeadFormPage.tsx`, `frontend/pages/PricingPage.tsx`, and `frontend/pages/PublicPartnersPage.tsx`.

### Testing

- No automated tests were executed as part of this change.  
- Static type checks and local runtime verification are recommended before deploying to staging.  
- Manual visual verification should be performed to confirm no placeholder/mock icon flashes and that clicking logos navigates to `'/dashboard'` for authenticated users and `'/login'` otherwise.  
- If desired, add a small Playwright or Cypress test to assert logo click behavior and absence of mock-icon flash after `useFrontendSettings` resolves.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695179e8b5cc83259aa8924593e93a59)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logo now dynamically links to the appropriate home location based on user authentication status.
  * Implemented consistent logo rendering across all pages with fallback icons when custom logos are unavailable.

* **Improvements**
  * Enhanced accessibility with improved ARIA labels on navigation elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->