### PR TITLE
Add crawl debug samples for skip reasons

### DIFF
--- a/admin/src/pages/CantonDetail.tsx
+++ b/admin/src/pages/CantonDetail.tsx
@@ -406,7 +406,7 @@ export default function CantonDetailPage() {
     
     setTriggeringCrawl(sourceId);
     try {
-      const response = await apiClient.post(`/admin/crawler/trigger/${sourceId}`);
+      const response = await apiClient.post(`/admin/crawler/trigger/${sourceId}?debug=1`);
       const results = response.data?.data || response.data;
       
       const discovered = results?.discovered || 0;
@@ -418,6 +418,7 @@ export default function CantonDetailPage() {
       const skipped = results?.skipped || 0;
       const errorsCount = results?.errors?.length || 0;
       const needsReview = created + updated;
+      const debug = results?.debug;
 
       // Show detailed results
       const message = results 
@@ -430,7 +431,12 @@ export default function CantonDetailPage() {
           `Unchanged: ${unchanged} documents\n` +
           `Skipped (classifier): ${skipped} documents\n` +
           (errorsCount > 0 ? `\nErrors: ${errorsCount}` : '') +
-          (needsReview > 0 ? `\n\nNext step: review ${needsReview} document(s) in the Policy Review tab.` : '')
+          (needsReview > 0 ? `\n\nNext step: review ${needsReview} document(s) in the Policy Review tab.` : '') +
+          (needsReview === 0 && debug ? (
+            `\n\nWhy nothing shows in Policy Review:\n` +
+            (debug.nonWhitelistedSamples?.length ? `- Non-whitelisted examples:\n${debug.nonWhitelistedSamples.slice(0, 5).map((s: any) => `  • ${s.url} (${s.reason})`).join('\n')}\n` : '') +
+            (debug.classifierSkippedSamples?.length ? `- Classifier-skipped examples:\n${debug.classifierSkippedSamples.slice(0, 5).map((s: any) => `  • ${s.url} (${s.reason})`).join('\n')}\n` : '')
+          ) : '')
         : t('admin:cantons.detail.crawlSuccess');
       
       alert(message);

--- a/api/src/crawler/crawler.controller.ts
+++ b/api/src/crawler/crawler.controller.ts
@@ -24,7 +24,7 @@ export class CrawlerController {
 
   // Trigger manual crawl with input validation
   @Post('trigger/:sourceId')
-  async triggerCrawl(@Param('sourceId') sourceId: string) {
+  async triggerCrawl(@Param('sourceId') sourceId: string, @Query('debug') debug?: string) {
     if (!this.isCrawlerEnabled()) {
       throw new BadRequestException('Crawler is disabled');
     }
@@ -36,7 +36,10 @@ export class CrawlerController {
     }
 
     try {
-      const results = await this.crawlerScheduler.triggerCrawl(id);
+      const debugEnabled = debug === '1' || debug === 'true';
+      const results = await this.crawlerScheduler.triggerCrawl(id, {
+        debug: debugEnabled,
+      });
       return { success: true, data: results };
     } catch (error: any) {
       // Provide user-friendly error messages

--- a/api/src/crawler/crawler.scheduler.ts
+++ b/api/src/crawler/crawler.scheduler.ts
@@ -77,11 +77,14 @@ export class CrawlerScheduler implements OnModuleInit {
   }
 
   // Manual trigger for admin
-  async triggerCrawl(sourceId: number): Promise<any> {
+  async triggerCrawl(
+    sourceId: number,
+    options?: { debug?: boolean; debugLimit?: number },
+  ): Promise<any> {
     if (!this.isCrawlerEnabled()) {
       throw new Error('Crawler is disabled (set CRAWLER_ENABLED=true to enable).');
     }
-    return this.crawler.crawlSource(sourceId);
+    return this.crawler.crawlSource(sourceId, options);
   }
 
   // Check for stale sources daily

--- a/api/src/crawler/crawler.service.ts
+++ b/api/src/crawler/crawler.service.ts
@@ -44,6 +44,7 @@ const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
 export class CrawlerService {
   private readonly logger = new Logger(CrawlerService.name);
   private systemUserId: string | null = null;
+  private readonly DEFAULT_DEBUG_LIMIT = 10;
 
   /**
    * Whitelisted domains for SSRF prevention.
@@ -101,7 +102,10 @@ export class CrawlerService {
     return this.systemUserId;
   }
 
-  async crawlSource(sourceId: number): Promise<{
+  async crawlSource(
+    sourceId: number,
+    options?: { debug?: boolean; debugLimit?: number },
+  ): Promise<{
     discovered: number;
     whitelisted: number;
     nonWhitelisted: number;
@@ -110,6 +114,10 @@ export class CrawlerService {
     unchanged: number;
     skipped: number;
     errors: string[];
+    debug?: {
+      nonWhitelistedSamples: Array<{ url: string; reason: string }>;
+      classifierSkippedSamples: Array<{ url: string; reason: string; anchorText: string; confidence: number }>;
+    };
   }> {
     const source = await this.prisma.cantonSource.findUnique({
       where: { id: sourceId },
@@ -120,6 +128,12 @@ export class CrawlerService {
       throw new Error(`Source ${sourceId} not found or inactive`);
     }
 
+    const debugEnabled = Boolean(options?.debug);
+    const debugLimit = Math.max(
+      1,
+      Math.min(options?.debugLimit ?? this.DEFAULT_DEBUG_LIMIT, 50),
+    );
+
     const results = { 
       discovered: 0,
       whitelisted: 0,
@@ -129,6 +143,17 @@ export class CrawlerService {
       unchanged: 0,
       skipped: 0,
       errors: [] as string[],
+      debug: debugEnabled
+        ? {
+            nonWhitelistedSamples: [] as Array<{ url: string; reason: string }>,
+            classifierSkippedSamples: [] as Array<{
+              url: string;
+              reason: string;
+              anchorText: string;
+              confidence: number;
+            }>,
+          }
+        : undefined,
     };
 
     try {
@@ -166,7 +191,14 @@ export class CrawlerService {
           return true;
         } catch (error: any) {
           // Silently skip non-whitelisted domains (social media, external sites, etc.)
-          this.logger.debug(`Skipping non-whitelisted URL: ${candidate.url} (${error.message})`);
+          const reason = error?.message || 'Non-whitelisted URL';
+          this.logger.debug(`Skipping non-whitelisted URL: ${candidate.url} (${reason})`);
+
+          if (debugEnabled && results.debug) {
+            if (results.debug.nonWhitelistedSamples.length < debugLimit) {
+              results.debug.nonWhitelistedSamples.push({ url: candidate.url, reason });
+            }
+          }
           return false;
         }
       });
@@ -183,7 +215,15 @@ export class CrawlerService {
       // Step 2: Process each candidate with rate limiting
       for (const candidate of candidates) {
         try {
-          const result = await this.processCandidate(candidate, source);
+          const result = await this.processCandidate(candidate, source, {
+            debugEnabled,
+            debugLimit,
+            onClassifierSkip: (info) => {
+              if (!results.debug) return;
+              if (results.debug.classifierSkippedSamples.length >= debugLimit) return;
+              results.debug.classifierSkippedSamples.push(info);
+            },
+          });
           results[result]++;
           
           // Per-document rate limit: 500ms between candidates
@@ -245,6 +285,16 @@ export class CrawlerService {
   private async processCandidate(
     candidate: CandidateDocument,
     source: CantonSourceWithCanton,
+    debug?: {
+      debugEnabled: boolean;
+      debugLimit: number;
+      onClassifierSkip: (info: {
+        url: string;
+        reason: string;
+        anchorText: string;
+        confidence: number;
+      }) => void;
+    },
   ): Promise<'created' | 'updated' | 'unchanged' | 'skipped'> {
     
     // ==========================================
@@ -269,6 +319,15 @@ export class CrawlerService {
       this.logger.debug(
         `Skipping ${candidate.url} - not daycare-related (${reason}, confidence: ${classification.confidence.toFixed(2)}${topicsInfo}, anchor: "${candidate.anchorText}")`
       );
+
+      if (debug?.debugEnabled) {
+        debug.onClassifierSkip({
+          url: candidate.url,
+          reason: `not daycare-related (${reason})`,
+          anchorText: candidate.anchorText,
+          confidence: classification.confidence,
+        });
+      }
       return 'skipped';
     }
 
@@ -344,6 +403,14 @@ export class CrawlerService {
 
         if (!finalClassification.isDaycareRelated) {
           this.logger.debug(`After parsing, ${candidate.url} still not daycare-related - skipping`);
+          if (debug?.debugEnabled) {
+            debug.onClassifierSkip({
+              url: candidate.url,
+              reason: 'not daycare-related after PDF parse',
+              anchorText: candidate.anchorText,
+              confidence: finalClassification.confidence,
+            });
+          }
           return 'skipped';
         }
       } catch (parseError) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional debug mode parameter to crawl trigger endpoint for enhanced diagnostics
  * Debug mode provides detailed information about crawl filtering decisions when no documents require review, including up to 5 non-whitelisted samples and up to 5 classifier-skipped samples with corresponding URLs and reasons

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->