### PR TITLE
Discount termination page error

### DIFF
--- a/admin/src/pages/DiscountTerminations.tsx
+++ b/admin/src/pages/DiscountTerminations.tsx
@@ -238,7 +238,7 @@ const DiscountTerminationsPage: React.FC = () => {
             onClick={handleCreate}
             disabled={upsertMutation.isPending}
             variant="primary"
-            leftIcon={<Plus className="w-4 h-4" />}
+            leftIcon={Plus}
           >
             {upsertMutation.isPending ? t('common:saving', 'Saving...') : t('common:add', 'Add / Update')}
           </Button>
@@ -294,7 +294,7 @@ const DiscountTerminationsPage: React.FC = () => {
                         size="sm"
                         onClick={() => markTerminated(vc)}
                         disabled={upsertMutation.isPending}
-                        leftIcon={<CheckCircle2 className="w-4 h-4" />}
+                        leftIcon={CheckCircle2}
                       >
                         {t('admin:admin.discountTerminations.actions.markCompleted', 'Mark Completed')}
                       </Button>


### PR DESCRIPTION
Fixes blank screen on discount termination page by passing icon components directly to `Button`'s `leftIcon` prop.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-52b053e6-71d2-49d2-ae2c-8dd35d53e02c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-52b053e6-71d2-49d2-ae2c-8dd35d53e02c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

