### PR TITLE
fix: render AddPromoCodeModal in empty state of PromoCodesDisplaySection

### DIFF
--- a/frontend/components/profile/PromoCodesDisplaySection.tsx
+++ b/frontend/components/profile/PromoCodesDisplaySection.tsx
@@ -255,36 +255,48 @@ const PromoCodesDisplaySection: React.FC<PromoCodesDisplaySectionProps> = ({
 
   if (displayCodes.length === 0) {
     return (
-      <Card className="p-6">
-        <div className="flex items-center gap-2 mb-4">
-          <TagIcon className="h-5 w-5 text-swiss-mint" />
-          <h3 className="text-lg font-semibold text-swiss-charcoal">
-            {t('promoCodesDisplay.title', 'Promo Codes')}
-          </h3>
-        </div>
-        <div className="text-center py-4 space-y-3">
-          <p className="text-sm text-gray-500">
-            {isOwnProfile
-              ? t('settingsPromoCodeManager.noCodesYet')
-              : t('promoCodesDisplay.noActivePromoCodes')}
-          </p>
-          {isOwnProfile && (
-            <div className="flex items-center justify-center gap-2">
-              <Button variant="light" size="sm" leftIcon={ArrowPathIcon} onClick={loadPromoCodes}>
-                {t('common:buttons.refresh')}
-              </Button>
-              <Button
-                variant="primary"
-                size="sm"
-                leftIcon={PlusCircleIcon}
-                onClick={() => handleOpenModal()}
-              >
-                {t('settingsPromoCodeManager.addNewCode')}
-              </Button>
-            </div>
-          )}
-        </div>
-      </Card>
+      <>
+        <Card className="p-6">
+          <div className="flex items-center gap-2 mb-4">
+            <TagIcon className="h-5 w-5 text-swiss-mint" />
+            <h3 className="text-lg font-semibold text-swiss-charcoal">
+              {t('promoCodesDisplay.title', 'Promo Codes')}
+            </h3>
+          </div>
+          <div className="text-center py-4 space-y-3">
+            <p className="text-sm text-gray-500">
+              {isOwnProfile
+                ? t('settingsPromoCodeManager.noCodesYet')
+                : t('promoCodesDisplay.noActivePromoCodes')}
+            </p>
+            {isOwnProfile && (
+              <div className="flex items-center justify-center gap-2">
+                <Button variant="light" size="sm" leftIcon={ArrowPathIcon} onClick={loadPromoCodes}>
+                  {t('common:buttons.refresh')}
+                </Button>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  leftIcon={PlusCircleIcon}
+                  onClick={() => handleOpenModal()}
+                >
+                  {t('settingsPromoCodeManager.addNewCode')}
+                </Button>
+              </div>
+            )}
+          </div>
+        </Card>
+        {/* Add/Edit Modal (owners only) - must be outside Card for empty state */}
+        {isOwnProfile && (
+          <AddPromoCodeModal
+            isOpen={isModalOpen}
+            onClose={handleCloseModal}
+            onSave={handleSavePromo}
+            editingPromo={editingPromo}
+            isSaving={isSaving}
+          />
+        )}
+      </>
     );
   }
 


### PR DESCRIPTION
The modal was only being rendered in the main return block that displays promo codes. When the list was empty, the component returned early with the empty state view but without the modal, so clicking 'Add New Code' did nothing.

Fixed by wrapping the empty state return in a Fragment and including the AddPromoCodeModal component so it's always rendered when isOwnProfile is true.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the modal structure and rendering logic for adding promo codes, enhancing the modal's display behavior and lifecycle management when managing promotional offers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->