### PR TITLE
Forgot password issue

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -27,6 +27,7 @@ import SubscriptionsPage from './pages/Subscriptions';
 import DiscountTerminationsPage from './pages/DiscountTerminations';
 import AdminUserProfileEdit from './pages/AdminUserProfileEdit';
 import AdminOrganizationProfileEdit from './pages/AdminOrganizationProfileEdit';
+import ResetPassword from './pages/ResetPassword';
 
 // Create a client
 const queryClient = new QueryClient({
@@ -71,6 +72,7 @@ function App() {
       <Routes>
         <Route path="/login" element={<AdminLoginPage />} />
         <Route path="/signup" element={<AdminSignupPage />} />
+        <Route path="/reset-password" element={<ResetPassword />} />
         <Route path="/access-denied" element={<AccessDeniedPage />} />
         <Route
           path="/"

--- a/admin/src/components/auth/AdminCustomLoginFormNew.tsx
+++ b/admin/src/components/auth/AdminCustomLoginFormNew.tsx
@@ -283,9 +283,12 @@ export default function AdminCustomLoginForm() {
                 <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
                   {t('admin:auth.login.passwordLabel')}
                 </label>
-                <a href="#/password-reset" onClick={(e) => {e.preventDefault(); alert('Password reset functionality TBD');}} className="text-xs text-swiss-mint hover:underline">
-                    {t('admin:auth.login.forgotPassword')}
-                </a>
+                <Link
+                  to={formData.email ? `/reset-password?email=${encodeURIComponent(formData.email)}` : '/reset-password'}
+                  className="text-xs text-swiss-mint hover:underline"
+                >
+                  {t('admin:auth.login.forgotPassword')}
+                </Link>
             </div>
             <div className="relative">
                 <input

--- a/admin/src/pages/ResetPassword.tsx
+++ b/admin/src/pages/ResetPassword.tsx
@@ -1,0 +1,266 @@
+import React, { useMemo, useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { useAuth, useSignIn } from '@clerk/clerk-react';
+import { useTranslation } from 'react-i18next';
+import Card from '../components/design-system/Card';
+import Button from '../components/design-system/Button';
+import { STANDARD_INPUT_FIELD } from '../constants/design-system';
+import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
+
+type Step = 'request' | 'verify';
+
+function getClerkErrorMessage(err: any): string | null {
+  const first = err?.errors?.[0];
+  if (first?.longMessage) return String(first.longMessage);
+  if (first?.message) return String(first.message);
+  if (typeof err?.message === 'string') return err.message;
+  return null;
+}
+
+export default function ResetPassword() {
+  const { t } = useTranslation(['auth', 'common', 'admin']);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { isSignedIn, isLoaded: isAuthLoaded } = useAuth();
+  const { signIn, isLoaded: isSignInLoaded, setActive } = useSignIn();
+
+  const queryEmail = useMemo(() => {
+    try {
+      return new URLSearchParams(location.search).get('email') || '';
+    } catch {
+      return '';
+    }
+  }, [location.search]);
+
+  const [step, setStep] = useState<Step>('request');
+  const [email, setEmail] = useState(queryEmail);
+  const [code, setCode] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  if (isAuthLoaded && isSignedIn) {
+    navigate('/dashboard', { replace: true });
+  }
+
+  if (!isSignInLoaded || !isAuthLoaded) {
+    return (
+      <div className="min-h-screen bg-page-bg flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-swiss-mint"></div>
+      </div>
+    );
+  }
+
+  const handleRequestReset = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setInfo(null);
+
+    if (!email) {
+      setError(t('common:forms.required', 'This field is required'));
+      return;
+    }
+    if (!signIn) {
+      setError(t('common:errors.unknown', 'An unknown error occurred'));
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await signIn.create({
+        strategy: 'reset_password_email_code',
+        identifier: email,
+      });
+      setStep('verify');
+      setInfo(t('common:verifyEmailMessage', 'We sent you a 6-digit code. Enter it below to verify.'));
+    } catch (err: any) {
+      console.error('Admin password reset request failed:', err);
+      setError(getClerkErrorMessage(err) || t('common:errors.unknown', 'An unknown error occurred'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleVerifyAndReset = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setInfo(null);
+
+    if (!code) {
+      setError(t('common:forms.required', 'This field is required'));
+      return;
+    }
+    if (!password) {
+      setError(t('common:forms.required', 'This field is required'));
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError(t('common:forms.passwordsDoNotMatch', 'Passwords do not match'));
+      return;
+    }
+    if (!signIn) {
+      setError(t('common:errors.unknown', 'An unknown error occurred'));
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const attempt = await signIn.attemptFirstFactor({
+        strategy: 'reset_password_email_code',
+        code,
+      });
+
+      if (attempt.status === 'needs_new_password' || signIn.status === 'needs_new_password') {
+        const resetAttempt = await signIn.resetPassword({ password });
+        if (resetAttempt.status === 'complete') {
+          await setActive({ session: resetAttempt.createdSessionId });
+          navigate('/dashboard', { replace: true });
+          return;
+        }
+        setError(t('common:errors.unknown', 'An unknown error occurred'));
+        return;
+      }
+
+      if (attempt.status === 'complete') {
+        await setActive({ session: attempt.createdSessionId });
+        navigate('/dashboard', { replace: true });
+        return;
+      }
+
+      setError(t('common:errors.unknown', 'An unknown error occurred'));
+    } catch (err: any) {
+      console.error('Admin password reset failed:', err);
+      setError(getClerkErrorMessage(err) || t('common:errors.unknown', 'An unknown error occurred'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-page-bg flex flex-col items-center justify-center p-4 sm:p-6 lg:p-8">
+      <Card className="w-full max-w-md p-8 shadow-xl">
+        <div className="text-center mb-6">
+          <h1 className="text-2xl font-bold text-swiss-charcoal">{t('common:resetPassword', 'Reset Password')}</h1>
+          <p className="text-sm text-gray-500">
+            {step === 'request'
+              ? t('admin:auth.login.forgotPassword', 'Forgot Password')
+              : t('common:labels.verificationCode', 'Verification Code')}
+          </p>
+        </div>
+
+        {error && <div className="mb-4 p-3 bg-red-100 text-red-700 rounded-md text-sm">{error}</div>}
+        {info && <div className="mb-4 p-3 bg-blue-50 text-blue-800 border border-blue-200 rounded-md text-sm">{info}</div>}
+
+        {step === 'request' ? (
+          <form onSubmit={handleRequestReset} className="space-y-6">
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+                {t('admin:auth.login.emailLabel', 'Email Address')}
+              </label>
+              <input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className={STANDARD_INPUT_FIELD}
+                placeholder={t('admin:auth.login.emailPlaceholder', 'Enter your email')}
+                required
+              />
+            </div>
+            <Button type="submit" variant="primary" size="lg" className="w-full" disabled={isSubmitting}>
+              {isSubmitting ? t('common:buttons.sending', 'Sending...') : t('common:buttons.continue', 'Continue')}
+            </Button>
+            <div className="text-center text-xs text-gray-600">
+              <Link to="/login" className="font-medium text-swiss-mint hover:underline">
+                {t('common:buttons.goToLogin', 'Go to Login')}
+              </Link>
+            </div>
+          </form>
+        ) : (
+          <form onSubmit={handleVerifyAndReset} className="space-y-6">
+            <div>
+              <label htmlFor="code" className="block text-sm font-medium text-gray-700 mb-1">
+                {t('common:labels.verificationCode', 'Verification Code')}
+              </label>
+              <input
+                id="code"
+                type="text"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                className={STANDARD_INPUT_FIELD}
+                placeholder={t('common:settingsAccountSecurity.changeEmail.verificationCodePlaceholder', 'Enter 6-digit code')}
+                required
+              />
+            </div>
+
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+                {t('common:buttons.resetPassword', 'Reset Password')}
+              </label>
+              <div className="relative">
+                <input
+                  id="password"
+                  type={showPassword ? 'text' : 'password'}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className={STANDARD_INPUT_FIELD}
+                  placeholder={t('common:settingsAccountSecurity.changePassword.newPasswordLabel', 'New Password')}
+                  required
+                  autoComplete="new-password"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  className="absolute inset-y-0 right-0 px-3 flex items-center text-gray-500 hover:text-swiss-teal"
+                  aria-label={showPassword ? t('common:hidePassword', 'Hide password') : t('common:showPassword', 'Show password')}
+                >
+                  {showPassword ? <EyeSlashIcon className="h-5 w-5" /> : <EyeIcon className="h-5 w-5" />}
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700 mb-1">
+                {t('common:confirmPassword', 'Confirm Password')}
+              </label>
+              <div className="relative">
+                <input
+                  id="confirmPassword"
+                  type={showConfirmPassword ? 'text' : 'password'}
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  className={STANDARD_INPUT_FIELD}
+                  placeholder={t('common:confirmPassword', 'Confirm Password')}
+                  required
+                  autoComplete="new-password"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowConfirmPassword((v) => !v)}
+                  className="absolute inset-y-0 right-0 px-3 flex items-center text-gray-500 hover:text-swiss-teal"
+                  aria-label={showConfirmPassword ? t('common:hidePassword', 'Hide password') : t('common:showPassword', 'Show password')}
+                >
+                  {showConfirmPassword ? <EyeSlashIcon className="h-5 w-5" /> : <EyeIcon className="h-5 w-5" />}
+                </button>
+              </div>
+            </div>
+
+            <Button type="submit" variant="primary" size="lg" className="w-full" disabled={isSubmitting}>
+              {isSubmitting ? t('common:buttons.saving', 'Saving') : t('common:buttons.resetPassword', 'Reset Password')}
+            </Button>
+            <div className="text-center text-xs text-gray-600">
+              <Link to="/login" className="font-medium text-swiss-mint hover:underline">
+                {t('common:buttons.goToLogin', 'Go to Login')}
+              </Link>
+            </div>
+          </form>
+        )}
+      </Card>
+    </div>
+  );
+}
+

--- a/admin/src/pages/ResetPassword.tsx
+++ b/admin/src/pages/ResetPassword.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth, useSignIn } from '@clerk/clerk-react';
 import { useTranslation } from 'react-i18next';
@@ -43,9 +43,11 @@ export default function ResetPassword() {
   const [info, setInfo] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  if (isAuthLoaded && isSignedIn) {
-    navigate('/dashboard', { replace: true });
-  }
+  useEffect(() => {
+    if (isAuthLoaded && isSignedIn) {
+      navigate('/dashboard', { replace: true });
+    }
+  }, [isAuthLoaded, isSignedIn, navigate]);
 
   if (!isSignInLoaded || !isAuthLoaded) {
     return (

--- a/admin/src/providers/AppProvider.tsx
+++ b/admin/src/providers/AppProvider.tsx
@@ -24,9 +24,9 @@ export function AppProvider({ children }: AppProviderProps) {
   return (
     <ClerkProvider 
       publishableKey={clerkPubKey}
-      signInUrl="/sign-in"
-      signUpUrl="/sign-up"
-      afterSignOutUrl="/sign-in"
+      signInUrl="/login"
+      signUpUrl="/signup"
+      afterSignOutUrl="/login"
     >
       {children}
     </ClerkProvider>

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -94,6 +94,7 @@ import EducatorProfileViewPage from './pages/profile/EducatorProfileViewPage';
 import LoginPageE2E from './pages/LoginPageE2E';
 import SignupPageE2E from './pages/SignupPageE2E';
 import PricingPage from './pages/PricingPage';
+import ResetPasswordPage from './pages/ResetPasswordPage';
 
 
 const ProtectedRoute: React.FC<{ children: React.ReactElement; roles: UserRole[] }> = ({ children, roles }): React.ReactElement | null => {
@@ -592,6 +593,7 @@ const App: React.FC = () => {
             <Route path="/signup" element={<SignupPageE2E />} />
             <Route path="/pricing" element={<PricingPage />} />
             <Route path="/parent-lead-form" element={<ParentLeadFormPage />} />
+            <Route path="/reset-password" element={<Navigate to="/login" replace />} />
 
             {/* Protected routes: always redirect to login in E2E */}
             <Route path="/dashboard" element={<Navigate to="/login" replace />} />
@@ -621,6 +623,7 @@ const App: React.FC = () => {
                 <Route path="/pricing" element={<PricingPage />} />
                 <Route path="/partners" element={<PublicPartnersPage />} />
                 <Route path="/parent-lead-form" element={<ParentLeadFormPage />} />
+                <Route path="/reset-password" element={<ResetPasswordPage />} />
                 <Route path="/*" element={<ProtectedLayout />} />
               </Routes>
             </SubscriptionProvider>

--- a/frontend/pages/LoginPage.tsx
+++ b/frontend/pages/LoginPage.tsx
@@ -401,7 +401,7 @@ const LoginPage: React.FC = () => {
                     {t('common:loginPage.passwordLabel')}
                   </label>
                   <Link
-                    to="/reset-password"
+                    to={email ? `/reset-password?email=${encodeURIComponent(email)}` : '/reset-password'}
                     className="text-xs text-swiss-mint hover:underline"
                   >
                     {t('common:loginPage.forgotPassword')}

--- a/frontend/pages/ResetPasswordPage.tsx
+++ b/frontend/pages/ResetPasswordPage.tsx
@@ -139,7 +139,7 @@ const ResetPasswordPage: React.FC = () => {
           navigate('/dashboard', { replace: true });
           return;
         }
-        setError(t('common:resetPassword', 'Reset Password') + ' ' + t('common:errors.unknown', 'An unknown error occurred'));
+        setError(t('common:errors.unknown', 'An unknown error occurred'));
         return;
       }
 

--- a/frontend/pages/ResetPasswordPage.tsx
+++ b/frontend/pages/ResetPasswordPage.tsx
@@ -1,0 +1,356 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { useAuth, useSignIn } from '@clerk/clerk-react';
+import { useTranslation } from 'react-i18next';
+import Card from '../components/ui/Card';
+import Button from '../components/ui/Button';
+import { STANDARD_INPUT_FIELD, APP_NAME } from '../constants';
+import { EyeIcon, EyeSlashIcon, SquaresPlusIcon } from '@heroicons/react/24/outline';
+import LanguageSwitcher from '../components/ui/LanguageSwitcher';
+import LogoLink from '../components/shared/LogoLink';
+import { useFrontendSettings } from '../hooks/useFrontendSettings';
+
+type Step = 'request' | 'verify';
+
+function getClerkErrorMessage(err: any): string | null {
+  const first = err?.errors?.[0];
+  if (first?.longMessage) return String(first.longMessage);
+  if (first?.message) return String(first.message);
+  if (typeof err?.message === 'string') return err.message;
+  return null;
+}
+
+const ResetPasswordPage: React.FC = () => {
+  const { t } = useTranslation(['auth', 'common']);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { isSignedIn, isLoaded: isAuthLoaded } = useAuth();
+  const { signIn, isLoaded: isSignInLoaded, setActive } = useSignIn();
+  const { settings, loading: settingsLoading } = useFrontendSettings();
+
+  const queryEmail = useMemo(() => {
+    try {
+      return new URLSearchParams(location.search).get('email') || '';
+    } catch {
+      return '';
+    }
+  }, [location.search]);
+
+  const [step, setStep] = useState<Step>('request');
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [error, setError] = useState('');
+  const [info, setInfo] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const logoUrl = settings?.logoAsset?.publicUrl;
+  const showLogoFallback = !settingsLoading && !logoUrl;
+
+  useEffect(() => {
+    if (queryEmail && !email) setEmail(queryEmail);
+    // only seed once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [queryEmail]);
+
+  useEffect(() => {
+    if (isAuthLoaded && isSignedIn) {
+      navigate('/dashboard', { replace: true });
+    }
+  }, [isAuthLoaded, isSignedIn, navigate]);
+
+  if (!isSignInLoaded || !isAuthLoaded) {
+    return (
+      <div className="min-h-screen bg-page-bg flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-swiss-mint"></div>
+      </div>
+    );
+  }
+
+  const handleRequestReset = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setInfo('');
+
+    if (!email) {
+      setError(t('common:forms.required', 'This field is required'));
+      return;
+    }
+
+    if (!signIn) {
+      setError(t('common:loginPage.authServiceNotReady', 'Authentication service not ready. Please try again.'));
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await signIn.create({
+        strategy: 'reset_password_email_code',
+        identifier: email,
+      });
+      setStep('verify');
+      setInfo(t('common:verifyEmailMessage', 'We sent you a 6-digit code. Enter it below to verify.'));
+    } catch (err: any) {
+      console.error('Password reset request failed:', err);
+      setError(getClerkErrorMessage(err) || t('common:errors.unknown', 'An unknown error occurred'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleVerifyAndReset = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setInfo('');
+
+    if (!code) {
+      setError(t('common:forms.required', 'This field is required'));
+      return;
+    }
+    if (!password) {
+      setError(t('common:forms.required', 'This field is required'));
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError(t('common:forms.passwordsDoNotMatch', 'Passwords do not match'));
+      return;
+    }
+
+    if (!signIn) {
+      setError(t('common:loginPage.authServiceNotReady', 'Authentication service not ready. Please try again.'));
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const attempt = await signIn.attemptFirstFactor({
+        strategy: 'reset_password_email_code',
+        code,
+      });
+
+      // Clerk typically returns `needs_new_password` here.
+      if (attempt.status === 'needs_new_password' || signIn.status === 'needs_new_password') {
+        const resetAttempt = await signIn.resetPassword({ password });
+        if (resetAttempt.status === 'complete') {
+          await setActive({ session: resetAttempt.createdSessionId });
+          navigate('/dashboard', { replace: true });
+          return;
+        }
+        setError(t('common:resetPassword', 'Reset Password') + ' ' + t('common:errors.unknown', 'An unknown error occurred'));
+        return;
+      }
+
+      if (attempt.status === 'complete') {
+        await setActive({ session: attempt.createdSessionId });
+        navigate('/dashboard', { replace: true });
+        return;
+      }
+
+      setError(
+        t(
+          'common:errors.unknown',
+          'An unknown error occurred'
+        )
+      );
+    } catch (err: any) {
+      console.error('Password reset verification failed:', err);
+      setError(getClerkErrorMessage(err) || t('common:errors.unknown', 'An unknown error occurred'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleResendCode = async () => {
+    setError('');
+    setInfo('');
+    if (!signIn) {
+      setError(t('common:loginPage.authServiceNotReady', 'Authentication service not ready. Please try again.'));
+      return;
+    }
+    if (!email) {
+      setError(t('common:forms.required', 'This field is required'));
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await signIn.create({
+        strategy: 'reset_password_email_code',
+        identifier: email,
+      });
+      setInfo(t('common:verificationCodeResent', 'A new verification code has been sent.'));
+    } catch (err: any) {
+      console.error('Resend reset code failed:', err);
+      setError(getClerkErrorMessage(err) || t('common:errors.unknown', 'An unknown error occurred'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-page-bg flex flex-col items-center justify-center p-2 sm:p-3 md:p-4 lg:p-6">
+      <Card className="w-full max-w-md p-3 sm:p-4 md:p-6 shadow-xl">
+        <div className="text-center mb-3 sm:mb-4 md:mb-5">
+          <LogoLink
+            to="/login"
+            ariaLabel={t('common:buttons.goToLogin', 'Go to Login')}
+            logoUrl={logoUrl}
+            altText={settings?.siteName || APP_NAME}
+            showFallback={showLogoFallback}
+            imageClassName="h-12 sm:h-14 md:h-[72px] w-auto mx-auto mb-1.5 sm:mb-2"
+            iconClassName="h-10 w-10 sm:h-12 sm:w-12 md:h-14 md:w-14 text-swiss-mint mx-auto mb-1.5 sm:mb-2"
+            fallbackIcon={SquaresPlusIcon}
+          />
+          <h1 className="text-base sm:text-lg md:text-xl font-bold text-swiss-charcoal">
+            {t('common:resetPassword', 'Reset Password')}
+          </h1>
+          <p className="text-xs text-gray-500">
+            {step === 'request'
+              ? t('auth:forgotPassword', 'Forgot your password?')
+              : t('common:labels.verificationCode', 'Verification Code')}
+          </p>
+        </div>
+
+        {error && (
+          <div className="mb-2 sm:mb-3 p-2 bg-red-100 text-red-700 rounded-md text-xs sm:text-sm">
+            {error}
+          </div>
+        )}
+        {info && (
+          <div className="mb-2 sm:mb-3 p-2 bg-blue-50 text-blue-800 border border-blue-200 rounded-md text-xs sm:text-sm">
+            {info}
+          </div>
+        )}
+
+        {step === 'request' ? (
+          <form onSubmit={handleRequestReset} className="space-y-3 sm:space-y-4">
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+                {t('common:loginPage.emailLabel', 'Email Address')}
+              </label>
+              <input
+                type="email"
+                id="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className={STANDARD_INPUT_FIELD}
+                required
+                placeholder={t('common:loginPage.emailPlaceholder', 'Enter your email')}
+                autoComplete="email"
+              />
+            </div>
+            <Button type="submit" className="w-full" disabled={isSubmitting}>
+              {isSubmitting ? t('common:buttons.sending', 'Sending...') : t('common:buttons.continue', 'Continue')}
+            </Button>
+            <div className="text-center text-xs text-gray-600">
+              <Link to="/login" className="font-medium text-swiss-mint hover:underline">
+                {t('common:buttons.goToLogin', 'Go to Login')}
+              </Link>
+            </div>
+          </form>
+        ) : (
+          <form onSubmit={handleVerifyAndReset} className="space-y-3 sm:space-y-4">
+            <div>
+              <label htmlFor="code" className="block text-sm font-medium text-gray-700 mb-1">
+                {t('common:labels.verificationCode', 'Verification Code')}
+              </label>
+              <input
+                type="text"
+                id="code"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                className={STANDARD_INPUT_FIELD}
+                required
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                placeholder={t('common:settingsAccountSecurity.changeEmail.verificationCodePlaceholder', 'Enter 6-digit code')}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+                {t('auth:resetPassword', 'Reset Password')}
+              </label>
+              <div className="relative">
+                <input
+                  type={showPassword ? 'text' : 'password'}
+                  id="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className={STANDARD_INPUT_FIELD}
+                  required
+                  autoComplete="new-password"
+                  placeholder={t('common:settingsAccountSecurity.changePassword.newPasswordLabel', 'New Password')}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  className="absolute inset-y-0 right-0 px-3 flex items-center text-gray-500 hover:text-swiss-teal"
+                  aria-label={showPassword ? t('common:hidePassword', 'Hide password') : t('common:showPassword', 'Show password')}
+                >
+                  {showPassword ? <EyeSlashIcon className="h-5 w-5" /> : <EyeIcon className="h-5 w-5" />}
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700 mb-1">
+                {t('common:confirmPassword', 'Confirm Password')}
+              </label>
+              <div className="relative">
+                <input
+                  type={showConfirmPassword ? 'text' : 'password'}
+                  id="confirmPassword"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  className={STANDARD_INPUT_FIELD}
+                  required
+                  autoComplete="new-password"
+                  placeholder={t('common:confirmPassword', 'Confirm Password')}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowConfirmPassword((v) => !v)}
+                  className="absolute inset-y-0 right-0 px-3 flex items-center text-gray-500 hover:text-swiss-teal"
+                  aria-label={
+                    showConfirmPassword ? t('common:hidePassword', 'Hide password') : t('common:showPassword', 'Show password')
+                  }
+                >
+                  {showConfirmPassword ? <EyeSlashIcon className="h-5 w-5" /> : <EyeIcon className="h-5 w-5" />}
+                </button>
+              </div>
+            </div>
+
+            <Button type="submit" className="w-full" disabled={isSubmitting}>
+              {isSubmitting ? t('common:buttons.saving', 'Saving') : t('common:buttons.resetPassword', 'Reset Password')}
+            </Button>
+
+            <div className="flex items-center justify-between text-xs">
+              <button
+                type="button"
+                className="text-swiss-mint hover:underline disabled:opacity-60"
+                onClick={handleResendCode}
+                disabled={isSubmitting}
+              >
+                {t('common:buttons.resendCode', 'Resend code')}
+              </button>
+              <Link to="/login" className="text-gray-600 hover:underline">
+                {t('common:buttons.goToLogin', 'Go to Login')}
+              </Link>
+            </div>
+          </form>
+        )}
+
+        <div className="mt-3 sm:mt-4 flex justify-center">
+          <LanguageSwitcher />
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default ResetPasswordPage;
+


### PR DESCRIPTION
Implement forgot password reset flows for both frontend and admin applications.

The existing "Forgot password" links either pointed to non-existent routes or explicitly displayed a "TBD" message, preventing users from resetting their passwords.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9cbbf70-c573-4278-87a1-1f958c81ab48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c9cbbf70-c573-4278-87a1-1f958c81ab48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added password reset flows for admin and frontend users with email/code verification, password visibility toggles, validation, and resending support.
  * Forgot-password links now navigate to the in-app reset flow and preserve an entered email when present.

* **Updates**
  * Standardized authentication-related route names/redirects for consistency across the apps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces complete password reset flows using Clerk email code verification across admin and user apps.
> 
> - Adds `ResetPassword` pages (`admin/src/pages/ResetPassword.tsx`, `frontend/pages/ResetPasswordPage.tsx`) with 2-step request/verify, password visibility toggles, and session activation on success
> - Wires routes: `/reset-password` in both apps; updates login forms to link to reset page (including `email` query param)
> - Aligns Clerk URLs in admin provider (`signInUrl`/`signUpUrl`/`afterSignOutUrl` -> `/login` and `/signup`)
> - Frontend: supports resend code, branding via settings, and E2E mode redirects `/reset-password` to `/login`
> - Minor UI changes: error/info messaging and loading states during auth operations
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc179ba8f22ead42cf78f4debad6c95fc0dec11e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->