### PR TITLE
Signup data persistence

### DIFF
--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException, ConflictException, ForbiddenException, Logger } from '@nestjs/common';
-import { Prisma, UserRole } from '@prisma/client';
+import { OrganizationType, Prisma, UserRole } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -533,14 +533,88 @@ export class UsersService {
           },
         });
       });
-      
-      // If organization details are provided, we should ideally create the organization here
-      // This is a simplification
-      if (dto.organisationName) {
-         // Logic to create organization would go here
-         // For now we rely on the user updating their profile/org later or implement a separate flow
-         this.logger.log(`🏢 [COMPLETE PROFILE] Organization name provided: ${dto.organisationName}`);
-      }
+    }
+
+    // Ensure we persist any organization/profile fields supplied during signup/profile completion.
+    // This prevents users from needing to re-enter organization details on the org profile page.
+    const organisationName = dto.organisationName?.trim() || null;
+    const ORG_ROLES: UserRole[] = [UserRole.FOUNDATION, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER];
+    const isOrganizationRole = ORG_ROLES.includes(dto.role);
+
+    if (isOrganizationRole && organisationName) {
+      const nameParts = dto.contactPerson ? dto.contactPerson.trim().split(' ') : [];
+      const firstName = nameParts[0] || null;
+      const lastName = nameParts.slice(1).join(' ') || null;
+      const derivedContactPerson = dto.contactPerson?.trim() || `${firstName ?? ''} ${lastName ?? ''}`.trim() || null;
+
+      await this.prisma.$transaction(async (tx) => {
+        // Guarantee the profile row exists and apply contact info updates when provided.
+        const profile = await tx.user.upsert({
+          where: { clerkId },
+          update: {
+            role: dto.role,
+            ...(email ? { email } : {}),
+            ...(dto.phone !== undefined ? { phoneNumber: dto.phone } : {}),
+            ...(dto.contactPerson ? { firstName, lastName } : {}),
+          },
+          create: {
+            clerkId,
+            email,
+            role: dto.role,
+            firstName,
+            lastName,
+            phoneNumber: dto.phone,
+            isActive: true,
+          },
+          select: { id: true },
+        });
+
+        const existingMembership = await tx.userOrganization.findFirst({
+          where: { userId: profile.id },
+          select: { organizationId: true },
+        });
+
+        if (existingMembership) {
+          // Organization already exists/linked; don't overwrite it here.
+          return;
+        }
+
+        const orgType: OrganizationType =
+          dto.role === UserRole.FOUNDATION
+            ? OrganizationType.FOUNDATION
+            : dto.role === UserRole.PRODUCT_SUPPLIER
+              ? OrganizationType.PRODUCT_SUPPLIER
+              : OrganizationType.SERVICE_PROVIDER;
+
+        const organization = await tx.organization.create({
+          data: {
+            name: organisationName,
+            type: orgType,
+            contactPerson: derivedContactPerson,
+            phoneNumber: dto.phone ?? null,
+            canton: dto.canton?.trim() || null,
+            regionsServed: dto.canton?.trim() ? [dto.canton.trim()] : [],
+            languages: [],
+            pedagogy: [],
+            serviceCategories: [],
+            productCategories: [],
+            capacity: dto.role === UserRole.FOUNDATION ? (dto.capacity ?? null) : null,
+            productCategory:
+              dto.role === UserRole.PRODUCT_SUPPLIER ? (dto.category?.trim() || null) : null,
+            serviceType:
+              dto.role === UserRole.SERVICE_PROVIDER ? (dto.serviceType?.trim() || null) : null,
+            isActive: true,
+          },
+        });
+
+        await tx.userOrganization.create({
+          data: {
+            userId: profile.id,
+            organizationId: organization.id,
+            role: dto.role,
+          },
+        });
+      });
     }
 
     return this.findByClerkId(clerkId);

--- a/api/src/webhooks/clerk-webhook.controller.ts
+++ b/api/src/webhooks/clerk-webhook.controller.ts
@@ -13,7 +13,7 @@ import { Request, Response } from 'express';
 import { PrismaService } from '../prisma/prisma.service';
 import { createClerkClient } from '@clerk/clerk-sdk-node';
 import { ConfigService } from '@nestjs/config';
-import { UserRole } from '@prisma/client';
+import { OrganizationType, UserRole } from '@prisma/client';
 
 // Simple in-memory set for idempotency (replace with Redis in production)
 const processedEvents = new Set<string>();
@@ -553,6 +553,32 @@ ${'='.repeat(100)}`);
     const lastName = data.last_name || 'User';
     const phoneNumber = data.phone_numbers?.[0]?.phone_number || null;
 
+    // Signup metadata (captured on frontend) used to provision org/profile fields.
+    const unsafe = (data?.unsafe_metadata ?? {}) as Record<string, any>;
+    const signupOrganisationNameRaw = unsafe.organisationName ?? unsafe.organizationName ?? null;
+    const signupOrganisationName =
+      typeof signupOrganisationNameRaw === 'string' ? signupOrganisationNameRaw.trim() : null;
+    const signupPhone =
+      typeof unsafe.phone === 'string' && unsafe.phone.trim() ? unsafe.phone.trim() : null;
+    const signupCanton =
+      typeof unsafe.canton === 'string' && unsafe.canton.trim() ? unsafe.canton.trim() : null;
+    const signupCapacity =
+      typeof unsafe.capacity === 'number'
+        ? unsafe.capacity
+        : typeof unsafe.capacity === 'string'
+          ? Number.parseInt(unsafe.capacity, 10)
+          : null;
+    const signupCategory =
+      typeof unsafe.category === 'string' && unsafe.category.trim() ? unsafe.category.trim() : null;
+    const signupServiceType =
+      typeof unsafe.serviceType === 'string' && unsafe.serviceType.trim()
+        ? unsafe.serviceType.trim()
+        : null;
+    const signupContactPerson =
+      typeof unsafe.contactPerson === 'string' && unsafe.contactPerson.trim()
+        ? unsafe.contactPerson.trim()
+        : `${firstName} ${lastName}`.trim() || null;
+
     console.log(`👤 [E2E DEBUG] USER DETAILS EXTRACTED:`, {
       clerkId,
       primaryEmail,
@@ -588,6 +614,7 @@ ${'='.repeat(100)}`);
     console.log(`💾 [E2E DEBUG] STARTING DATABASE OPERATIONS...`);
 
     let appUser: any;
