### PR TITLE
fix: use correct Readable type for AWS SDK S3 streaming

### DIFF
--- a/api/src/upload/cloudflare-r2.service.ts
+++ b/api/src/upload/cloudflare-r2.service.ts
@@ -5,6 +5,7 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { AssetKind } from '@prisma/client';
 import { createHash } from 'crypto';
 import * as fs from 'fs';
+import { Readable } from 'stream';
 
 export interface UploadResult {
   key: string;
@@ -123,7 +124,7 @@ export class CloudflareR2Service {
 
       const key = this.generateStorageKey(file.originalname, assetKind, appUserId, subcategory, conversationId);
       
-      let fileBody: Buffer | NodeJS.ReadableStream;
+      let fileBody: Buffer | Readable;
       let checksum: string;
       
       if (file.buffer) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -563,6 +563,9 @@ importers:
       '@sentry/vite-plugin':
         specifier: ^4.6.1
         version: 4.6.1
+      dompurify:
+        specifier: ^3.3.1
+        version: 3.3.1
       emoji-picker-react:
         specifier: ^4.15.2
         version: 4.16.1(react@19.1.1)
@@ -9040,6 +9043,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}


### PR DESCRIPTION
The AWS SDK PutObjectCommand expects a Node.js Readable stream, not NodeJS.ReadableStream. Import Readable from 'stream' module and use it as the type for fileBody.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file upload type handling to ensure consistent compatibility with different file input methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->