### PR TITLE
Avoid blocking UI when reloading profile after save

### DIFF
--- a/frontend/pages/ProfileEditPage.tsx
+++ b/frontend/pages/ProfileEditPage.tsx
@@ -304,8 +304,8 @@ const ProfileEditPage: React.FC = () => {
           type: 'success',
         });
         
-        // Reload profile data to reflect changes
-        await loadProfileData();
+        // Reload profile data to reflect changes without blocking UI state
+        void loadProfileData();
         
         // Hide success message after 3 seconds
         setTimeout(() => setSaveSuccess(false), 3000);


### PR DESCRIPTION
### Motivation
- The profile edit page could leave the save UI (toast/Save button) stuck in a saving state after a successful save because the code awaited a profile reload.
- Waiting for the reload made the UI remain busy until the network reload finished, causing poor feedback to the user.

### Description
- Stop awaiting the post-save profile reload by replacing `await loadProfileData()` with `void loadProfileData()` in `frontend/pages/ProfileEditPage.tsx` so the UI can clear saving state immediately.
- The change keeps the reload behavior (profile data is still refreshed) but does not block the `isSaving`/toast flow.
- Only `frontend/pages/ProfileEditPage.tsx` was modified.

### Testing
- No automated tests were run for this change.
- The change is a small non-functional improvement that should be covered by existing UI/CI tests when run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69527872e3108325bd236421efee05b0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile save experience by allowing the UI to update faster while profile data loads in the background.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->