### PR TITLE
Normalize `GET /users/:id` response and fix candidate edit user loading

### DIFF
--- a/admin/src/pages/Candidates.tsx
+++ b/admin/src/pages/Candidates.tsx
@@ -154,7 +154,6 @@ const Candidates: React.FC = () => {
       'success' in responseData &&
       'data' in responseData
     ) {
-      // TODO: Remove legacy fallback once all endpoints return wrapped payloads.
       const wrappedData = responseData as { data?: User | null }
       return wrappedData.data ?? null
     }

--- a/admin/src/pages/Candidates.tsx
+++ b/admin/src/pages/Candidates.tsx
@@ -142,7 +142,10 @@ const Candidates: React.FC = () => {
     return <LoadingSpinner />
   }
 
-  const selectedUser = selectedUserResponse?.data?.data || null
+  const selectedUser =
+    (selectedUserResponse?.data?.data as User | undefined) ??
+    (selectedUserResponse?.data as unknown as User | undefined) ??
+    null
   const currentUser = currentUserResponse?.data?.data
 
   return (

--- a/admin/src/pages/Candidates.tsx
+++ b/admin/src/pages/Candidates.tsx
@@ -154,6 +154,7 @@ const Candidates: React.FC = () => {
       'success' in responseData &&
       'data' in responseData
     ) {
+      // TODO: Remove legacy fallback once all endpoints return wrapped payloads.
       const wrappedData = responseData as { data?: User | null }
       return wrappedData.data ?? null
     }

--- a/admin/src/pages/Candidates.tsx
+++ b/admin/src/pages/Candidates.tsx
@@ -142,10 +142,25 @@ const Candidates: React.FC = () => {
     return <LoadingSpinner />
   }
 
-  const selectedUser =
-    (selectedUserResponse?.data?.data as User | undefined) ??
-    (selectedUserResponse?.data as unknown as User | undefined) ??
-    null
+  const selectedUser = (() => {
+    const responseData = selectedUserResponse?.data
+    if (!responseData) {
+      return null
+    }
+
+    if (
+      typeof responseData === 'object' &&
+      responseData !== null &&
+      'success' in responseData &&
+      'data' in responseData
+    ) {
+      // TODO: Remove legacy fallback once all endpoints return wrapped payloads.
+      const wrappedData = responseData as { data?: User | null }
+      return wrappedData.data ?? null
+    }
+
+    return responseData as User
+  })()
   const currentUser = currentUserResponse?.data?.data
 
   return (

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -304,8 +304,12 @@ export class UsersController {
 
   @Get(':id')
   @Roles(UserRole.SUPER_ADMIN, UserRole.ADMIN)
-  findOne(@Param('id', ParseUUIDPipe) id: string) {
-    return this.usersService.findOne(id);
+  async findOne(@Param('id', ParseUUIDPipe) id: string) {
+    const user = await this.usersService.findOne(id);
+    return {
+      success: true,
+      data: user,
+    };
   }
 
   @Patch('me')


### PR DESCRIPTION
### Motivation
- Ensure the API returns a consistent payload for `GET /users/:id` so the admin UI expects a `{ success, data }` envelope.
- Make the candidate edit flow tolerant of legacy raw user responses to prevent UI breakage when the backend returns a raw user object.
- Prevent runtime errors in the admin `Candidates` page when opening the edit modal by handling both response shapes.

### Description
- Updated `api/src/users/users.controller.ts` `findOne` to be `async` and return `{ success: true, data: user }` for `GET /users/:id` responses.
- Updated `admin/src/pages/Candidates.tsx` to coerce `selectedUser` from either `selectedUserResponse.data.data` or the legacy `selectedUserResponse.data` using typed fallbacks.
- Preserved backward compatibility in the admin UI by adding a safe fallback that handles both nested and raw user payloads.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953110655108325bcd9f43645bea976)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved candidate selection to robustly handle multiple API response data structure variations, reducing potential undefined-related issues.

* **Refactor**
  * User lookup endpoint updated to return consistently formatted responses with success status indicator and structured data payload for improved API consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->