### PR TITLE
Extract shared `LogoLink` component and replace duplicated `renderLogo` logic

### DIFF
--- a/frontend/components/shared/LogoLink.tsx
+++ b/frontend/components/shared/LogoLink.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+interface LogoLinkProps {
+  to: string;
+  ariaLabel: string;
+  logoUrl?: string | null;
+  altText: string;
+  showFallback: boolean;
+  imageClassName?: string;
+  iconClassName?: string;
+  fallbackIcon?: React.ElementType;
+  fallback?: React.ReactNode;
+  placeholderClassName?: string;
+  className?: string;
+}
+
+const LogoLink: React.FC<LogoLinkProps> = ({
+  to,
+  ariaLabel,
+  logoUrl,
+  altText,
+  showFallback,
+  imageClassName,
+  iconClassName,
+  fallbackIcon: FallbackIcon,
+  fallback,
+  placeholderClassName,
+  className,
+}) => {
+  if (logoUrl) {
+    return (
+      <Link to={to} aria-label={ariaLabel} className={className}>
+        <img src={logoUrl} alt={altText} className={imageClassName} />
+      </Link>
+    );
+  }
+
+  if (showFallback) {
+    return (
+      <Link to={to} aria-label={ariaLabel} className={className}>
+        {fallback ?? (FallbackIcon ? <FallbackIcon className={iconClassName} /> : null)}
+      </Link>
+    );
+  }
+
+  return <span className={placeholderClassName ?? imageClassName} aria-hidden="true" />;
+};
+
+export default LogoLink;

--- a/frontend/pages/LoginPage.tsx
+++ b/frontend/pages/LoginPage.tsx
@@ -11,6 +11,7 @@ import { useAppContext } from '../contexts/AppContext';
 import { useAuthContext } from '../providers/AuthProvider';
 import { useFrontendSettings } from '../hooks/useFrontendSettings';
 import { getHomePath } from '../utils/navigation';
+import LogoLink from '../components/shared/LogoLink';
 
 // Social icons
 const GoogleIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
