### PR TITLE
Missing catalogs table

### DIFF
--- a/api/prisma/migrations/20260206000000_create_missing_catalogs_table/migration.sql
+++ b/api/prisma/migrations/20260206000000_create_missing_catalogs_table/migration.sql
@@ -1,0 +1,57 @@
+-- CreateTable (idempotent: only if not exists)
+-- The catalogs table was defined in the initial migration but may not exist
+-- in some database instances, causing download failures (P2021 error).
+CREATE TABLE IF NOT EXISTS "public"."catalogs" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "supplierId" TEXT NOT NULL,
+    "pdfAssetId" TEXT,
+    "csvAssetId" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "uploadedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "catalogs_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey (idempotent: only if constraint does not exist)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'catalogs_pdfAssetId_fkey'
+    ) THEN
+        ALTER TABLE "public"."catalogs"
+            ADD CONSTRAINT "catalogs_pdfAssetId_fkey"
+            FOREIGN KEY ("pdfAssetId")
+            REFERENCES "public"."assets"("id")
+            ON DELETE SET NULL ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'catalogs_csvAssetId_fkey'
+    ) THEN
+        ALTER TABLE "public"."catalogs"
+            ADD CONSTRAINT "catalogs_csvAssetId_fkey"
+            FOREIGN KEY ("csvAssetId")
+            REFERENCES "public"."assets"("id")
+            ON DELETE SET NULL ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'catalogs_supplierId_fkey'
+    ) THEN
+        ALTER TABLE "public"."catalogs"
+            ADD CONSTRAINT "catalogs_supplierId_fkey"
+            FOREIGN KEY ("supplierId")
+            REFERENCES "public"."organizations"("id")
+            ON DELETE RESTRICT ON UPDATE CASCADE;
+    END IF;
+END $$;

--- a/api/src/upload/upload.service.ts
+++ b/api/src/upload/upload.service.ts
@@ -342,35 +342,74 @@ export class UploadService {
    * Returns asset if user has access, throws error otherwise
    */
   async verifyFileAccess(storageKey: string, appUserId: string) {
-    const asset = await this.prisma.asset.findFirst({
-      where: { storageKey },
-      include: {
-        uploader: {
-          select: {
-            id: true,
-            email: true,
-            clerkId: true,
-            role: true,
+    let asset: any;
+    let catalogQueryFailed = false;
+
+    try {
+      // Try the full query including catalog relations
+      asset = await this.prisma.asset.findFirst({
+        where: { storageKey },
+        include: {
+          uploader: {
+            select: {
+              id: true,
+              email: true,
+              clerkId: true,
+              role: true,
+            },
+          },
+          organizationDocuments: {
+            where: { isActive: true },
+            select: {
+              id: true,
+              organizationId: true,
+              documentType: true,
+            },
+          },
+          catalogPdfs: {
+            where: { isActive: true },
+            select: { id: true, supplierId: true },
+          },
+          catalogCsvs: {
+            where: { isActive: true },
+            select: { id: true, supplierId: true },
           },
         },
-        organizationDocuments: {
-          where: { isActive: true },
-          select: {
-            id: true,
-            organizationId: true,
-            documentType: true,
+      });
+    } catch (error: any) {
+      // Handle case where catalogs table doesn't exist yet (P2021)
+      // This allows non-catalog file downloads to continue working
+      if (error?.code === 'P2021' && error?.meta?.table?.includes('catalogs')) {
+        this.logger.warn(
+          'Catalogs table does not exist yet. Falling back to query without catalog relations. Run migrations to fix this permanently.',
+        );
+        catalogQueryFailed = true;
+
+        asset = await this.prisma.asset.findFirst({
+          where: { storageKey },
+          include: {
+            uploader: {
+              select: {
+                id: true,
+                email: true,
+                clerkId: true,
+                role: true,
+              },
+            },
+            organizationDocuments: {
+              where: { isActive: true },
+              select: {
+                id: true,
+                organizationId: true,
+                documentType: true,
+              },
+            },
           },
-        },
-        catalogPdfs: {
-          where: { isActive: true },
-          select: { id: true, supplierId: true },
-        },
-        catalogCsvs: {
-          where: { isActive: true },
-          select: { id: true, supplierId: true },
-        },
-      },
-    });
+        });
+      } else {
+        throw error;
+      }
+    }
 
     if (!asset) {
       throw new NotFoundException('File not found');
@@ -390,7 +429,9 @@ export class UploadService {
     const isOwner = asset.uploadedById === appUserId;
     const isAdmin = requestingUser?.role === 'SUPER_ADMIN' || requestingUser?.role === 'ADMIN';
     const isOrganizationDocument = asset.organizationDocuments?.length > 0;
-    const isCatalogAsset = (asset.catalogPdfs?.length || 0) > 0 || (asset.catalogCsvs?.length || 0) > 0;
+    const isCatalogAsset = catalogQueryFailed
+      ? false
+      : (asset.catalogPdfs?.length || 0) > 0 || (asset.catalogCsvs?.length || 0) > 0;
 
     if (!isOwner && !isAdmin && !isOrganizationDocument && !isCatalogAsset) {
       this.logger.warn(


### PR DESCRIPTION
Fixes file download failures by creating the missing `catalogs` table and making the file access verification resilient to its absence.

The `catalogs` table was defined in the Prisma schema and initial migration but was missing in some production environments. The `UploadService.verifyFileAccess` method, used for *all* file downloads, included relations to this table, causing a `PrismaClientKnownRequestError: P2021` and blocking all downloads when the table was absent. This PR adds a migration to create the table and updates `verifyFileAccess` to gracefully handle the table's absence, ensuring non-catalog downloads work even before the migration is fully deployed.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-602aef91-79b4-4e30-8b74-131ff3672f52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-602aef91-79b4-4e30-8b74-131ff3672f52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system resilience and stability for file and asset operations through enhanced error handling
  * System now gracefully handles scenarios where infrastructure components are temporarily unavailable
  * Ensures uninterrupted user access to assets and documents during system updates and initialization
  * Enhanced reliability of asset retrieval and management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->