### PR TITLE
fix: use disk storage and streaming for large file uploads

### DIFF
--- a/api/src/content/content.controller.ts
+++ b/api/src/content/content.controller.ts
@@ -19,6 +19,7 @@ import {
 import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
 import { extname } from 'path';
+import { randomUUID } from 'crypto';
 import { ContentService } from './content.service';
 import { ClerkAuthGuard } from '../auth/guards/clerk-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -66,8 +67,8 @@ export class ContentController {
     storage: diskStorage({
       destination: '/tmp', // Use /tmp for temporary storage (works on Render)
       filename: (req, file, cb) => {
-        // Generate unique filename to avoid collisions
-        const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9);
+        // Generate unique filename using UUID for collision resistance
+        const uniqueSuffix = Date.now() + '-' + randomUUID();
         const ext = extname(file.originalname);
         cb(null, `upload-${uniqueSuffix}${ext}`);
       },

--- a/api/src/content/content.controller.ts
+++ b/api/src/content/content.controller.ts
@@ -17,6 +17,8 @@ import {
   UsePipes,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { diskStorage } from 'multer';
+import { extname } from 'path';
 import { ContentService } from './content.service';
 import { ClerkAuthGuard } from '../auth/guards/clerk-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -61,6 +63,15 @@ export class ContentController {
   @Post('elearning')
   @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
   @UseInterceptors(FileInterceptor('file', {
+    storage: diskStorage({
+      destination: '/tmp', // Use /tmp for temporary storage (works on Render)
+      filename: (req, file, cb) => {
+        // Generate unique filename to avoid collisions
+        const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9);
+        const ext = extname(file.originalname);
+        cb(null, `upload-${uniqueSuffix}${ext}`);
+      },
+    }),
     limits: {
       fileSize: 500 * 1024 * 1024, // 500MB max for video uploads
     },

--- a/api/src/upload/cloudflare-r2.service.ts
+++ b/api/src/upload/cloudflare-r2.service.ts
@@ -4,6 +4,7 @@ import { S3Client, PutObjectCommand, DeleteObjectCommand, GetObjectCommand, Head
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { AssetKind } from '@prisma/client';
 import { createHash } from 'crypto';
+import * as fs from 'fs';
 
 export interface UploadResult {
   key: string;
@@ -105,11 +106,6 @@ export class CloudflareR2Service {
     subcategory?: string,
     conversationId?: string,
   ): Promise<UploadResult> {
-    // Import fs for reading files from disk
-    const fs = await import('fs');
-    const fsPromises = fs.promises;
-    const crypto = await import('crypto');
-    
     try {
       // Validate file first
       this.validateFile(file, assetKind);
@@ -140,7 +136,7 @@ export class CloudflareR2Service {
         this.logger.log(`Using disk storage for ${file.originalname} (${(file.size / 1024 / 1024).toFixed(2)}MB), streaming from ${file.path}`);
         
         // Calculate checksum by streaming (memory efficient)
-        const hash = crypto.createHash('sha256');
+        const hash = createHash('sha256');
         const checksumStream = fs.createReadStream(file.path);
         for await (const chunk of checksumStream) {
           hash.update(chunk);
@@ -175,7 +171,7 @@ export class CloudflareR2Service {
       // Clean up temp file if using disk storage
       if (file.path) {
         try {
-          await fsPromises.unlink(file.path);
+          await fs.promises.unlink(file.path);
           this.logger.log(`Cleaned up temp file: ${file.path}`);
         } catch (cleanupError) {
           this.logger.warn(`Failed to clean up temp file ${file.path}:`, cleanupError);
@@ -208,7 +204,6 @@ export class CloudflareR2Service {
       // Clean up temp file on error if using disk storage
       if (file.path) {
         try {
-          const fs = await import('fs');
           await fs.promises.unlink(file.path);
         } catch (cleanupError) {
           this.logger.warn(`Failed to clean up temp file on error:`, cleanupError);

--- a/api/src/upload/cloudflare-r2.service.ts
+++ b/api/src/upload/cloudflare-r2.service.ts
@@ -95,6 +95,8 @@ export class CloudflareR2Service {
 
   /**
    * Upload file directly from server with checksum verification
+   * Supports both memory storage (file.buffer) and disk storage (file.path)
+   * Uses streaming for disk storage to avoid loading large files into memory
    */
   async uploadFile(
     file: Express.Multer.File,
@@ -103,6 +105,11 @@ export class CloudflareR2Service {
     subcategory?: string,
     conversationId?: string,
   ): Promise<UploadResult> {
+    // Import fs for reading files from disk
+    const fs = await import('fs');
+    const fsPromises = fs.promises;
+    const crypto = await import('crypto');
+    
     try {
       // Validate file first
       this.validateFile(file, assetKind);
@@ -120,14 +127,38 @@ export class CloudflareR2Service {
 
       const key = this.generateStorageKey(file.originalname, assetKind, appUserId, subcategory, conversationId);
       
-      // Calculate SHA-256 checksum
-      const checksum = this.calculateChecksum(file.buffer);
+      let fileBody: Buffer | NodeJS.ReadableStream;
+      let checksum: string;
+      
+      if (file.buffer) {
+        // Memory storage - file is already in memory (small files)
+        fileBody = file.buffer;
+        checksum = this.calculateChecksum(file.buffer);
+        this.logger.log(`Using memory storage for ${file.originalname} (${(file.size / 1024 / 1024).toFixed(2)}MB)`);
+      } else if (file.path) {
+        // Disk storage - stream file directly to R2 (large files)
+        this.logger.log(`Using disk storage for ${file.originalname} (${(file.size / 1024 / 1024).toFixed(2)}MB), streaming from ${file.path}`);
+        
+        // Calculate checksum by streaming (memory efficient)
+        const hash = crypto.createHash('sha256');
+        const checksumStream = fs.createReadStream(file.path);
+        for await (const chunk of checksumStream) {
+          hash.update(chunk);
+        }
+        checksum = hash.digest('base64');
+        
+        // Create fresh read stream for upload
+        fileBody = fs.createReadStream(file.path);
+      } else {
+        throw new BadRequestException('File data not available');
+      }
       
       const command = new PutObjectCommand({
         Bucket: this.bucketName,
         Key: key,
-        Body: file.buffer,
+        Body: fileBody,
         ContentType: file.mimetype,
+        ContentLength: file.size, // Required for streaming
         ChecksumSHA256: checksum, // S3-compatible checksum
         Metadata: {
           'uploaded-by': appUserId,
@@ -140,6 +171,16 @@ export class CloudflareR2Service {
       this.logger.log(`Uploading file: ${file.originalname} (${assetKind}) to ${key} with checksum: ${checksum.substring(0, 16)}...`);
       
       await this.s3Client.send(command);
+      
+      // Clean up temp file if using disk storage
+      if (file.path) {
+        try {
+          await fsPromises.unlink(file.path);
+          this.logger.log(`Cleaned up temp file: ${file.path}`);
+        } catch (cleanupError) {
+          this.logger.warn(`Failed to clean up temp file ${file.path}:`, cleanupError);
+        }
+      }
       
       // Verify upload by fetching ETag
       const headCommand = new HeadObjectCommand({
@@ -164,6 +205,16 @@ export class CloudflareR2Service {
         checksum,
       };
     } catch (error) {
+      // Clean up temp file on error if using disk storage
+      if (file.path) {
+        try {
+          const fs = await import('fs');
+          await fs.promises.unlink(file.path);
+        } catch (cleanupError) {
+          this.logger.warn(`Failed to clean up temp file on error:`, cleanupError);
+        }
+      }
+      
       this.logger.error('Failed to upload file', {
         error: error.message,
         filename: file?.originalname,


### PR DESCRIPTION
Root cause: Server ran out of memory (512MB limit) when handling 123MB video upload because Multer loads entire file into memory.

Solution:
- Configure Multer to use disk storage (/tmp) instead of memory
- Stream files directly to R2 instead of loading into memory
- Calculate checksum by streaming (memory efficient)
- Clean up temp files after upload

This allows uploading large video files without exceeding Render's 512MB memory limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * File uploads now support disk-backed streaming transfers for more efficient handling of large files.
  * Uploads include checksum verification and explicit content-length handling for more reliable transfers.
  * Temporary upload files are automatically removed after success or on error to free storage.
  * Enhanced error handling and logging around uploads for clearer diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->