### PR TITLE
fix(admin): increase HTTP timeout for crawler scan/ingest operations

### DIFF
--- a/admin/src/pages/CantonDetail.tsx
+++ b/admin/src/pages/CantonDetail.tsx
@@ -583,7 +583,10 @@ const CrawlResultsModal: React.FC<{
         const resp = await apiClient.post(
           `/admin/crawler/scan/${source.id}`,
           undefined,
-          { signal: controller.signal } as any,
+          { 
+            signal: controller.signal,
+            timeout: 600000, // 10 minutes - crawling can take a while with deep subpages
+          } as any,
         );
         const data: ScanResult = resp.data?.data || resp.data;
         setScan(data);
@@ -648,11 +651,17 @@ const CrawlResultsModal: React.FC<{
     setIngesting(true);
     setError(null);
     try {
-      const resp = await apiClient.post(`/admin/crawler/ingest/${source.id}`, {
-        urls: selectedUrls,
-        force,
-        queueUnchanged,
-      });
+      const resp = await apiClient.post(
+        `/admin/crawler/ingest/${source.id}`, 
+        {
+          urls: selectedUrls,
+          force,
+          queueUnchanged,
+        },
+        {
+          timeout: 600000, // 10 minutes - ingesting many URLs can take a while
+        },
+      );
       const data: IngestResult = resp.data?.data || resp.data;
       setIngestResult(data);
       await onAfterIngest();


### PR DESCRIPTION
The frontend axios client was using a 60 second default timeout which was causing 'timeout of 60000ms exceeded' errors when crawling sites with many subpages.

Now uses 10 minute (600000ms) timeout for:
- /admin/crawler/scan/:sourceId - scanning can take several minutes
- /admin/crawler/ingest/:sourceId - ingesting many URLs can take a while

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended timeout duration for page crawling operations to allow scanning of deeper subpage hierarchies without interruption.
  * Increased timeout limit for URL ingestion workflows to support processing larger batches of URLs in a single operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->