### PR TITLE
Render build migration failure

### DIFF
--- a/api/prisma/migrations/20251114140526_add_i18n_translation_tables/migration.sql
+++ b/api/prisma/migrations/20251114140526_add_i18n_translation_tables/migration.sql
@@ -65,7 +65,7 @@ END
 $$;
 
 -- CreateTable
-CREATE TABLE "static_translations" (
+CREATE TABLE IF NOT EXISTS "static_translations" (
     "namespace" TEXT NOT NULL,
     "key" TEXT NOT NULL,
     "lang" TEXT NOT NULL,
@@ -81,7 +81,7 @@ CREATE TABLE "static_translations" (
 );
 
 -- CreateTable
-CREATE TABLE "translation_memory" (
+CREATE TABLE IF NOT EXISTS "translation_memory" (
     "id" TEXT NOT NULL,
     "sourceTextHash" TEXT NOT NULL,
     "sourceLang" TEXT NOT NULL,
@@ -96,7 +96,7 @@ CREATE TABLE "translation_memory" (
 );
 
 -- CreateTable
-CREATE TABLE "translation_releases" (
+CREATE TABLE IF NOT EXISTS "translation_releases" (
     "id" TEXT NOT NULL,
     "version" TEXT NOT NULL,
     "description" TEXT,
@@ -108,7 +108,7 @@ CREATE TABLE "translation_releases" (
 );
 
 -- CreateTable
-CREATE TABLE "translation_audit_logs" (
+CREATE TABLE IF NOT EXISTS "translation_audit_logs" (
     "id" TEXT NOT NULL,
     "type" TEXT NOT NULL,
     "namespace" TEXT,
@@ -127,7 +127,7 @@ CREATE TABLE "translation_audit_logs" (
 );
 
 -- CreateTable
-CREATE TABLE "mt_cost_tracking" (
+CREATE TABLE IF NOT EXISTS "mt_cost_tracking" (
     "id" TEXT NOT NULL,
     "date" DATE NOT NULL,
     "provider" TEXT NOT NULL,

--- a/api/prisma/migrations/20251117145622_add_content_category_field/migration.sql
+++ b/api/prisma/migrations/20251117145622_add_content_category_field/migration.sql
@@ -1,6 +1,5 @@
 -- AlterTable
-ALTER TABLE "assets" ADD COLUMN "contentCategory" TEXT;
+ALTER TABLE "assets" ADD COLUMN IF NOT EXISTS "contentCategory" TEXT;
 
 -- CreateIndex
-CREATE INDEX "assets_contentCategory_idx" ON "assets"("contentCategory");
-
+CREATE INDEX IF NOT EXISTS "assets_contentCategory_idx" ON "assets"("contentCategory");

--- a/api/prisma/migrations/20251118101500_add_service_metadata/migration.sql
+++ b/api/prisma/migrations/20251118101500_add_service_metadata/migration.sql
@@ -1,7 +1,7 @@
 -- Add service metadata fields used by the frontend upload form
 ALTER TABLE "services"
-ADD COLUMN "priceInfo" TEXT,
-ADD COLUMN "availability" TEXT,
-ADD COLUMN "deliveryType" TEXT NOT NULL DEFAULT 'On-site',
-ADD COLUMN "tags" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
-ADD COLUMN "imageUrl" TEXT;
+ADD COLUMN IF NOT EXISTS "priceInfo" TEXT,
+ADD COLUMN IF NOT EXISTS "availability" TEXT,
+ADD COLUMN IF NOT EXISTS "deliveryType" TEXT NOT NULL DEFAULT 'On-site',
+ADD COLUMN IF NOT EXISTS "tags" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN IF NOT EXISTS "imageUrl" TEXT;


### PR DESCRIPTION
Make database migrations idempotent to fix Render build failures.

The build was failing because `prisma migrate deploy` encountered errors when applying migrations that were not idempotent, meaning they attempted to create database objects (tables, columns, indexes) that already existed. This change ensures migrations can run safely without error, even if the target objects are already present.

---
<a href="https://cursor.com/background-agent?bcId=bc-2de620d9-1d63-4298-8022-8fa595a9570b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2de620d9-1d63-4298-8022-8fa595a9570b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

