### PR TITLE
Redis connection error

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -45,6 +45,14 @@ APP_URL=http://localhost:3000
 # DeepL Translation (optional)
 DEEPL_API_KEY=your_deepl_api_key
 
+# Redis queue (optional)
+# In production, queue workers are disabled unless REDIS_URL or REDIS_HOST is set.
+# REDIS_URL=redis://default:password@your-redis-host:6379/0
+# REDIS_HOST=localhost
+# REDIS_PORT=6379
+# REDIS_PASSWORD=your_redis_password
+# REDIS_QUEUE_ENABLED=true
+
 # Prometheus Monitoring (optional)
 PROMETHEUS_SCRAPE_TOKEN=your_prometheus_token
 

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -4,7 +4,7 @@ import { ThrottlerModule } from '@nestjs/throttler';
 import { ScheduleModule } from '@nestjs/schedule';
 import { CustomThrottlerGuard } from './common/guards/custom-throttler.guard';
 import { BullModule } from '@nestjs/bull';
-import { sharedRedisOptions } from './common/redis.config';
+import { isRedisQueueEnabled, sharedRedisOptions } from './common/redis.config';
 import { APP_GUARD } from '@nestjs/core';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -69,15 +69,21 @@ import {
   UPLOAD_TTL_SECONDS,
 } from './common/decorators/throttle.decorator';
 
+const bullImports = isRedisQueueEnabled
+  ? [
+      BullModule.forRoot({
+        redis: sharedRedisOptions,
+      }),
+    ]
+  : [];
+
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
     }),
     ScheduleModule.forRoot(),