+    let profileId: string | null = null;
 
     try {
       await this.prisma.$transaction(async (tx) => {
@@ -606,7 +633,7 @@ ${'='.repeat(100)}`);
           select: { id: true, role: true, email: true },
         });
 
-        await tx.user.upsert({
+        const profile = await tx.user.upsert({
           where: { clerkId },
           update: {
             email: primaryEmail,
@@ -625,7 +652,61 @@ ${'='.repeat(100)}`);
             phoneNumber,
             isActive: true,
           },
+          select: { id: true },
         });
+
+        profileId = profile.id;
+
+        // Provision organization at signup for organization roles, so users don't need to re-enter
+        // their org details later in the organization profile/settings page.
+        const ORG_ROLES: UserRole[] = [UserRole.FOUNDATION, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER];
+        const isOrganizationRole = ORG_ROLES.includes(validRole as UserRole);
+
+        if (isOrganizationRole && signupOrganisationName) {
+          const existingMembership = await tx.userOrganization.findFirst({
+            where: { userId: profile.id },
+            select: { organizationId: true },
+          });
+
+          if (!existingMembership) {
+            const orgType: OrganizationType =
+              (validRole as UserRole) === UserRole.FOUNDATION
+                ? OrganizationType.FOUNDATION
+                : (validRole as UserRole) === UserRole.PRODUCT_SUPPLIER
+                  ? OrganizationType.PRODUCT_SUPPLIER
+                  : OrganizationType.SERVICE_PROVIDER;
+
+            const organization = await tx.organization.create({
+              data: {
+                name: signupOrganisationName,
+                type: orgType,
+                contactPerson: signupContactPerson,
+                phoneNumber: signupPhone ?? phoneNumber,
+                canton: signupCanton,
+                regionsServed: signupCanton ? [signupCanton] : [],
+                languages: [],
+                pedagogy: [],
+                serviceCategories: [],
+                productCategories: [],
+                capacity:
+                  (validRole as UserRole) === UserRole.FOUNDATION ? (signupCapacity ?? null) : null,
+                productCategory:
+                  (validRole as UserRole) === UserRole.PRODUCT_SUPPLIER ? signupCategory : null,
+                serviceType:
+                  (validRole as UserRole) === UserRole.SERVICE_PROVIDER ? signupServiceType : null,
+                isActive: true,
+              },
+            });
+
+            await tx.userOrganization.create({
+              data: {
+                userId: profile.id,
+                organizationId: organization.id,
+                role: validRole as UserRole,
+              },
+            });
+          }
+        }
       });
 
       console.log(`✅ [E2E DEBUG] APPUSER & USER UPSERTED SUCCESSFULLY:`, {
@@ -635,6 +716,7 @@ ${'='.repeat(100)}`);
         email: primaryEmail,
         role: validRole,
         hasPhone: !!phoneNumber,
+        profileId,
       });
     } catch (error) {
       console.error(`❌ [E2E DEBUG] FAILED TO UPSERT ACCOUNT/PROFILE:`, {

--- a/frontend/pages/SignupPage.tsx
+++ b/frontend/pages/SignupPage.tsx
@@ -488,9 +488,16 @@ const SignupPage: React.FC = () => {
           // Backend will assign actual role via publicMetadata (secure)
             signupType: selectedRole,
             pendingRole: pendingUserRole,
+            // Persist the full signup form so users don't need to re-enter it later
+            contactPerson: formData.contactPerson || undefined,
             organisationName: requiresOrganizationDetails ? formData.organisationName : undefined,
             phone: formData.phone || undefined,
             canton: formData.canton || undefined,
+            capacity: formData.capacity ?? undefined,
+            category: formData.category || undefined,
+            serviceType: formData.serviceType || undefined,
+            childAge: formData.childAge ?? undefined,
+            childStartDate: formData.childStartDate || undefined,
         },
       });
 


### PR DESCRIPTION
Store all signup form fields to automatically provision user and organization profiles, preventing re-entry of details.

Previously, organization-role users (FOUNDATION, PRODUCT_SUPPLIER, SERVICE_PROVIDER) had to re-enter contact person, organization name, phone, canton, capacity, category, and service type details on their organization profile page after signing up. This PR updates the frontend to pass all relevant signup fields via Clerk metadata, and the backend (Clerk webhook and `/users/complete-profile` endpoint) to persist these details immediately, creating and linking the organization upon initial signup.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a5d1627-9b89-46e2-a3fc-4396538e0486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3a5d1627-9b89-46e2-a3fc-4396538e0486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Streamlined organization onboarding: Users selecting organization-based roles can now complete their organization profile during signup, with automatic organization creation and role-based linkage setup based on provided information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->