### PR TITLE
feat: add Multer file size limit and detailed upload logging

### DIFF
--- a/api/src/content/content.controller.ts
+++ b/api/src/content/content.controller.ts
@@ -60,7 +60,11 @@ export class ContentController {
 
   @Post('elearning')
   @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
-  @UseInterceptors(FileInterceptor('file'))
+  @UseInterceptors(FileInterceptor('file', {
+    limits: {
+      fileSize: 500 * 1024 * 1024, // 500MB max for video uploads
+    },
+  }))
   @UsePipes(new ValidationPipe({ 
     transform: true, 
     whitelist: true,
@@ -78,6 +82,7 @@ export class ContentController {
     @Body() dto: UploadElearningDto,
     @Request() req,
   ) {
+    console.log('📥 E-Learning Upload Request received at:', new Date().toISOString());
     console.log('📥 E-Learning Upload Request:', {
       file: file ? { name: file.originalname, size: file.size, mimetype: file.mimetype } : null,
       body: req.body,

--- a/api/src/content/content.service.ts
+++ b/api/src/content/content.service.ts
@@ -84,7 +84,13 @@ export class ContentService {
     dto: UploadElearningDto,
     userId: string,
   ) {
-    this.logger.log(`Uploading e-learning content: ${dto.title}`);
+    const startTime = Date.now();
+    this.logger.log(`📤 [UPLOAD START] E-learning content: ${dto.title}`);
+    this.logger.log(`📤 [UPLOAD CONFIG] Max file size: ${this.fileSizeLimits.ELEARNING / 1024 / 1024}MB`);
+    
+    if (file) {
+      this.logger.log(`📤 [UPLOAD FILE] Name: ${file.originalname}, Size: ${(file.size / 1024 / 1024).toFixed(2)}MB, Type: ${file.mimetype}`);
+    }
 
     // Validate file based on content type
     if (dto.type !== ELearningContentType.LINK && dto.videoSourceType !== 'url') {
@@ -93,18 +99,23 @@ export class ContentService {
       }
 
       // Validate file size
+      this.logger.log(`📤 [VALIDATION] Checking file size: ${file.size} bytes vs limit: ${this.fileSizeLimits.ELEARNING} bytes`);
       if (file.size > this.fileSizeLimits.ELEARNING) {
+        this.logger.error(`📤 [VALIDATION FAILED] File size ${file.size} exceeds limit ${this.fileSizeLimits.ELEARNING}`);
         throw new BadRequestException(
           `File size exceeds maximum allowed (${this.fileSizeLimits.ELEARNING / 1024 / 1024}MB)`,
         );
       }
+      this.logger.log(`📤 [VALIDATION] File size OK`);
 
       // Validate MIME type
       if (!ALLOWED_MIME_TYPES.ELEARNING.includes(file.mimetype)) {
+        this.logger.error(`📤 [VALIDATION FAILED] Invalid MIME type: ${file.mimetype}`);
         throw new BadRequestException(
           `Invalid file type. Allowed types: ${ALLOWED_MIME_TYPES.ELEARNING.join(', ')}`,
         );
       }
+      this.logger.log(`📤 [VALIDATION] MIME type OK`);
     }
 
     // Ensure unique title by auto-suffixing duplicates for e-learning


### PR DESCRIPTION
- Added explicit 500MB file size limit to FileInterceptor in content controller
- Added detailed step-by-step logging for upload debugging:
  - Upload start with timestamp
  - File size configuration
  - File details (name, size, type)
  - Validation steps with pass/fail status
- This helps debug upload issues on Render

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* E-Learning file uploads are now limited to 500 MB.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->