### PR TITLE
Remove duplicate organisation profile summary

### DIFF
--- a/frontend/pages/foundation/FoundationOrganisationProfilePage.tsx
+++ b/frontend/pages/foundation/FoundationOrganisationProfilePage.tsx
@@ -579,45 +579,6 @@ const FoundationOrganisationProfilePage: React.FC = () => {
             )}
           </Card>
 
-          <div className="space-y-3">
-            <Card className="p-6 space-y-4">
-              <div>
-                <h3 className="text-lg font-semibold text-swiss-charcoal">
-                  {t('foundationOrganisationProfilePage.sections.summary.title', 'Organization profile summary')}
-                </h3>
-                <p className="text-sm text-gray-500">
-                  {t(
-                    'foundationOrganisationProfilePage.sections.summary.subtitle',
-                    'This overview reflects the latest saved capacity, pedagogy, and language details.',
-                  )}
-                </p>
-              </div>
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                <InfoItem
-                  icon={UserGroupIcon}
-                  label={t('common:organizationProfileForm.labels.capacity', 'Capacity')}
-                  value={capacityValue}
-                />
-                <InfoItem
-                  icon={GlobeAltIcon}
-                  label={t('foundationOrganisationProfilePage.labels.languages', 'Languages')}
-                  value={renderTagList(
-                    languages,
-                    t('foundationOrganisationProfilePage.empty.languages', 'No languages added yet.'),
-                  )}
-                />
-                <InfoItem
-                  icon={AcademicCapIcon}
-                  label={t('foundationOrganisationProfilePage.labels.pedagogy', 'Pedagogy')}
-                  value={renderTagList(
-                    pedagogy,
-                    t('foundationOrganisationProfilePage.empty.pedagogy', 'No pedagogy styles recorded.'),
-                    'settings:companyProfile.pedagogyOptions',
-                  )}
-                />
-              </div>
-            </Card>
-          </div>
         </>
       )}
     </div>


### PR DESCRIPTION
### Motivation
- The foundation organisation profile page contained a repeated "Organization profile summary" card which duplicates information already shown elsewhere on the page. 
- Removing the duplicate reduces visual clutter and avoids confusing users with repeated data. 

### Description
- Deleted the duplicate summary card JSX that rendered the summary header and the three `InfoItem` entries (capacity, languages, pedagogy) from `frontend/pages/foundation/FoundationOrganisationProfilePage.tsx`.
- The rest of the page (metadata card, booking/direct order links, and the remaining profile content) is unchanged.

### Testing
- No automated tests were executed for this change.
- A lint/build/test run was not requested as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951912649e88325aa936adc56edc76a)