### PR TITLE
Add candidate pool column and editor for admin candidates page

### DIFF
--- a/admin/src/components/EditUserModal.tsx
+++ b/admin/src/components/EditUserModal.tsx
@@ -12,9 +12,18 @@ export interface EditUserModalProps {
   onSave: (user: User) => Promise<void>
   isLoading: boolean
   currentUserRole?: UserRole
+  showCandidatePoolControls?: boolean
 }
 
-const EditUserModal: React.FC<EditUserModalProps> = ({ isOpen, onClose, user, onSave, isLoading, currentUserRole }) => {
+const EditUserModal: React.FC<EditUserModalProps> = ({
+  isOpen,
+  onClose,
+  user,
+  onSave,
+  isLoading,
+  currentUserRole,
+  showCandidatePoolControls,
+}) => {
   const [formData, setFormData] = useState<Partial<User>>({})
   const { t } = useTranslation(['common', 'admin'])
   const [error, setError] = useState<string | null>(null)
@@ -29,10 +38,11 @@ const EditUserModal: React.FC<EditUserModalProps> = ({ isOpen, onClose, user, on
         lastName: user.lastName || '',
         role: user.role,
         status: user.status,
+        candidatePoolVisible: showCandidatePoolControls ? Boolean(user.candidatePoolVisible) : undefined,
       })
       setError(null)
     }
-  }, [user, isOpen])
+  }, [user, isOpen, showCandidatePoolControls])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -53,6 +63,9 @@ const EditUserModal: React.FC<EditUserModalProps> = ({ isOpen, onClose, user, on
         lastName: formData.lastName,
         role: formData.role,
         status: formData.status,
+        ...(showCandidatePoolControls
+          ? { candidatePoolVisible: Boolean(formData.candidatePoolVisible) }
+          : {}),
       } as User
       await onSave(updatePayload)
     } catch (err) {
@@ -162,6 +175,28 @@ const EditUserModal: React.FC<EditUserModalProps> = ({ isOpen, onClose, user, on
                 <option value={UserStatus.INACTIVE}>{t('common:inactive')}</option>
               </select>
             </div>
+
+            {showCandidatePoolControls && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  {t('admin:users.editUser.candidatePool', 'Candidate pool')}
+                </label>
+                <select
+                  className={STANDARD_INPUT_FIELD}
+                  value={formData.candidatePoolVisible ? 'true' : 'false'}
+                  onChange={(e) =>
+                    setFormData({ ...formData, candidatePoolVisible: e.target.value === 'true' })
+                  }
+                >
+                  <option value="true">
+                    {t('admin:users.editUser.candidatePoolIn', 'In pool')}
+                  </option>
+                  <option value="false">
+                    {t('admin:users.editUser.candidatePoolOut', 'Not in pool')}
+                  </option>
+                </select>
+              </div>
+            )}
           </div>
 
           <div className="px-6 py-4 bg-gray-50 border-t border-gray-200 flex justify-end space-x-3">

--- a/admin/src/pages/Candidates.tsx
+++ b/admin/src/pages/Candidates.tsx
@@ -82,14 +82,6 @@ const Candidates: React.FC = () => {
     },
   })
 
-  const toggleCandidatePoolVisibilityMutation = useMutation({
-    mutationFn: ({ appUserId, candidatePoolVisible }: { appUserId: string; candidatePoolVisible: boolean }) =>
-      apiService.updateUser(apiClient, appUserId, { candidatePoolVisible } as any),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['candidates'] })
-    },
-  })
-
   const handleCreateCandidate = async (data: CandidateFormData) => {
     await createCandidateMutation.mutateAsync(data)
   }
