### PR TITLE
Show city/regions served on foundation profile

### DIFF
--- a/frontend/pages/foundation/FoundationOrganisationProfilePage.tsx
+++ b/frontend/pages/foundation/FoundationOrganisationProfilePage.tsx
@@ -23,7 +23,6 @@ import LoadingSpinner from '../../components/shared/LoadingSpinner';
 import { useAuthenticatedApi } from '../../hooks/useAuthenticatedApi';
 import { useAppContext } from '../../contexts/AppContext';
 import { useNotifications } from '../../contexts/NotificationContext';
-import OrganizationProfileForm from '../../components/settings/OrganizationProfileForm';
 import { UserRole } from '../../types';
 import { PEDAGOGY_KEY_MAP } from '../../constants';
 
@@ -33,6 +32,8 @@ interface FoundationSettingsData {
   phoneNumber?: string;
   address?: string;
   canton?: string;
+  city?: string;
+  regionsServed?: string[];
   languages?: string[];
   capacity?: number;
   pedagogy?: string[];
@@ -48,6 +49,8 @@ interface OrganizationDetails {
   contactPerson?: string | null;
   phoneNumber?: string | null;
   canton?: string | null;
+  city?: string | null;
+  regionsServed?: string[];
   languages?: string[];
   capacity?: number | null;
   pedagogy?: string[];
@@ -194,6 +197,8 @@ const FoundationOrganisationProfilePage: React.FC = () => {
             phoneNumber: '',
             address: '',
             canton: '',
+            city: '',
+            regionsServed: [],
             languages: [],
             capacity: undefined,
             pedagogy: [],
@@ -210,6 +215,8 @@ const FoundationOrganisationProfilePage: React.FC = () => {
           phoneNumber: data.phoneNumber || '',
           address: data.address || '',
           canton: data.canton || '',
+          city: data.city || '',
+          regionsServed: Array.isArray(data.regionsServed) ? data.regionsServed.filter(Boolean) : [],
           languages: Array.isArray(data.languages) ? data.languages.filter(Boolean) : [],
           capacity: typeof data.capacity === 'number' ? data.capacity : undefined,
           pedagogy: Array.isArray(data.pedagogy) ? data.pedagogy.filter(Boolean) : [],
@@ -290,8 +297,10 @@ const FoundationOrganisationProfilePage: React.FC = () => {
   const contactEmail = foundationSettings?.contactEmail || currentUser?.email || notProvidedLabel;
   const phoneNumber = foundationSettings?.phoneNumber || organizationDetails?.phoneNumber || notProvidedLabel;
   const contactPerson = organizationDetails?.contactPerson || notProvidedLabel;
-  const addressLine = foundationSettings?.address || organizationDetails?.region || '';
-  const cantonValue = foundationSettings?.canton || organizationDetails?.canton || '';
+  const cityValue = foundationSettings?.city || organizationDetails?.city || '';
+  const regionsServed = foundationSettings?.regionsServed?.length
+    ? foundationSettings.regionsServed
+    : organizationDetails?.regionsServed ?? [];
   const languages = foundationSettings?.languages?.length
     ? foundationSettings.languages
     : organizationDetails?.languages ?? [];
@@ -320,10 +329,14 @@ const FoundationOrganisationProfilePage: React.FC = () => {
   );
 
   const locationValue =
-    addressLine || cantonValue ? (
+    cityValue || regionsServed.length ? (
       <div className="space-y-1">
-        <span>{addressLine || notProvidedLabel}</span>
-        {cantonValue && <span className="block text-xs text-gray-500">{cantonValue}</span>}
+        {cityValue && <span>{cityValue}</span>}
+        {regionsServed.length > 0 && (
+          <span className="block text-xs text-gray-500">
+            {t('foundationOrganisationProfilePage.labels.regionsServed', 'Regions served')}: {regionsServed.join(', ')}
+          </span>
+        )}
       </div>
     ) : (
       notProvidedLabel
@@ -567,19 +580,43 @@ const FoundationOrganisationProfilePage: React.FC = () => {
           </Card>
 
           <div className="space-y-3">
-            <h3 className="text-lg font-semibold text-swiss-charcoal">
-              {t(
-                'foundationOrganisationProfilePage.sections.edit.title',
-                'Update core organization profile information',
-              )}
-            </h3>
-            <p className="text-sm text-gray-500">
-              {t(
-                'foundationOrganisationProfilePage.sections.edit.subtitle',
-                'Use the form below to adjust capacity, pedagogy and languages. Changes are saved directly to the database.',
-              )}
-            </p>
-            <OrganizationProfileForm />
+            <Card className="p-6 space-y-4">
+              <div>
+                <h3 className="text-lg font-semibold text-swiss-charcoal">
+                  {t('foundationOrganisationProfilePage.sections.summary.title', 'Organization profile summary')}
+                </h3>
+                <p className="text-sm text-gray-500">
+                  {t(
+                    'foundationOrganisationProfilePage.sections.summary.subtitle',
+                    'This overview reflects the latest saved capacity, pedagogy, and language details.',
+                  )}
+                </p>
+              </div>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                <InfoItem
+                  icon={UserGroupIcon}
+                  label={t('common:organizationProfileForm.labels.capacity', 'Capacity')}
+                  value={capacityValue}
+                />
+                <InfoItem
+                  icon={GlobeAltIcon}
+                  label={t('foundationOrganisationProfilePage.labels.languages', 'Languages')}
+                  value={renderTagList(
+                    languages,
+                    t('foundationOrganisationProfilePage.empty.languages', 'No languages added yet.'),
+                  )}
+                />
+                <InfoItem
+                  icon={AcademicCapIcon}
+                  label={t('foundationOrganisationProfilePage.labels.pedagogy', 'Pedagogy')}
+                  value={renderTagList(
+                    pedagogy,
+                    t('foundationOrganisationProfilePage.empty.pedagogy', 'No pedagogy styles recorded.'),
+                    'settings:companyProfile.pedagogyOptions',
+                  )}
+                />
+              </div>
+            </Card>
           </div>
         </>
       )}

--- a/packages/translations/locales/de/common.json
+++ b/packages/translations/locales/de/common.json
@@ -773,6 +773,7 @@
     },
     "labels": {
       "address": "Standort",
+      "regionsServed": "Regions served",
       "contactEmail": "Kontakt-E-Mail",
       "contactPerson": "Kontaktperson",
       "createdAt": "Erstellt",
@@ -787,6 +788,10 @@
     "sections": {
       "contact": {
         "title": "Kontaktinformationen"
+      },
+      "summary": {
+        "subtitle": "This overview reflects the latest saved capacity, pedagogy, and language details.",
+        "title": "Organization profile summary"
       },
       "metadata": {
         "title": "Organisations-Metadaten"

--- a/packages/translations/locales/de/dashboard.json
+++ b/packages/translations/locales/de/dashboard.json
@@ -861,6 +861,7 @@
     },
     "labels": {
       "address": "Standort",
+      "regionsServed": "Regions served",
       "contactEmail": "Primäre E-Mail",
       "contactPerson": "Kontaktperson",
       "createdAt": "Erstellt",
@@ -881,6 +882,10 @@
       "edit": {
         "subtitle": "Verwenden Sie das untenstehende Formular, um Kapazität, Pädagogik und Sprachen anzupassen. Änderungen werden direkt in der Datenbank gespeichert.",
         "title": "Kern-Organisationsprofilinformationen aktualisieren"
+      },
+      "summary": {
+        "subtitle": "This overview reflects the latest saved capacity, pedagogy, and language details.",
+        "title": "Organization profile summary"
       },
       "metadata": {
         "title": "Organisationsmetadaten"

--- a/packages/translations/locales/en/common.json
+++ b/packages/translations/locales/en/common.json
@@ -803,6 +803,7 @@
     },
     "labels": {
       "address": "Location",
+      "regionsServed": "Regions served",
       "contactEmail": "Contact Email",
       "contactPerson": "Contact Person",
       "createdAt": "Created",
@@ -817,6 +818,10 @@
     "sections": {
       "contact": {
         "title": "Contact Information"
+      },
+      "summary": {
+        "subtitle": "This overview reflects the latest saved capacity, pedagogy, and language details.",
+        "title": "Organization profile summary"
       },
       "metadata": {
         "title": "Organization Metadata"

--- a/packages/translations/locales/en/dashboard.json
+++ b/packages/translations/locales/en/dashboard.json
@@ -601,6 +601,7 @@
     },
     "labels": {
       "address": "Location",
+      "regionsServed": "Regions served",
       "contactEmail": "Primary email",
       "contactPerson": "Contact person",
       "createdAt": "Created",
@@ -631,6 +632,10 @@
       "edit": {
         "subtitle": "Use the form below to adjust capacity, pedagogy and languages. Changes are saved directly to the database.",
         "title": "Update core organization profile information"
+      },
+      "summary": {
+        "subtitle": "This overview reflects the latest saved capacity, pedagogy, and language details.",
+        "title": "Organization profile summary"
       },
       "metadata": {
         "title": "Organization metadata"

--- a/packages/translations/locales/fr/common.json
+++ b/packages/translations/locales/fr/common.json
@@ -764,6 +764,7 @@
     },
     "labels": {
       "address": "Localisation",
+      "regionsServed": "Regions served",
       "contactEmail": "Courriel de contact",
       "contactPerson": "Personne de contact",
       "createdAt": "Créé",
@@ -778,6 +779,10 @@
     "sections": {
       "contact": {
         "title": "Informations de contact"
+      },
+      "summary": {
+        "subtitle": "This overview reflects the latest saved capacity, pedagogy, and language details.",
+        "title": "Organization profile summary"
       },
       "metadata": {
         "title": "Métadonnées de l'organisation"

--- a/packages/translations/locales/fr/dashboard.json
+++ b/packages/translations/locales/fr/dashboard.json
@@ -891,6 +891,7 @@
     },
     "labels": {
       "address": "Localisation",
+      "regionsServed": "Regions served",
       "contactEmail": "Email principal",
       "contactPerson": "Personne de contact",
       "createdAt": "Créé",
@@ -911,6 +912,10 @@
       "edit": {
         "subtitle": "Utilisez le formulaire ci-dessous pour ajuster la capacité, la pédagogie et les langues. Les modifications sont enregistrées directement dans la base de données.",
         "title": "Mettre à jour les informations principales du profil de l'organisation"
+      },
+      "summary": {
+        "subtitle": "This overview reflects the latest saved capacity, pedagogy, and language details.",
+        "title": "Organization profile summary"
       },
       "metadata": {
         "title": "Métadonnées de l'organisation"


### PR DESCRIPTION
### Motivation
- Foundation profile must display `city` and `regionsServed` instead of relying on `address`/`canton` which cannot be set.
- The profile summary should be read-only on the profile view while editable fields remain on the edit page.
- All new UI strings must follow the translation workflow so locales are available in the app. 
- Changes should be implemented safely in the UI layer without assuming schema/migration work was necessary for this change.

### Description
- Added `city` and `regionsServed` to the `FoundationSettingsData` and `OrganizationDetails` types and populated them from the settings/profile API responses in `FoundationOrganisationProfilePage.tsx`.
- Replaced the previous editable section (removed `OrganizationProfileForm` usage) with a read-only summary `Card` showing `capacity`, `languages`, and `pedagogy` using `InfoItem` components.
- Updated the location display to render `city` and a labeled, comma-separated `regionsServed` list instead of `address`/`canton` via the `locationValue` expression.
- Added new translation keys (`foundationOrganisationProfilePage.labels.regionsServed` and `foundationOrganisationProfilePage.sections.summary`) in `packages/translations/locales/{en,de,fr}` and updated dashboard/common locales accordingly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69518843e4dc8325b5c267e5b03cec44)