### PR TITLE
Add crawler scan + ingest UI for reviewing found links

### DIFF
--- a/admin/src/pages/CantonDetail.tsx
+++ b/admin/src/pages/CantonDetail.tsx
@@ -35,6 +35,48 @@ interface CantonSource {
   nextCrawlAt?: string;
 }
 
+interface CandidateScanResult {
+  url: string;
+  title: string;
+  anchorText: string;
+  sectionHeading?: string;
+  isPdf: boolean;
+  whitelisted: boolean;
+  whitelistError?: string;
+  classification?: {
+    isDaycareRelated: boolean;
+    confidence: number;
+    category: string;
+    docType: string;
+    language: 'fr' | 'de' | 'en';
+    topics: string[];
+  };
+  classifierSkipReason?: string;
+}
+
+interface ScanResult {
+  sourceId: number;
+  sourceLabel: string;
+  sourceUrl: string;
+  discovered: number;
+  whitelisted: number;
+  nonWhitelisted: number;
+  pdfCount: number;
+  daycareRelated: number;
+  classifierSkipped: number;
+  candidates: CandidateScanResult[];
+}
+
+interface IngestResult {
+  requested: number;
+  created: number;
+  updated: number;
+  unchanged: number;
+  skipped: number;
+  errors: Array<{ url: string; error: string }>;
+  results: Array<{ url: string; outcome: 'created' | 'updated' | 'unchanged' | 'skipped' | 'error' }>;
+}
+
 interface AddSourceModalProps {
   cantonId: number;
   onClose: () => void;
@@ -364,6 +406,270 @@ const EditSourceModal: React.FC<EditSourceModalProps> = ({ source, onClose, onSu
   );
 };
 
+const CrawlResultsModal: React.FC<{
+  source: CantonSource;
+  cantonName: string;
+  onClose: () => void;
+  onAfterIngest: () => Promise<void>;
+}> = ({ source, cantonName, onClose, onAfterIngest }) => {
+  const apiClient = useApiClient();
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(true);
+  const [scan, setScan] = useState<ScanResult | null>(null);
+  const [selected, setSelected] = useState<Record<string, boolean>>({});
+  const [onlyPdf, setOnlyPdf] = useState(false);
+  const [onlyWhitelisted, setOnlyWhitelisted] = useState(true);
+  const [force, setForce] = useState(false);
+  const [ingesting, setIngesting] = useState(false);
+  const [ingestResult, setIngestResult] = useState<IngestResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const run = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        setIngestResult(null);
+
+        const resp = await apiClient.post(`/admin/crawler/scan/${source.id}`);
+        const data: ScanResult = resp.data?.data || resp.data;
+        setScan(data);
+
+        // Default-select all whitelisted links
+        const initial: Record<string, boolean> = {};
+        for (const c of data.candidates || []) {
+          if (c.whitelisted) initial[c.url] = true;
+        }
+        setSelected(initial);
+      } catch (e: any) {
+        setError(e.response?.data?.message || e.message || 'Failed to scan source');
+      } finally {
+        setLoading(false);
+      }
+    };
+    run();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [source.id]);
+
+  const visibleCandidates = (scan?.candidates || []).filter(c => {
+    if (onlyWhitelisted && !c.whitelisted) return false;
+    if (onlyPdf && !c.isPdf) return false;
+    return true;
+  });
+
+  const selectedUrls = Object.entries(selected)
+    .filter(([, v]) => v)
+    .map(([k]) => k);
+
+  const toggleAllVisible = (value: boolean) => {
+    const next = { ...selected };
+    for (const c of visibleCandidates) {
+      next[c.url] = value;
+    }
+    setSelected(next);
+  };
+
+  const ingestSelected = async () => {
+    if (selectedUrls.length === 0) {
+      alert('Select at least one link to ingest.');
+      return;
+    }
+    setIngesting(true);
+    setError(null);
+    try {
+      const resp = await apiClient.post(`/admin/crawler/ingest/${source.id}`, {
+        urls: selectedUrls,
+        force,
+      });
+      const data: IngestResult = resp.data?.data || resp.data;
+      setIngestResult(data);
+      await onAfterIngest();
+    } catch (e: any) {
+      setError(e.response?.data?.message || e.message || 'Failed to ingest URLs');
+    } finally {
+      setIngesting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-6 w-full max-w-5xl mx-4 max-h-[90vh] overflow-y-auto">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-bold">Crawl results</h2>
+            <p className="text-sm text-gray-600 mt-1">
+              {source.label} — <span className="break-all">{source.url}</span>
+            </p>
+          </div>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-2xl leading-none">
+            ×
+          </button>
+        </div>
+
+        {error ? (
+          <div className="mt-4 bg-red-50 border border-red-200 rounded p-3">
+            <p className="text-red-800 text-sm">{error}</p>
+          </div>
+        ) : null}
+
+        {loading ? (
+          <div className="mt-6 flex items-center justify-center h-40">
+            <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-blue-600" />
+          </div>
+        ) : scan ? (
+          <>
+            <div className="mt-4 grid grid-cols-2 md:grid-cols-4 gap-3">
+              <div className="rounded border bg-gray-50 p-3">
+                <div className="text-xs text-gray-500">Discovered</div>
+                <div className="text-lg font-semibold">{scan.discovered}</div>
+              </div>
+              <div className="rounded border bg-gray-50 p-3">
+                <div className="text-xs text-gray-500">Whitelisted</div>
+                <div className="text-lg font-semibold">{scan.whitelisted}</div>
+              </div>
+              <div className="rounded border bg-gray-50 p-3">
+                <div className="text-xs text-gray-500">PDFs</div>
+                <div className="text-lg font-semibold">{scan.pdfCount}</div>
+              </div>
+              <div className="rounded border bg-gray-50 p-3">
+                <div className="text-xs text-gray-500">Classifier skipped</div>
+                <div className="text-lg font-semibold">{scan.classifierSkipped}</div>
+              </div>
+            </div>
+
+            <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+              <div className="flex flex-wrap items-center gap-4">
+                <label className="flex items-center gap-2 text-sm">
+                  <input type="checkbox" checked={onlyWhitelisted} onChange={e => setOnlyWhitelisted(e.target.checked)} />
+                  Only whitelisted
+                </label>
+                <label className="flex items-center gap-2 text-sm">
+                  <input type="checkbox" checked={onlyPdf} onChange={e => setOnlyPdf(e.target.checked)} />
+                  Only PDFs
+                </label>
+                <button
+                  type="button"
+                  className="text-sm text-blue-600 hover:underline"
+                  onClick={() => toggleAllVisible(true)}
+                >
+                  Select all visible
+                </button>
+                <button
+                  type="button"
+                  className="text-sm text-blue-600 hover:underline"
+                  onClick={() => toggleAllVisible(false)}
+                >
+                  Clear visible
+                </button>
+              </div>
+
+              <div className="flex items-center gap-3">
+                <label className="flex items-center gap-2 text-sm">
+                  <input type="checkbox" checked={force} onChange={e => setForce(e.target.checked)} />
+                  Force ingest (ignore classifier)
+                </label>
+                <button
+                  type="button"
+                  disabled={ingesting || selectedUrls.length === 0}
+                  onClick={ingestSelected}
+                  className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                >
+                  {ingesting ? 'Ingesting…' : `Ingest selected (${selectedUrls.length})`}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => navigate(`/policy-crawler/review?canton=${encodeURIComponent(cantonName)}`)}
+                  className="px-4 py-2 border rounded hover:bg-gray-50"
+                >
+                  Open Policy Review
+                </button>
+              </div>
+            </div>
+
+            {ingestResult ? (
+              <div className="mt-4 rounded border border-green-200 bg-green-50 p-3 text-sm text-green-900">
+                Ingest completed. Created: {ingestResult.created}, Updated: {ingestResult.updated}, Unchanged:{' '}
+                {ingestResult.unchanged}, Skipped: {ingestResult.skipped}, Errors: {ingestResult.errors?.length || 0}.
+              </div>
+            ) : null}
+
+            <div className="mt-4 overflow-x-auto border rounded">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">
+                      <input
+                        type="checkbox"
+                        checked={visibleCandidates.length > 0 && visibleCandidates.every(c => selected[c.url])}
+                        onChange={e => toggleAllVisible(e.target.checked)}
+                      />
+                    </th>
+                    <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Type</th>
+                    <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">URL</th>
+                    <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Whitelisted</th>
+                    <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Classifier</th>
+                    <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Reason</th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {visibleCandidates.map(c => (
+                    <tr key={c.url} className="hover:bg-gray-50">
+                      <td className="px-3 py-2">
+                        <input
+                          type="checkbox"
+                          checked={Boolean(selected[c.url])}
+                          onChange={e => setSelected(prev => ({ ...prev, [c.url]: e.target.checked }))}
+                        />
+                      </td>
+                      <td className="px-3 py-2 text-xs">
+                        <span className={`px-2 py-1 rounded ${c.isPdf ? 'bg-purple-100 text-purple-800' : 'bg-gray-100 text-gray-700'}`}>
+                          {c.isPdf ? 'PDF' : 'HTML'}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2 text-sm">
+                        <a href={c.url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline break-all">
+                          {c.url}
+                        </a>
+                        <div className="text-xs text-gray-500 mt-1 line-clamp-1">{c.anchorText}</div>
+                      </td>
+                      <td className="px-3 py-2 text-sm">
+                        {c.whitelisted ? (
+                          <span className="text-green-700">Yes</span>
+                        ) : (
+                          <span className="text-red-700" title={c.whitelistError}>
+                            No
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 text-sm">
+                        {c.classification ? (
+                          c.classification.isDaycareRelated ? (
+                            <span className="text-green-700">Match ({Math.round(c.classification.confidence * 100)}%)</span>
+                          ) : (
+                            <span className="text-amber-700">Skipped</span>
+                          )
+                        ) : (
+                          <span className="text-gray-400">—</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 text-xs text-gray-600">
+                        {!c.whitelisted ? c.whitelistError : c.classifierSkipReason || '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {visibleCandidates.length === 0 ? (
+                <div className="p-6 text-center text-sm text-gray-500">No links match the current filters.</div>
+              ) : null}
+            </div>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
 export default function CantonDetailPage() {
   const { t } = useTranslation(['admin']);
   const { code } = useParams<{ code: string }>();
@@ -374,7 +680,7 @@ export default function CantonDetailPage() {
   const [loading, setLoading] = useState(true);
   const [showAddSource, setShowAddSource] = useState(false);
   const [editingSource, setEditingSource] = useState<CantonSource | null>(null);
-  const [triggeringCrawl, setTriggeringCrawl] = useState<number | null>(null);
+  const [crawlModalSource, setCrawlModalSource] = useState<CantonSource | null>(null);
   const [deletingSource, setDeletingSource] = useState<number | null>(null);
 
   useEffect(() => {
@@ -401,61 +707,8 @@ export default function CantonDetailPage() {
     }
   };
 
-  const handleTriggerCrawl = async (sourceId: number) => {
-    if (!confirm(t('admin:cantons.detail.actions.crawlNow'))) return;
-    
-    setTriggeringCrawl(sourceId);
-    try {
-      const response = await apiClient.post(`/admin/crawler/trigger/${sourceId}?debug=1`);
-      const results = response.data?.data || response.data;
-      
-      const discovered = results?.discovered || 0;
-      const whitelisted = results?.whitelisted;
-      const nonWhitelisted = results?.nonWhitelisted;
-      const created = results?.created || 0;
-      const updated = results?.updated || 0;
-      const unchanged = results?.unchanged || 0;
-      const skipped = results?.skipped || 0;
-      const errorsCount = results?.errors?.length || 0;
-      const needsReview = created + updated;
-      const debug = results?.debug;
-
-      // Show detailed results
-      const message = results 
-        ? `Crawl completed!\n\n` +
-          `Discovered: ${discovered} links\n` +
-          (typeof whitelisted === 'number' ? `Whitelisted: ${whitelisted} links\n` : '') +
-          (typeof nonWhitelisted === 'number' ? `Non-whitelisted (SSRF blocked): ${nonWhitelisted} links\n` : '') +
-          `Created: ${created} new documents\n` +
-          `Updated: ${updated} changed documents\n` +
-          `Unchanged: ${unchanged} documents\n` +
-          `Skipped (classifier): ${skipped} documents\n` +
-          (errorsCount > 0 ? `\nErrors: ${errorsCount}` : '') +
-          (needsReview > 0 ? `\n\nNext step: review ${needsReview} document(s) in the Policy Review tab.` : '') +
-          (needsReview === 0 && debug ? (
-            `\n\nWhy nothing shows in Policy Review:\n` +
-            (debug.nonWhitelistedSamples?.length ? `- Non-whitelisted examples:\n${debug.nonWhitelistedSamples.slice(0, 5).map((s: any) => `  • ${s.url} (${s.reason})`).join('\n')}\n` : '') +
-            (debug.classifierSkippedSamples?.length ? `- Classifier-skipped examples:\n${debug.classifierSkippedSamples.slice(0, 5).map((s: any) => `  • ${s.url} (${s.reason})`).join('\n')}\n` : '')
-          ) : '')
-        : t('admin:cantons.detail.crawlSuccess');
-      
-      alert(message);
-
-      // Refresh source status after crawl
-      await fetchData();
-
-      // Offer to jump straight to review queue if there is anything to review
-      if (needsReview > 0 && canton?.name) {
-        const openReview = confirm(`Open Policy Review now to review ${needsReview} document(s)?`);
-        if (openReview) {
-          navigate(`/policy-crawler/review?canton=${encodeURIComponent(canton.name)}`);
-        }
-      }
-    } catch (err: any) {
-      alert(`${t('admin:cantons.detail.crawlError')}: ${err.response?.data?.message || err.message}`);
-    } finally {
-      setTriggeringCrawl(null);
-    }
+  const handleOpenCrawlResults = (source: CantonSource) => {
+    setCrawlModalSource(source);
   };
 
   const handleDeleteSource = async (sourceId: number) => {
@@ -561,12 +814,11 @@ export default function CantonDetailPage() {
                 <td className="px-4 py-3 text-sm">
                   <div className="flex space-x-2">
                     <button 
-                      onClick={() => handleTriggerCrawl(source.id)}
-                      disabled={triggeringCrawl === source.id}
+                      onClick={() => handleOpenCrawlResults(source)}
                       className="text-blue-600 hover:underline text-sm disabled:opacity-50 flex items-center gap-1"
                     >
                       <Play className="h-4 w-4" />
-                      {triggeringCrawl === source.id ? t('admin:cantons.detail.status.crawling') : t('admin:cantons.detail.actions.crawlNow')}
+                      {t('admin:cantons.detail.actions.crawlNow')}
                     </button>
                     <button 
                       onClick={() => setEditingSource(source)}
@@ -612,6 +864,15 @@ export default function CantonDetailPage() {
           onSuccess={fetchData}
         />
       )}
+
+      {crawlModalSource && canton ? (
+        <CrawlResultsModal
+          source={crawlModalSource}
+          cantonName={canton.name}
+          onClose={() => setCrawlModalSource(null)}
+          onAfterIngest={fetchData}
+        />
+      ) : null}
     </div>
   );
 }

--- a/admin/src/pages/CantonDetail.tsx
+++ b/admin/src/pages/CantonDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useApiClient } from '../services/api';
@@ -423,15 +423,21 @@ const CrawlResultsModal: React.FC<{
   const [ingesting, setIngesting] = useState(false);
   const [ingestResult, setIngestResult] = useState<IngestResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const selectAllRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
+    const controller = new AbortController();
     const run = async () => {
       try {
         setLoading(true);
         setError(null);
         setIngestResult(null);
 
-        const resp = await apiClient.post(`/admin/crawler/scan/${source.id}`);
+        const resp = await apiClient.post(
+          `/admin/crawler/scan/${source.id}`,
+          undefined,
+          { signal: controller.signal } as any,
+        );
         const data: ScanResult = resp.data?.data || resp.data;
         setScan(data);
 
@@ -442,20 +448,38 @@ const CrawlResultsModal: React.FC<{
         }
         setSelected(initial);
       } catch (e: any) {
+        // Axios uses ERR_CANCELED for aborted requests
+        if (controller.signal.aborted || e?.code === 'ERR_CANCELED') return;
         setError(e.response?.data?.message || e.message || 'Failed to scan source');
       } finally {
         setLoading(false);
       }
     };
     run();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [source.id]);
+    return () => controller.abort();
+  }, [apiClient, source.id]);
+
+  // Close on Escape for keyboard users
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [onClose]);
 
   const visibleCandidates = (scan?.candidates || []).filter(c => {
     if (onlyWhitelisted && !c.whitelisted) return false;
     if (onlyPdf && !c.isPdf) return false;
     return true;
   });
+
+  useEffect(() => {
+    if (!selectAllRef.current) return;
+    const allSelected = visibleCandidates.length > 0 && visibleCandidates.every(c => selected[c.url]);
+    const someSelected = visibleCandidates.some(c => selected[c.url]);
+    selectAllRef.current.indeterminate = someSelected && !allSelected;
+  }, [visibleCandidates, selected]);
 
   const selectedUrls = Object.entries(selected)
     .filter(([, v]) => v)
@@ -471,7 +495,7 @@ const CrawlResultsModal: React.FC<{
 
   const ingestSelected = async () => {
     if (selectedUrls.length === 0) {
-      alert('Select at least one link to ingest.');
+      setError('Select at least one link to ingest.');
       return;
     }
     setIngesting(true);
@@ -492,16 +516,29 @@ const CrawlResultsModal: React.FC<{
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg p-6 w-full max-w-5xl mx-4 max-h-[90vh] overflow-y-auto">
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="crawl-results-title"
+        className="bg-white rounded-lg p-6 w-full max-w-5xl mx-4 max-h-[90vh] overflow-y-auto"
+        onClick={e => e.stopPropagation()}
+      >
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h2 className="text-xl font-bold">Crawl results</h2>
+            <h2 id="crawl-results-title" className="text-xl font-bold">Crawl results</h2>
             <p className="text-sm text-gray-600 mt-1">
               {source.label} — <span className="break-all">{source.url}</span>
             </p>
           </div>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-2xl leading-none">
+          <button
+            onClick={onClose}
+            aria-label="Close crawl results"
+            className="text-gray-400 hover:text-gray-600 text-2xl leading-none"
+          >
             ×
           </button>
         </div>
@@ -600,6 +637,7 @@ const CrawlResultsModal: React.FC<{
                     <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">
                       <input
                         type="checkbox"
+                        ref={selectAllRef}
                         checked={visibleCandidates.length > 0 && visibleCandidates.every(c => selected[c.url])}
                         onChange={e => toggleAllVisible(e.target.checked)}
                       />

--- a/api/src/crawler/crawler.controller.ts
+++ b/api/src/crawler/crawler.controller.ts
@@ -6,7 +6,7 @@ import { ClerkAuthGuard } from '../auth/guards/clerk-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { UserRole } from '@prisma/client';
-import { CreateSourceDto, UpdateSourceDto, ReviewQueueQueryDto } from './dto/crawler.dto';
+import { CreateSourceDto, UpdateSourceDto, ReviewQueueQueryDto, IngestUrlsDto } from './dto/crawler.dto';
 
 @Controller('admin/crawler')
 @UseGuards(ClerkAuthGuard, RolesGuard)
@@ -46,6 +46,49 @@ export class CrawlerController {
       if (error.message?.includes('Network error') || error.message?.includes('ETIMEDOUT')) {
         throw new BadRequestException(
           `Failed to crawl source: ${error.message}. This may be due to network connectivity issues or the target URL being unreachable.`
+        );
+      }
+      throw error;
+    }
+  }
+
+  // Scan a source page and return discovered links + classification (no DB writes)
+  @Post('scan/:sourceId')
+  async scanSource(@Param('sourceId') sourceId: string) {
+    if (!this.isCrawlerEnabled()) {
+      throw new BadRequestException('Crawler is disabled');
+    }
+
+    const id = parseInt(sourceId, 10);
+    if (isNaN(id) || id <= 0) {
+      throw new BadRequestException(`Invalid sourceId: '${sourceId}'. Must be a positive integer.`);
+    }
+
+    const results = await this.crawlerService.scanSource(id);
+    return { success: true, data: results };
+  }
+
+  // Ingest selected URLs into the review queue (creates/updates assets)
+  @Post('ingest/:sourceId')
+  async ingestUrls(@Param('sourceId') sourceId: string, @Body() dto: IngestUrlsDto) {
+    if (!this.isCrawlerEnabled()) {
+      throw new BadRequestException('Crawler is disabled');
+    }
+
+    const id = parseInt(sourceId, 10);
+    if (isNaN(id) || id <= 0) {
+      throw new BadRequestException(`Invalid sourceId: '${sourceId}'. Must be a positive integer.`);
+    }
+
+    try {
+      const results = await this.crawlerService.ingestUrlsFromSource(id, dto.urls, {
+        force: Boolean(dto.force),
+      });
+      return { success: true, data: results };
+    } catch (error: any) {
+      if (error.message?.includes('Network error') || error.message?.includes('ETIMEDOUT')) {
+        throw new BadRequestException(
+          `Failed to ingest URLs: ${error.message}. This may be due to network connectivity issues or the target URL being unreachable.`
         );
       }
       throw error;

--- a/api/src/crawler/crawler.service.ts
+++ b/api/src/crawler/crawler.service.ts
@@ -37,6 +37,25 @@ interface CantonSourceWithCanton {
   };
 }
 
+interface CandidateScanResult {
+  url: string;
+  title: string;
+  anchorText: string;
+  sectionHeading?: string;
+  isPdf: boolean;
+  whitelisted: boolean;
+  whitelistError?: string;
+  classification?: {
+    isDaycareRelated: boolean;
+    confidence: number;
+    category: string;
+    docType: string;
+    language: 'fr' | 'de' | 'en';
+    topics: string[];
+  };
+  classifierSkipReason?: string;
+}
+
 /** Maximum file size for PDF downloads (50MB) */
 const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
 
@@ -68,6 +87,186 @@ export class CrawlerService {
     private playwrightRenderer: PlaywrightRendererService,
     private classifier: ClassifierService,
   ) {}
+
+  private classifierSkipReason(classification: any): string {
+    const debug = classification?._debug || {};
+    return debug.negativePattern
+      ? `negative pattern: "${debug.negativePattern}"`
+      : `score ${debug.rawScore?.toFixed?.(1) || '0'} < threshold ${debug.threshold || CLASSIFIER_CONFIG.threshold}`;
+  }
+
+  /**
+   * Scan a source page and return discovered candidate links + classification results.
+   * This does NOT create/update any assets.
+   */
+  async scanSource(sourceId: number): Promise<{
+    sourceId: number;
+    sourceLabel: string;
+    sourceUrl: string;
+    discovered: number;
+    whitelisted: number;
+    nonWhitelisted: number;
+    pdfCount: number;
+    daycareRelated: number;
+    classifierSkipped: number;
+    candidates: CandidateScanResult[];
+  }> {
+    const source = await this.prisma.cantonSource.findUnique({
+      where: { id: sourceId },
+      include: { canton: true },
+    });
+
+    if (!source || !source.isActive) {
+      throw new Error(`Source ${sourceId} not found or inactive`);
+    }
+
+    this.logger.log(`Scanning source: ${source.label} (${source.url})`);
+    this.validateUrl(source.url);
+
+    const html = await this.fetchPage(source.url, source.renderType === 'dynamic');
+    const extracted = this.htmlParser.extractLinks(html, source.url, source.cssSelector);
+
+    const candidates: CandidateScanResult[] = extracted.map(candidate => {
+      let whitelisted = true;
+      let whitelistError: string | undefined;
+      try {
+        this.validateUrl(candidate.url);
+      } catch (e: any) {
+        whitelisted = false;
+        whitelistError = e?.message || 'Not whitelisted';
+      }
+
+      if (!whitelisted) {
+        return {
+          url: candidate.url,
+          title: candidate.title,
+          anchorText: candidate.anchorText,
+          sectionHeading: candidate.sectionHeading,
+          isPdf: candidate.isPdf,
+          whitelisted,
+          whitelistError,
+        };
+      }
+
+      const classification: any = this.classifier.classifyFromMetadata({
+        anchorText: candidate.anchorText,
+        url: candidate.url,
+        sectionHeading: candidate.sectionHeading,
+        defaultLang: source.canton.defaultLang,
+      });
+
+      const isDaycareRelated = Boolean(classification.isDaycareRelated);
+
+      return {
+        url: candidate.url,
+        title: candidate.title,
+        anchorText: candidate.anchorText,
+        sectionHeading: candidate.sectionHeading,
+        isPdf: candidate.isPdf,
+        whitelisted,
+        classification: {
+          isDaycareRelated,
+          confidence: classification.confidence,
+          category: classification.category,
+          docType: classification.docType,
+          language: classification.language,
+          topics: classification.topics,
+        },
+        classifierSkipReason: isDaycareRelated ? undefined : this.classifierSkipReason(classification),
+      };
+    });
+
+    const whitelistedCount = candidates.filter(c => c.whitelisted).length;
+    const nonWhitelistedCount = candidates.length - whitelistedCount;
+    const pdfCount = candidates.filter(c => c.isPdf).length;
+    const classifierSkipped = candidates.filter(c => c.whitelisted && c.classification && !c.classification.isDaycareRelated).length;
+    const daycareRelated = candidates.filter(c => c.whitelisted && c.classification && c.classification.isDaycareRelated).length;
+
+    return {
+      sourceId: source.id,
+      sourceLabel: source.label,
+      sourceUrl: source.url,
+      discovered: candidates.length,
+      whitelisted: whitelistedCount,
+      nonWhitelisted: nonWhitelistedCount,
+      pdfCount,
+      daycareRelated,
+      classifierSkipped,
+      candidates,
+    };
+  }
+
+  /**
+   * Ingest a list of URLs from a given source page into the review queue.
+   * Fetches the source page to get consistent metadata (anchor text / PDF flag).
+   */
+  async ingestUrlsFromSource(
+    sourceId: number,
+    urls: string[],
+    options?: { force?: boolean },
+  ): Promise<{
+    requested: number;
+    created: number;
+    updated: number;
+    unchanged: number;
+    skipped: number;
+    errors: Array<{ url: string; error: string }>;
+    results: Array<{ url: string; outcome: 'created' | 'updated' | 'unchanged' | 'skipped' | 'error' }>;
+  }> {
+    const source = await this.prisma.cantonSource.findUnique({
+      where: { id: sourceId },
+      include: { canton: true },
+    });
+
+    if (!source || !source.isActive) {
+      throw new Error(`Source ${sourceId} not found or inactive`);
+    }
+
+    // Fetch source page to get anchor text / pdf flag for requested URLs
+    this.validateUrl(source.url);
+    const html = await this.fetchPage(source.url, source.renderType === 'dynamic');
+    const extracted = this.htmlParser.extractLinks(html, source.url, source.cssSelector);
+    const byUrl = new Map<string, CandidateDocument>(extracted.map(c => [c.url, c]));
+
+    const summary = {
+      requested: urls.length,
+      created: 0,
+      updated: 0,
+      unchanged: 0,
+      skipped: 0,
+      errors: [] as Array<{ url: string; error: string }>,
+      results: [] as Array<{ url: string; outcome: 'created' | 'updated' | 'unchanged' | 'skipped' | 'error' }>,
+    };
+
+    for (const url of urls) {
+      try {
+        const candidate =
+          byUrl.get(url) ||
+          ({
+            url,
+            title: this.extractFilename(url),
+            anchorText: this.extractFilename(url),
+            isPdf: url.toLowerCase().endsWith('.pdf') || url.toLowerCase().includes('.pdf?'),
+          } as CandidateDocument);
+
+        // SSRF prevention
+        this.validateUrl(candidate.url);
+
+        const outcome = await this.processCandidate(candidate, source as any, {
+          force: Boolean(options?.force),
+        });
+
+        summary[outcome]++;
+        summary.results.push({ url, outcome });
+      } catch (e: any) {
+        const error = e?.message || 'Unknown error';
+        summary.errors.push({ url, error });
+        summary.results.push({ url, outcome: 'error' });
+      }
+    }
+
+    return summary;
+  }
 
   /**
    * Get or create system user for crawler operations
@@ -285,10 +484,11 @@ export class CrawlerService {
   private async processCandidate(
     candidate: CandidateDocument,
     source: CantonSourceWithCanton,
-    debug?: {
-      debugEnabled: boolean;
-      debugLimit: number;
-      onClassifierSkip: (info: {
+    options?: {
+      force?: boolean;
+      debugEnabled?: boolean;
+      debugLimit?: number;
+      onClassifierSkip?: (info: {
         url: string;
         reason: string;
         anchorText: string;
@@ -307,28 +507,32 @@ export class CrawlerService {
       defaultLang: source.canton.defaultLang,
     });
 
-    // Skip if NOT daycare-related (regardless of confidence - if score is below threshold, skip)
+    // Skip if NOT daycare-related (unless forced)
     if (!classification.isDaycareRelated) {
-      const debug = (classification as any)._debug || {};
-      const reason = debug.negativePattern 
-        ? `negative pattern: "${debug.negativePattern}"`
-        : `score ${debug.rawScore?.toFixed(1) || '0'} < threshold ${debug.threshold || CLASSIFIER_CONFIG.threshold}`;
-      const topicsInfo = debug.topicsFound && debug.topicsFound.length > 0 
-        ? ` (topics: ${debug.topicsFound.join(', ')})`
+      const classifierReason = this.classifierSkipReason(classification as any);
+      const topicsInfo = (classification as any)?._debug?.topicsFound?.length
+        ? ` (topics: ${(classification as any)._debug.topicsFound.join(', ')})`
         : '';
-      this.logger.debug(
-        `Skipping ${candidate.url} - not daycare-related (${reason}, confidence: ${classification.confidence.toFixed(2)}${topicsInfo}, anchor: "${candidate.anchorText}")`
-      );
 
-      if (debug?.debugEnabled) {
-        debug.onClassifierSkip({
-          url: candidate.url,
-          reason: `not daycare-related (${reason})`,
-          anchorText: candidate.anchorText,
-          confidence: classification.confidence,
-        });
+      if (!options?.force) {
+        this.logger.debug(
+          `Skipping ${candidate.url} - not daycare-related (${classifierReason}, confidence: ${classification.confidence.toFixed(2)}${topicsInfo}, anchor: "${candidate.anchorText}")`
+        );
+
+        if (options?.debugEnabled && options.onClassifierSkip) {
+          options.onClassifierSkip({
+            url: candidate.url,
+            reason: `not daycare-related (${classifierReason})`,
+            anchorText: candidate.anchorText,
+            confidence: classification.confidence,
+          });
+        }
+        return 'skipped';
       }
-      return 'skipped';
+
+      this.logger.warn(
+        `FORCING ingest for ${candidate.url} despite classifier (${classifierReason}, confidence: ${classification.confidence.toFixed(2)}${topicsInfo})`
+      );
     }
 
     // ==========================================
@@ -401,10 +605,10 @@ export class CrawlerService {
           source.canton.defaultLang,
         );
 
-        if (!finalClassification.isDaycareRelated) {
+        if (!finalClassification.isDaycareRelated && !options?.force) {
           this.logger.debug(`After parsing, ${candidate.url} still not daycare-related - skipping`);
-          if (debug?.debugEnabled) {
-            debug.onClassifierSkip({
+          if (options?.debugEnabled && options.onClassifierSkip) {
+            options.onClassifierSkip({
               url: candidate.url,
               reason: 'not daycare-related after PDF parse',
               anchorText: candidate.anchorText,

--- a/api/src/crawler/crawler.service.ts
+++ b/api/src/crawler/crawler.service.ts
@@ -265,6 +265,30 @@ export class CrawlerService {
       }
     }
 
+    // Update source crawl status (manual ingest should count as a crawl)
+    const totalProcessed = summary.created + summary.updated + summary.unchanged + summary.skipped;
+    const status =
+      summary.errors.length === 0
+        ? 'success'
+        : totalProcessed > 0
+          ? 'partial'
+          : 'failed';
+
+    await this.prisma.cantonSource.update({
+      where: { id: sourceId },
+      data: {
+        lastCrawlAt: new Date(),
+        lastCrawlStatus: status,
+        lastCrawlError: summary.errors.length > 0
+          ? summary.errors.slice(0, 3).map(e => `${e.url}: ${e.error}`).join('; ')
+          : null,
+        nextCrawlAt:
+          status === 'failed'
+            ? new Date(Date.now() + 24 * 60 * 60 * 1000)
+            : new Date(Date.now() + source.crawlFrequencyDays * 24 * 60 * 60 * 1000),
+      },
+    });
+
     return summary;
   }
 
@@ -507,14 +531,17 @@ export class CrawlerService {
       defaultLang: source.canton.defaultLang,
     });
 
-    // Skip if NOT daycare-related (unless forced)
+    // Allow low-confidence PDFs to proceed to content-based reclassification
+    const shouldAttemptPdfReclass = Boolean(candidate.isPdf) && classification.confidence < 0.5;
+
+    // Skip if NOT daycare-related (unless forced or reclassifying a low-confidence PDF)
     if (!classification.isDaycareRelated) {
       const classifierReason = this.classifierSkipReason(classification as any);
       const topicsInfo = (classification as any)?._debug?.topicsFound?.length
         ? ` (topics: ${(classification as any)._debug.topicsFound.join(', ')})`
         : '';
 
-      if (!options?.force) {
+      if (!options?.force && !shouldAttemptPdfReclass) {
         this.logger.debug(
           `Skipping ${candidate.url} - not daycare-related (${classifierReason}, confidence: ${classification.confidence.toFixed(2)}${topicsInfo}, anchor: "${candidate.anchorText}")`
         );
@@ -530,9 +557,16 @@ export class CrawlerService {
         return 'skipped';
       }
 
-      this.logger.warn(
-        `FORCING ingest for ${candidate.url} despite classifier (${classifierReason}, confidence: ${classification.confidence.toFixed(2)}${topicsInfo})`
-      );
+      if (options?.force) {
+        this.logger.warn(
+          `FORCING ingest for ${candidate.url} despite classifier (${classifierReason}, confidence: ${classification.confidence.toFixed(2)}${topicsInfo})`
+        );
+      } else {
+        // We’ll attempt content-based reclassification before skipping
+        this.logger.debug(
+          `Low-confidence PDF ${candidate.url} failed metadata classifier (${classifierReason}, confidence: ${classification.confidence.toFixed(2)}${topicsInfo}); attempting PDF parse before skipping`
+        );
+      }
     }
 
     // ==========================================
@@ -591,7 +625,7 @@ export class CrawlerService {
     let finalClassification = classification;
 
     // Only download and parse PDF if we're uncertain about classification
-    if (classification.confidence < 0.5 && candidate.isPdf) {
+    if (shouldAttemptPdfReclass) {
       this.logger.log(`Low confidence (${classification.confidence.toFixed(2)}) for ${candidate.url}, parsing PDF...`);
       
       try {

--- a/api/src/crawler/dto/crawler.dto.ts
+++ b/api/src/crawler/dto/crawler.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsInt, IsBoolean, IsEnum, Min, Max } from 'class-validator';
+import { IsString, IsOptional, IsInt, IsBoolean, IsEnum, Min, Max, IsArray, ArrayMinSize } from 'class-validator';
 import { Type, Transform } from 'class-transformer';
 
 export enum SourceType {
@@ -98,5 +98,21 @@ export class ReviewQueueQueryDto {
   @IsOptional()
   @Type(() => Number)
   limit?: number = 100;
+}
+
+export class IngestUrlsDto {
+  @IsArray()
+  @ArrayMinSize(1)
+  @IsString({ each: true })
+  urls!: string[];
+
+  @IsBoolean()
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (value === 'true' || value === true) return true;
+    if (value === 'false' || value === false) return false;
+    return undefined;
+  })
+  force?: boolean;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Crawl results preview modal now opens from the Canton detail page instead of running inline
  * Preview shows summary metrics, loading/error states, filters (whitelist, PDFs), and per-link candidates
  * Select candidate links (select/clear visible) and run ingest with optional "force" and progress/results summary
  * After ingest, quick navigation to Policy Review and automatic canton data refresh

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->