@@ -34,26 +35,6 @@ const LoginPage: React.FC = () => {
   const homePath = getHomePath(currentUser);
   const logoUrl = settings?.logoAsset?.publicUrl;
   const showLogoFallback = !settingsLoading && !logoUrl;
-
-  const renderLogo = (imageClassName: string, iconClassName: string) => {
-    if (logoUrl) {
-      return (
-        <Link to={homePath} aria-label={t('common:buttons.goHome', 'Go to home')}>
-          <img src={logoUrl} alt={settings?.siteName || APP_NAME} className={imageClassName} />
-        </Link>
-      );
-    }
-
-    if (showLogoFallback) {
-      return (
-        <Link to={homePath} aria-label={t('common:buttons.goHome', 'Go to home')}>
-          <SquaresPlusIcon className={iconClassName} />
-        </Link>
-      );
-    }
-
-    return <span className={imageClassName} aria-hidden="true" />;
-  };
   
   useEffect(() => {
     if (settingsError) {
@@ -214,10 +195,16 @@ const LoginPage: React.FC = () => {
       <div className="min-h-screen bg-page-bg flex flex-col items-center justify-center p-2 sm:p-3 md:p-4 lg:p-6">
         <Card className="w-full max-w-md p-3 sm:p-4 md:p-6 shadow-xl">
           <div className="text-center mb-3 sm:mb-4 md:mb-5">
-            {renderLogo(
-              'h-12 sm:h-14 md:h-[72px] w-auto mx-auto mb-1.5 sm:mb-2',
-              'h-10 w-10 sm:h-12 sm:w-12 md:h-14 md:w-14 text-swiss-mint mx-auto mb-1.5 sm:mb-2'
-            )}
+            <LogoLink
+              to={homePath}
+              ariaLabel={t('common:buttons.goHome', 'Go to home')}
+              logoUrl={logoUrl}
+              altText={settings?.siteName || APP_NAME}
+              showFallback={showLogoFallback}
+              imageClassName="h-12 sm:h-14 md:h-[72px] w-auto mx-auto mb-1.5 sm:mb-2"
+              iconClassName="h-10 w-10 sm:h-12 sm:w-12 md:h-14 md:w-14 text-swiss-mint mx-auto mb-1.5 sm:mb-2"
+              fallbackIcon={SquaresPlusIcon}
+            />
             <h1 className="text-base sm:text-lg md:text-xl font-bold text-swiss-charcoal">
               {t('common:loginPage.title', { appName: settings?.siteName || APP_NAME })}
             </h1>
@@ -297,10 +284,16 @@ const LoginPage: React.FC = () => {
       <div className="min-h-screen bg-page-bg flex flex-col items-center justify-center p-2 sm:p-3 md:p-4 lg:p-6">
         <Card className="w-full max-w-md p-3 sm:p-4 md:p-6 shadow-xl">
           <div className="text-center mb-3 sm:mb-4 md:mb-5">
-            {renderLogo(
-              'h-12 sm:h-14 md:h-[72px] w-auto mx-auto mb-1.5 sm:mb-2',
-              'h-10 w-10 sm:h-12 sm:w-12 md:h-14 md:w-14 text-swiss-mint mx-auto mb-1.5 sm:mb-2'
-            )}
+            <LogoLink
+              to={homePath}
+              ariaLabel={t('common:buttons.goHome', 'Go to home')}
+              logoUrl={logoUrl}
+              altText={settings?.siteName || APP_NAME}
+              showFallback={showLogoFallback}
+              imageClassName="h-12 sm:h-14 md:h-[72px] w-auto mx-auto mb-1.5 sm:mb-2"
+              iconClassName="h-10 w-10 sm:h-12 sm:w-12 md:h-14 md:w-14 text-swiss-mint mx-auto mb-1.5 sm:mb-2"
+              fallbackIcon={SquaresPlusIcon}
+            />
             <h1 className="text-base sm:text-lg md:text-xl font-bold text-swiss-charcoal">
               {t('common:loginPage.completeRegistration', 'Complete Your Registration')}
             </h1>
@@ -351,10 +344,16 @@ const LoginPage: React.FC = () => {
     <div className="min-h-screen bg-page-bg flex flex-col items-center justify-center p-2 sm:p-3 md:p-4 lg:p-6">
       <Card className="w-full max-w-md p-3 sm:p-4 md:p-6 shadow-xl">
         <div className="text-center mb-3 sm:mb-4 md:mb-5">
-          {renderLogo(
-            'h-12 sm:h-14 md:h-[72px] w-auto mx-auto mb-1.5 sm:mb-2',
-            'h-10 w-10 sm:h-12 sm:w-12 md:h-14 md:w-14 text-swiss-mint mx-auto mb-1.5 sm:mb-2'
-          )}
+          <LogoLink
+            to={homePath}
+            ariaLabel={t('common:buttons.goHome', 'Go to home')}
+            logoUrl={logoUrl}
+            altText={settings?.siteName || APP_NAME}
+            showFallback={showLogoFallback}
+            imageClassName="h-12 sm:h-14 md:h-[72px] w-auto mx-auto mb-1.5 sm:mb-2"
+            iconClassName="h-10 w-10 sm:h-12 sm:w-12 md:h-14 md:w-14 text-swiss-mint mx-auto mb-1.5 sm:mb-2"
+            fallbackIcon={SquaresPlusIcon}
+          />
           <h1 className="text-base sm:text-lg md:text-xl font-bold text-swiss-charcoal">
             {t('common:loginPage.title', { appName: settings?.siteName || APP_NAME })}
           </h1>

--- a/frontend/pages/ParentLeadFormPage.tsx
+++ b/frontend/pages/ParentLeadFormPage.tsx
@@ -10,6 +10,7 @@ import { UserRole } from '../types';
 import { useTranslation } from 'react-i18next';
 import { useFrontendSettings } from '../hooks/useFrontendSettings';
 import { getHomePath } from '../utils/navigation';
+import LogoLink from '../components/shared/LogoLink';
 
 const ParentLeadFormPage: React.FC = () => {
   const { t } = useTranslation(['parentLeadForm', 'common']);
@@ -20,26 +21,6 @@ const ParentLeadFormPage: React.FC = () => {
   const homePath = getHomePath(currentUser);
   const logoUrl = settings?.logoAsset?.publicUrl;
   const showLogoFallback = !settingsLoading && !logoUrl;
-
-  const renderLogo = (imageClassName: string, iconClassName: string) => {
-    if (logoUrl) {
-      return (
-        <Link to={homePath} aria-label={t('common:buttons.goHome', 'Go to home')}>
-          <img src={logoUrl} alt={settings?.siteName || APP_NAME} className={imageClassName} />
-        </Link>
-      );
-    }
-
-    if (showLogoFallback) {
-      return (
-        <Link to={homePath} aria-label={t('common:buttons.goHome', 'Go to home')}>
-          <SquaresPlusIcon className={iconClassName} />
-        </Link>
-      );
-    }
-
-    return <span className={imageClassName} aria-hidden="true" />;
-  };
   const [formData, setFormData] = useState({
     canton: '',
     municipality: '',
@@ -152,7 +133,16 @@ const ParentLeadFormPage: React.FC = () => {
       <div className="min-h-screen bg-swiss-light-gray flex flex-col items-center justify-center p-4">
         <BackButton maxWidthClass="max-w-lg" />
         <Card className="w-full max-w-lg p-8 text-center">
-            {renderLogo('h-16 w-auto mx-auto mb-4', 'h-16 w-16 text-swiss-mint mx-auto mb-4')}
+            <LogoLink
+              to={homePath}
+              ariaLabel={t('common:buttons.goHome', 'Go to home')}
+              logoUrl={logoUrl}
+              altText={settings?.siteName || APP_NAME}
+              showFallback={showLogoFallback}
+              imageClassName="h-16 w-auto mx-auto mb-4"
+              iconClassName="h-16 w-16 text-swiss-mint mx-auto mb-4"
+              fallbackIcon={SquaresPlusIcon}
+            />
           <h1 className="text-2xl font-bold text-swiss-charcoal mb-4">{t('parentLeadForm:messages.success')}</h1>
           {unauthenticatedSuccess ? (
             <>
@@ -178,7 +168,16 @@ const ParentLeadFormPage: React.FC = () => {
     <div className="min-h-screen bg-page-bg flex flex-col items-center justify-center p-6">
       <BackButton maxWidthClass="max-w-2xl" />
       <div className="text-center mb-8">
-        {renderLogo('h-16 w-auto mx-auto mb-2', 'h-12 w-12 text-swiss-mint mx-auto mb-2')}
+        <LogoLink
+          to={homePath}
+          ariaLabel={t('common:buttons.goHome', 'Go to home')}
+          logoUrl={logoUrl}
+          altText={settings?.siteName || APP_NAME}
+          showFallback={showLogoFallback}
+          imageClassName="h-16 w-auto mx-auto mb-2"
+          iconClassName="h-12 w-12 text-swiss-mint mx-auto mb-2"
+          fallbackIcon={SquaresPlusIcon}
+        />
         <h1 className="text-3xl font-bold text-swiss-charcoal">{t('parentLeadForm:title')}</h1>
         <p className="text-gray-600">{t('parentLeadForm:subtitle')}</p>
       </div>

--- a/frontend/pages/PricingPage.tsx
+++ b/frontend/pages/PricingPage.tsx
@@ -1,7 +1,7 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate, Link } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { PricingPlan, UserRole, SubscriptionTier } from '../types';
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
@@ -18,6 +18,7 @@ import { useSubscription } from '../contexts/SubscriptionContext';
 import { apiService } from '../services/api';
 import type { SubscriptionPlan } from '../contexts/SubscriptionContext';
 import { getHomePath } from '../utils/navigation';
+import LogoLink from '../components/shared/LogoLink';
 
 const PricingPage: React.FC = () => {
   const { t } = useTranslation(['pricing', 'common']);
@@ -249,19 +250,18 @@ const PricingPage: React.FC = () => {
   return (
     <div className="bg-page-bg min-h-screen py-12 px-4 sm:px-6 lg:px-8 relative text-swiss-charcoal">
        <div className="absolute top-0 left-0 w-full p-4 sm:p-6 lg:p-8 flex justify-between items-center z-10">
-        <Link to={homePath} className="flex items-center space-x-2 text-swiss-charcoal hover:text-swiss-teal transition-colors" aria-label={t('common:buttons.goHome', 'Go to home')}>
-            {logoUrl ? (
-              <img 
-                src={logoUrl} 
-                alt={settings?.siteName || APP_NAME} 
-                className="h-10 w-auto" 
-              />
-            ) : showLogoFallback ? (
-              <SquaresPlusIcon className="h-8 w-8 text-swiss-mint" />
-            ) : (
-              <span className="h-10 w-10" aria-hidden="true" />
-            )}
-        </Link>
+        <LogoLink
+          to={homePath}
+          ariaLabel={t('common:buttons.goHome', 'Go to home')}
+          logoUrl={logoUrl}
+          altText={settings?.siteName || APP_NAME}
+          showFallback={showLogoFallback}
+          imageClassName="h-10 w-auto"
+          iconClassName="h-8 w-8 text-swiss-mint"
+          placeholderClassName="h-10 w-10"
+          fallbackIcon={SquaresPlusIcon}
+          className="flex items-center space-x-2 text-swiss-charcoal hover:text-swiss-teal transition-colors"
+        />
         <Button variant="light" onClick={() => navigate(-1)} leftIcon={ArrowLeftIcon}>
             {t('common:buttons.goBack')}
         </Button>

--- a/frontend/pages/PublicPartnersPage.tsx
+++ b/frontend/pages/PublicPartnersPage.tsx
@@ -9,6 +9,7 @@ import { useAppContext } from '../contexts/AppContext';
 import { getHomePath } from '../utils/navigation';
 import Button from '../components/ui/Button';
 import LanguageSwitcher from '../components/ui/LanguageSwitcher';
+import LogoLink from '../components/shared/LogoLink';
 import {
   BuildingStorefrontIcon,
   ArrowTopRightOnSquareIcon,
@@ -327,24 +328,24 @@ const PublicPartnersPage: React.FC = () => {
       <nav className="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur-lg border-b border-gray-100">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
-            <Link to={homePath} className="flex items-center space-x-3 group" aria-label={t('common:buttons.goHome', 'Go to home')}>
-              {logoUrl ? (
-                <img
-                  src={logoUrl}
-                  alt={settings?.siteName || APP_NAME}
-                  className="h-10 w-auto"
-                />
-              ) : showLogoFallback ? (
+            <LogoLink
+              to={homePath}
+              ariaLabel={t('common:buttons.goHome', 'Go to home')}
+              logoUrl={logoUrl}
+              altText={settings?.siteName || APP_NAME}
+              showFallback={showLogoFallback}
+              imageClassName="h-10 w-auto"
+              placeholderClassName="h-10 w-10"
+              className="flex items-center space-x-3 group"
+              fallback={
                 <div className="flex items-center gap-2">
                   <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-swiss-mint to-swiss-teal flex items-center justify-center">
                     <SwissFlagIcon className="w-6 h-6 text-white" />
                   </div>
                   <span className="text-xl font-bold text-swiss-charcoal">{APP_NAME}</span>
                 </div>
-              ) : (
-                <span className="h-10 w-10" aria-hidden="true" />
-              )}
-            </Link>
+              }
+            />
 
             <div className="flex items-center gap-4">
               <LanguageSwitcher />
@@ -610,24 +611,24 @@ const PublicPartnersPage: React.FC = () => {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex flex-col md:flex-row items-center justify-between gap-6">
             <div className="flex items-center gap-3">
-              <Link to={homePath} className="flex items-center gap-3" aria-label={t('common:buttons.goHome', 'Go to home')}>
-                {logoUrl ? (
-                  <img
-                    src={logoUrl}
-                    alt={settings?.siteName || APP_NAME}
-                    className="h-8 w-auto brightness-0 invert"
-                  />
-                ) : showLogoFallback ? (
+              <LogoLink
+                to={homePath}
+                ariaLabel={t('common:buttons.goHome', 'Go to home')}
+                logoUrl={logoUrl}
+                altText={settings?.siteName || APP_NAME}
+                showFallback={showLogoFallback}
+                imageClassName="h-8 w-auto brightness-0 invert"
+                placeholderClassName="h-8 w-8"
+                className="flex items-center gap-3"
+                fallback={
                   <div className="flex items-center gap-2">
                     <div className="w-8 h-8 rounded-lg bg-swiss-mint flex items-center justify-center">
                       <SwissFlagIcon className="w-5 h-5 text-white" />
                     </div>
                     <span className="text-lg font-bold">{APP_NAME}</span>
                   </div>
-                ) : (
-                  <span className="h-8 w-8" aria-hidden="true" />
-                )}
-              </Link>
+                }
+              />
             </div>
             
             <div className="flex items-center gap-8 text-sm text-gray-400">

--- a/frontend/pages/SignupPage.tsx
+++ b/frontend/pages/SignupPage.tsx
@@ -15,6 +15,7 @@ import { useAuthContext } from '../providers/AuthProvider';
 import { apiService } from '../services/api';
 import { API_ENDPOINTS } from '../services/api-endpoints';
 import { getHomePath } from '../utils/navigation';
+import LogoLink from '../components/shared/LogoLink';
 
 const SIGNUP_ROLE_TO_USER_ROLE: Record<SignupRole, UserRole> = {
   [SignupRole.FOUNDATION]: UserRole.FOUNDATION,
@@ -35,26 +36,6 @@ const SignupPage: React.FC = () => {
   const homePath = getHomePath(currentUser);
   const logoUrl = settings?.logoAsset?.publicUrl;
   const showLogoFallback = !settingsLoading && !logoUrl;
-
-  const renderLogo = (imageClassName: string, iconClassName: string) => {
-    if (logoUrl) {
-      return (
-        <Link to={homePath} aria-label={t('common:buttons.goHome', 'Go to home')}>
-          <img src={logoUrl} alt={settings?.siteName || APP_NAME} className={imageClassName} />
-        </Link>
-      );
-    }
-
-    if (showLogoFallback) {
-      return (
-        <Link to={homePath} aria-label={t('common:buttons.goHome', 'Go to home')}>
-          <SquaresPlusIcon className={iconClassName} />
-        </Link>
-      );
-    }
-
-    return <span className={imageClassName} aria-hidden="true" />;
-  };
 
   // Detect if this is a user who needs to complete their profile (signed in but no backend user)
   // This can happen for:
@@ -770,10 +751,16 @@ const SignupPage: React.FC = () => {
         ) : (
           <>
             <div className="text-center mb-2">
-              {renderLogo(
-                'h-14 sm:h-16 md:h-20 w-auto mx-auto mb-2',
-                'w-10 h-10 sm:w-12 sm:h-12 md:w-14 md:h-14 text-swiss-mint mx-auto mb-2'
-              )}
+              <LogoLink
+                to={homePath}
+                ariaLabel={t('common:buttons.goHome', 'Go to home')}
+                logoUrl={logoUrl}
+                altText={settings?.siteName || APP_NAME}
+                showFallback={showLogoFallback}
+                imageClassName="h-14 sm:h-16 md:h-20 w-auto mx-auto mb-2"
+                iconClassName="w-10 h-10 sm:w-12 sm:h-12 md:w-14 md:h-14 text-swiss-mint mx-auto mb-2"
+                fallbackIcon={SquaresPlusIcon}
+              />
               <h1 className="text-lg sm:text-xl md:text-2xl font-bold text-swiss-charcoal">{formTitle}</h1>
               <p className="text-xs sm:text-sm text-gray-500 mt-1">{progressText}</p>
             </div>


### PR DESCRIPTION
### Motivation
- Consolidate duplicated logo rendering logic present in multiple pages to follow DRY principles. 
- Provide a single, reusable component to handle logo image, fallback icon, and placeholder behavior consistently. 
- Make it easier to customize fallback UI per page and reduce maintenance burden. 

### Description
- Added a new component `frontend/components/shared/LogoLink.tsx` that renders the site logo, a configurable fallback icon or node, or a placeholder span. 
- Replaced local `renderLogo` helper usage with the shared `<LogoLink />` in `frontend/pages/LoginPage.tsx`, `frontend/pages/SignupPage.tsx`, `frontend/pages/ParentLeadFormPage.tsx`, `frontend/pages/PricingPage.tsx`, and `frontend/pages/PublicPartnersPage.tsx`. 
- The `LogoLink` API exposes props like `to`, `ariaLabel`, `logoUrl`, `altText`, `showFallback`, `imageClassName`, `iconClassName`, `fallback`, and `placeholderClassName` for flexible usage. 
- Removed the duplicated `renderLogo` functions and adjusted each page to pass either `fallbackIcon={SquaresPlusIcon}` or a custom `fallback` node where needed. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695187def3008325b69cfe8b2058144b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated logo rendering logic across multiple pages into a single, reusable component.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->