### PR TITLE
Candidate pool edit user

### DIFF
--- a/admin/src/components/EditUserModal.tsx
+++ b/admin/src/components/EditUserModal.tsx
@@ -66,7 +66,7 @@ const EditUserModal: React.FC<EditUserModalProps> = ({
       // Only send fields that are allowed by the UpdateUserDto
       // The DTO whitelist allows: email, firstName, lastName, role, orgId, phoneNumber, address, avatarUrl, status
       const updatePayload = {
-        id: user!.id,
+        id: user.id,
         email: formData.email,
         firstName: formData.firstName,
         lastName: formData.lastName,

--- a/admin/src/components/EditUserModal.tsx
+++ b/admin/src/components/EditUserModal.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { User } from '../types/api'
 import { UserRole, UserStatus } from '../types'
 import { STANDARD_INPUT_FIELD } from '../constants/design-system'
+import LoadingSpinner from '../components/ui/LoadingSpinner'
 
 export interface EditUserModalProps {
   isOpen: boolean
@@ -11,6 +12,8 @@ export interface EditUserModalProps {
   user: User | null
   onSave: (user: User) => Promise<void>
   isLoading: boolean
+  /** When true, show a loading state even if `user` is null */
+  isFetchingUser?: boolean
   currentUserRole?: UserRole
   showCandidatePoolControls?: boolean
 }
@@ -21,6 +24,7 @@ const EditUserModal: React.FC<EditUserModalProps> = ({
   user,
   onSave,
   isLoading,
+  isFetchingUser,
   currentUserRole,
   showCandidatePoolControls,
 }) => {
@@ -48,6 +52,11 @@ const EditUserModal: React.FC<EditUserModalProps> = ({
     e.preventDefault()
     setError(null)
 
+    if (!user) {
+      setError(t('admin:users.editUser.loadFailed', 'Failed to load user'))
+      return
+    }
+
     if (!formData.email) {
       setError(t('admin:users.editUser.emailRequired', 'Email is required'))
       return
@@ -73,7 +82,51 @@ const EditUserModal: React.FC<EditUserModalProps> = ({
     }
   }
 
-  if (!isOpen || !user) return null
+  if (!isOpen) return null
+
+  // Show a visible modal immediately, even while user data is loading.
+  if (!user) {
+    return (
+      <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50">
+        <div className="w-full max-w-lg bg-white shadow-xl rounded-lg overflow-hidden">
+          <div className="flex justify-between items-center px-6 py-4 border-b border-gray-200">
+            <h2 className="text-xl font-semibold text-gray-900">{t('admin:users.editUser.title', 'Edit User')}</h2>
+            <button
+              onClick={onClose}
+              className="p-1 rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors"
+              disabled={isLoading}
+            >
+              <X className="w-6 h-6" />
+            </button>
+          </div>
+
+          <div className="p-8">
+            {isFetchingUser ? (
+              <div className="flex items-center justify-center gap-3 text-gray-600">
+                <LoadingSpinner />
+                <span>{t('admin:users.editUser.loading', 'Loading user...')}</span>
+              </div>
+            ) : (
+              <div className="text-sm text-red-600">
+                {t('admin:users.editUser.loadFailed', 'Failed to load user')}
+              </div>
+            )}
+          </div>
+
+          <div className="px-6 py-4 bg-gray-50 border-t border-gray-200 flex justify-end">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isLoading}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 disabled:opacity-50"
+            >
+              {t('common:close', 'Close')}
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   const canAssignSuperAdmin = currentUserRole === UserRole.SUPER_ADMIN
   const isEditingSuperAdmin = user.role === UserRole.SUPER_ADMIN

--- a/admin/src/pages/Candidates.tsx
+++ b/admin/src/pages/Candidates.tsx
@@ -87,7 +87,8 @@ const Candidates: React.FC = () => {
   }
 
   const handleEditUser = (candidate: Candidate) => {
-    setSelectedUserId(candidate.id)
+    // Prefer profileId when available; backend supports either profileId or appUserId.
+    setSelectedUserId(candidate.profileId || candidate.id)
     setIsEditModalOpen(true)
   }
 
@@ -175,11 +176,12 @@ const Candidates: React.FC = () => {
       />
 
       <EditUserModal
-        isOpen={isEditModalOpen && !isSelectedUserLoading}
+        isOpen={isEditModalOpen}
         onClose={handleCloseEditModal}
         user={selectedUser}
         onSave={handleUpdateUser}
         isLoading={updateUserMutation.isPending}
+        isFetchingUser={isSelectedUserLoading}
         currentUserRole={currentUser?.role}
         showCandidatePoolControls
       />

--- a/admin/src/pages/Users.tsx
+++ b/admin/src/pages/Users.tsx
@@ -1251,6 +1251,7 @@ const Users: React.FC = () => {
         user={selectedUser}
         onSave={handleUpdateUser}
         isLoading={updateUserMutation.isPending}
+        isFetchingUser={false}
         currentUserRole={currentUser?.role}
       />
 

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -1102,12 +1102,33 @@ export class UsersService {
   }
 
   async update(id: string, updateUserDto: UpdateUserDto, changedBy?: string, callerRole?: UserRole) {
-    const appUser = await this.prisma.appUser.findUnique({
-      where: { id },
-    });
+    // Admin UIs may pass either AppUser.id (account id) OR User.id (profile id).
+    // Support both to keep edit flows (e.g. candidate pool) reliable.
+    let appUser = await this.prisma.appUser.findUnique({ where: { id } });
+    let appUserId = id;
 
     if (!appUser) {
-      throw new NotFoundException('User not found');
+      const profile = await this.prisma.user.findUnique({ where: { id } });
+      if (!profile) {
+        throw new NotFoundException('User not found');
+      }
+
+      // Ensure an AppUser exists for the profile's clerkId so updates can proceed.
+      const existingAppUser = await this.prisma.appUser.findUnique({
+        where: { clerkId: profile.clerkId },
+      });
+
+      appUser =
+        existingAppUser ??
+        (await this.prisma.appUser.create({
+          data: {
+            clerkId: profile.clerkId,
+            email: profile.email,
+            role: profile.role,
+          },
+        }));
+
+      appUserId = appUser.id;
     }
 
     // Check if role is changing - if so, validate and use RoleSyncService for proper Clerk sync
@@ -1131,7 +1152,7 @@ export class UsersService {
       // Handle role change through RoleSyncService (includes Clerk sync)
       if (isRoleChanging && targetRole) {
         await this.roleSyncService.changeRole({
-          appUserId: id,
+          appUserId: appUserId,
           newRole: targetRole,
           changedBy: changedBy || 'system',
           reason: isElevatingToAdmin ? `Role elevation from ${previousRole} to ${targetRole}` : 'Admin user update',
@@ -1141,7 +1162,7 @@ export class UsersService {
 
       // Update AppUser table (non-role fields)
       const updatedAppUser = await tx.appUser.update({
-        where: { id },
+        where: { id: appUserId },
         data: {
           email: updateUserDto.email || appUser.email,
           // Role is already handled by RoleSyncService above
@@ -1236,12 +1257,12 @@ export class UsersService {
     // This ensures the user can log in with their new email
     const isEmailChanging = updateUserDto.email && updateUserDto.email !== appUser.email;
     if (isEmailChanging && updateUserDto.email) {
-      this.logger.log(`📧 [UPDATE] Email changed for user ${id}, syncing to Clerk...`);
+      this.logger.log(`📧 [UPDATE] Email changed for user ${appUserId}, syncing to Clerk...`);
       await this.syncEmailToClerkWithFallback(appUser.clerkId, updateUserDto.email);
     }
 
     // Fetch the latest role (in case it was updated by RoleSyncService)
-    const latestAppUser = await this.prisma.appUser.findUnique({ where: { id } });
+    const latestAppUser = await this.prisma.appUser.findUnique({ where: { id: appUserId } });
 
     // Return the fully refreshed user profile (ensures status/isActive/candidatePoolVisible are correct)
     return this.findByClerkId(updatedAppUser.clerkId);


### PR DESCRIPTION
Improve the "Edit User" button functionality on the candidate pool page by showing a loading state immediately and allowing the backend to update users by either profile or app user ID.

The "Edit User" button on the candidate pool page appeared unresponsive because the modal only rendered after user data was fully loaded. If the fetch was slow or failed, the UI showed nothing. Additionally, the ID passed to the backend could be a profile ID instead of an app user ID, causing update failures. This PR addresses both issues by making the modal open immediately with a loading state and enabling the backend to resolve and update users using either ID type.

---
<a href="https://cursor.com/background-agent?bcId=bc-554b9812-9b6b-45fe-8092-72601fadec97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-554b9812-9b6b-45fe-8092-72601fadec97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit modal now stays open and shows a loading spinner or "Failed to load user" message while fetching user data.
  * Support for selecting and updating users via profile-based IDs, improving edit coverage for profiles without primary accounts.

* **Bug Fixes**
  * Prevents submitting edits when user data hasn't loaded.
  * Improved handling of updates and role changes when user records are resolved/created during edits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->