### PR TITLE
Force hard delete with dependent cleanup

### DIFF
--- a/admin/src/services/api.ts
+++ b/admin/src/services/api.ts
@@ -324,7 +324,7 @@ export const apiService = {
   deleteUser: (apiClient: AxiosInstance, id: string) => apiClient.delete<ApiResponse<null>>(`/users/${id}`),
   /** Hard delete (permanent) */
   deleteUserHard: (apiClient: AxiosInstance, id: string) =>
-    apiClient.delete<ApiResponse<null>>(`/users/${id}`, { params: { hard: true } }),
+    apiClient.delete<ApiResponse<null>>(`/users/${id}`, { params: { hard: true, force: true } }),
   
   // Role Elevation - Super Admin only
   elevateUserToAdmin: (

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -359,9 +359,13 @@ export class UsersController {
 
   @Delete(':id')
   @Roles(UserRole.SUPER_ADMIN)
-  remove(@Param('id', ParseUUIDPipe) id: string, @Query('hard') hard?: string) {
+  remove(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('hard') hard?: string,
+    @Query('force') force?: string,
+  ) {
     if ((hard || '').toLowerCase() === 'true') {
-      return this.usersService.hardRemove(id);
+      return this.usersService.hardRemove(id, { force: (force || '').toLowerCase() === 'true' });
     }
     return this.usersService.remove(id);
   }

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -1487,6 +1487,7 @@ export class UsersService {
     // (typically newly created accounts) to avoid blowing away important history.
     const [
       assetCount,
+      courseCount,
       orgMembershipCount,
       contactInfoCount,
       messageCount,
@@ -1497,6 +1498,7 @@ export class UsersService {
       ticketResponseCount,
     ] = await Promise.all([
       this.prisma.asset.count({ where: { uploadedById: appUser.id } }),
+      this.prisma.course.count({ where: { createdBy: appUser.id } }),
       profile ? this.prisma.userOrganization.count({ where: { userId: profile.id } }) : Promise.resolve(0),
       profile ? this.prisma.userContactInfo.count({ where: { userId: profile.id } }) : Promise.resolve(0),
       profile
@@ -1515,6 +1517,7 @@ export class UsersService {
     // but refuse when the user has any "real" dependent data.
     const blocking: Record<string, number> = {
       assetsUploaded: assetCount,
+      coursesCreated: courseCount,
       messages: messageCount,
       conversationParticipants: conversationParticipantCount,
       subscriptions: subscriptionCount,
@@ -1541,9 +1544,45 @@ export class UsersService {
       await this.prisma.$transaction(async (tx) => {
         // In force mode, aggressively delete dependent data so the user can be removed.
         if (force && profile) {
+          // Track conversation IDs that might become orphaned after we remove this user's
+          // messages and participant membership, so we can clean them up safely.
+          const [participantConversations, messageConversations] = await Promise.all([
+            tx.conversationParticipant.findMany({
+              where: { userId: profile.id },
+              select: { conversationId: true },
+            }),
+            tx.message.findMany({
+              where: {
+                OR: [{ senderId: profile.id }, { receiverId: profile.id }],
+                conversationId: { not: null },
+              },
+              select: { conversationId: true },
+            }),
+          ]);
+          const candidateConversationIds = Array.from(
+            new Set(
+              [
+                ...participantConversations.map((c) => c.conversationId),
+                ...messageConversations.map((m) => m.conversationId as string),
+              ].filter(Boolean),
+            ),
+          );
+
           // Messaging
           await tx.message.deleteMany({ where: { OR: [{ senderId: profile.id }, { receiverId: profile.id }] } });
           await tx.conversationParticipant.deleteMany({ where: { userId: profile.id } });
+
+          // Remove conversations that were only kept alive by this user's participation/messages.
+          // We restrict deletion to conversations we touched to avoid sweeping unrelated records.
+          if (candidateConversationIds.length > 0) {
+            await tx.conversation.deleteMany({
+              where: {
+                id: { in: candidateConversationIds },
+                participants: { none: {} },
+                messages: { none: {} },
+              },
+            });
+          }
 
           // Jobs / support / subscriptions
           await tx.jobApplication.deleteMany({ where: { candidateId: profile.id } });
@@ -1560,25 +1599,33 @@ export class UsersService {
         }
 
         // If the AppUser has uploaded assets, we cannot delete it due to onDelete: Restrict.
-        // Reassign uploaded assets (and courses) to a system AppUser so the user can be deleted.
-        if (force && assetCount > 0) {
+        // Courses also reference AppUser via Course.createdBy (non-nullable), so we must
+        // reassign ownership before deleting the AppUser.
+        //
+        // NOTE: `clerkId: 'system'` is a reserved placeholder and must never be used for
+        // real authentication flows.
+        if (force && (assetCount > 0 || courseCount > 0)) {
           const systemAppUser = await tx.appUser.upsert({
             where: { clerkId: 'system' },
             update: {},
             create: {
               clerkId: 'system',
               email: null,
-              role: UserRole.ADMIN,
+              role: UserRole.PARENT, // minimal privileges; only an ownership placeholder
             },
           });
-          await tx.asset.updateMany({
-            where: { uploadedById: appUser.id },
-            data: { uploadedById: systemAppUser.id },
-          });
-          await tx.course.updateMany({
-            where: { createdBy: appUser.id },
-            data: { createdBy: systemAppUser.id },
-          });
+          if (assetCount > 0) {
+            await tx.asset.updateMany({
+              where: { uploadedById: appUser.id },
+              data: { uploadedById: systemAppUser.id },
+            });
+          }
+          if (courseCount > 0) {
+            await tx.course.updateMany({
+              where: { createdBy: appUser.id },
+              data: { createdBy: systemAppUser.id },
+            });
+          }
         }
 
         if (profile) {

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -1474,7 +1474,8 @@ export class UsersService {
    * break referential integrity (messages, subscriptions, uploaded assets, etc.),
    * we refuse with a 409 and provide counts so an admin can decide what to do.
    */
-  async hardRemove(id: string) {
+  async hardRemove(id: string, opts?: { force?: boolean }) {
+    const force = Boolean(opts?.force);
     const appUser = await this.prisma.appUser.findUnique({ where: { id } });
     if (!appUser) {
       throw new NotFoundException('User not found');
@@ -1523,7 +1524,7 @@ export class UsersService {
     };
 
     const hasBlocking = Object.values(blocking).some((n) => n > 0);
-    if (hasBlocking) {
+    if (hasBlocking && !force) {
       throw new ConflictException({
         message:
           'User cannot be hard-deleted because dependent records exist. Use soft delete, or manually purge dependent data first.',
@@ -1538,6 +1539,48 @@ export class UsersService {
 
     try {
       await this.prisma.$transaction(async (tx) => {
+        // In force mode, aggressively delete dependent data so the user can be removed.
+        if (force && profile) {
+          // Messaging
+          await tx.message.deleteMany({ where: { OR: [{ senderId: profile.id }, { receiverId: profile.id }] } });
+          await tx.conversationParticipant.deleteMany({ where: { userId: profile.id } });
+
+          // Jobs / support / subscriptions
+          await tx.jobApplication.deleteMany({ where: { candidateId: profile.id } });
+          await tx.ticketResponse.deleteMany({ where: { userId: profile.id } });
+          await tx.supportTicket.deleteMany({ where: { OR: [{ userId: profile.id }, { assignedTo: profile.id }] } });
+          await tx.userSubscription.deleteMany({ where: { userId: profile.id } });
+          await tx.subscription.deleteMany({ where: { userId: profile.id } });
+
+          // E-learning
+          await tx.certificate.deleteMany({ where: { userId: profile.id } });
+          await tx.discussionReply.deleteMany({ where: { userId: profile.id } });
+          await tx.courseDiscussion.deleteMany({ where: { userId: profile.id } });
+          await tx.courseEnrollment.deleteMany({ where: { userId: profile.id } });
+        }
+
+        // If the AppUser has uploaded assets, we cannot delete it due to onDelete: Restrict.
+        // Reassign uploaded assets (and courses) to a system AppUser so the user can be deleted.
+        if (force && assetCount > 0) {
+          const systemAppUser = await tx.appUser.upsert({
+            where: { clerkId: 'system' },
+            update: {},
+            create: {
+              clerkId: 'system',
+              email: null,
+              role: UserRole.ADMIN,
+            },
+          });
+          await tx.asset.updateMany({
+            where: { uploadedById: appUser.id },
+            data: { uploadedById: systemAppUser.id },
+          });
+          await tx.course.updateMany({
+            where: { createdBy: appUser.id },
+            data: { createdBy: systemAppUser.id },
+          });
+        }
+
         if (profile) {
           await tx.userOrganization.deleteMany({ where: { userId: profile.id } });
           await tx.userContactInfo.deleteMany({ where: { userId: profile.id } });

--- a/api/src/users/users.service.unit.spec.ts
+++ b/api/src/users/users.service.unit.spec.ts
@@ -107,6 +107,7 @@ describe('UsersService.hardRemove (hard delete)', () => {
       appUser: { findUnique: jest.fn().mockResolvedValue(appUser) },
       user: { findUnique: jest.fn().mockResolvedValue(profile) },
       asset: { count: jest.fn().mockResolvedValue(0) },
+      course: { count: jest.fn().mockResolvedValue(0) },
       userOrganization: { count: jest.fn().mockResolvedValue(0) },
       userContactInfo: { count: jest.fn().mockResolvedValue(0) },
       message: { count: jest.fn().mockResolvedValue(1) }, // blocking
@@ -146,8 +147,9 @@ describe('UsersService.hardRemove (hard delete)', () => {
 
     const tx = {
       // dependency deletes
-      message: { deleteMany: jest.fn() },
-      conversationParticipant: { deleteMany: jest.fn() },
+      message: { findMany: jest.fn().mockResolvedValue([]), deleteMany: jest.fn() },
+      conversationParticipant: { findMany: jest.fn().mockResolvedValue([]), deleteMany: jest.fn() },
+      conversation: { deleteMany: jest.fn() },
       jobApplication: { deleteMany: jest.fn() },
       ticketResponse: { deleteMany: jest.fn() },
       supportTicket: { deleteMany: jest.fn() },
@@ -173,6 +175,7 @@ describe('UsersService.hardRemove (hard delete)', () => {
       appUser: { findUnique: jest.fn().mockResolvedValue(appUser) },
       user: { findUnique: jest.fn().mockResolvedValue(profile) },
       asset: { count: jest.fn().mockResolvedValue(1) },
+      course: { count: jest.fn().mockResolvedValue(1) },
       userOrganization: { count: jest.fn().mockResolvedValue(0) },
       userContactInfo: { count: jest.fn().mockResolvedValue(0) },
       message: { count: jest.fn().mockResolvedValue(1) },
@@ -196,6 +199,13 @@ describe('UsersService.hardRemove (hard delete)', () => {
     await expect(service.hardRemove(appUser.id, { force: true })).resolves.toEqual({ success: true });
     expect(tx.message.deleteMany).toHaveBeenCalled();
     expect(tx.asset.updateMany).toHaveBeenCalled();
+    expect(tx.course.updateMany).toHaveBeenCalled();
+    expect(tx.appUser.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { clerkId: 'system' },
+        create: expect.objectContaining({ clerkId: 'system', role: UserRole.PARENT }),
+      }),
+    );
     expect(tx.appUser.delete).toHaveBeenCalledWith({ where: { id: appUser.id } });
   });
 
@@ -221,6 +231,7 @@ describe('UsersService.hardRemove (hard delete)', () => {
       appUser: { findUnique: jest.fn().mockResolvedValue(appUser) },
       user: { findUnique: jest.fn().mockResolvedValue(profile) },
       asset: { count: jest.fn().mockResolvedValue(0) },
+      course: { count: jest.fn().mockResolvedValue(0) },
       userOrganization: { count: jest.fn().mockResolvedValue(0) },
       userContactInfo: { count: jest.fn().mockResolvedValue(0) },
       message: { count: jest.fn().mockResolvedValue(0) },

--- a/api/src/users/users.service.unit.spec.ts
+++ b/api/src/users/users.service.unit.spec.ts
@@ -133,6 +133,72 @@ describe('UsersService.hardRemove (hard delete)', () => {
     });
   });
 
+  it('force hard-delete deletes dependent records and completes', async () => {
+    const appUser = {
+      id: 'app-user-id',
+      clerkId: 'clerk_123',
+      email: 'user@example.com',
+      role: UserRole.FOUNDATION,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const profile = { id: 'profile-id', clerkId: appUser.clerkId } as any;
+
+    const tx = {
+      // dependency deletes
+      message: { deleteMany: jest.fn() },
+      conversationParticipant: { deleteMany: jest.fn() },
+      jobApplication: { deleteMany: jest.fn() },
+      ticketResponse: { deleteMany: jest.fn() },
+      supportTicket: { deleteMany: jest.fn() },
+      userSubscription: { deleteMany: jest.fn() },
+      subscription: { deleteMany: jest.fn() },
+      certificate: { deleteMany: jest.fn() },
+      discussionReply: { deleteMany: jest.fn() },
+      courseDiscussion: { deleteMany: jest.fn() },
+      courseEnrollment: { deleteMany: jest.fn() },
+
+      // uploader reassignment
+      asset: { updateMany: jest.fn() },
+      course: { updateMany: jest.fn() },
+
+      // final deletes
+      userOrganization: { deleteMany: jest.fn() },
+      userContactInfo: { deleteMany: jest.fn() },
+      user: { delete: jest.fn(), deleteMany: jest.fn() },
+      appUser: { upsert: jest.fn().mockResolvedValue({ id: 'system-app-user' }), delete: jest.fn() },
+    } as any;
+
+    const prisma = {
+      appUser: { findUnique: jest.fn().mockResolvedValue(appUser) },
+      user: { findUnique: jest.fn().mockResolvedValue(profile) },
+      asset: { count: jest.fn().mockResolvedValue(1) },
+      userOrganization: { count: jest.fn().mockResolvedValue(0) },
+      userContactInfo: { count: jest.fn().mockResolvedValue(0) },
+      message: { count: jest.fn().mockResolvedValue(1) },
+      conversationParticipant: { count: jest.fn().mockResolvedValue(1) },
+      subscription: { count: jest.fn().mockResolvedValue(1) },
+      jobApplication: { count: jest.fn().mockResolvedValue(1) },
+      supportTicket: { count: jest.fn().mockResolvedValue(1) },
+      ticketResponse: { count: jest.fn().mockResolvedValue(1) },
+      $transaction: jest.fn(async (fn: any) => fn(tx)),
+      outbox: { create: jest.fn() },
+    };
+
+    const service = new UsersService(
+      prisma as any,
+      {} as any,
+      {} as any,
+      { get: jest.fn().mockReturnValue(undefined) } as any,
+    );
+    (service as any).clerk = { users: { deleteUser: jest.fn().mockResolvedValue(undefined) } };
+
+    await expect(service.hardRemove(appUser.id, { force: true })).resolves.toEqual({ success: true });
+    expect(tx.message.deleteMany).toHaveBeenCalled();
+    expect(tx.asset.updateMany).toHaveBeenCalled();
+    expect(tx.appUser.delete).toHaveBeenCalledWith({ where: { id: appUser.id } });
+  });
+
   it('hard-deletes a clean user (no blocking dependents)', async () => {
     const appUser = {
       id: 'app-user-id',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a force delete option for user accounts that allows permanent removal by cleaning or reassigning dependent data so deletion can complete even when blockers exist.
* **Behavior Changes / Bug Fixes**
  * Deletion now respects an explicit force flag to bypass blocking dependent records.
* **Tests**
  * Added unit tests covering the forced hard-delete flow and dependency cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->