### PR TITLE
Prisma migration failure investigation

### DIFF
--- a/api/scripts/prebuild-db-setup.mjs
+++ b/api/scripts/prebuild-db-setup.mjs
@@ -1187,9 +1187,52 @@ const main = async () => {
   log(`Using schema: ${SCHEMA_PATH}`);
   log(`Using Prisma CLI: ${PRISMA_BIN ? PRISMA_BIN : 'npx prisma (fallback)'}`);
 
-  // If Render points us at an existing DB that was created outside Prisma Migrate,
-  // `prisma migrate deploy` will fail with P3005 unless we baseline it first.
-  await maybeBaselineExistingDatabase();
+  // Determine whether this DB is already managed by Prisma Migrate.
+  // Important: On a fresh empty DB, we must NOT create any tables here, otherwise
+  // `prisma migrate deploy` will immediately fail with P3005 ("schema is not empty").
+  let migrationsTableExists = false;
+  let nonPrismaTableCount = 0;
+  try {
+    migrationsTableExists = getPrismaMigrationsTableExists();
+    nonPrismaTableCount = getNonPrismaTableCount();
+  } catch (e) {
+    // If we can’t inspect the DB, migrations will fail anyway. Surface a clear error.
+    throw new Error(`Could not inspect database schema: ${e.message}`);
+  }
+
+  log(
+    `Database inspection: _prisma_migrations=${migrationsTableExists ? 'present' : 'missing'}, ` +
+      `nonPrismaTables=${nonPrismaTableCount}`
+  );
+
+  if (!migrationsTableExists) {
+    if (nonPrismaTableCount === 0) {
+      log(
+        'Empty database detected (no tables, no Prisma migration history). ' +
+          'Skipping prebuild recovery steps so `prisma migrate deploy` can bootstrap the schema.'
+      );
+      log('Done.');
+      return;
+    }
+
+    // Non-empty schema but no Prisma migration history: Prisma will throw P3005.
+    // Do NOT attempt to "help" by creating more tables here; that only increases drift.
+    // Instead, attempt safe baseline (only if the schema matches) and otherwise fail fast
+    // with actionable instructions.
+    await maybeBaselineExistingDatabase();
+
+    // Re-check: if we still don't have a migrations table, stop here.
+    migrationsTableExists = getPrismaMigrationsTableExists();
+    if (!migrationsTableExists) {
+      error(
+        '❌ Database has tables but no `_prisma_migrations` history table. ' +
+          '`prisma migrate deploy` will fail with P3005 until this DB is reset or baselined.'
+      );
+      error('   Dev fix: use a fresh empty database (recommended) or wipe/reset this database.');
+      error('   Prisma baseline docs: https://pris.ly/d/migrate-baseline');
+      throw new Error('Database is not managed by Prisma Migrate (P3005 precondition).');
+    }
+  }
 
   // Known migration handlers (documented in api/scripts/README-MIGRATION-RECOVERY.md)
   // For already-applied migrations, just ensure schema exists (idempotent safety net)


### PR DESCRIPTION
Modify `prebuild-db-setup.mjs` to prevent `P3005` errors on fresh dev databases.

The previous logic could create tables before `prisma migrate deploy` ran, causing the database schema to be "not empty" and triggering `P3005` errors because the `_prisma_migrations` table was missing. This change ensures the prebuild script is a no-op on empty databases, allowing `prisma migrate deploy` to bootstrap correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb63752d-fb1b-4c51-8c75-31acd63c441f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb63752d-fb1b-4c51-8c75-31acd63c441f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

