### PR TITLE
Admin educator status wrap

### DIFF
--- a/admin/src/pages/Candidates.tsx
+++ b/admin/src/pages/Candidates.tsx
@@ -333,8 +333,12 @@ const Candidates: React.FC = () => {
                     <td className="px-6 py-4 whitespace-nowrap">
                       <div className="text-sm text-gray-900">{position}</div>
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${statusColors[status] || 'bg-gray-100 text-gray-800'}`}>
+                    <td className="px-6 py-4 align-top">
+                      <span
+                        className={`inline-block max-w-[220px] whitespace-normal break-words px-2 py-1 text-xs font-semibold leading-snug rounded-full ${
+                          statusColors[status] || 'bg-gray-100 text-gray-800'
+                        }`}
+                      >
                         {status}
                       </span>
                     </td>


### PR DESCRIPTION
Allow educator status text to wrap in the admin dashboard to prevent overflow and improve readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-69a43ff7-e659-4789-b9f5-f27766a37f34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-69a43ff7-e659-4789-b9f5-f27766a37f34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves readability of long candidate status labels by enabling wrapping and constraining width in the Candidates table.
> 
> - Update status cell: switch `td` to `align-top` and use a wrapping `span` (`inline-block max-w-[220px] whitespace-normal break-words leading-snug`) instead of `whitespace-nowrap`
> - Preserve existing `statusColors` styling behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85183b61ed02743acd99dab6a9871f42838e7a07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->