### PR TITLE
Document upload failure

### DIFF
--- a/api/src/security/mime-validation.service.ts
+++ b/api/src/security/mime-validation.service.ts
@@ -18,6 +18,8 @@ export class MimeValidationService {
   private readonly allowedExtensions: string[];
   private readonly allowedMimeTypes: string[];
   private readonly maxFileSize: number;
+  private readonly officeZipExtensions = new Set(['docx', 'xlsx', 'pptx']);
+  private readonly officeLegacyExtensions = new Set(['doc', 'xls', 'ppt']);
 
   constructor(private configService: ConfigService) {
     // Default extensions include video formats for e-learning content
@@ -58,8 +60,61 @@ export class MimeValidationService {
     const originalMimeType = mime.lookup(originalName) || '';
 
     // Get detected extension and MIME type
-    const detectedExt = fileType?.ext || originalExt;
-    const detectedMimeType = fileType?.mime || originalMimeType;
+    let detectedExt = fileType?.ext || originalExt;
+    let detectedMimeType = fileType?.mime || originalMimeType;
+
+    /**
+     * Special-case handling for Microsoft Office formats:
+     * - Modern Office files (.docx/.xlsx/.pptx) are ZIP containers, and `file-type`
+     *   often reports them as application/zip. We validate that the ZIP contains
+     *   expected OOXML entries, then treat the detected type as the original.
+     * - Legacy Office files (.doc/.xls/.ppt) are Compound File Binary (CFB) and may be
+     *   detected generically; if the buffer matches the CFB signature, we treat the
+     *   detected type as the original.
+     */
+    const normalizedOriginalExt = originalExt.toLowerCase();
+    const normalizedDetectedMime = (detectedMimeType || '').toLowerCase();
+    const normalizedDetectedExt = (detectedExt || '').toLowerCase();
+
+    if (
+      this.officeZipExtensions.has(normalizedOriginalExt) &&
+      (normalizedDetectedMime === 'application/zip' || normalizedDetectedExt === 'zip')
+    ) {
+      const ooxmlCheck = this.validateOfficeOpenXmlZipContainer(buffer, normalizedOriginalExt as 'docx' | 'xlsx' | 'pptx');
+      if (!ooxmlCheck.isValid) {
+        return {
+          isValid: false,
+          detectedExt,
+          detectedMimeType,
+          originalExt,
+          originalMimeType,
+          reason: ooxmlCheck.reason,
+        };
+      }
+
+      // Treat the detected type as the original intended OOXML type
+      detectedExt = originalExt;
+      detectedMimeType = originalMimeType;
+    }
+
+    if (
+      this.officeLegacyExtensions.has(normalizedOriginalExt) &&
+      (normalizedDetectedExt === 'cfb' || normalizedDetectedMime === 'application/x-cfb')
+    ) {
+      if (!this.isCompoundFileBinary(buffer)) {
+        return {
+          isValid: false,
+          detectedExt,
+          detectedMimeType,
+          originalExt,
+          originalMimeType,
+          reason: "Invalid legacy Office document structure (expected Compound File Binary format)",
+        };
+      }
+
+      detectedExt = originalExt;
+      detectedMimeType = originalMimeType;
+    }
 
     // Validate detected types
     const isValidExt = this.allowedExtensions.includes(detectedExt.toLowerCase());
@@ -90,6 +145,60 @@ export class MimeValidationService {
     this.logger.log(`MIME validation for '${originalName}': ${result.isValid ? 'VALID' : 'INVALID'} - ${result.reason || 'OK'}`);
     
     return result;
+  }
+
+  /**
+   * Validate OOXML files (docx/xlsx/pptx) when detected as a generic ZIP.
+   * This is a lightweight structural check that avoids full ZIP parsing.
+   * It looks for key entry names which are stored as plain strings in ZIP metadata.
+   */
+  private validateOfficeOpenXmlZipContainer(
+    buffer: Buffer,
+    extension: 'docx' | 'xlsx' | 'pptx',
+  ): { isValid: boolean; reason?: string } {
+    // ZIP local file header signature "PK\x03\x04"
+    const isZip = buffer.length >= 4 && buffer[0] === 0x50 && buffer[1] === 0x4b && buffer[2] === 0x03 && buffer[3] === 0x04;
+    if (!isZip) {
+      return { isValid: false, reason: 'Invalid Office document: expected ZIP container' };
+    }
+
+    // All OOXML files should include [Content_Types].xml
+    const hasContentTypes = buffer.indexOf(Buffer.from('[Content_Types].xml')) !== -1;
+    if (!hasContentTypes) {
+      return { isValid: false, reason: 'Invalid Office document: missing [Content_Types].xml' };
+    }
+
+    // Minimal type-specific markers
+    const markers: Record<typeof extension, string[]> = {
+      docx: ['word/document.xml', 'word/'],
+      xlsx: ['xl/workbook.xml', 'xl/'],
+      pptx: ['ppt/presentation.xml', 'ppt/'],
+    };
+
+    const hasAnyMarker = markers[extension].some((m) => buffer.indexOf(Buffer.from(m)) !== -1);
+    if (!hasAnyMarker) {
+      return { isValid: false, reason: `Invalid Office document: missing expected ${extension.toUpperCase()} content` };
+    }
+
+    return { isValid: true };
+  }
+
+  /**
+   * Check for Compound File Binary signature (used by legacy Office .doc/.xls/.ppt).
+   * Signature bytes: D0 CF 11 E0 A1 B1 1A E1
+   */
+  private isCompoundFileBinary(buffer: Buffer): boolean {
+    if (buffer.length < 8) return false;
+    return (
+      buffer[0] === 0xd0 &&
+      buffer[1] === 0xcf &&
+      buffer[2] === 0x11 &&
+      buffer[3] === 0xe0 &&
+      buffer[4] === 0xa1 &&
+      buffer[5] === 0xb1 &&
+      buffer[6] === 0x1a &&
+      buffer[7] === 0xe1
+    );
   }
 
   /**


### PR DESCRIPTION
Allow modern and legacy Office document uploads by correctly validating their internal structure when mis-detected as generic ZIP or CFB.

The `file-type` library often incorrectly identifies modern Office files (.docx, .xlsx, .pptx) as `application/zip` because they are ZIP containers. The existing `MimeValidationService` would then reject these files due to a MIME/extension mismatch. This PR introduces specific checks for OOXML files to verify their internal structure (e.g., `[Content_Types].xml` and type-specific markers) and for legacy Office files (.doc, .xls, .ppt) to verify their Compound File Binary signature, allowing them to pass validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-62e3d03d-e74f-431b-bd2d-5d85bcf21cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-62e3d03d-e74f-431b-bd2d-5d85bcf21cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for Microsoft Office file formats with enhanced detection of both modern (docx, xlsx, pptx) and legacy (doc, xls, ppt) documents.
  * Better error reporting for invalid Office file structures with more precise failure diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->