### PR TITLE
Logo and favicon caching

### DIFF
--- a/api/src/upload/cloudflare-r2.service.ts
+++ b/api/src/upload/cloudflare-r2.service.ts
@@ -5,6 +5,28 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { AssetKind } from '@prisma/client';
 import { createHash } from 'crypto';
 
+const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365;
+const IMMUTABLE_PUBLIC_CACHE_CONTROL = `public, max-age=${ONE_YEAR_SECONDS}, immutable`;
+
+function getCacheControlForUpload(assetKind: AssetKind, mimeType?: string): string | undefined {
+  // Branding assets (logo/favicon) are referenced by URL and the storage key includes a timestamp,
+  // so they are safe to cache "forever" (new upload => new URL => instant cache bust).
+  const isImage = !!mimeType && mimeType.startsWith('image/');
+  const isBranding =
+    assetKind === 'FRONTEND_LOGO' ||
+    assetKind === 'FRONTEND_FAVICON' ||
+    assetKind === 'FRONTEND_OG_IMAGE' ||
+    assetKind === 'ADMIN_LOGO' ||
+    assetKind === 'ADMIN_FAVICON' ||
+    assetKind === 'SIDEBAR_LOGO';
+
+  if (isBranding || isImage) {
+    return IMMUTABLE_PUBLIC_CACHE_CONTROL;
+  }
+
+  return undefined;
+}
+
 export interface UploadResult {
   key: string;
   url: string;
@@ -65,11 +87,13 @@ export class CloudflareR2Service {
     appUserId: string,
   ): Promise<PresignedUploadData> {
     const key = this.generateStorageKey(filename, assetKind, appUserId, undefined);
+    const cacheControl = getCacheControlForUpload(assetKind, mimeType);
     
     const command = new PutObjectCommand({
       Bucket: this.bucketName,
       Key: key,
       ContentType: mimeType,
+      CacheControl: cacheControl,
       Metadata: {
         'uploaded-by': appUserId,
         'asset-kind': assetKind,
@@ -84,6 +108,7 @@ export class CloudflareR2Service {
         url,
         fields: {
           'Content-Type': mimeType,
+          ...(cacheControl ? { 'Cache-Control': cacheControl } : {}),
         },
         key,
       };
@@ -122,12 +147,14 @@ export class CloudflareR2Service {
       
       // Calculate SHA-256 checksum
       const checksum = this.calculateChecksum(file.buffer);
+      const cacheControl = getCacheControlForUpload(assetKind, file.mimetype);
       
       const command = new PutObjectCommand({
         Bucket: this.bucketName,
         Key: key,
         Body: file.buffer,
         ContentType: file.mimetype,
+        CacheControl: cacheControl,
         ChecksumSHA256: checksum, // S3-compatible checksum
         Metadata: {
           'uploaded-by': appUserId,

--- a/api/src/upload/r2.service.ts
+++ b/api/src/upload/r2.service.ts
@@ -3,6 +3,9 @@ import { ConfigService } from '@nestjs/config';
 import { S3Client, PutObjectCommand, DeleteObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
+const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365;
+const IMMUTABLE_PUBLIC_CACHE_CONTROL = `public, max-age=${ONE_YEAR_SECONDS}, immutable`;
+
 export interface UploadResult {
   key: string;
   url: string;
@@ -74,12 +77,14 @@ export class R2Service {
       }
 
       const key = this.generateStorageKey(file.originalname, category);
+      const cacheControl = file.mimetype?.startsWith('image/') ? IMMUTABLE_PUBLIC_CACHE_CONTROL : undefined;
       
       const command = new PutObjectCommand({
         Bucket: this.bucketName,
         Key: key,
         Body: file.buffer,
         ContentType: file.mimetype,
+        CacheControl: cacheControl,
         Metadata: {
           'original-filename': file.originalname,
           'category': category,


### PR DESCRIPTION
Add `Cache-Control: public, max-age=31536000, immutable` headers to uploaded R2 assets (logos, favicons, and other images) to enable browser caching and prevent re-downloads on every visit.

Uploaded assets were missing cache metadata, causing browsers to re-fetch them frequently despite Nginx configurations already caching static files aggressively. This change ensures that once a user downloads an image, it's reused from the browser cache on subsequent visits. New uploads (which generate new URLs) will automatically bust the cache.

---
<a href="https://cursor.com/background-agent?bcId=bc-9316d8c2-e12c-485e-8ee9-17cd0e9ae74d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9316d8c2-e12c-485e-8ee9-17cd0e9ae74d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Uploaded images and branding assets now implement intelligent caching that extends asset cache lifetime to one year. This significantly reduces load times when users access these assets repeatedly. Cache optimization is consistently applied across all upload methods to maximize application performance and responsiveness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->