### PR TITLE
Use centralized pedagogy options and enforce i18n labels in FoundationProfileForm

### DIFF
--- a/frontend/components/profile/edit/FoundationProfileForm.tsx
+++ b/frontend/components/profile/edit/FoundationProfileForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SettingsFormData, SwissCanton, SupportedLanguage } from '../../../types';
-import { STANDARD_INPUT_FIELD, SWISS_CANTONS } from '../../../constants';
+import { PEDAGOGY_OPTIONS, STANDARD_INPUT_FIELD, SWISS_CANTONS } from '../../../constants';
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../../../contexts/AppContext';
 import CoverImageSection from './shared/CoverImageSection';
@@ -16,18 +16,6 @@ const SUPPORTED_LANGUAGES_OPTIONS_BASE: { labelKey: string, value: SupportedLang
   { labelKey: 'common:languageSwitcher.en', value: 'EN'},
   { labelKey: 'common:languageSwitcher.fr', value: 'FR'},
   { labelKey: 'common:languageSwitcher.de', value: 'DE'},
-];
-
-const PEDAGOGY_OPTIONS = [
-  'Montessori',
-  'Reggio Emilia',
-  'Waldorf',
-  'Play-based',
-  'Academic-focused',
-  'Bilingual',
-  'Nature-based',
-  'Inclusive',
-  'Other'
 ];
 
 interface FoundationProfileFormProps {
@@ -261,16 +249,16 @@ const FoundationProfileForm: React.FC<FoundationProfileFormProps> = ({ formData,
             <div className="flex flex-wrap gap-2">
               {PEDAGOGY_OPTIONS.map(option => (
                 <button
-                  key={option}
+                  key={option.value}
                   type="button"
-                  onClick={() => handleMultiSelectChange('pedagogy', option)}
+                  onClick={() => handleMultiSelectChange('pedagogy', option.value)}
                   className={`px-3 py-1.5 text-sm font-medium rounded-full border transition-colors duration-150 ${
-                    (formData.pedagogy || []).includes(option)
+                    (formData.pedagogy || []).includes(option.value)
                       ? 'bg-swiss-mint text-white border-swiss-mint'
                       : 'bg-white text-gray-700 border-gray-300 hover:border-swiss-teal'
                   }`}
                 >
-                  {option}
+                  {t(`settings:companyProfile.pedagogyOptions.${option.key}`)}
                 </button>
               ))}
             </div>


### PR DESCRIPTION
### Motivation
- Centralize pedagogy option definitions so the foundation profile uses the same source-of-truth as the rest of the app.
- Remove hardcoded English defaults and enforce translation keys to follow the established i18n workflow.
- Keep stored values consistent by using the shared `value` from the centralized options when persisting selections.

### Description
- Import `PEDAGOGY_OPTIONS` from `frontend/constants.ts` and remove the local `PEDAGOGY_OPTIONS` array in `FoundationProfileForm.tsx`.
- Use `option.value` as the React `key`, the value passed to `handleMultiSelectChange('pedagogy', ...)`, and when checking selection membership.
- Render labels strictly via `t('settings:companyProfile.pedagogyOptions.${option.key}')` with no hardcoded default fallback to ensure translations are used.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695188b15acc832594b3807e6db4e5b1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization by consolidating shared pedagogy options into a centralized constants file. This change maintains existing functionality while enhancing code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->