### PR TITLE
Organization profile website validation

### DIFF
--- a/admin/src/pages/AdminOrganizationProfileEdit.tsx
+++ b/admin/src/pages/AdminOrganizationProfileEdit.tsx
@@ -41,7 +41,7 @@ interface OrganizationProfile {
   description: string;
   vatNumber: string;
   languages: string[];
-  website: string;
+  websiteUrl: string;
   logoUrl: string | null;
   logoAssetId: string | null;
   coverImageUrl: string | null;
@@ -119,7 +119,8 @@ const AdminOrganizationProfileEdit: React.FC = () => {
         description: profile.description || '',
         vatNumber: profile.vatNumber || '',
         languages: profile.languages || [],
-        website: profile.website || '',
+        // Backend canonical field is `websiteUrl` (older admin UIs used `website`)
+        websiteUrl: profile.websiteUrl || (profile as any).website || '',
         capacity: profile.capacity || 0,
         pedagogy: profile.pedagogy || [],
         productCategory: profile.productCategory || '',
@@ -373,8 +374,8 @@ const AdminOrganizationProfileEdit: React.FC = () => {
               </label>
               <input
                 type="url"
-                value={formData.website || ''}
-                onChange={(e) => handleChange('website', e.target.value)}
+                value={formData.websiteUrl || ''}
+                onChange={(e) => handleChange('websiteUrl', e.target.value)}
                 className={STANDARD_INPUT_FIELD}
                 placeholder="https://example.com"
               />

--- a/api/src/admin/admin-profiles.controller.ts
+++ b/api/src/admin/admin-profiles.controller.ts
@@ -191,6 +191,16 @@ class AdminUpdateOrganizationProfileDto {
   @IsString()
   catalogUrl?: string;
 
+  // Public website (canonical field is Organization.websiteUrl)
+  // Keep `website` as a backwards-compatible alias for admin UIs that still send it.
+  @IsOptional()
+  @IsString()
+  websiteUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  website?: string;
+
   // Service Provider-specific
   @IsOptional()
   @IsString()
@@ -507,6 +517,9 @@ export class AdminProfilesController {
         description: org.description ?? '',
         vatNumber: org.vatNumber ?? '',
         languages: org.languages ?? [],
+        // Public website (admin UI historically used `website`)
+        websiteUrl: org.websiteUrl ?? '',
+        website: org.websiteUrl ?? '',
         logoUrl: org.logoAsset?.publicUrl ?? null,
         logoAssetId: org.logoAssetId ?? null,
         coverImageUrl: org.coverAsset?.publicUrl ?? null,
@@ -557,6 +570,10 @@ export class AdminProfilesController {
       throw new BadRequestException(`Invalid organization type: ${dto.type}. Valid types are: ${VALID_ORGANIZATION_TYPES.join(', ')}`);
     }
 
+    // Normalize website field (support both websiteUrl and legacy website)
+    const normalizedWebsiteUrl =
+      dto.websiteUrl !== undefined ? dto.websiteUrl : dto.website !== undefined ? dto.website : undefined;
+
     await this.prisma.$transaction(async (tx) => {
       // Update contact email separately
       if (dto.contactEmail !== undefined) {
@@ -595,6 +612,7 @@ export class AdminProfilesController {
           ...(dto.minimumOrderQuantity !== undefined && { minimumOrderQuantity: dto.minimumOrderQuantity }),
           ...(dto.directOrderLink !== undefined && { directOrderLink: dto.directOrderLink }),
           ...(dto.catalogUrl !== undefined && { catalogUrl: dto.catalogUrl }),
+          ...(normalizedWebsiteUrl !== undefined && { websiteUrl: normalizedWebsiteUrl }),
           // Service Provider-specific
           ...(dto.serviceType !== undefined && { serviceType: dto.serviceType }),
           ...(dto.serviceCategories !== undefined && { serviceCategories: dto.serviceCategories }),


### PR DESCRIPTION
Enable editing the organization's website from the admin dashboard by updating the API DTO and UI to handle `websiteUrl` and `website` fields.

The admin API's `AdminUpdateOrganizationProfileDto` previously did not include a `website` field, leading to global DTO validation errors when the admin UI attempted to send this data. This fix introduces `websiteUrl` as the canonical field in the DTO and UI, while also providing backward compatibility for the `website` field in the API for older admin clients.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-247f7127-a4ea-4524-b841-395863a2d1e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-247f7127-a4ea-4524-b841-395863a2d1e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized organization website field naming for consistency and clarity.
  * Added backward-compatible support to preserve existing website data during updates.
  * Enhanced admin profile API responses to reliably include website information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->