### PR TITLE
fix(crawler): include HTML policy pages in recursive crawl results

### DIFF
--- a/api/src/crawler/crawler.service.ts
+++ b/api/src/crawler/crawler.service.ts
@@ -263,9 +263,14 @@ export class CrawlerService {
           }
           
           const candidateNormalized = normalizeUrl(candidate.url);
+          const isDocument = isLikelyDocument(candidate.url);
+          const isSubpage = isLikelySubpage(candidate.url, candidate.anchorText);
           
-          if (isLikelyDocument(candidate.url)) {
-            // It's a document - add to document candidates if not already found
+          // Add to document candidates if:
+          // 1. It's a document file (PDF, DOC, etc.), OR
+          // 2. It's an HTML page that passed the subpage filter (i.e., not navigation)
+          // This ensures HTML policy pages are also collected as candidates
+          if (isDocument || isSubpage) {
             if (!documentCandidates.some(c => normalizeUrl(c.url) === candidateNormalized)) {
               documentCandidates.push({
                 ...candidate,
@@ -273,8 +278,10 @@ export class CrawlerService {
                 depth: current.depth,
               });
             }
-          } else if (current.depth < maxDepth && isLikelySubpage(candidate.url, candidate.anchorText)) {
-            // It's a potential subpage - add to queue if not visited and within depth
+          }
+          
+          // Also add to traversal queue if it's a subpage and we haven't reached max depth
+          if (!isDocument && isSubpage && current.depth < maxDepth) {
             if (!visitedPages.has(candidateNormalized) && isSameDomain(candidate.url)) {
               // Check if already in queue
               const inQueue = queue.some(q => normalizeUrl(q.url) === candidateNormalized);
@@ -303,7 +310,7 @@ export class CrawlerService {
     
     this.logger.log(
       `Recursive crawl complete: visited ${visitedPages.size} pages, ` +
-      `found ${documentCandidates.length} document candidates`
+      `found ${documentCandidates.length} candidates (PDFs + HTML pages)`
     );
     
     return {


### PR DESCRIPTION
When maxSubpageDepth > 0, HTML pages that pass the subpage filter (i.e., not navigation links) are now also collected as document candidates, not just used for traversal.

This ensures HTML policy pages discovered on subpages are returned for classification and potential ingestion, matching the behavior of the single-page crawl path.

The logic now:
1. Adds PDFs/docs AND valid HTML pages to document candidates
2. Also queues HTML pages for traversal if within depth limit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved candidate detection to include HTML subpages alongside document files in crawl results.
  * Enhanced crawl traversal to properly enqueue and record HTML subpages as candidates during the crawling process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->