### PR TITLE
Admin menu structure

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -17,10 +17,7 @@ import ParentLeadsPage from './pages/ParentLeads';
 import OrdersPage from './pages/Orders';
 import ContentPage from './pages/Content';
 import MessagingPage from './pages/Messaging';
-import SystemMonitorPage from './pages/SystemMonitor';
 import SettingsPage from './pages/Settings';
-import DesignSystemPage from './pages/DesignSystem';
-import TranslationsPage from './pages/Translations';
 import AccessDeniedPage from './pages/AccessDenied';
 import SupportPage from './pages/Support';
 import SupportTicketPage from './pages/SupportTicket';
@@ -107,10 +104,10 @@ function App() {
           {/* Policy crawler (always visible; status is indicated inside) */}
           <Route path="policy-crawler/*" element={<PolicyCrawlerPage />} />
 
-          <Route path="system" element={<SystemMonitorPage />} />
-          <Route path="translations" element={<TranslationsPage />} />
+          <Route path="system" element={<Navigate to="/settings?tab=systemMonitoring" replace />} />
+          <Route path="translations" element={<Navigate to="/settings?tab=translations" replace />} />
           <Route path="settings" element={<SettingsPage />} />
-          <Route path="design-system" element={<DesignSystemPage />} />
+          <Route path="design-system" element={<Navigate to="/settings?tab=designSystem" replace />} />
 
           <Route index element={<Navigate to="/dashboard" />} />
         </Route>

--- a/admin/src/components/Sidebar.tsx
+++ b/admin/src/components/Sidebar.tsx
@@ -14,12 +14,8 @@ import {
   FileText,
   MessageSquare,
   Settings,
-  Monitor,
-  Mail,
   X,
   Shield,
-  Palette,
-  Globe,
   Handshake,
   LifeBuoy,
   CreditCard,
@@ -52,9 +48,6 @@ const navigation = [
   { key: 'discountTerminations', href: '/discount-terminations', icon: Tag },
   { key: 'subscriptions', href: '/subscriptions', icon: CreditCard },
   { key: 'policyCrawler', href: '/policy-crawler', icon: FileSearch },
-  { key: 'systemMonitoring', href: '/system', icon: Monitor },
-  { key: 'translations', href: '/translations', icon: Globe },
-  { key: 'designSystem', href: '/design-system', icon: Palette },
   { key: 'settings', href: '/settings', icon: Settings },
 ]
 

--- a/admin/src/components/settings/SettingsLayout.tsx
+++ b/admin/src/components/settings/SettingsLayout.tsx
@@ -10,6 +10,9 @@ import NotificationSettings from './NotificationSettings'
 import IntegrationSettings from './IntegrationSettings'
 import EmailNotificationPage from '../../pages/EmailNotificationPage'
 import SystemConfigurationPage from '../../pages/SystemConfigurationPage'
+import DesignSystemPage from '../../pages/DesignSystem'
+import TranslationsPage from '../../pages/Translations'
+import SystemMonitorPage from '../../pages/SystemMonitor'
 
 const SettingsLayout: React.FC = () => {
   const { t } = useTranslation(['admin', 'common'])
@@ -24,6 +27,9 @@ const SettingsLayout: React.FC = () => {
     { name: t('admin:settings.tabs.integrations'), key: 'integrations', component: IntegrationSettings },
     { name: t('admin:settings.tabs.emailTemplates'), key: 'emailTemplates', component: EmailNotificationPage },
     { name: t('admin:settings.tabs.systemConfig'), key: 'systemConfig', component: SystemConfigurationPage },
+    { name: t('admin:settings.tabs.designSystem'), key: 'designSystem', component: DesignSystemPage },
+    { name: t('admin:settings.tabs.translations'), key: 'translations', component: TranslationsPage },
+    { name: t('admin:settings.tabs.systemMonitoring'), key: 'systemMonitoring', component: SystemMonitorPage },
   ]
 
 function classNames(...classes: string[]) {
@@ -62,13 +68,13 @@ function classNames(...classes: string[]) {
       <div className="bg-white rounded-card shadow-soft border border-gray-200">
         <Tab.Group selectedIndex={selectedIndex} onChange={handleTabChange}>
           <div className="border-b border-gray-200">
-            <Tab.List className="flex space-x-8 px-6">
+            <Tab.List className="flex flex-nowrap space-x-8 px-6 overflow-x-auto">
               {tabs.map((tab) => (
                 <Tab
                   key={tab.key}
                   className={({ selected }) =>
                     classNames(
-                      'py-4 px-1 border-b-2 font-medium text-sm transition-colors duration-200',
+                      'py-4 px-1 border-b-2 font-medium text-sm transition-colors duration-200 whitespace-nowrap',
                       selected
                         ? 'border-swiss-teal text-swiss-teal'
                         : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'

--- a/packages/translations/locales/de/admin.json
+++ b/packages/translations/locales/de/admin.json
@@ -423,6 +423,9 @@
       "notifications": "Benachrichtigungen",
       "integrations": "Integrationen",
       "systemConfig": "Systemkonfiguration",
+      "designSystem": "Designsystem",
+      "translations": "Übersetzungen",
+      "systemMonitoring": "Systemüberwachung",
       "branding": "Branding",
       "content": "Inhalt",
       "general": "Allgemein"

--- a/packages/translations/locales/en/admin.json
+++ b/packages/translations/locales/en/admin.json
@@ -423,6 +423,9 @@
       "notifications": "Notifications",
       "integrations": "Integrations",
       "systemConfig": "System Config",
+      "designSystem": "Design System",
+      "translations": "Translations",
+      "systemMonitoring": "System Monitoring",
       "branding": "Branding",
       "content": "Content",
       "general": "General"

--- a/packages/translations/locales/fr/admin.json
+++ b/packages/translations/locales/fr/admin.json
@@ -423,6 +423,9 @@
       "notifications": "Notifications",
       "integrations": "Intégrations",
       "systemConfig": "Configuration système",
+      "designSystem": "Système de design",
+      "translations": "Traductions",
+      "systemMonitoring": "Surveillance du système",
       "branding": "Image de marque",
       "content": "Contenu",
       "general": "Général"


### PR DESCRIPTION
Moves Design System, Translations, and System Monitoring from the main navbar to the Settings page's horizontal menu.

Old routes for these sections now redirect to their respective tabs within the Settings page to maintain backward compatibility.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e7cb9e4c-b771-4fe5-90da-8814c9664648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e7cb9e4c-b771-4fe5-90da-8814c9664648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

