### PR TITLE
Login session stuck

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -27,6 +27,7 @@ import PolicyCrawlerPage from './pages/PolicyCrawler';
 import AdminUserProfileEdit from './pages/AdminUserProfileEdit';
 import AdminOrganizationProfileEdit from './pages/AdminOrganizationProfileEdit';
 import ResetPassword from './pages/ResetPassword';
+import ChooseOrganization from './pages/ChooseOrganization';
 
 // Create a client
 const queryClient = new QueryClient({
@@ -73,6 +74,7 @@ function App() {
         <Route path="/login" element={<AdminLoginPage />} />
         <Route path="/signup" element={<AdminSignupPage />} />
         <Route path="/reset-password" element={<ResetPassword />} />
+        <Route path="/choose-organization" element={<ChooseOrganization />} />
         <Route path="/access-denied" element={<AccessDeniedPage />} />
         <Route
           path="/"

--- a/admin/src/components/auth/AdminCustomLoginFormNew.tsx
+++ b/admin/src/components/auth/AdminCustomLoginFormNew.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
-import { useSignIn, useAuth, useUser } from '@clerk/clerk-react';
+import { useSignIn, useAuth, useUser, useClerk } from '@clerk/clerk-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, Link } from 'react-router-dom';
 import { SquaresPlusIcon, EyeIcon, EyeSlashIcon, CheckCircleIcon } from '@heroicons/react/24/outline';
-import toast from 'react-hot-toast';
 import { useSettings } from '../../hooks/useSettings';
 import Card from '../design-system/Card';
 import Button from '../design-system/Button';
@@ -26,6 +25,7 @@ export default function AdminCustomLoginForm() {
   const navigate = useNavigate();
   const { signIn, isLoaded, setActive } = useSignIn();
   const { isSignedIn, isLoaded: authLoaded } = useAuth();
+  const { signOut } = useClerk();
   const { user } = useUser();
   const { settings } = useSettings();
   
@@ -66,9 +66,17 @@ export default function AdminCustomLoginForm() {
       if (result.status === 'complete') {
         // User signed in successfully, activate session and redirect to admin dashboard
         try {
-          // Immediately activate session and navigate - no re-render in between
-          await setActive({ session: result.createdSessionId });
-          navigate('/dashboard');
+          // Immediately activate session and handle any pending session tasks (e.g. choose-organization)
+          await setActive({
+            session: result.createdSessionId,
+            navigate: async ({ session }) => {
+              if (session.currentTask?.key === 'choose-organization') {
+                navigate('/choose-organization', { replace: true });
+                return;
+              }
+              navigate('/dashboard', { replace: true });
+            },
+          });
         } catch (setActiveError: any) {
           console.error('Session activation failed:', setActiveError);
           setError(t('auth:errors.sessionActivationFailed'));
@@ -153,10 +161,13 @@ export default function AdminCustomLoginForm() {
   const handleSignOut = async () => {
     setIsSigningOut(true);
     try {
-      // Navigate to homepage after sign out
-      navigate('/login');
+      await signOut();
+      navigate('/login', { replace: true });
     } catch (error) {
       console.error('Sign out error:', error);
+      setError(t('auth:errors.signOutFailed', 'Sign out failed. Please try again.'));
+      // Best-effort escape hatch: force navigation even if sign-out fails.
+      window.location.href = '/login';
     } finally {
       setIsSigningOut(false);
     }

--- a/admin/src/components/auth/AdminCustomSignupFormNew.tsx
+++ b/admin/src/components/auth/AdminCustomSignupFormNew.tsx
@@ -125,7 +125,14 @@ export default function AdminCustomSignupForm() {
 
       if (result.status === 'complete') {
         try {
-          await setActive({ session: result.createdSessionId });
+          await setActive({
+            session: result.createdSessionId,
+            navigate: async ({ session }) => {
+              if (session.currentTask?.key === 'choose-organization') {
+                navigate('/choose-organization', { replace: true });
+              }
+            },
+          });
           setCurrentStep(3);
         } catch (setActiveError: any) {
           console.error('Session activation failed:', setActiveError);
@@ -187,7 +194,14 @@ export default function AdminCustomSignupForm() {
       
       if (result.status === 'complete') {
         try {
-          await setActive({ session: result.createdSessionId });
+          await setActive({
+            session: result.createdSessionId,
+            navigate: async ({ session }) => {
+              if (session.currentTask?.key === 'choose-organization') {
+                navigate('/choose-organization', { replace: true });
+              }
+            },
+          });
           setCurrentStep(3);
         } catch (setActiveError: any) {
           console.error('Session activation failed:', setActiveError);

--- a/admin/src/pages/ChooseOrganization.tsx
+++ b/admin/src/pages/ChooseOrganization.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect } from 'react';
+import { TaskChooseOrganization, useAuth, useSession } from '@clerk/clerk-react';
+import { useNavigate } from 'react-router-dom';
+import Card from '../components/design-system/Card';
+
+export default function ChooseOrganization() {
+  const navigate = useNavigate();
+  const { isLoaded, isSignedIn } = useAuth();
+  const { session } = useSession();
+
+  useEffect(() => {
+    if (!isLoaded) return;
+    if (!isSignedIn) return;
+    if (session?.currentTask) return;
+    navigate('/dashboard', { replace: true });
+  }, [isLoaded, isSignedIn, session?.currentTask, navigate]);
+
+  if (!isLoaded) {
+    return (
+      <div className="min-h-screen bg-page-bg flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-swiss-mint"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-page-bg flex items-center justify-center p-4">
+      <Card className="w-full max-w-lg p-8 shadow-xl">
+        <TaskChooseOrganization redirectUrlComplete="/dashboard" />
+      </Card>
+    </div>
+  );
+}
+

--- a/admin/src/pages/ResetPassword.tsx
+++ b/admin/src/pages/ResetPassword.tsx
@@ -119,8 +119,16 @@ export default function ResetPassword() {
       if (attempt.status === 'needs_new_password' || signIn.status === 'needs_new_password') {
         const resetAttempt = await signIn.resetPassword({ password });
         if (resetAttempt.status === 'complete') {
-          await setActive({ session: resetAttempt.createdSessionId });
-          navigate('/dashboard', { replace: true });
+          await setActive({
+            session: resetAttempt.createdSessionId,
+            navigate: async ({ session }) => {
+              if (session.currentTask?.key === 'choose-organization') {
+                navigate('/choose-organization', { replace: true });
+                return;
+              }
+              navigate('/dashboard', { replace: true });
+            },
+          });
           return;
         }
         setError(t('common:errors.unknown', 'An unknown error occurred'));
@@ -128,8 +136,16 @@ export default function ResetPassword() {
       }
 
       if (attempt.status === 'complete') {
-        await setActive({ session: attempt.createdSessionId });
-        navigate('/dashboard', { replace: true });
+        await setActive({
+          session: attempt.createdSessionId,
+          navigate: async ({ session }) => {
+            if (session.currentTask?.key === 'choose-organization') {
+              navigate('/choose-organization', { replace: true });
+              return;
+            }
+            navigate('/dashboard', { replace: true });
+          },
+        });
         return;
       }
 

--- a/admin/src/providers/AppProvider.tsx
+++ b/admin/src/providers/AppProvider.tsx
@@ -26,7 +26,12 @@ export function AppProvider({ children }: AppProviderProps) {
       publishableKey={clerkPubKey}
       signInUrl="/login"
       signUpUrl="/signup"
+      afterSignInUrl="/dashboard"
+      afterSignUpUrl="/dashboard"
       afterSignOutUrl="/login"
+      taskUrls={{
+        'choose-organization': '/choose-organization',
+      }}
     >
       {children}
     </ClerkProvider>

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -35,6 +35,7 @@ const devLog = (...args: any[]) => {
 import PartnersPage from './pages/PartnersPage';
 import LoginPage from './pages/LoginPage'; // New Login Page
 import SignupPage from './pages/SignupPage'; // New Signup Page Placeholder
+import ChooseOrganizationPage from './pages/ChooseOrganizationPage';
 import ParentLeadFormPage from './pages/ParentLeadFormPage';
 import ParentEnquiriesPage from './pages/parent/ParentEnquiriesPage';
 import FoundationLeadsPage from './pages/foundation/FoundationLeadsPage';
@@ -594,6 +595,7 @@ const App: React.FC = () => {
             <Route path="/pricing" element={<PricingPage />} />
             <Route path="/parent-lead-form" element={<ParentLeadFormPage />} />
             <Route path="/reset-password" element={<Navigate to="/login" replace />} />
+            <Route path="/choose-organization" element={<Navigate to="/login" replace />} />
 
             {/* Protected routes: always redirect to login in E2E */}
             <Route path="/dashboard" element={<Navigate to="/login" replace />} />
@@ -624,6 +626,7 @@ const App: React.FC = () => {
                 <Route path="/partners" element={<PublicPartnersPage />} />
                 <Route path="/parent-lead-form" element={<ParentLeadFormPage />} />
                 <Route path="/reset-password" element={<ResetPasswordPage />} />
+                <Route path="/choose-organization" element={<ChooseOrganizationPage />} />
                 <Route path="/*" element={<ProtectedLayout />} />
               </Routes>
             </SubscriptionProvider>

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -25,11 +25,11 @@ if (!rootElement) {
 const AppWithProviders = () => {
   return (
     <I18nextProvider i18n={i18nInstance}>
-      <AuthProvider>
-        <BrowserRouter>
+      <BrowserRouter>
+        <AuthProvider>
           <App />
-        </BrowserRouter>
-      </AuthProvider>
+        </AuthProvider>
+      </BrowserRouter>
     </I18nextProvider>
   );
 };

--- a/frontend/pages/ChooseOrganizationPage.tsx
+++ b/frontend/pages/ChooseOrganizationPage.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect } from 'react';
+import { TaskChooseOrganization, useAuth, useSession } from '@clerk/clerk-react';
+import { useNavigate } from 'react-router-dom';
+import Card from '../components/ui/Card';
+
+const ChooseOrganizationPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { isLoaded, isSignedIn } = useAuth();
+  const { session } = useSession();
+
+  // Once the task is resolved, proceed to the dashboard.
+  useEffect(() => {
+    if (!isLoaded) return;
+    if (!isSignedIn) return;
+    if (session?.currentTask) return;
+    navigate('/dashboard', { replace: true });
+  }, [isLoaded, isSignedIn, session?.currentTask, navigate]);
+
+  if (!isLoaded) {
+    return (
+      <div className="min-h-screen bg-page-bg flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-swiss-mint"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-page-bg flex items-center justify-center p-4">
+      <Card className="w-full max-w-lg p-6 shadow-xl">
+        <TaskChooseOrganization redirectUrlComplete="/dashboard" />
+      </Card>
+    </div>
+  );
+};
+
+export default ChooseOrganizationPage;
+

--- a/frontend/pages/LoginPage.tsx
+++ b/frontend/pages/LoginPage.tsx
@@ -115,11 +115,17 @@ const LoginPage: React.FC = () => {
 
       if (result.status === 'complete') {
         try {
-          // Immediately activate session and navigate - no re-render in between
-          await setActive({ session: result.createdSessionId });
-          
-          // Navigate immediately - proper render gating prevents Active Session UI from showing
-          navigate('/dashboard', { replace: true });
+          // Immediately activate session and handle any pending session tasks (e.g. choose-organization)
+          await setActive({
+            session: result.createdSessionId,
+            navigate: async ({ session }) => {
+              if (session.currentTask?.key === 'choose-organization') {
+                navigate('/choose-organization', { replace: true });
+                return;
+              }
+              navigate('/dashboard', { replace: true });
+            },
+          });
         } catch (setActiveError: any) {
           console.error('Session activation failed:', setActiveError);
           setError(t('common:loginPage.sessionActivationFailed'));

--- a/frontend/pages/ResetPasswordPage.tsx
+++ b/frontend/pages/ResetPasswordPage.tsx
@@ -137,8 +137,16 @@ const ResetPasswordPage: React.FC = () => {
       if (attempt.status === 'needs_new_password' || signIn.status === 'needs_new_password') {
         const resetAttempt = await signIn.resetPassword({ password });
         if (resetAttempt.status === 'complete') {
-          await setActive({ session: resetAttempt.createdSessionId });
-          navigate('/dashboard', { replace: true });
+          await setActive({
+            session: resetAttempt.createdSessionId,
+            navigate: async ({ session }) => {
+              if (session.currentTask?.key === 'choose-organization') {
+                navigate('/choose-organization', { replace: true });
+                return;
+              }
+              navigate('/dashboard', { replace: true });
+            },
+          });
           return;
         }
         setError(t('common:errors.unknown', 'An unknown error occurred'));
@@ -146,8 +154,16 @@ const ResetPasswordPage: React.FC = () => {
       }
 
       if (attempt.status === 'complete') {
-        await setActive({ session: attempt.createdSessionId });
-        navigate('/dashboard', { replace: true });
+        await setActive({
+          session: attempt.createdSessionId,
+          navigate: async ({ session }) => {
+            if (session.currentTask?.key === 'choose-organization') {
+              navigate('/choose-organization', { replace: true });
+              return;
+            }
+            navigate('/dashboard', { replace: true });
+          },
+        });
         return;
       }
 

--- a/frontend/pages/SignupPage.tsx
+++ b/frontend/pages/SignupPage.tsx
@@ -498,7 +498,14 @@ const SignupPage: React.FC = () => {
 
         if (result.status === 'complete') {
           try {
-            await setActive({ session: result.createdSessionId });
+            await setActive({
+              session: result.createdSessionId,
+              navigate: async ({ session }) => {
+                if (session.currentTask?.key === 'choose-organization') {
+                  navigate('/choose-organization', { replace: true });
+                }
+              },
+            });
             setSuccessRedirect(getSuccessRedirectForRole());
             setCurrentStep(3);
           } catch (setActiveError: any) {
@@ -593,7 +600,14 @@ const SignupPage: React.FC = () => {
 
         try {
           console.log('[Signup Debug] handleVerification: activating session');
-          await setActive({ session: result.createdSessionId });
+          await setActive({
+            session: result.createdSessionId,
+            navigate: async ({ session }) => {
+              if (session.currentTask?.key === 'choose-organization') {
+                navigate('/choose-organization', { replace: true });
+              }
+            },
+          });
           console.log('[Signup Debug] handleVerification: session activated successfully');
         } catch (activationError: any) {
           console.error('Session activation failed after verification:', activationError);

--- a/frontend/providers/AuthProvider.tsx
+++ b/frontend/providers/AuthProvider.tsx
@@ -872,7 +872,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   return (
     <ClerkProvider 
       publishableKey={publishableKey}
+      signInUrl="/login"
+      signUpUrl="/signup"
+      afterSignInUrl="/dashboard"
+      afterSignUpUrl="/dashboard"
       afterSignOutUrl="/login"
+      taskUrls={{
+        'choose-organization': '/choose-organization',
+      }}
       appearance={{
         elements: {
           // Disable Clerk's built-in CAPTCHA since we're using hCaptcha


### PR DESCRIPTION
Fixes Clerk "pending tasks" issue by configuring task URLs and adding a dedicated page for organization selection.

The frontend and admin apps were getting stuck after sign-in due to unhandled Clerk "pending tasks" (specifically `choose-organization`), preventing proper navigation and displaying the warning: `Session has pending tasks but no handling is configured...`. This PR configures Clerk to handle these tasks by routing to a new `/choose-organization` page, ensuring users can complete their sign-in flow and proceed to the dashboard.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e2951b66-c6f4-432d-8408-a00029e324ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e2951b66-c6f4-432d-8408-a00029e324ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

