### PR TITLE
Video upload failure limits

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -20,9 +20,12 @@ PRICE_ANNUAL_ONETIME=price_annual_onetime_id
 CLAMAV_HOST=localhost
 CLAMAV_PORT=3310
 UPLOAD_MODE=local
-UPLOAD_MAX_MB=20
-UPLOAD_ALLOWED_EXT=pdf,png,jpg,jpeg,webp,doc,docx
-UPLOAD_ALLOWED_MIME=application/pdf,image/png,image/jpeg,image/webp,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document
+# Max file size in MB (set to 100MB for video uploads)
+UPLOAD_MAX_MB=100
+# Allowed file extensions (includes video formats: mp4, mov, webm, avi)
+UPLOAD_ALLOWED_EXT=pdf,png,jpg,jpeg,webp,doc,docx,mp4,mov,webm,avi,ppt,pptx,xls,xlsx
+# Allowed MIME types (includes video formats)
+UPLOAD_ALLOWED_MIME=application/pdf,image/png,image/jpeg,image/webp,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,video/mp4,video/quicktime,video/webm,video/x-msvideo,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
 
 # Email (SMTP for testing)
 MAIL_PROVIDER=SMTP

--- a/.env.test
+++ b/.env.test
@@ -25,7 +25,8 @@ UPLOAD_MAX_MB=100
 # Allowed file extensions (includes video formats: mp4, mov, webm, avi)
 UPLOAD_ALLOWED_EXT=pdf,png,jpg,jpeg,webp,doc,docx,mp4,mov,webm,avi,ppt,pptx,xls,xlsx
 # Allowed MIME types (includes video formats)
-UPLOAD_ALLOWED_MIME=application/pdf,image/png,image/jpeg,image/webp,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,video/mp4,video/quicktime,video/webm,video/x-msvideo,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+# Note: AVI files can be detected as video/x-msvideo or video/vnd.avi depending on file-type library version
+UPLOAD_ALLOWED_MIME=application/pdf,image/png,image/jpeg,image/webp,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,video/mp4,video/quicktime,video/webm,video/x-msvideo,video/vnd.avi,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
 
 # Email (SMTP for testing)
 MAIL_PROVIDER=SMTP

--- a/api/.env.example
+++ b/api/.env.example
@@ -28,7 +28,8 @@ UPLOAD_MAX_MB=100
 # Allowed file extensions (includes video formats: mp4, mov, webm, avi)
 UPLOAD_ALLOWED_EXT=pdf,png,jpg,jpeg,webp,doc,docx,mp4,mov,webm,avi,ppt,pptx,xls,xlsx
 # Allowed MIME types (includes video formats)
-UPLOAD_ALLOWED_MIME=application/pdf,image/png,image/jpeg,image/webp,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,video/mp4,video/quicktime,video/webm,video/x-msvideo,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+# Note: AVI files can be detected as video/x-msvideo or video/vnd.avi depending on file-type library version
+UPLOAD_ALLOWED_MIME=application/pdf,image/png,image/jpeg,image/webp,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,video/mp4,video/quicktime,video/webm,video/x-msvideo,video/vnd.avi,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
 UPLOAD_MODE=local
 R2_BUCKET_SAFE=pc-solutions-assets-safe
 R2_BUCKET_QUARANTINE=pc-solutions-assets-quarantine

--- a/api/.env.example
+++ b/api/.env.example
@@ -21,9 +21,14 @@ CLERK_WEBHOOK_SECRET=whsec_your_clerk_webhook_secret_here
 MALWARE_SCANNING_ENABLED=false
 # If true, uploads are blocked when scanner is unavailable (only relevant if scanning enabled)
 # MALWARE_SCAN_REQUIRED=false
-UPLOAD_MAX_MB=20
-UPLOAD_ALLOWED_EXT=pdf,png,jpg,jpeg,webp,doc,docx
-UPLOAD_ALLOWED_MIME=application/pdf,image/png,image/jpeg,image/webp,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document
+
+# Upload validation settings
+# Max file size in MB (set to 100MB for video uploads)
+UPLOAD_MAX_MB=100
+# Allowed file extensions (includes video formats: mp4, mov, webm, avi)
+UPLOAD_ALLOWED_EXT=pdf,png,jpg,jpeg,webp,doc,docx,mp4,mov,webm,avi,ppt,pptx,xls,xlsx
+# Allowed MIME types (includes video formats)
+UPLOAD_ALLOWED_MIME=application/pdf,image/png,image/jpeg,image/webp,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,video/mp4,video/quicktime,video/webm,video/x-msvideo,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
 UPLOAD_MODE=local
 R2_BUCKET_SAFE=pc-solutions-assets-safe
 R2_BUCKET_QUARANTINE=pc-solutions-assets-quarantine

--- a/api/src/content/dto/content.enums.ts
+++ b/api/src/content/dto/content.enums.ts
@@ -133,7 +133,8 @@ export const ALLOWED_MIME_TYPES = {
     'video/mp4',
     'video/quicktime',
     'video/webm',
-    'video/x-msvideo', // AVI format
+    'video/x-msvideo', // AVI format (legacy MIME type)
+    'video/vnd.avi', // AVI format (detected by file-type library v21+)
     'application/vnd.ms-powerpoint',
     'application/vnd.openxmlformats-officedocument.presentationml.presentation',
   ],