@@ -189,6 +181,7 @@ const Candidates: React.FC = () => {
         onSave={handleUpdateUser}
         isLoading={updateUserMutation.isPending}
         currentUserRole={currentUser?.role}
+        showCandidatePoolControls
       />
 
       {/* Filters */}
@@ -239,6 +232,9 @@ const Candidates: React.FC = () => {
                   {t('admin:candidates.table.status')}
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  {t('admin:candidates.table.pool', 'POOL')}
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   {t('admin:candidates.table.appliedDate')}
                 </th>
                 <th className="relative px-6 py-3">
@@ -254,6 +250,7 @@ const Candidates: React.FC = () => {
                 const position = candidate.currentRoleOrTitle || candidate.role
                 const status = candidate.availabilityStatus || ''
                 const appliedDate = candidate.createdAt
+                const isInPool = Boolean(candidate.candidatePoolVisible)
                 return (
                   <tr key={candidate.id} className="hover:bg-gray-50">
                     <td className="px-6 py-4 whitespace-nowrap">
@@ -287,6 +284,17 @@ const Candidates: React.FC = () => {
                       </span>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
+                      <span
+                        className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+                          isInPool ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-700'
+                        }`}
+                      >
+                        {isInPool
+                          ? t('admin:candidates.poolStatus.inPool', 'In pool')
+                          : t('admin:candidates.poolStatus.outOfPool', 'Not in pool')}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
                       <div className="text-sm text-gray-900 flex items-center">
                         <Calendar className="h-4 w-4 mr-1" />
                         {appliedDate ? new Date(appliedDate).toLocaleDateString() : ''}
@@ -316,25 +324,6 @@ const Candidates: React.FC = () => {
                                   >
                                     <FileText className="h-4 w-4 mr-2" />
                                     {t('admin:candidates.actions.viewProfile', 'View Profile')}
-                                  </button>
-                                )}
-                              </Menu.Item>
-                              <Menu.Item>
-                                {({ active }) => (
-                                  <button
-                                    className={`${active ? 'bg-gray-100' : ''} flex items-center w-full px-4 py-2 text-sm text-gray-700`}
-                                    onClick={() =>
-                                      toggleCandidatePoolVisibilityMutation.mutate({
-                                        appUserId: candidate.id,
-                                        candidatePoolVisible: !(candidate as any).candidatePoolVisible,
-                                      })
-                                    }
-                                    disabled={toggleCandidatePoolVisibilityMutation.isPending}
-                                  >
-                                    <UserCheck className="h-4 w-4 mr-2" />
-                                    {(candidate as any).candidatePoolVisible
-                                      ? t('admin:candidates.actions.removeFromPool', 'Remove from pool')
-                                      : t('admin:candidates.actions.addToPool', 'Add to pool')}
                                   </button>
                                 )}
                               </Menu.Item>

--- a/packages/translations/locales/de/admin.json
+++ b/packages/translations/locales/de/admin.json
@@ -1084,6 +1084,9 @@
       "email": "E-Mail",
       "role": "Rolle",
       "status": "Status",
+      "candidatePool": "Kandidatenpool",
+      "candidatePoolIn": "Im Pool",
+      "candidatePoolOut": "Nicht im Pool",
       "emailRequired": "E-Mail ist erforderlich",
       "updateFailed": "Fehler beim Aktualisieren des Benutzers",
       "saveChanges": "Änderungen speichern",
@@ -1159,7 +1162,12 @@
       "experience": "ERFAHRUNG",
       "candidate": "KANDIDAT",
       "position": "POSITION",
-      "status": "STATUS"
+      "status": "STATUS",
+      "pool": "POOL"
+    },
+    "poolStatus": {
+      "inPool": "Im Pool",
+      "outOfPool": "Nicht im Pool"
     },
     "statusFilter": {
       "all": "Alle Status"

--- a/packages/translations/locales/en/admin.json
+++ b/packages/translations/locales/en/admin.json
@@ -1058,6 +1058,9 @@
       "email": "Email",
       "role": "Role",
       "status": "Status",
+      "candidatePool": "Candidate pool",
+      "candidatePoolIn": "In pool",
+      "candidatePoolOut": "Not in pool",
       "emailRequired": "Email is required",
       "updateFailed": "Failed to update user",
       "saveChanges": "Save Changes",
@@ -1151,7 +1154,12 @@
       "experience": "EXPERIENCE",
       "candidate": "CANDIDATE",
       "position": "POSITION",
-      "status": "STATUS"
+      "status": "STATUS",
+      "pool": "POOL"
+    },
+    "poolStatus": {
+      "inPool": "In pool",
+      "outOfPool": "Not in pool"
     },
     "statusFilter": {
       "all": "All Status"

--- a/packages/translations/locales/fr/admin.json
+++ b/packages/translations/locales/fr/admin.json
@@ -1084,6 +1084,9 @@
       "email": "E-mail",
       "role": "Rôle",
       "status": "Statut",
+      "candidatePool": "Groupe de candidats",
+      "candidatePoolIn": "Dans le groupe",
+      "candidatePoolOut": "Hors du groupe",
       "emailRequired": "L'e-mail est requis",
       "updateFailed": "Échec de la mise à jour de l'utilisateur",
       "saveChanges": "Enregistrer les modifications",
@@ -1159,7 +1162,12 @@
       "experience": "EXPÉRIENCE",
       "candidate": "CANDIDAT",
       "position": "POSTE",
-      "status": "STATUT"
+      "status": "STATUT",
+      "pool": "GROUPE"
+    },
+    "poolStatus": {
+      "inPool": "Dans le groupe",
+      "outOfPool": "Hors du groupe"
     },
     "statusFilter": {
       "all": "Tous les statuts"


### PR DESCRIPTION
### Motivation
- Surface whether a candidate is visible in the candidate pool directly in the admin candidates table instead of only providing a single-action button.
- Reuse the existing edit modal UX so admins can add/remove candidates from the pool and manage related fields in one place.
- Keep UI changes localized to the admin frontend and translation namespaces.

### Description
- Added a `POOL` column with status badges to `admin/src/pages/Candidates.tsx` and removed the single-click toggle action from the row menu.
- Extended `EditUserModal` (`admin/src/components/EditUserModal.tsx`) with a `showCandidatePoolControls` prop and UI to edit `candidatePoolVisible`, and include it in the update payload when enabled.
- Passed `showCandidatePoolControls` into the candidates page modal so admins can edit pool membership from the modal.
- Added translation keys and strings for the new column and modal labels in `packages/translations/locales/{en,fr,de}/admin.json`.

### Testing
- Started the admin dev server with `pnpm --filter admin dev` to verify the UI changes load locally (server started successfully).
- Ran an automated Playwright script to open `/candidates` and capture a screenshot at `artifacts/admin-candidates-pool-column.png`, and the navigation/screenshot completed successfully.
- No unit tests or type-check runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952a8fb1b348325b6242272cff9a81d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a candidate pool status column to the candidates table, displaying membership status for each candidate.
  * Added candidate pool controls to the user editor modal.

* **Documentation**
  * Added translations for candidate pool terminology in German, English, and French.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->