### PR TITLE
Services status display issue

### DIFF
--- a/frontend/components/profile/OrganizationPublicProfile.tsx
+++ b/frontend/components/profile/OrganizationPublicProfile.tsx
@@ -17,7 +17,7 @@ import Card from '../ui/Card';
 import Button from '../ui/Button';
 import OrganizationDocumentsList from './OrganizationDocumentsList';
 import { User, UserRole, Product, Service, JobListing, Organization } from '../../types';
-import { formatServiceCategory, formatServiceDeliveryType, formatCategory } from '../../utils/serviceFormatting';
+import { formatServiceCategory, formatServiceCategoryForService, formatServiceDeliveryType, formatCategory } from '../../utils/serviceFormatting';
 import { openExternalUrl, toExternalUrl } from '../../utils/url';
 
 type OrganizationPublicProfileProps = {
@@ -498,7 +498,7 @@ const OrganizationPublicProfile: React.FC<OrganizationPublicProfileProps> = ({
                         <div className="flex-1">
                           <h3 className="font-semibold text-swiss-charcoal">{service.title}</h3>
                             <p className="text-xs text-gray-500 mt-1">
-                              {formatServiceCategory(t, service.category)}
+                              {formatServiceCategoryForService(t, service)}
                             </p>
                         </div>
                         {typeof service.price === 'number' && (

--- a/frontend/components/service-provider/ServiceUploadModal.tsx
+++ b/frontend/components/service-provider/ServiceUploadModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, FormEvent } from 'react';
-import { Service, ServiceCategory, SERVICE_CATEGORIES, ServiceDeliveryType, SERVICE_DELIVERY_TYPES } from '../../types';
+import { Service, ServiceCategory, SERVICE_DELIVERY_TYPES } from '../../types';
 import { STANDARD_INPUT_FIELD, SUGGESTED_SERVICE_CATEGORIES } from '../../constants';
 import Button from '../ui/Button';
 import ChipInput from '../ui/ChipInput';
@@ -7,6 +7,7 @@ import { XMarkIcon, PaperClipIcon, ArrowUpTrayIcon } from '@heroicons/react/24/o
 import { useAppContext } from '../../contexts/AppContext';
 import { useTranslation } from 'react-i18next';
 import { useCategories } from '../../hooks/useCategories';
+import { inferServiceCategoryFromFlexibleCategories } from '../../utils/serviceFormatting';
 
 interface ServiceUploadModalProps {
   isOpen: boolean;
@@ -30,7 +31,8 @@ const ServiceUploadModal: React.FC<ServiceUploadModalProps> = ({ isOpen, onClose
   const initialFormState: ServiceFormData = {
     title: '',
     description: '',
-    category: SERVICE_CATEGORIES[0],
+    // Default to OTHER; we'll infer a better enum from `categories` when possible.
+    category: ServiceCategory.OTHER,
     categories: [],
     availability: '',
     tags: [],
@@ -49,7 +51,11 @@ const ServiceUploadModal: React.FC<ServiceUploadModalProps> = ({ isOpen, onClose
         setFormData({
           title: existingService.title || '',
           description: existingService.description || '',
-          category: existingService.category || SERVICE_CATEGORIES[0],
+          // Prefer inferring the legacy enum from flexible categories when possible.
+          category:
+            inferServiceCategoryFromFlexibleCategories(existingService.categories) ||
+            existingService.category ||
+            ServiceCategory.OTHER,
           categories: existingService.categories || [],
           availability: existingService.availability || '',
           tags: existingService.tags || [],
@@ -133,7 +139,14 @@ const ServiceUploadModal: React.FC<ServiceUploadModalProps> = ({ isOpen, onClose
               <ChipInput<string>
                 selectedChips={formData.categories || []}
                 availableOptions={[...serviceCategoryOptions]}
-                onChange={(categories) => setFormData(prev => ({ ...prev, categories }))}
+                onChange={(categories) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    categories,
+                    category:
+                      inferServiceCategoryFromFlexibleCategories(categories) || ServiceCategory.OTHER,
+                  }))
+                }
                 placeholder={t('common:serviceUploadModal.placeholders.categories', 'Type or select categories...')}
                 allowCustomValues={true}
               />

--- a/frontend/components/service-provider/ServiceUploadModal.tsx
+++ b/frontend/components/service-provider/ServiceUploadModal.tsx
@@ -182,6 +182,12 @@ const ServiceUploadModal: React.FC<ServiceUploadModalProps> = ({ isOpen, onClose
                               (v, i, arr) =>
                                 arr.findIndex((x) => x.toLowerCase() === v.toLowerCase()) === i,
                             ),
+                          category:
+                            inferServiceCategoryFromFlexibleCategories(
+                              (prev.categories || [])
+                                .filter((c) => c !== 'Other')
+                                .concat([resolvedName]),
+                            ) || ServiceCategory.OTHER,
                         }));
                         setCustomServiceCategory('');
                       } catch (e: any) {

--- a/frontend/pages/partner/PartnerDetailPage.tsx
+++ b/frontend/pages/partner/PartnerDetailPage.tsx
@@ -28,7 +28,7 @@ import { useOrganizationMessaging } from '../../hooks/useOrganizationMessaging';
 import ActiveClientToggle from '../../components/shared/ActiveClientToggle';
 import OrganizationDocumentsList from '../../components/profile/OrganizationDocumentsList';
 import PromoCodesDisplaySection from '../../components/profile/PromoCodesDisplaySection';
-import { formatServiceCategory, formatServiceDeliveryType, formatCategory } from '../../utils/serviceFormatting';
+import { formatServiceCategoryForService, formatServiceDeliveryType, formatCategory } from '../../utils/serviceFormatting';
 import { openExternalUrl, toExternalUrl } from '../../utils/url';
 import { organizationService } from '../../services/organizationService';
 
@@ -487,7 +487,7 @@ const PartnerDetailPage: React.FC = () => {
                           {service.title}
                         </h3>
                         <p className="text-xs text-gray-500">
-                          {formatServiceCategory(t, service.category)}
+                          {formatServiceCategoryForService(t, service)}
                           {service.deliveryType && <> • {formatServiceDeliveryType(t, service.deliveryType)}</>}
                         </p>
                         <p className="text-sm text-gray-600 mt-1 line-clamp-2">{service.description}</p>

--- a/frontend/pages/service-provider/ServiceProviderListingsPage.tsx
+++ b/frontend/pages/service-provider/ServiceProviderListingsPage.tsx
@@ -7,7 +7,7 @@ import { Service, ServiceCategory, SERVICE_CATEGORIES } from '../../types';
 import ServiceUploadModal from '../../components/service-provider/ServiceUploadModal';
 import { useAppContext } from '../../contexts/AppContext';
 import { useTranslation } from 'react-i18next';
-import { formatServiceCategoryForService, formatServiceDeliveryType } from '../../utils/serviceFormatting';
+import { formatServiceCategory, formatServiceCategoryForService, formatServiceDeliveryType } from '../../utils/serviceFormatting';
 import { useAuthenticatedApi } from '../../hooks/useAuthenticatedApi';
 import LoadingSpinner from '../../components/ui/LoadingSpinner';
 import { UploadedAsset } from '../../services/api';

--- a/frontend/pages/service-provider/ServiceProviderListingsPage.tsx
+++ b/frontend/pages/service-provider/ServiceProviderListingsPage.tsx
@@ -7,7 +7,7 @@ import { Service, ServiceCategory, SERVICE_CATEGORIES } from '../../types';
 import ServiceUploadModal from '../../components/service-provider/ServiceUploadModal';
 import { useAppContext } from '../../contexts/AppContext';
 import { useTranslation } from 'react-i18next';
-import { formatServiceCategory, formatServiceDeliveryType } from '../../utils/serviceFormatting';
+import { formatServiceCategoryForService, formatServiceDeliveryType } from '../../utils/serviceFormatting';
 import { useAuthenticatedApi } from '../../hooks/useAuthenticatedApi';
 import LoadingSpinner from '../../components/ui/LoadingSpinner';
 import { UploadedAsset } from '../../services/api';
@@ -21,7 +21,7 @@ interface ServiceCardProps {
 
 const ProviderServiceCard: React.FC<ServiceCardProps> = ({ service, onEdit, onDelete }) => {
     const { t } = useTranslation(['dashboard', 'common']);
-    const categoryLabel = formatServiceCategory(t, service.category);
+    const categoryLabel = formatServiceCategoryForService(t, service);
     const deliveryLabel = formatServiceDeliveryType(t, service.deliveryType);
     return (
         <Card className="flex flex-col group" hoverEffect>

--- a/frontend/tests/unit/serviceFormatting.test.ts
+++ b/frontend/tests/unit/serviceFormatting.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import {
+  inferServiceCategoryFromFlexibleCategories,
+  formatServiceCategoryForService,
+} from '../../utils/serviceFormatting';
+import { ServiceCategory } from '../../types';
+
+describe('serviceFormatting', () => {
+  const t = ((key: string, fallback: string) => {
+    const dict: Record<string, string> = {
+      'common:serviceCategories.CLEANING': 'Cleaning & Maintenance',
+      'common:serviceCategories.IT_SUPPORT': 'IT & Technical Support',
+      'common:serviceCategories.MAINTENANCE': 'Facilities Maintenance',
+      'common:serviceCategories.CONSULTING': 'Consulting',
+      'common:serviceCategories.TRAINING': 'Training & Coaching',
+      'common:serviceCategories.OTHER': 'Other',
+    };
+    return dict[key] ?? fallback;
+  }) as any;
+
+  it('infers enum service category from known flexible labels', () => {
+    expect(inferServiceCategoryFromFlexibleCategories(['IT & Technical Support'])).toBe(
+      ServiceCategory.IT_SUPPORT,
+    );
+    expect(inferServiceCategoryFromFlexibleCategories(['Consulting'])).toBe(ServiceCategory.CONSULTING);
+  });
+
+  it('returns undefined for unknown flexible category labels', () => {
+    expect(inferServiceCategoryFromFlexibleCategories(['Graphic Design'])).toBeUndefined();
+  });
+
+  it('prefers flexible categories for display when present', () => {
+    const label = formatServiceCategoryForService(t, {
+      category: ServiceCategory.CLEANING,
+      categories: ['IT & Technical Support'],
+    });
+    expect(label).toBe('IT & Technical Support');
+  });
+
+  it('falls back to the raw flexible label when it cannot be mapped', () => {
+    const label = formatServiceCategoryForService(t, {
+      category: ServiceCategory.CLEANING,
+      categories: ['  Graphic Design for Childcare  '],
+    });
+    expect(label).toBe('Graphic Design for Childcare');
+  });
+
+  it('falls back to legacy enum category when no flexible categories exist', () => {
+    const label = formatServiceCategoryForService(t, {
+      category: ServiceCategory.MAINTENANCE,
+      categories: [],
+    });
+    expect(label).toBe('Facilities Maintenance');
+  });
+});
+

--- a/frontend/tests/unit/serviceFormatting.test.ts
+++ b/frontend/tests/unit/serviceFormatting.test.ts
@@ -18,8 +18,16 @@ describe('serviceFormatting', () => {
     return dict[key] ?? fallback;
   }) as any;
 
+  it('returns undefined when no valid flexible category exists', () => {
+    expect(inferServiceCategoryFromFlexibleCategories(undefined)).toBeUndefined();
+    expect(inferServiceCategoryFromFlexibleCategories([null, '', '  '])).toBeUndefined();
+  });
+
   it('infers enum service category from known flexible labels', () => {
     expect(inferServiceCategoryFromFlexibleCategories(['IT & Technical Support'])).toBe(
+      ServiceCategory.IT_SUPPORT,
+    );
+    expect(inferServiceCategoryFromFlexibleCategories(['it & technical support'])).toBe(
       ServiceCategory.IT_SUPPORT,
     );
     expect(inferServiceCategoryFromFlexibleCategories(['Consulting'])).toBe(ServiceCategory.CONSULTING);
@@ -51,6 +59,11 @@ describe('serviceFormatting', () => {
       categories: [],
     });
     expect(label).toBe('Facilities Maintenance');
+  });
+
+  it('handles null/undefined service inputs', () => {
+    expect(formatServiceCategoryForService(t, null)).toBe('Other');
+    expect(formatServiceCategoryForService(t, undefined)).toBe('Other');
   });
 });
 

--- a/frontend/utils/serviceFormatting.ts
+++ b/frontend/utils/serviceFormatting.ts
@@ -29,6 +29,25 @@ export const formatServiceCategory = (
 const normalizeFlexibleCategoryLabel = (value: string) =>
   value.trim().replace(/\s+/g, ' ').toLowerCase();
 
+const firstNonEmptyCategory = (
+  categories?: Array<string | null | undefined>,
+): string | undefined =>
+  (categories || []).find(
+    (c): c is string => typeof c === 'string' && c.trim().length > 0,
+  );
+
+// Only a subset of flexible labels correspond to the legacy enum values.
+// Everything else is intentionally left as a raw string label (custom categories
+// and extra suggestions like "Catering" are not representable in the enum).
+const FLEXIBLE_LABEL_TO_LEGACY_ENUM: Partial<Record<string, ServiceCategory>> = {
+  [normalizeFlexibleCategoryLabel('Cleaning & Maintenance')]: ServiceCategory.CLEANING,
+  [normalizeFlexibleCategoryLabel('IT & Technical Support')]: ServiceCategory.IT_SUPPORT,
+  [normalizeFlexibleCategoryLabel('Facilities Maintenance')]: ServiceCategory.MAINTENANCE,
+  [normalizeFlexibleCategoryLabel('Consulting')]: ServiceCategory.CONSULTING,
+  [normalizeFlexibleCategoryLabel('Training & Coaching')]: ServiceCategory.TRAINING,
+  [normalizeFlexibleCategoryLabel('Other')]: ServiceCategory.OTHER,
+};
+
 /**
  * Many parts of the app still render the legacy enum `service.category` (ServiceCategory),
  * but the newer UI stores user-selected categories in `service.categories` (string[]).
@@ -40,26 +59,11 @@ const normalizeFlexibleCategoryLabel = (value: string) =>
 export const inferServiceCategoryFromFlexibleCategories = (
   categories?: Array<string | null | undefined>,
 ): ServiceCategory | undefined => {
-  const first = (categories || []).find((c) => typeof c === 'string' && c.trim().length > 0);
+  const first = firstNonEmptyCategory(categories);
   if (!first) return undefined;
 
   const key = normalizeFlexibleCategoryLabel(first);
-  switch (key) {
-    case 'cleaning & maintenance':
-      return ServiceCategory.CLEANING;
-    case 'it & technical support':
-      return ServiceCategory.IT_SUPPORT;
-    case 'facilities maintenance':
-      return ServiceCategory.MAINTENANCE;
-    case 'consulting':
-      return ServiceCategory.CONSULTING;
-    case 'training & coaching':
-      return ServiceCategory.TRAINING;
-    case 'other':
-      return ServiceCategory.OTHER;
-    default:
-      return undefined;
-  }
+  return FLEXIBLE_LABEL_TO_LEGACY_ENUM[key];
 };
 
 export const formatServiceCategoryForService = (
@@ -73,7 +77,7 @@ export const formatServiceCategoryForService = (
     return formatServiceCategory(t, inferred);
   }
 
-  const firstFlexible = (service.categories || []).find((c) => typeof c === 'string' && c.trim().length > 0);
+  const firstFlexible = firstNonEmptyCategory(service.categories);
   if (firstFlexible) {
     // Preserve the original label as-entered (it may include punctuation like "&").
     return String(firstFlexible).trim();

--- a/frontend/utils/serviceFormatting.ts
+++ b/frontend/utils/serviceFormatting.ts
@@ -1,5 +1,5 @@
 import { TFunction } from 'i18next';
-import { ServiceCategory, ServiceDeliveryType } from '../types';
+import { Service, ServiceCategory, ServiceDeliveryType } from '../types';
 
 export const humanize = (value: string) =>
   value
@@ -24,6 +24,62 @@ export const formatServiceCategory = (
 
   const normalizedKey = String(category).toUpperCase();
   return t(`common:serviceCategories.${normalizedKey}`, humanize(String(category)));
+};
+
+const normalizeFlexibleCategoryLabel = (value: string) =>
+  value.trim().replace(/\s+/g, ' ').toLowerCase();
+
+/**
+ * Many parts of the app still render the legacy enum `service.category` (ServiceCategory),
+ * but the newer UI stores user-selected categories in `service.categories` (string[]).
+ *
+ * This helper maps known flexible labels back to the legacy enum so we can:
+ * - display the translated label via `common:serviceCategories.*`
+ * - avoid everything falling back to the modal's default enum (historically `CLEANING`)
+ */
+export const inferServiceCategoryFromFlexibleCategories = (
+  categories?: Array<string | null | undefined>,
+): ServiceCategory | undefined => {
+  const first = (categories || []).find((c) => typeof c === 'string' && c.trim().length > 0);
+  if (!first) return undefined;
+
+  const key = normalizeFlexibleCategoryLabel(first);
+  switch (key) {
+    case 'cleaning & maintenance':
+      return ServiceCategory.CLEANING;
+    case 'it & technical support':
+      return ServiceCategory.IT_SUPPORT;
+    case 'facilities maintenance':
+      return ServiceCategory.MAINTENANCE;
+    case 'consulting':
+      return ServiceCategory.CONSULTING;
+    case 'training & coaching':
+      return ServiceCategory.TRAINING;
+    case 'other':
+      return ServiceCategory.OTHER;
+    default:
+      return undefined;
+  }
+};
+
+export const formatServiceCategoryForService = (
+  t: TFunction,
+  service?: Pick<Service, 'category' | 'categories'> | null,
+) => {
+  if (!service) return formatServiceCategory(t, null);
+
+  const inferred = inferServiceCategoryFromFlexibleCategories(service.categories);
+  if (inferred) {
+    return formatServiceCategory(t, inferred);
+  }
+
+  const firstFlexible = (service.categories || []).find((c) => typeof c === 'string' && c.trim().length > 0);
+  if (firstFlexible) {
+    // Preserve the original label as-entered (it may include punctuation like "&").
+    return String(firstFlexible).trim();
+  }
+
+  return formatServiceCategory(t, service.category);
 };
 
 export const formatServiceDeliveryType = (


### PR DESCRIPTION
Fixes service category display on service cards and ensures correct `category` inference during service creation/edit.

All service cards were rendering "Cleaning & Maintenance" because the service creation/edit modal (`ServiceUploadModal.tsx`) defaulted the `category` field to `ServiceCategory.CLEANING` and never allowed users to pick a different enum value. This PR updates the display logic to prefer the flexible `service.categories` (string array) and modifies the modal to infer the legacy enum `category` from the selected flexible categories.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-a32b2e1f-86c3-4bee-94a6-d8512383bc7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a32b2e1f-86c3-4bee-94a6-d8512383bc7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service category display logic with enhanced fallback handling across organization profiles, partner details, and service listings pages.

* **Tests**
  * Added comprehensive unit tests for service category formatting utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->