### PR TITLE
Include user id in Prisma select for Clerk auth guard

### DIFF
--- a/api/src/auth/guards/clerk-auth.guard.ts
+++ b/api/src/auth/guards/clerk-auth.guard.ts
@@ -139,7 +139,7 @@ export class ClerkAuthGuard implements CanActivate {
         // Also fetch the User profile record
         const userProfile = await this.prisma.user.findUnique({
           where: { clerkId: payload.sub },
-          select: { isActive: true, deactivatedReasonText: true },
+          select: { id: true, isActive: true, deactivatedReasonText: true },
         });
         if (userProfile && userProfile.isActive === false) {
           const message =


### PR DESCRIPTION
### Motivation
- Ensure downstream references to `userProfile.id` are safe by selecting the `id` field from the database.
- Preserve existing suspension checks that rely on `userProfile.isActive` and `deactivatedReasonText`.
- Allow determination of a user’s primary organization by using the selected `id` for `userOrganization` lookup.

### Description
- Added `id: true` to the `select` object in the `prisma.user.findUnique` call inside the Clerk auth guard.
- Kept existing suspension handling logic that throws an `HttpException` when `isActive` is `false` and includes the deactivation reason.
- Continued to populate `request.clerk` and `request.context` for role/organization resolution without other behavioral changes.

### Testing
- No automated tests were run for this change.
- No test failures reported because no tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952aa46dd288325a0662ee3c58cca73)