--- a/api/src/content/dto/content.enums.ts
+++ b/api/src/content/dto/content.enums.ts
@@ -132,6 +132,8 @@ export const ALLOWED_MIME_TYPES = {
     'application/pdf',
     'video/mp4',
     'video/quicktime',
+    'video/webm',
+    'video/x-msvideo', // AVI format
     'application/vnd.ms-powerpoint',
     'application/vnd.openxmlformats-officedocument.presentationml.presentation',
   ],

--- a/api/src/security/mime-validation.service.ts
+++ b/api/src/security/mime-validation.service.ts
@@ -28,7 +28,8 @@ export class MimeValidationService {
       .filter(Boolean);
     
     // Default MIME types include video formats for e-learning content
-    const defaultMimeTypes = 'application/pdf,image/png,image/jpeg,image/webp,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,video/mp4,video/quicktime,video/webm,video/x-msvideo,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    // Note: AVI files can be detected as either video/x-msvideo or video/vnd.avi depending on the file-type library version
+    const defaultMimeTypes = 'application/pdf,image/png,image/jpeg,image/webp,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,video/mp4,video/quicktime,video/webm,video/x-msvideo,video/vnd.avi,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
     this.allowedMimeTypes = (this.configService.get<string>('UPLOAD_ALLOWED_MIME') || defaultMimeTypes)
       .split(',')
       .map(mime => mime.trim().toLowerCase())

--- a/api/src/security/mime-validation.service.ts
+++ b/api/src/security/mime-validation.service.ts
@@ -20,17 +20,22 @@ export class MimeValidationService {
   private readonly maxFileSize: number;
 
   constructor(private configService: ConfigService) {
-    this.allowedExtensions = (this.configService.get<string>('UPLOAD_ALLOWED_EXT') || 'pdf,png,jpg,jpeg,webp,doc,docx')
+    // Default extensions include video formats for e-learning content
+    const defaultExtensions = 'pdf,png,jpg,jpeg,webp,doc,docx,mp4,mov,webm,avi,ppt,pptx,xls,xlsx';
+    this.allowedExtensions = (this.configService.get<string>('UPLOAD_ALLOWED_EXT') || defaultExtensions)
       .split(',')
       .map(ext => ext.trim().toLowerCase())
       .filter(Boolean);
     
-    this.allowedMimeTypes = (this.configService.get<string>('UPLOAD_ALLOWED_MIME') || 'application/pdf,image/png,image/jpeg,image/webp,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document')
+    // Default MIME types include video formats for e-learning content
+    const defaultMimeTypes = 'application/pdf,image/png,image/jpeg,image/webp,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,video/mp4,video/quicktime,video/webm,video/x-msvideo,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    this.allowedMimeTypes = (this.configService.get<string>('UPLOAD_ALLOWED_MIME') || defaultMimeTypes)
       .split(',')
       .map(mime => mime.trim().toLowerCase())
       .filter(Boolean);
     
-    this.maxFileSize = Number(this.configService.get<string>('UPLOAD_MAX_MB') || '20') * 1024 * 1024;
+    // Default max file size is 100MB to support video uploads
+    this.maxFileSize = Number(this.configService.get<string>('UPLOAD_MAX_MB') || '100') * 1024 * 1024;
     
     this.logger.log(`MIME validation configured: ${this.allowedExtensions.length} extensions, ${this.allowedMimeTypes.length} MIME types, max ${this.maxFileSize / (1024 * 1024)}MB`);
   }

--- a/api/src/upload/cloudflare-r2.service.ts
+++ b/api/src/upload/cloudflare-r2.service.ts
@@ -284,7 +284,8 @@ export class CloudflareR2Service {
         'application/pdf',
         'video/mp4',
         'video/quicktime',
-        'video/x-msvideo', // AVI
+        'video/x-msvideo', // AVI (legacy MIME type)
+        'video/vnd.avi', // AVI (detected by file-type library v21+)
         'video/webm',
         'application/vnd.ms-powerpoint',
         'application/vnd.openxmlformats-officedocument.presentationml.presentation',


### PR DESCRIPTION
Enable video uploads by increasing the maximum file size and adding video formats to the allowed extensions and MIME types in the MIME validation service.

The `MimeValidationService` was configured with default limits that were too restrictive for video files (20MB max size, no video extensions/MIME types), causing all video uploads to fail at the initial validation step, even though content-specific limits were higher.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e40ee30-2d09-483e-a9ee-b622bbdef24b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2e40ee30-2d09-483e-a9ee-b622bbdef24b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased maximum file upload size to 100 MB (from 20 MB).
  * Added support for video uploads (MP4, MOV, WebM, AVI).
  * Added support for Office presentations and spreadsheets (PPT, PPTX, XLS, XLSX).

* **Documentation**
  * Clarified upload validation settings and allowed types in configuration examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->