-    BullModule.forRoot({
-      redis: sharedRedisOptions,
-    }),
+    ...bullImports,
     ThrottlerModule.forRoot([
       {
         name: 'short',

--- a/api/src/common/redis.config.ts
+++ b/api/src/common/redis.config.ts
@@ -6,10 +6,96 @@
  * stay in sync and any change to retry / timeout policy
  * only has to be made in one place.
  */
+interface RedisBaseOptions {
+  host: string;
+  port: number;
+  username?: string;
+  password?: string;
+  db?: number;
+  tls?: Record<string, never>;
+}
+
+const DEFAULT_REDIS_PORT = 6379;
+
+function parseRedisPort(value: string | undefined, fallback = DEFAULT_REDIS_PORT): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function parseRedisDb(pathname: string): number | undefined {
+  if (!pathname || pathname === '/') {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(pathname.replace(/^\//, ''), 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function resolveRedisBaseOptions(): RedisBaseOptions | null {
+  const queueToggle = process.env.REDIS_QUEUE_ENABLED ?? process.env.REDIS_ENABLED;
+  if (queueToggle === 'false') {
+    return null;
+  }
+
+  const redisUrl = process.env.REDIS_URL?.trim();
+  if (redisUrl) {
+    try {
+      const parsed = new URL(redisUrl);
+      const username = parsed.username ? decodeURIComponent(parsed.username) : undefined;
+      const password = parsed.password ? decodeURIComponent(parsed.password) : undefined;
+
+      return {
+        host: parsed.hostname,
+        port: parseRedisPort(parsed.port),
+        username: username || process.env.REDIS_USERNAME,
+        password: password || process.env.REDIS_PASSWORD,
+        db: parseRedisDb(parsed.pathname),
+        ...(parsed.protocol === 'rediss:' ? { tls: {} } : {}),
+      };
+    } catch {
+      // Invalid REDIS_URL; fall back to host/port env handling below.
+    }
+  }
+
+  const redisHost = process.env.REDIS_HOST?.trim();
+  if (redisHost) {
+    return {
+      host: redisHost,
+      port: parseRedisPort(process.env.REDIS_PORT),
+      username: process.env.REDIS_USERNAME,
+      password: process.env.REDIS_PASSWORD,
+    };
+  }
+
+  // Keep localhost fallback for local development only.
+  if (process.env.NODE_ENV !== 'production' || queueToggle === 'true') {
+    return {
+      host: 'localhost',
+      port: parseRedisPort(process.env.REDIS_PORT),
+      username: process.env.REDIS_USERNAME,
+      password: process.env.REDIS_PASSWORD,
+    };
+  }
+
+  // Production without explicit Redis configuration should not start queue workers.
+  return null;
+}
+
+const resolvedRedisBaseOptions = resolveRedisBaseOptions();
+
+/**
+ * Whether Redis-backed queues should be initialized.
+ * In production, queues are disabled unless Redis is explicitly configured.
+ */
+export const isRedisQueueEnabled = resolvedRedisBaseOptions !== null;
+
 export const sharedRedisOptions = {
-  host: process.env.REDIS_HOST || 'localhost',
-  port: parseInt(process.env.REDIS_PORT || '6379'),
-  password: process.env.REDIS_PASSWORD,
+  host: resolvedRedisBaseOptions?.host ?? 'localhost',
+  port: resolvedRedisBaseOptions?.port ?? DEFAULT_REDIS_PORT,
+  username: resolvedRedisBaseOptions?.username,
+  password: resolvedRedisBaseOptions?.password,
+  db: resolvedRedisBaseOptions?.db,
+  tls: resolvedRedisBaseOptions?.tls,
   /** Fail fast instead of blocking the request thread for minutes. */
   maxRetriesPerRequest: 3,
   connectTimeout: 5000,

--- a/api/src/translation/translation-queue.module.ts
+++ b/api/src/translation/translation-queue.module.ts
@@ -5,32 +5,41 @@ import { DeepLService } from './deepl.service';
 import { TranslationMemoryService } from './translation-memory.service';
 import { CostTrackingService } from './cost-tracking.service';
 import { PrismaModule } from '../prisma/prisma.module';
-import { sharedRedisOptions } from '../common/redis.config';
+import { isRedisQueueEnabled, sharedRedisOptions } from '../common/redis.config';
+
+const translationQueueImports = isRedisQueueEnabled
+  ? [
+      BullModule.registerQueue({
+        name: 'translation',
+        redis: sharedRedisOptions,
+        defaultJobOptions: {
+          attempts: 3,
+          backoff: {
+            type: 'exponential',
+            delay: 2000,
+          },
+          removeOnComplete: true,
+          removeOnFail: false, // Keep failed jobs for debugging
+        },
+      }),
+    ]
+  : [];
+
+const translationQueueProviders = isRedisQueueEnabled ? [TranslationQueueProcessor] : [];
+const translationQueueExports = isRedisQueueEnabled ? [BullModule] : [];
 
 @Module({
   imports: [
-    BullModule.registerQueue({
-      name: 'translation',
-      redis: sharedRedisOptions,
-      defaultJobOptions: {
-        attempts: 3,
-        backoff: {
-          type: 'exponential',
-          delay: 2000,
-        },
-        removeOnComplete: true,
-        removeOnFail: false, // Keep failed jobs for debugging
-      },
-    }),
+    ...translationQueueImports,
     PrismaModule,
   ],
   providers: [
-    TranslationQueueProcessor,
+    ...translationQueueProviders,
     DeepLService,
     TranslationMemoryService,
     CostTrackingService,
   ],
-  exports: [BullModule, DeepLService, TranslationMemoryService, CostTrackingService],
+  exports: [...translationQueueExports, DeepLService, TranslationMemoryService, CostTrackingService],
 })
 export class TranslationQueueModule {}
 

--- a/api/src/translation/translation.service.ts
+++ b/api/src/translation/translation.service.ts
@@ -27,13 +27,15 @@ export class TranslationService {
   constructor(
     private prisma: PrismaService,
     private configService: ConfigService,
-    @InjectQueue('translation') private translationQueue?: Queue,
+    @Optional() @InjectQueue('translation') private translationQueue?: Queue,
     @Optional() private deepLService?: DeepLService,
   ) {
     if (this.translationQueue) {
       this.logger.log('Translation queue injected successfully');
     } else {
-      this.logger.error('Translation queue NOT injected - translations will NOT be processed! Check Redis connection and queue module setup.');
+      this.logger.warn(
+        'Translation queue not injected. Redis-backed workers are disabled; inline fallback will be used when possible.',
+      );
     }
     
     if (this.deepLService) {


### PR DESCRIPTION
Make Redis queue bootstrapping conditional and support `REDIS_URL` to prevent application crashes.

The application was crashing in production due to an unhandled `ECONNREFUSED` error from Bull trying to connect to `localhost:6379`. This fix introduces conditional initialization of Redis-backed queues, disabling them in production environments unless `REDIS_URL` or `REDIS_HOST` is explicitly configured. It also adds support for parsing `REDIS_URL` to configure the Redis connection.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-915aaac1-155a-4049-a477-ea3d4969c76d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-915aaac1-155a-4049-a477-ea3d4969c76d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

