### PR TITLE
Cursor/policy crawler subpage depth e059

### DIFF
--- a/admin/src/pages/CantonDetail.tsx
+++ b/admin/src/pages/CantonDetail.tsx
@@ -30,6 +30,9 @@ interface CantonSource {
   isActive: boolean;
   crawlFrequencyDays: number;
   maxSubpageDepth: number;
+  maxCrawlPages: number;
+  maxCrawlDurationSec: number;
+  crawlDelayMs: number;
   lastCrawlAt?: string;
   lastCrawlStatus?: string;
   lastCrawlError?: string;
@@ -99,6 +102,9 @@ const AddSourceModal: React.FC<AddSourceModalProps> = ({ cantonId, onClose, onSu
     cssSelector: '',
     crawlFrequencyDays: 7,
     maxSubpageDepth: 0,
+    maxCrawlPages: 100,
+    maxCrawlDurationSec: 300,
+    crawlDelayMs: 200,
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -232,6 +238,51 @@ const AddSourceModal: React.FC<AddSourceModalProps> = ({ cantonId, onClose, onSu
             </p>
           </div>
 
+          {/* Crawl Settings - only show when subpage depth > 0 */}
+          {form.maxSubpageDepth > 0 && (
+            <div className="border-t pt-4 mt-2">
+              <h4 className="text-sm font-medium text-gray-700 mb-3">Crawl Settings</h4>
+              <div className="grid grid-cols-3 gap-4">
+                <div>
+                  <label className="block text-sm font-medium mb-1">Max Pages</label>
+                  <input
+                    type="number"
+                    min="1"
+                    max="1000"
+                    value={form.maxCrawlPages}
+                    onChange={e => setForm({...form, maxCrawlPages: parseInt(e.target.value) || 100})}
+                    className="w-full border rounded px-3 py-2"
+                  />
+                  <p className="text-xs text-gray-500 mt-1">Limit pages per crawl</p>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">Timeout (sec)</label>
+                  <input
+                    type="number"
+                    min="60"
+                    max="3600"
+                    value={form.maxCrawlDurationSec}
+                    onChange={e => setForm({...form, maxCrawlDurationSec: parseInt(e.target.value) || 300})}
+                    className="w-full border rounded px-3 py-2"
+                  />
+                  <p className="text-xs text-gray-500 mt-1">Max crawl duration</p>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">Delay (ms)</label>
+                  <input
+                    type="number"
+                    min="50"
+                    max="2000"
+                    value={form.crawlDelayMs}
+                    onChange={e => setForm({...form, crawlDelayMs: parseInt(e.target.value) || 200})}
+                    className="w-full border rounded px-3 py-2"
+                  />
+                  <p className="text-xs text-gray-500 mt-1">Between requests</p>
+                </div>
+              </div>
+            </div>
+          )}
+
           <div className="flex justify-end gap-3 pt-4">
             <button
               type="button"
@@ -293,6 +344,9 @@ const EditSourceModal: React.FC<EditSourceModalProps> = ({ source, onClose, onSu
     cssSelector: source.cssSelector || '',
     crawlFrequencyDays: source.crawlFrequencyDays,
     maxSubpageDepth: source.maxSubpageDepth ?? 0,
+    maxCrawlPages: source.maxCrawlPages ?? 100,
+    maxCrawlDurationSec: source.maxCrawlDurationSec ?? 300,
+    crawlDelayMs: source.crawlDelayMs ?? 200,
     isActive: source.isActive,
   });
   const [loading, setLoading] = useState(false);
@@ -419,6 +473,51 @@ const EditSourceModal: React.FC<EditSourceModalProps> = ({ source, onClose, onSu
               How many levels of subpages to crawl for documents.
             </p>
           </div>
+
+          {/* Crawl Settings - only show when subpage depth > 0 */}
+          {form.maxSubpageDepth > 0 && (
+            <div className="border-t pt-4 mt-2">
+              <h4 className="text-sm font-medium text-gray-700 mb-3">Crawl Settings</h4>
+              <div className="grid grid-cols-3 gap-4">
+                <div>
+                  <label className="block text-sm font-medium mb-1">Max Pages</label>
+                  <input
+                    type="number"
+                    min="1"
+                    max="1000"
+                    value={form.maxCrawlPages}
+                    onChange={e => setForm({...form, maxCrawlPages: parseInt(e.target.value) || 100})}
+                    className="w-full border rounded px-3 py-2"
+                  />
+                  <p className="text-xs text-gray-500 mt-1">Limit pages per crawl</p>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">Timeout (sec)</label>
+                  <input
+                    type="number"
+                    min="60"
+                    max="3600"
+                    value={form.maxCrawlDurationSec}
+                    onChange={e => setForm({...form, maxCrawlDurationSec: parseInt(e.target.value) || 300})}
+                    className="w-full border rounded px-3 py-2"
+                  />
+                  <p className="text-xs text-gray-500 mt-1">Max crawl duration</p>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">Delay (ms)</label>
+                  <input
+                    type="number"
+                    min="50"
+                    max="2000"
+                    value={form.crawlDelayMs}
+                    onChange={e => setForm({...form, crawlDelayMs: parseInt(e.target.value) || 200})}
+                    className="w-full border rounded px-3 py-2"
+                  />
+                  <p className="text-xs text-gray-500 mt-1">Between requests</p>
+                </div>
+              </div>
+            </div>
+          )}
 
           <div className="flex items-center">
             <input

--- a/api/.env.example
+++ b/api/.env.example
@@ -63,3 +63,9 @@ PORT=3000
 CRAWLER_ENABLED=false
 # Enables scheduled jobs (daily crawl + stale-source checks)
 CRAWLER_SCHEDULER_ENABLED=false
+# Maximum pages to crawl per session (default: 500)
+# CRAWLER_MAX_PAGES=500
+# Maximum crawl duration in milliseconds (default: 900000 = 15 minutes)
+# CRAWLER_MAX_DURATION_MS=900000
+# Delay between page fetches in milliseconds (default: 200ms, be respectful to servers)
+# CRAWLER_PAGE_DELAY_MS=200

--- a/api/.env.example
+++ b/api/.env.example
@@ -63,9 +63,3 @@ PORT=3000
 CRAWLER_ENABLED=false
 # Enables scheduled jobs (daily crawl + stale-source checks)
 CRAWLER_SCHEDULER_ENABLED=false
-# Maximum pages to crawl per session (default: 500)
-# CRAWLER_MAX_PAGES=500
-# Maximum crawl duration in milliseconds (default: 900000 = 15 minutes)
-# CRAWLER_MAX_DURATION_MS=900000
-# Delay between page fetches in milliseconds (default: 200ms, be respectful to servers)
-# CRAWLER_PAGE_DELAY_MS=200

--- a/api/prisma/migrations/20260204000001_add_crawl_settings_to_canton_sources/migration.sql
+++ b/api/prisma/migrations/20260204000001_add_crawl_settings_to_canton_sources/migration.sql
@@ -1,0 +1,11 @@
+-- Add configurable crawl settings to canton_sources table
+-- These allow per-source tuning of crawl behavior
+
+-- Max pages to crawl per session (default: 100)
+ALTER TABLE "canton_sources" ADD COLUMN IF NOT EXISTS "maxCrawlPages" INTEGER NOT NULL DEFAULT 100;
+
+-- Max crawl duration in seconds (default: 300 = 5 minutes)
+ALTER TABLE "canton_sources" ADD COLUMN IF NOT EXISTS "maxCrawlDurationSec" INTEGER NOT NULL DEFAULT 300;
+
+-- Delay between page fetches in milliseconds (default: 200ms)
+ALTER TABLE "canton_sources" ADD COLUMN IF NOT EXISTS "crawlDelayMs" INTEGER NOT NULL DEFAULT 200;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -617,6 +617,9 @@ model CantonSource {
   isActive           Boolean  @default(true)
   crawlFrequencyDays Int      @default(7)
   maxSubpageDepth    Int      @default(0)  // 0 = only source page, 1 = source + direct subpages, etc.
+  maxCrawlPages      Int      @default(100) // Max pages to crawl per session
+  maxCrawlDurationSec Int     @default(300) // Max crawl duration in seconds (5 min default)
+  crawlDelayMs       Int      @default(200) // Delay between page fetches in ms
 
   lastCrawlAt        DateTime?
   lastCrawlStatus    String?  // success, failed, partial

--- a/api/src/crawler/crawler.service.ts
+++ b/api/src/crawler/crawler.service.ts
@@ -119,6 +119,12 @@ export class CrawlerService {
     private classifier: ClassifierService,
   ) {}
 
+  /** Maximum number of pages to crawl in a single recursive crawl session */
+  private readonly MAX_PAGES_PER_CRAWL = 50;
+  
+  /** Maximum time (ms) for a recursive crawl session (3 minutes) */
+  private readonly MAX_CRAWL_DURATION_MS = 3 * 60 * 1000;
+
   /**
    * Recursively crawl pages starting from a source URL up to maxDepth levels.
    * Collects document candidates (PDFs and relevant pages) from all visited pages.
@@ -143,6 +149,9 @@ export class CrawlerService {
     
     // Queue of pages to visit: [url, depth]
     const queue: Array<{ url: string; depth: number }> = [{ url: startUrl, depth: 0 }];
+    
+    // Track crawl start time for timeout
+    const crawlStartTime = Date.now();
     
     // Normalize URL for comparison (remove trailing slash, hash, normalize path)
     const normalizeUrl = (url: string): string => {
@@ -219,9 +228,22 @@ export class CrawlerService {
       return true;
     };
 
-    this.logger.log(`Starting recursive crawl from ${startUrl} with max depth ${maxDepth}`);
+    this.logger.log(`Starting recursive crawl from ${startUrl} with max depth ${maxDepth} (max ${this.MAX_PAGES_PER_CRAWL} pages, ${this.MAX_CRAWL_DURATION_MS / 1000}s timeout)`);
 
     while (queue.length > 0) {
+      // Check page limit
+      if (visitedPages.size >= this.MAX_PAGES_PER_CRAWL) {
+        this.logger.warn(`Reached maximum page limit (${this.MAX_PAGES_PER_CRAWL}), stopping crawl`);
+        break;
+      }
+      
+      // Check timeout
+      const elapsedMs = Date.now() - crawlStartTime;
+      if (elapsedMs >= this.MAX_CRAWL_DURATION_MS) {
+        this.logger.warn(`Crawl timeout reached (${Math.round(elapsedMs / 1000)}s), stopping crawl`);
+        break;
+      }
+      
       const current = queue.shift()!;
       const normalizedUrl = normalizeUrl(current.url);
       
@@ -245,7 +267,7 @@ export class CrawlerService {
       }
       
       visitedPages.add(normalizedUrl);
-      this.logger.debug(`Crawling page [depth=${current.depth}]: ${current.url}`);
+      this.logger.debug(`Crawling page [depth=${current.depth}, ${visitedPages.size}/${this.MAX_PAGES_PER_CRAWL}]: ${current.url}`);
       
       try {
         // Fetch and parse page
@@ -297,9 +319,9 @@ export class CrawlerService {
           }
         }
         
-        // Rate limiting between page fetches (200ms to avoid overwhelming servers)
+        // Rate limiting between page fetches (100ms to avoid overwhelming servers)
         if (queue.length > 0) {
-          await this.delay(200);
+          await this.delay(100);
         }
         
       } catch (error: any) {
@@ -308,9 +330,11 @@ export class CrawlerService {
       }
     }
     
+    const totalDurationSec = ((Date.now() - crawlStartTime) / 1000).toFixed(1);
     this.logger.log(
-      `Recursive crawl complete: visited ${visitedPages.size} pages, ` +
-      `found ${documentCandidates.length} candidates (PDFs + HTML pages)`
+      `Recursive crawl complete in ${totalDurationSec}s: visited ${visitedPages.size}/${this.MAX_PAGES_PER_CRAWL} pages, ` +
+      `found ${documentCandidates.length} candidates (PDFs + HTML pages), ` +
+      `${queue.length} pages remaining in queue`
     );
     
     return {

--- a/api/src/crawler/crawler.service.ts
+++ b/api/src/crawler/crawler.service.ts
@@ -97,6 +97,18 @@ export class CrawlerService {
   private readonly DEFAULT_DEBUG_LIMIT = 10;
 
   /**
+   * Crawl configuration - configurable via environment variables
+   */
+  /** Maximum number of pages to crawl in a single recursive crawl session */
+  private readonly MAX_PAGES_PER_CRAWL: number;
+  
+  /** Maximum time (ms) for a recursive crawl session */
+  private readonly MAX_CRAWL_DURATION_MS: number;
+  
+  /** Delay between page fetches in milliseconds (to avoid overwhelming servers) */
+  private readonly PAGE_FETCH_DELAY_MS: number;
+
+  /**
    * Whitelisted domains for SSRF prevention.
    * Only URLs from these domains (or subdomains) are allowed.
    */
@@ -117,13 +129,17 @@ export class CrawlerService {
     private pdfParser: PdfParserService,
     private playwrightRenderer: PlaywrightRendererService,
     private classifier: ClassifierService,
-  ) {}
-
-  /** Maximum number of pages to crawl in a single recursive crawl session */
-  private readonly MAX_PAGES_PER_CRAWL = 500;
-  
-  /** Maximum time (ms) for a recursive crawl session (15 minutes) */
-  private readonly MAX_CRAWL_DURATION_MS = 15 * 60 * 1000;
+  ) {
+    // Initialize configurable crawl settings from environment variables
+    this.MAX_PAGES_PER_CRAWL = parseInt(process.env.CRAWLER_MAX_PAGES || '500', 10);
+    this.MAX_CRAWL_DURATION_MS = parseInt(process.env.CRAWLER_MAX_DURATION_MS || String(15 * 60 * 1000), 10);
+    this.PAGE_FETCH_DELAY_MS = parseInt(process.env.CRAWLER_PAGE_DELAY_MS || '200', 10);
+    
+    this.logger.log(
+      `Crawler initialized with: maxPages=${this.MAX_PAGES_PER_CRAWL}, ` +
+      `maxDuration=${this.MAX_CRAWL_DURATION_MS}ms, pageDelay=${this.PAGE_FETCH_DELAY_MS}ms`
+    );
+  }
 
   /**
    * Recursively crawl pages starting from a source URL up to maxDepth levels.
@@ -319,9 +335,9 @@ export class CrawlerService {
           }
         }
         
-        // Rate limiting between page fetches (100ms to avoid overwhelming servers)
+        // Rate limiting between page fetches to avoid overwhelming servers
         if (queue.length > 0) {
-          await this.delay(100);
+          await this.delay(this.PAGE_FETCH_DELAY_MS);
         }
         
       } catch (error: any) {

--- a/api/src/crawler/crawler.service.ts
+++ b/api/src/crawler/crawler.service.ts
@@ -120,10 +120,10 @@ export class CrawlerService {
   ) {}
 
   /** Maximum number of pages to crawl in a single recursive crawl session */
-  private readonly MAX_PAGES_PER_CRAWL = 50;
+  private readonly MAX_PAGES_PER_CRAWL = 500;
   
-  /** Maximum time (ms) for a recursive crawl session (3 minutes) */
-  private readonly MAX_CRAWL_DURATION_MS = 3 * 60 * 1000;
+  /** Maximum time (ms) for a recursive crawl session (15 minutes) */
+  private readonly MAX_CRAWL_DURATION_MS = 15 * 60 * 1000;
 
   /**
    * Recursively crawl pages starting from a source URL up to maxDepth levels.

--- a/api/src/crawler/crawler.service.ts
+++ b/api/src/crawler/crawler.service.ts
@@ -26,6 +26,9 @@ interface CantonSourceWithCanton {
   isActive: boolean;
   crawlFrequencyDays: number;
   maxSubpageDepth: number;
+  maxCrawlPages: number;
+  maxCrawlDurationSec: number;
+  crawlDelayMs: number;
   lastCrawlAt: Date | null;
   lastCrawlStatus: string | null;
   lastCrawlError: string | null;
@@ -97,18 +100,6 @@ export class CrawlerService {
   private readonly DEFAULT_DEBUG_LIMIT = 10;
 
   /**
-   * Crawl configuration - configurable via environment variables
-   */
-  /** Maximum number of pages to crawl in a single recursive crawl session */
-  private readonly MAX_PAGES_PER_CRAWL: number;
-  
-  /** Maximum time (ms) for a recursive crawl session */
-  private readonly MAX_CRAWL_DURATION_MS: number;
-  
-  /** Delay between page fetches in milliseconds (to avoid overwhelming servers) */
-  private readonly PAGE_FETCH_DELAY_MS: number;
-
-  /**
    * Whitelisted domains for SSRF prevention.
    * Only URLs from these domains (or subdomains) are allowed.
    */
@@ -129,17 +120,7 @@ export class CrawlerService {
     private pdfParser: PdfParserService,
     private playwrightRenderer: PlaywrightRendererService,
     private classifier: ClassifierService,
-  ) {
-    // Initialize configurable crawl settings from environment variables
-    this.MAX_PAGES_PER_CRAWL = parseInt(process.env.CRAWLER_MAX_PAGES || '500', 10);
-    this.MAX_CRAWL_DURATION_MS = parseInt(process.env.CRAWLER_MAX_DURATION_MS || String(15 * 60 * 1000), 10);
-    this.PAGE_FETCH_DELAY_MS = parseInt(process.env.CRAWLER_PAGE_DELAY_MS || '200', 10);
-    
-    this.logger.log(
-      `Crawler initialized with: maxPages=${this.MAX_PAGES_PER_CRAWL}, ` +
-      `maxDuration=${this.MAX_CRAWL_DURATION_MS}ms, pageDelay=${this.PAGE_FETCH_DELAY_MS}ms`
-    );
-  }
+  ) {}
 
   /**
    * Recursively crawl pages starting from a source URL up to maxDepth levels.
@@ -150,6 +131,7 @@ export class CrawlerService {
    * @param renderType Whether to use dynamic rendering (Playwright) or static fetch
    * @param cssSelector Optional CSS selector to limit link extraction
    * @param baseUrlDomain Domain to restrict crawling to (prevents crawling external sites)
+   * @param crawlSettings Per-source crawl settings (limits and delays)
    * @returns RecursiveCrawlResult with visited pages and discovered candidates
    */
   private async crawlPagesRecursively(
@@ -158,6 +140,11 @@ export class CrawlerService {
     renderType: string,
     cssSelector: string | null,
     baseUrlDomain: string,
+    crawlSettings: {
+      maxPages: number;
+      maxDurationMs: number;
+      delayMs: number;
+    },
   ): Promise<RecursiveCrawlResult> {
     const visitedPages = new Set<string>();
     const documentCandidates: CandidateWithSource[] = [];
@@ -168,6 +155,8 @@ export class CrawlerService {
     
     // Track crawl start time for timeout
     const crawlStartTime = Date.now();
+    
+    const { maxPages, maxDurationMs, delayMs } = crawlSettings;
     
     // Normalize URL for comparison (remove trailing slash, hash, normalize path)
     const normalizeUrl = (url: string): string => {
@@ -244,18 +233,18 @@ export class CrawlerService {
       return true;
     };
 
-    this.logger.log(`Starting recursive crawl from ${startUrl} with max depth ${maxDepth} (max ${this.MAX_PAGES_PER_CRAWL} pages, ${this.MAX_CRAWL_DURATION_MS / 1000}s timeout)`);
+    this.logger.log(`Starting recursive crawl from ${startUrl} with max depth ${maxDepth} (max ${maxPages} pages, ${maxDurationMs / 1000}s timeout, ${delayMs}ms delay)`);
 
     while (queue.length > 0) {
       // Check page limit
-      if (visitedPages.size >= this.MAX_PAGES_PER_CRAWL) {
-        this.logger.warn(`Reached maximum page limit (${this.MAX_PAGES_PER_CRAWL}), stopping crawl`);
+      if (visitedPages.size >= maxPages) {
+        this.logger.warn(`Reached maximum page limit (${maxPages}), stopping crawl`);
         break;
       }
       
       // Check timeout
       const elapsedMs = Date.now() - crawlStartTime;
-      if (elapsedMs >= this.MAX_CRAWL_DURATION_MS) {
+      if (elapsedMs >= maxDurationMs) {
         this.logger.warn(`Crawl timeout reached (${Math.round(elapsedMs / 1000)}s), stopping crawl`);
         break;
       }
@@ -283,7 +272,7 @@ export class CrawlerService {
       }
       
       visitedPages.add(normalizedUrl);
-      this.logger.debug(`Crawling page [depth=${current.depth}, ${visitedPages.size}/${this.MAX_PAGES_PER_CRAWL}]: ${current.url}`);
+      this.logger.debug(`Crawling page [depth=${current.depth}, ${visitedPages.size}/${maxPages}]: ${current.url}`);
       
       try {
         // Fetch and parse page
@@ -337,7 +326,7 @@ export class CrawlerService {
         
         // Rate limiting between page fetches to avoid overwhelming servers
         if (queue.length > 0) {
-          await this.delay(this.PAGE_FETCH_DELAY_MS);
+          await this.delay(delayMs);
         }
         
       } catch (error: any) {
@@ -348,7 +337,7 @@ export class CrawlerService {
     
     const totalDurationSec = ((Date.now() - crawlStartTime) / 1000).toFixed(1);
     this.logger.log(
-      `Recursive crawl complete in ${totalDurationSec}s: visited ${visitedPages.size}/${this.MAX_PAGES_PER_CRAWL} pages, ` +
+      `Recursive crawl complete in ${totalDurationSec}s: visited ${visitedPages.size}/${maxPages} pages, ` +
       `found ${documentCandidates.length} candidates (PDFs + HTML pages), ` +
       `${queue.length} pages remaining in queue`
     );
@@ -418,6 +407,11 @@ export class CrawlerService {
         source.renderType,
         source.cssSelector,
         baseDomain,
+        {
+          maxPages: source.maxCrawlPages,
+          maxDurationMs: source.maxCrawlDurationSec * 1000,
+          delayMs: source.crawlDelayMs,
+        },
       );
       
       pagesCrawled = crawlResult.visitedPages.size;
@@ -742,6 +736,11 @@ export class CrawlerService {
           source.renderType,
           source.cssSelector,
           baseDomain,
+          {
+            maxPages: source.maxCrawlPages,
+            maxDurationMs: source.maxCrawlDurationSec * 1000,
+            delayMs: source.crawlDelayMs,
+          },
         );
         
         results.pagesCrawled = crawlResult.visitedPages.size;

--- a/api/src/crawler/dto/crawler.dto.ts
+++ b/api/src/crawler/dto/crawler.dto.ts
@@ -50,6 +50,24 @@ export class CreateSourceDto {
   @Max(5)
   @IsOptional()
   maxSubpageDepth?: number = 0;
+
+  @IsInt()
+  @Min(1)
+  @Max(1000)
+  @IsOptional()
+  maxCrawlPages?: number = 100;
+
+  @IsInt()
+  @Min(60)
+  @Max(3600)
+  @IsOptional()
+  maxCrawlDurationSec?: number = 300;
+
+  @IsInt()
+  @Min(50)
+  @Max(2000)
+  @IsOptional()
+  crawlDelayMs?: number = 200;
 }
 
 export class UpdateSourceDto {
@@ -88,6 +106,24 @@ export class UpdateSourceDto {
   @Max(5)
   @IsOptional()
   maxSubpageDepth?: number;
+
+  @IsInt()
+  @Min(1)
+  @Max(1000)
+  @IsOptional()
+  maxCrawlPages?: number;
+
+  @IsInt()
+  @Min(60)
+  @Max(3600)
+  @IsOptional()
+  maxCrawlDurationSec?: number;
+
+  @IsInt()
+  @Min(50)
+  @Max(2000)
+  @IsOptional()
+  crawlDelayMs?: number;
 }
 
 export class ReviewQueueQueryDto {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-source crawl configuration options: maximum pages limit, timeout duration, and request delay. Three new fields available in source management forms when subpage depth is enabled, with defaults of 100 pages, 300-second timeout, and 200ms delay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->