### PR TITLE
Crawler post-crawl behavior

### DIFF
--- a/admin/src/pages/CantonDetail.tsx
+++ b/admin/src/pages/CantonDetail.tsx
@@ -409,19 +409,42 @@ export default function CantonDetailPage() {
       const response = await apiClient.post(`/admin/crawler/trigger/${sourceId}`);
       const results = response.data?.data || response.data;
       
+      const discovered = results?.discovered || 0;
+      const whitelisted = results?.whitelisted;
+      const nonWhitelisted = results?.nonWhitelisted;
+      const created = results?.created || 0;
+      const updated = results?.updated || 0;
+      const unchanged = results?.unchanged || 0;
+      const skipped = results?.skipped || 0;
+      const errorsCount = results?.errors?.length || 0;
+      const needsReview = created + updated;
+
       // Show detailed results
       const message = results 
         ? `Crawl completed!\n\n` +
-          `Discovered: ${results.discovered || 0} links\n` +
-          `Created: ${results.created || 0} new documents\n` +
-          `Updated: ${results.updated || 0} changed documents\n` +
-          `Unchanged: ${results.unchanged || 0} documents\n` +
-          `Skipped: ${results.skipped || 0} documents\n` +
-          (results.errors?.length > 0 ? `\nErrors: ${results.errors.length}` : '')
+          `Discovered: ${discovered} links\n` +
+          (typeof whitelisted === 'number' ? `Whitelisted: ${whitelisted} links\n` : '') +
+          (typeof nonWhitelisted === 'number' ? `Non-whitelisted (SSRF blocked): ${nonWhitelisted} links\n` : '') +
+          `Created: ${created} new documents\n` +
+          `Updated: ${updated} changed documents\n` +
+          `Unchanged: ${unchanged} documents\n` +
+          `Skipped (classifier): ${skipped} documents\n` +
+          (errorsCount > 0 ? `\nErrors: ${errorsCount}` : '') +
+          (needsReview > 0 ? `\n\nNext step: review ${needsReview} document(s) in the Policy Review tab.` : '')
         : t('admin:cantons.detail.crawlSuccess');
       
       alert(message);
-      fetchData();
+
+      // Refresh source status after crawl
+      await fetchData();
+
+      // Offer to jump straight to review queue if there is anything to review
+      if (needsReview > 0 && canton?.name) {
+        const openReview = confirm(`Open Policy Review now to review ${needsReview} document(s)?`);
+        if (openReview) {
+          navigate(`/policy-crawler/review?canton=${encodeURIComponent(canton.name)}`);
+        }
+      }
     } catch (err: any) {
       alert(`${t('admin:cantons.detail.crawlError')}: ${err.response?.data?.message || err.message}`);
     } finally {

--- a/admin/src/pages/PolicyReview.tsx
+++ b/admin/src/pages/PolicyReview.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useApiClient } from '../services/api';
 import { CheckCircle, XCircle, ExternalLink, Clock, FileText } from 'lucide-react';
 import { CANTON_CODES } from '@workspace/types/src/cantons';
+import { useLocation } from 'react-router-dom';
 
 interface StatePolicyAsset {
   id: string;
@@ -251,6 +252,7 @@ const PolicyReviewPanel: React.FC<{
 export default function PolicyReviewPage() {
   const { t } = useTranslation(['admin', 'content']);
   const apiClient = useApiClient();
+  const location = useLocation();
   const [policies, setPolicies] = useState<StatePolicyAsset[]>([]);
   const [filters, setFilters] = useState({
     canton: '',
@@ -258,6 +260,16 @@ export default function PolicyReviewPage() {
   });
   const [selectedPolicy, setSelectedPolicy] = useState<StatePolicyAsset | null>(null);
   const [loading, setLoading] = useState(true);
+
+  // Allow deep-linking into review queue via `?canton=<Canton Name>`
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const cantonFromQuery = params.get('canton');
+    if (cantonFromQuery && cantonFromQuery !== filters.canton) {
+      setFilters(prev => ({ ...prev, canton: cantonFromQuery }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.search]);
 
   useEffect(() => {
     fetchPolicies();

--- a/api/src/crawler/crawler.service.ts
+++ b/api/src/crawler/crawler.service.ts
@@ -103,6 +103,8 @@ export class CrawlerService {
 
   async crawlSource(sourceId: number): Promise<{
     discovered: number;
+    whitelisted: number;
+    nonWhitelisted: number;
     created: number;
     updated: number;
     unchanged: number;
@@ -119,7 +121,9 @@ export class CrawlerService {
     }
 
     const results = { 
-      discovered: 0, 
+      discovered: 0,
+      whitelisted: 0,
+      nonWhitelisted: 0,
       created: 0, 
       updated: 0, 
       unchanged: 0,
@@ -167,7 +171,14 @@ export class CrawlerService {
         }
       });
 
-      this.logger.log(`Source ${source.label}: Found ${allCandidates.length} candidate links, ${candidates.length} whitelisted`);
+      results.whitelisted = candidates.length;
+      results.nonWhitelisted = Math.max(0, allCandidates.length - candidates.length);
+
+      this.logger.log(
+        `Source ${source.label}: Found ${allCandidates.length} candidate links, ` +
+        `${results.whitelisted} whitelisted, ` +
+        `${results.nonWhitelisted} non-whitelisted`
+      );
 
       // Step 2: Process each candidate with rate limiting
       for (const candidate of candidates) {


### PR DESCRIPTION
Improve policy crawler admin UI feedback and guide users to the review queue to clarify post-crawl behavior.

The previous UI didn't clearly communicate that the crawler's primary output is `pending_review` assets for manual review, leading users to believe "nothing happens" if no immediate action was taken or if all links were skipped. This PR adds detailed skip counts (including SSRF vs. classifier) and a direct navigation prompt to the review queue.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d6acebf-1e32-4bf1-9de1-686d364ffa29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d6acebf-1e32-4bf1-9de1-686d364ffa29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced crawl metrics display now shows whitelisted and non-whitelisted item counts alongside crawl summary.
  * Automatic data refresh and navigation to Policy Review page when items require post-crawl review.
  * Added URL-based deep-linking capability for direct access to specific canton policy review queues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->