### PR TITLE
Policy type region selection

### DIFF
--- a/admin/src/components/ContentUploadModal.tsx
+++ b/admin/src/components/ContentUploadModal.tsx
@@ -21,6 +21,7 @@ export enum PolicyType {
   DIRECTIVE = 'Directive',
   LAW = 'Law',
   COMPLIANCE_PROCEDURE = 'Compliance Procedure',
+  ADMINISTRATIVE_PROCEDURE = 'Administrative Procedure',
 }
 
 // Define categories

--- a/admin/src/components/ContentUploadModal.tsx
+++ b/admin/src/components/ContentUploadModal.tsx
@@ -19,7 +19,8 @@ export enum PolicyType {
   GUIDELINE = 'Guideline',
   STANDARD = 'Standard',
   DIRECTIVE = 'Directive',
-  LAW = 'Law'
+  LAW = 'Law',
+  COMPLIANCE_PROCEDURE = 'Compliance Procedure',
 }
 
 // Define categories
@@ -292,6 +293,10 @@ const ContentUploadModal: React.FC<ContentUploadModalProps> = ({
     if (formData.country && contentType === 'policy') {
       const validRegions = REGIONS_BY_COUNTRY[formData.country] ?? SWISS_CANTONS;
       const currentRegion = (formData.region ?? '') as string;
+      // Allow sentinel value meaning "applies to all regions/cantons".
+      if (currentRegion === 'All') {
+        return;
+      }
       if (!validRegions.includes(currentRegion)) {
         setFormData(prev => ({ ...prev, region: validRegions[0] as string }));
       }
@@ -791,6 +796,7 @@ const ContentUploadModal: React.FC<ContentUploadModalProps> = ({
         <div>
           <label htmlFor="policyRegion" className="block text-sm font-medium text-gray-700 mb-1">{t('content.region','Region/Canton')} <span className="text-red-500 ml-0.5">*</span></label>
           <select name="region" id="policyRegion" value={formData.region || SWISS_CANTONS[0]} onChange={handleInputChange} required className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
+            <option value="All">{t('common:filters.all', 'All')}</option>
             {(formData.country ? (REGIONS_BY_COUNTRY[formData.country] ?? SWISS_CANTONS) : SWISS_CANTONS).map(region => <option key={region} value={region}>{region}</option>)}
           </select>
         </div>

--- a/admin/src/constants/design-system.ts
+++ b/admin/src/constants/design-system.ts
@@ -13,6 +13,12 @@ export const SWISS_CANTONS = [
   'Ticino', 'Uri', 'Valais', 'Vaud', 'Zug', 'Zürich'
 ] as const;
 
+// Sentinel value meaning "applies to all regions/cantons".
+export const ALL_REGIONS_OPTION = 'All' as const;
+
+// Convenience list for selects where users can choose to cover all cantons.
+export const SWISS_CANTONS_WITH_ALL = [ALL_REGIONS_OPTION, ...SWISS_CANTONS] as const;
+
 export const SERVICE_CATEGORIES = [
   'Legal', 'Catering', 'Cleaning', 'Workshops', 'IT_Support', 'Consulting', 
   'Maintenance', 'Photography', 'Staff_Training', 'Landscaping', 'Other'

--- a/admin/src/constants/design-system.ts
+++ b/admin/src/constants/design-system.ts
@@ -283,7 +283,7 @@ export const COUNTRIES_FOR_POLICIES = ['Switzerland', 'Germany', 'France', 'Ital
 export type CountryForPolicies = typeof COUNTRIES_FOR_POLICIES[number];
 
 export const REGIONS_BY_COUNTRY: Record<CountryForPolicies, readonly string[]> = {
-    'Switzerland': ["All Cantons", ...SWISS_CANTONS],
+    'Switzerland': [ALL_REGIONS_OPTION, ...SWISS_CANTONS],
     'Germany': ["All Länder", "Bavaria"], // Reduced for brevity
     'France': ["All Régions", "Île-de-France"], // Reduced for brevity
     'Italy': ["All Regioni", "Lombardy"], // Reduced for brevity

--- a/admin/src/pages/AdminOrganizationProfileEdit.tsx
+++ b/admin/src/pages/AdminOrganizationProfileEdit.tsx
@@ -25,7 +25,7 @@ import Card from '../components/design-system/Card';
 import Button from '../components/design-system/Button';
 import ChipInput from '../components/design-system/ChipInput';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
-import { STANDARD_INPUT_FIELD, SWISS_CANTONS, SERVICE_CATEGORIES, SERVICE_DELIVERY_TYPES } from '../constants/design-system';
+import { ALL_REGIONS_OPTION, STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL, SWISS_CANTONS, SERVICE_CATEGORIES, SERVICE_DELIVERY_TYPES } from '../constants/design-system';
 
 interface OrganizationProfile {
   id: string;
@@ -159,7 +159,19 @@ const AdminOrganizationProfileEdit: React.FC = () => {
   const handleMultiSelectChange = (field: keyof OrganizationProfile, value: string) => {
     const currentValues = (formData[field] as string[]) || [];
     let newValues: string[];
-    if (currentValues.includes(value)) {
+    if (field === 'regionsServed') {
+      const hasAll = currentValues.includes(ALL_REGIONS_OPTION);
+      const isAllValue = value === ALL_REGIONS_OPTION;
+
+      if (isAllValue) {
+        newValues = hasAll ? currentValues.filter((v) => v !== ALL_REGIONS_OPTION) : [ALL_REGIONS_OPTION];
+      } else {
+        const withoutAll = currentValues.filter((v) => v !== ALL_REGIONS_OPTION);
+        newValues = withoutAll.includes(value)
+          ? withoutAll.filter((v) => v !== value)
+          : [...withoutAll, value];
+      }
+    } else if (currentValues.includes(value)) {
       newValues = currentValues.filter((v) => v !== value);
     } else {
       newValues = [...currentValues, value];
@@ -401,6 +413,7 @@ const AdminOrganizationProfileEdit: React.FC = () => {
                   className={STANDARD_INPUT_FIELD}
                 >
                   <option value="">{t('admin:orgProfile.selectCanton', 'Select canton')}</option>
+                  <option value={ALL_REGIONS_OPTION}>{t('common:filters.all', 'All')}</option>
                   {SWISS_CANTONS.map((canton) => (
                     <option key={canton} value={canton}>
                       {canton}
@@ -429,7 +442,7 @@ const AdminOrganizationProfileEdit: React.FC = () => {
                 {t('admin:orgProfile.regionsServedHint', 'Select all cantons where this organization operates')}
               </p>
               <div className="flex flex-wrap gap-2">
-                {SWISS_CANTONS.map((canton) => (
+                {SWISS_CANTONS_WITH_ALL.map((canton) => (
                   <button
                     key={canton}
                     type="button"
@@ -440,7 +453,7 @@ const AdminOrganizationProfileEdit: React.FC = () => {
                         : 'bg-white text-gray-700 border-gray-300 hover:border-swiss-teal'
                     }`}
                   >
-                    {canton}
+                    {canton === ALL_REGIONS_OPTION ? t('common:filters.all', 'All') : canton}
                   </button>
                 ))}
               </div>

--- a/admin/src/pages/AdminOrganizationProfileEdit.tsx
+++ b/admin/src/pages/AdminOrganizationProfileEdit.tsx
@@ -413,7 +413,6 @@ const AdminOrganizationProfileEdit: React.FC = () => {
                   className={STANDARD_INPUT_FIELD}
                 >
                   <option value="">{t('admin:orgProfile.selectCanton', 'Select canton')}</option>
-                  <option value={ALL_REGIONS_OPTION}>{t('common:filters.all', 'All')}</option>
                   {SWISS_CANTONS.map((canton) => (
                     <option key={canton} value={canton}>
                       {canton}

--- a/admin/src/pages/AdminUserProfileEdit.tsx
+++ b/admin/src/pages/AdminUserProfileEdit.tsx
@@ -22,7 +22,7 @@ import Card from '../components/design-system/Card';
 import Button from '../components/design-system/Button';
 import ChipInput from '../components/design-system/ChipInput';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
-import { STANDARD_INPUT_FIELD, SWISS_CANTONS } from '../constants/design-system';
+import { ALL_REGIONS_OPTION, STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL } from '../constants/design-system';
 import { UserRole } from '../types';
 
 interface UserProfile {
@@ -335,9 +335,9 @@ const AdminUserProfileEdit: React.FC = () => {
                   className={STANDARD_INPUT_FIELD}
                 >
                   <option value="">{t('admin:userProfile.selectRegion', 'Select a region')}</option>
-                  {SWISS_CANTONS.map((canton) => (
+                  {SWISS_CANTONS_WITH_ALL.map((canton) => (
                     <option key={canton} value={canton}>
-                      {canton}
+                      {canton === ALL_REGIONS_OPTION ? t('common:filters.all', 'All') : canton}
                     </option>
                   ))}
                 </select>

--- a/admin/src/pages/PolicyReview.tsx
+++ b/admin/src/pages/PolicyReview.tsx
@@ -195,7 +195,7 @@ const PolicyReviewPanel: React.FC<{
             onChange={e => setForm({...form, policyType: e.target.value})}
             className="w-full border rounded px-3 py-2"
           >
-            {['Law', 'Regulation', 'Directive', 'Guideline', 'Standard', 'Compliance Procedure'].map(type => (
+            {['Law', 'Regulation', 'Directive', 'Guideline', 'Standard', 'Compliance Procedure', 'Administrative Procedure'].map(type => (
               <option key={type} value={type}>{type}</option>
             ))}
           </select>

--- a/admin/src/pages/PolicyReview.tsx
+++ b/admin/src/pages/PolicyReview.tsx
@@ -195,7 +195,7 @@ const PolicyReviewPanel: React.FC<{
             onChange={e => setForm({...form, policyType: e.target.value})}
             className="w-full border rounded px-3 py-2"
           >
-            {['Law', 'Regulation', 'Directive', 'Guideline', 'Standard'].map(type => (
+            {['Law', 'Regulation', 'Directive', 'Guideline', 'Standard', 'Compliance Procedure'].map(type => (
               <option key={type} value={type}>{type}</option>
             ))}
           </select>

--- a/api/src/admin/admin-profiles.controller.ts
+++ b/api/src/admin/admin-profiles.controller.ts
@@ -40,6 +40,7 @@ import {
   normalizeEducationItems,
   normalizeWorkExperienceItems,
 } from '../utils/educator-profile-items';
+import { normalizeRegionsServed } from '../common/utils/regions.util';
 
 // Valid organization types for validation
 const VALID_ORGANIZATION_TYPES = Object.values(OrganizationType);
@@ -694,6 +695,9 @@ export class AdminProfilesController {
     const normalizedWebsiteUrl =
       dto.websiteUrl !== undefined ? dto.websiteUrl : dto.website !== undefined ? dto.website : undefined;
 
+    const normalizedRegionsServed =
+      dto.regionsServed !== undefined ? normalizeRegionsServed(dto.regionsServed) : undefined;
+
     await this.prisma.$transaction(async (tx) => {
       // Update contact email separately
       if (dto.contactEmail !== undefined) {
@@ -720,7 +724,7 @@ export class AdminProfilesController {
           ...(dto.region !== undefined && { region: dto.region }),
           ...(dto.canton !== undefined && { canton: dto.canton }),
           ...(dto.city !== undefined && { city: dto.city }),
-          ...(dto.regionsServed !== undefined && { regionsServed: dto.regionsServed }),
+          ...(normalizedRegionsServed !== undefined && { regionsServed: normalizedRegionsServed }),
           ...(dto.description !== undefined && { description: dto.description }),
           ...(dto.vatNumber !== undefined && { vatNumber: dto.vatNumber }),
           ...(dto.languages !== undefined && { languages: dto.languages }),

--- a/api/src/common/utils/regions.util.ts
+++ b/api/src/common/utils/regions.util.ts
@@ -1,0 +1,32 @@
+export const ALL_REGIONS_OPTION = 'All' as const;
+
+/**
+ * Normalize region/canton lists that support the special "All" sentinel.
+ *
+ * Invariant:
+ * - If "All" is present (any casing), it becomes the *only* value persisted: ["All"].
+ * - Otherwise values are trimmed, emptied removed, de-duped (preserving order).
+ *
+ * NOTE: Prisma scalar-list filters like `{ has: 'All' }` are case-sensitive.
+ * We enforce canonical casing at write-time to keep queries reliable.
+ */
+export function normalizeRegionsServed(values?: readonly string[] | null): string[] {
+  const list = (Array.isArray(values) ? values : [])
+    .map((value) => String(value).trim())
+    .filter(Boolean)
+    .map((value) => (value.toLowerCase() === 'all' ? ALL_REGIONS_OPTION : value));
+
+  if (list.includes(ALL_REGIONS_OPTION)) {
+    return [ALL_REGIONS_OPTION];
+  }
+
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of list) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    result.push(value);
+  }
+  return result;
+}
+

--- a/api/src/compat/compat.controller.ts
+++ b/api/src/compat/compat.controller.ts
@@ -585,6 +585,8 @@ export class CompatController {
           { region: region },
           { canton: region },
           { regionsServed: { has: region } },
+          // Organizations that explicitly serve all cantons/regions.
+          { regionsServed: { has: 'All' } },
         ];
       }
       

--- a/api/src/compat/compat.controller.ts
+++ b/api/src/compat/compat.controller.ts
@@ -585,6 +585,10 @@ export class CompatController {
           { region: region },
           { canton: region },
           { regionsServed: { has: region } },
+          // Backwards-compat: if some records store the sentinel in single-value fields,
+          // treat it as "serves all" too.
+          { region: 'All' },
+          { canton: 'All' },
           // Organizations that explicitly serve all cantons/regions.
           { regionsServed: { has: 'All' } },
         ];

--- a/api/src/content/content.service.ts
+++ b/api/src/content/content.service.ts
@@ -1129,7 +1129,11 @@ export class ContentService {
     }
 
     if (region) {
-      where.region = region;
+      // When a region is selected, also include policies that apply to all regions.
+      // Treat "All" as a UI sentinel meaning "no region filter".
+      if (region !== 'All') {
+        where.region = { in: [region, 'All'] };
+      }
     }
 
     if (isCritical !== undefined) {

--- a/api/src/content/dto/content.enums.ts
+++ b/api/src/content/dto/content.enums.ts
@@ -31,6 +31,7 @@ export enum PolicyType {
   DIRECTIVE = 'Directive',
   LAW = 'Law',
   COMPLIANCE_PROCEDURE = 'Compliance Procedure',
+  ADMINISTRATIVE_PROCEDURE = 'Administrative Procedure',
 }
 
 export enum FileType {

--- a/api/src/content/dto/content.enums.ts
+++ b/api/src/content/dto/content.enums.ts
@@ -30,6 +30,7 @@ export enum PolicyType {
   STANDARD = 'Standard',
   DIRECTIVE = 'Directive',
   LAW = 'Law',
+  COMPLIANCE_PROCEDURE = 'Compliance Procedure',
 }
 
 export enum FileType {

--- a/api/src/leads/leads.service.ts
+++ b/api/src/leads/leads.service.ts
@@ -271,6 +271,8 @@ export class LeadsService {
     if (lead.preferredLocation && lead.preferredLocation !== 'All') {
       where.OR = [
         { canton: { equals: lead.preferredLocation, mode: 'insensitive' } },
+        // Backwards-compat: treat a sentinel stored in the single-value canton field as global coverage.
+        { canton: { equals: 'All', mode: 'insensitive' } },
         { regionsServed: { has: lead.preferredLocation } },
         { regionsServed: { has: 'All' } },
         { region: { contains: lead.preferredLocation, mode: 'insensitive' } },
@@ -307,6 +309,7 @@ export class LeadsService {
       if (lead.preferredLocation && lead.preferredLocation !== 'All') {
         const cantonMatch =
           foundation.canton?.toLowerCase() === lead.preferredLocation.toLowerCase();
+        const globalCantonMatch = foundation.canton?.toLowerCase() === 'all';
         const regionsMatch = foundation.regionsServed?.some(
           r =>
             r.toLowerCase() === lead.preferredLocation!.toLowerCase() ||
@@ -314,7 +317,7 @@ export class LeadsService {
         );
         const regionMatch = foundation.region?.toLowerCase().includes(lead.preferredLocation.toLowerCase());
         
-        if (cantonMatch || regionsMatch || regionMatch) {
+        if (cantonMatch || globalCantonMatch || regionsMatch || regionMatch) {
           score += 30;
         }
       }

--- a/api/src/leads/leads.service.ts
+++ b/api/src/leads/leads.service.ts
@@ -267,10 +267,12 @@ export class LeadsService {
     };
 
     // Canton/Location matching - match against canton or regionsServed
-    if (lead.preferredLocation) {
+    // Treat "All" as no preferred location filter.
+    if (lead.preferredLocation && lead.preferredLocation !== 'All') {
       where.OR = [
         { canton: { equals: lead.preferredLocation, mode: 'insensitive' } },
         { regionsServed: { has: lead.preferredLocation } },
+        { regionsServed: { has: 'All' } },
         { region: { contains: lead.preferredLocation, mode: 'insensitive' } },
       ];
     }
@@ -302,10 +304,13 @@ export class LeadsService {
       let score = 0;
 
       // Canton/Location match (30 points)
-      if (lead.preferredLocation) {
-        const cantonMatch = foundation.canton?.toLowerCase() === lead.preferredLocation.toLowerCase();
+      if (lead.preferredLocation && lead.preferredLocation !== 'All') {
+        const cantonMatch =
+          foundation.canton?.toLowerCase() === lead.preferredLocation.toLowerCase();
         const regionsMatch = foundation.regionsServed?.some(
-          r => r.toLowerCase() === lead.preferredLocation!.toLowerCase()
+          r =>
+            r.toLowerCase() === lead.preferredLocation!.toLowerCase() ||
+            r.toLowerCase() === 'all'
         );
         const regionMatch = foundation.region?.toLowerCase().includes(lead.preferredLocation.toLowerCase());
         

--- a/api/src/leads/leads.service.ts
+++ b/api/src/leads/leads.service.ts
@@ -52,6 +52,11 @@ export class LeadsService {
     const parentEmail = createParentLeadDto.parentEmail.trim().toLowerCase();
     const parentName = createParentLeadDto.parentName.trim();
     const parentEmailHash = this.hashRecipient(parentEmail);
+    const rawPreferredLocation = createParentLeadDto.preferredLocation?.trim();
+    const preferredLocation =
+      rawPreferredLocation && rawPreferredLocation.toLowerCase() === 'all'
+        ? 'All'
+        : rawPreferredLocation;
 
     const [linkedParentUser, lead] = await this.prisma.$transaction(async (tx) => {
       const existingParentUser = await tx.user.findFirst({
@@ -73,7 +78,7 @@ export class LeadsService {
           childName: createParentLeadDto.childName.trim(),
           childAge: createParentLeadDto.childAge,
           message: createParentLeadDto.message?.trim() || undefined,
-          preferredLocation: createParentLeadDto.preferredLocation?.trim() || undefined,
+          preferredLocation: preferredLocation || undefined,
           preferredCities: this.normalizeStringArray(createParentLeadDto.preferredCities),
           preferredLanguages: this.normalizeStringArray(createParentLeadDto.preferredLanguages),
           specialRequirements: createParentLeadDto.specialRequirements?.trim() || undefined,
@@ -240,9 +245,21 @@ export class LeadsService {
   }
 
   async updateParentLead(id: string, updateParentLeadDto: UpdateParentLeadDto) {
+    const normalizedPreferredLocation =
+      updateParentLeadDto.preferredLocation !== undefined
+        ? (updateParentLeadDto.preferredLocation?.trim().toLowerCase() === 'all'
+            ? 'All'
+            : updateParentLeadDto.preferredLocation?.trim() || null)
+        : undefined;
+
     return this.prisma.parentLead.update({
       where: { id },
-      data: updateParentLeadDto,
+      data: {
+        ...updateParentLeadDto,
+        ...(normalizedPreferredLocation !== undefined && {
+          preferredLocation: normalizedPreferredLocation || undefined,
+        }),
+      },
     });
   }
 
@@ -274,6 +291,7 @@ export class LeadsService {
         // Backwards-compat: treat a sentinel stored in the single-value canton field as global coverage.
         { canton: { equals: 'All', mode: 'insensitive' } },
         { regionsServed: { has: lead.preferredLocation } },
+        // NOTE: `{ has: 'All' }` is case-sensitive. Keep writes canonical as exactly "All".
         { regionsServed: { has: 'All' } },
         { region: { contains: lead.preferredLocation, mode: 'insensitive' } },
       ];
@@ -522,6 +540,9 @@ export class LeadsService {
     });
 
     // Build the base foundation-scoping conditions
+    const foundationLocation = (foundation?.canton || foundation?.region || '').trim();
+    const hasGlobalLocation = foundationLocation.toLowerCase() === 'all';
+
     const foundationScopeConditions = [
       // Leads directly assigned to this foundation
       { foundationId: foundationId },
@@ -535,14 +556,23 @@ export class LeadsService {
       {
         status: 'NEW',
         foundationId: null,
-        ...(foundation?.region || foundation?.canton
-          ? {
-              preferredLocation: {
-                contains: foundation.canton || foundation.region || '',
-                mode: 'insensitive' as const,
-              },
-            }
-          : {}),
+        // If the foundation is global (canton/region === "All"), do NOT apply a location filter.
+        // Also include "All"/unset leads for canton-specific foundations so broad enquiries surface.
+        ...(!foundationLocation || hasGlobalLocation
+          ? {}
+          : {
+              OR: [
+                {
+                  preferredLocation: {
+                    contains: foundationLocation,
+                    mode: 'insensitive' as const,
+                  },
+                },
+                { preferredLocation: { equals: 'All', mode: 'insensitive' as const } },
+                { preferredLocation: null },
+                { preferredLocation: '' },
+              ],
+            }),
       },
     ];
 

--- a/api/src/policy-alerts/policy-alerts.service.ts
+++ b/api/src/policy-alerts/policy-alerts.service.ts
@@ -19,8 +19,10 @@ export class PolicyAlertsService {
 
     const where: any = {};
 
-    if (region) {
-      where.regions = { has: region };
+    // Treat "All" as a UI sentinel meaning "no region filter".
+    // When a specific region is selected, also include alerts that apply to all regions.
+    if (region && region !== 'All') {
+      where.regions = { hasSome: [region, 'All'] };
     }
 
     if (alertType) {
@@ -164,7 +166,9 @@ export class PolicyAlertsService {
   async getPolicyAlertsByRegion(region: string): Promise<PolicyAlert[]> {
     return this.prisma.policyAlert.findMany({
       where: {
-        regions: { has: region },
+        ...(region && region !== 'All'
+          ? { regions: { hasSome: [region, 'All'] } }
+          : {}),
         isActive: true,
         OR: [
           { endDate: null },

--- a/api/src/settings/settings.controller.ts
+++ b/api/src/settings/settings.controller.ts
@@ -36,6 +36,7 @@ import { UpdatePrivacySettingsDto } from './dto/privacy-settings.dto';
 import { UpdateNotificationSettingsDto } from './dto/notification-settings.dto';
 import { TranslationService } from '../translation/translation.service';
 import { FIELDS_BY_ENTITY } from '../translation/translation.config';
+import { normalizeRegionsServed } from '../common/utils/regions.util';
 
 @ApiTags('settings')
 @Controller('settings')
@@ -204,7 +205,9 @@ export class SettingsController {
         contactPerson: organization.contactPerson ?? '',
         address: organization.region ?? '',
         canton: organization.canton ?? '',
-        regionsServed: (organization as any).regionsServed ?? (organization.canton ? [organization.canton] : []),
+        regionsServed: normalizeRegionsServed(
+          (organization as any).regionsServed ?? (organization.canton ? [organization.canton] : []),
+        ),
         description: organization.description ?? '',
         vatNumber: organization.vatNumber ?? '',
         websiteUrl: (organization as any).websiteUrl ?? '',
@@ -273,7 +276,7 @@ export class SettingsController {
             region: settings.address,
             canton: settings.canton,
             city: settings.city,
-            regionsServed: settings.regionsServed ?? [],
+            regionsServed: normalizeRegionsServed(settings.regionsServed),
             description: settings.description,
             vatNumber: settings.vatNumber,
             websiteUrl: settings.websiteUrl,
@@ -295,7 +298,7 @@ export class SettingsController {
             region: settings.address,
             canton: settings.canton,
             city: settings.city,
-            regionsServed: settings.regionsServed ?? [],
+            regionsServed: normalizeRegionsServed(settings.regionsServed),
             description: settings.description,
             vatNumber: settings.vatNumber,
             websiteUrl: settings.websiteUrl,
@@ -680,7 +683,9 @@ export class SettingsController {
         contactPerson: organization.contactPerson ?? '',
         address: organization.region ?? '',
         canton: organization.canton ?? '',
-        regionsServed: (organization as any).regionsServed ?? (organization.canton ? [organization.canton] : []),
+        regionsServed: normalizeRegionsServed(
+          (organization as any).regionsServed ?? (organization.canton ? [organization.canton] : []),
+        ),
         description: organization.description ?? '',
         vatNumber: organization.vatNumber ?? '',
         websiteUrl: (organization as any).websiteUrl ?? '',
@@ -760,7 +765,7 @@ export class SettingsController {
             region: settings.address,
             canton: settings.canton,
             city: settings.city,
-            regionsServed: settings.regionsServed ?? [],
+            regionsServed: normalizeRegionsServed(settings.regionsServed),
             description: settings.description,
             vatNumber: settings.vatNumber,
             websiteUrl: settings.websiteUrl,
@@ -790,7 +795,7 @@ export class SettingsController {
             region: settings.address,
             canton: settings.canton,
             city: settings.city,
-            regionsServed: settings.regionsServed ?? [],
+            regionsServed: normalizeRegionsServed(settings.regionsServed),
             description: settings.description,
             vatNumber: settings.vatNumber,
             websiteUrl: settings.websiteUrl,
@@ -900,7 +905,9 @@ export class SettingsController {
         contactPerson: organization.contactPerson ?? '',
         address: organization.region ?? '',
         canton: organization.canton ?? '',
-        regionsServed: (organization as any).regionsServed ?? (organization.canton ? [organization.canton] : []),
+        regionsServed: normalizeRegionsServed(
+          (organization as any).regionsServed ?? (organization.canton ? [organization.canton] : []),
+        ),
         description: organization.description ?? '',
         vatNumber: organization.vatNumber ?? '',
         websiteUrl: (organization as any).websiteUrl ?? '',
@@ -958,7 +965,7 @@ export class SettingsController {
             region: settings.address,
             canton: settings.canton,
             city: settings.city,
-            regionsServed: settings.regionsServed ?? [],
+            regionsServed: normalizeRegionsServed(settings.regionsServed),
             description: settings.description,
             vatNumber: settings.vatNumber,
             websiteUrl: settings.websiteUrl,
@@ -984,7 +991,7 @@ export class SettingsController {
           region: settings.address,
           canton: settings.canton,
           city: settings.city,
-          regionsServed: settings.regionsServed ?? [],
+          regionsServed: normalizeRegionsServed(settings.regionsServed),
           description: settings.description,
           vatNumber: settings.vatNumber,
           websiteUrl: settings.websiteUrl,

--- a/frontend/components/admin/ContentUploadModal.tsx
+++ b/frontend/components/admin/ContentUploadModal.tsx
@@ -158,7 +158,12 @@ const ContentUploadModal: React.FC<ContentUploadModalProps> = ({ isOpen, onClose
    useEffect(() => {
     if (formData.country && contentType === 'policy') {
       const validRegions = REGIONS_BY_COUNTRY[formData.country];
-      if (!validRegions.includes(formData.region || '')) {
+      const currentRegion = formData.region || '';
+      // Allow sentinel value meaning "applies to all regions/cantons".
+      if (currentRegion === 'All') {
+        return;
+      }
+      if (!validRegions.includes(currentRegion)) {
         setFormData(prev => ({ ...prev, region: validRegions[0] }));
       }
     }
@@ -634,6 +639,7 @@ const ContentUploadModal: React.FC<ContentUploadModalProps> = ({ isOpen, onClose
         <div>
           <label htmlFor="policyRegion" className="block text-sm font-medium text-gray-700 mb-1">{t('common:contentUploadModal.labels.regionCanton')} <span className="text-red-500 ml-0.5">*</span></label>
           <select name="region" id="policyRegion" value={formData.region} onChange={handleInputChange} required className={policySpecificInputClass}>
+            <option value="All">{t('common:filters.all', 'All')}</option>
             {(formData.country ? REGIONS_BY_COUNTRY[formData.country] : SWISS_CANTONS).map(region => <option key={region} value={region}>{region}</option>)}
           </select>
         </div>

--- a/frontend/components/admin/PolicyAlertModal.tsx
+++ b/frontend/components/admin/PolicyAlertModal.tsx
@@ -1,10 +1,10 @@
 
 import React, { useState, useEffect, FormEvent } from 'react';
-import { PolicyAlert, PolicyAlertType, SWISS_CANTONS } from '../../types';
+import { PolicyAlert, PolicyAlertType } from '../../types';
 import Button from '../ui/Button';
 import Card from '../ui/Card';
 import { XMarkIcon } from '@heroicons/react/24/outline';
-import { STANDARD_INPUT_FIELD } from '../../constants'; // Import constant
+import { ALL_REGIONS_OPTION, STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL } from '../../constants'; // Import constant
 import { useTranslation } from 'react-i18next';
 
 interface PolicyAlertModalProps {
@@ -20,7 +20,7 @@ const PolicyAlertModal: React.FC<PolicyAlertModalProps> = ({ isOpen, onClose, on
     title: '',
     message: '',
     type: PolicyAlertType.INFO,
-    regionScope: 'All',
+    regionScope: ALL_REGIONS_OPTION,
     isActive: true,
     displayStartDate: '',
     displayEndDate: '',
@@ -67,7 +67,7 @@ const PolicyAlertModal: React.FC<PolicyAlertModalProps> = ({ isOpen, onClose, on
 
   if (!isOpen) return null;
 
-  const cantonOptions = ['All', ...SWISS_CANTONS];
+  const cantonOptions = SWISS_CANTONS_WITH_ALL;
 
   return (
     <div className={`fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50 transition-opacity duration-300 ${isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'}`} role="dialog" aria-modal="true" aria-labelledby="policyAlertModalTitle">
@@ -101,7 +101,7 @@ const PolicyAlertModal: React.FC<PolicyAlertModalProps> = ({ isOpen, onClose, on
               <div>
                 <label htmlFor="regionScope" className="block text-sm font-medium text-gray-700">{t("policyAlertModal.labels.regionScope")} *</label>
                 <select name="regionScope" id="regionScope" value={formData.regionScope} onChange={handleChange} required className={`${STANDARD_INPUT_FIELD} mt-1`}>
-                  {cantonOptions.map(canton => <option key={canton} value={canton}>{canton === 'All' ? t('common:filters.all') : canton}</option>)}
+                  {cantonOptions.map(canton => <option key={canton} value={canton}>{canton === ALL_REGIONS_OPTION ? t('common:filters.all') : canton}</option>)}
                 </select>
               </div>
             </div>

--- a/frontend/components/profile/edit/EducatorProfileForm.tsx
+++ b/frontend/components/profile/edit/EducatorProfileForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { SettingsFormData, WorkExperienceItem, EducationItem, CertificationItem } from '../../../types';
-import { STANDARD_INPUT_FIELD, SWISS_CANTONS } from '../../../constants';
+import { STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL, ALL_REGIONS_OPTION } from '../../../constants';
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../../../contexts/AppContext';
 import CoverImageSection from './shared/CoverImageSection';
@@ -303,9 +303,9 @@ const EducatorProfileForm: React.FC<EducatorProfileFormProps> = ({ formData, onC
               required
             >
               <option value="">{t('settings:educatorProfile.locationPlaceholder', 'Select a canton')}</option>
-              {SWISS_CANTONS.map((canton) => (
+              {SWISS_CANTONS_WITH_ALL.map((canton) => (
                 <option key={canton} value={canton}>
-                  {canton}
+                  {canton === ALL_REGIONS_OPTION ? t('common:filters.all', 'All') : canton}
                 </option>
               ))}
             </select>

--- a/frontend/components/profile/edit/FoundationProfileForm.tsx
+++ b/frontend/components/profile/edit/FoundationProfileForm.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { SettingsFormData, SwissCanton, SupportedLanguage } from '../../../types';
-import { PEDAGOGY_OPTIONS, STANDARD_INPUT_FIELD, SWISS_CANTONS } from '../../../constants';
+import { PEDAGOGY_OPTIONS, STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL, ALL_REGIONS_OPTION } from '../../../constants';
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../../../contexts/AppContext';
+import { toggleMultiSelectWithAll } from '../../../utils/regionSelection';
 import CoverImageSection from './shared/CoverImageSection';
 import ContactDetailsSection from './shared/ContactDetailsSection';
 import AvatarSection from './shared/AvatarSection';
@@ -30,7 +31,9 @@ const FoundationProfileForm: React.FC<FoundationProfileFormProps> = ({ formData,
   const handleMultiSelectChange = (field: keyof SettingsFormData, selectedValue: string) => {
     const currentValues = (formData[field] as string[] || []) as Array<SwissCanton | SupportedLanguage | string>;
     let newValues: Array<SwissCanton | SupportedLanguage | string>;
-    if (currentValues.includes(selectedValue as any)) {
+    if (field === 'regionsServed') {
+      newValues = toggleMultiSelectWithAll(currentValues as string[], selectedValue);
+    } else if (currentValues.includes(selectedValue as any)) {
       newValues = currentValues.filter(v => v !== selectedValue);
     } else {
       newValues = [...currentValues, selectedValue as any];
@@ -162,7 +165,7 @@ const FoundationProfileForm: React.FC<FoundationProfileFormProps> = ({ formData,
             </label>
             <p className="text-xs text-gray-500 mb-3">{t('common:settingsCompanyProfile.cantonsHelpText', 'Select all cantons where your organization operates')}</p>
             <div className="flex flex-wrap gap-2">
-              {SWISS_CANTONS.map(canton => (
+              {SWISS_CANTONS_WITH_ALL.map(canton => (
                 <button
                   key={canton}
                   type="button"
@@ -173,7 +176,7 @@ const FoundationProfileForm: React.FC<FoundationProfileFormProps> = ({ formData,
                       : 'bg-white text-gray-700 border-gray-300 hover:border-swiss-teal'
                   }`}
                 >
-                  {canton}
+                  {canton === ALL_REGIONS_OPTION ? t('common:filters.all', 'All') : canton}
                 </button>
               ))}
             </div>

--- a/frontend/components/profile/edit/ServiceProviderProfileForm.tsx
+++ b/frontend/components/profile/edit/ServiceProviderProfileForm.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { SettingsFormData, SwissCanton, SupportedLanguage } from '../../../types';
-import { STANDARD_INPUT_FIELD, SWISS_CANTONS } from '../../../constants';
+import { STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL, ALL_REGIONS_OPTION } from '../../../constants';
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../../../contexts/AppContext';
+import { toggleMultiSelectWithAll } from '../../../utils/regionSelection';
 import CoverImageSection from './shared/CoverImageSection';
 import ContactDetailsSection from './shared/ContactDetailsSection';
 import AvatarSection from './shared/AvatarSection';
@@ -71,7 +72,9 @@ const ServiceProviderProfileForm: React.FC<ServiceProviderProfileFormProps> = ({
   const handleMultiSelectChange = (field: keyof SettingsFormData, selectedValue: string) => {
     const currentValues = (formData[field] as string[] || []) as Array<SwissCanton | SupportedLanguage | string>;
     let newValues: Array<SwissCanton | SupportedLanguage | string>;
-    if (currentValues.includes(selectedValue as any)) {
+    if (field === 'regionsServed') {
+      newValues = toggleMultiSelectWithAll(currentValues as string[], selectedValue);
+    } else if (currentValues.includes(selectedValue as any)) {
       newValues = currentValues.filter(v => v !== selectedValue);
     } else {
       newValues = [...currentValues, selectedValue as any];
@@ -212,7 +215,7 @@ const ServiceProviderProfileForm: React.FC<ServiceProviderProfileFormProps> = ({
             </label>
             <p className="text-xs text-gray-500 mb-3">{t('common:settingsCompanyProfile.cantonsHelpText', 'Select all cantons where your organization operates')}</p>
             <div className="flex flex-wrap gap-2">
-              {SWISS_CANTONS.map(canton => (
+              {SWISS_CANTONS_WITH_ALL.map(canton => (
                 <button
                   key={canton}
                   type="button"
@@ -223,7 +226,7 @@ const ServiceProviderProfileForm: React.FC<ServiceProviderProfileFormProps> = ({
                       : 'bg-white text-gray-700 border-gray-300 hover:border-swiss-teal'
                   }`}
                 >
-                  {canton}
+                  {canton === ALL_REGIONS_OPTION ? t('common:filters.all', 'All') : canton}
                 </button>
               ))}
             </div>

--- a/frontend/components/profile/edit/SupplierProfileForm.tsx
+++ b/frontend/components/profile/edit/SupplierProfileForm.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { SettingsFormData, SwissCanton, SupportedLanguage } from '../../../types';
-import { STANDARD_INPUT_FIELD, SWISS_CANTONS } from '../../../constants';
+import { STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL, ALL_REGIONS_OPTION } from '../../../constants';
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../../../contexts/AppContext';
+import { toggleMultiSelectWithAll } from '../../../utils/regionSelection';
 import CoverImageSection from './shared/CoverImageSection';
 import ContactDetailsSection from './shared/ContactDetailsSection';
 import AvatarSection from './shared/AvatarSection';
@@ -30,7 +31,9 @@ const SupplierProfileForm: React.FC<SupplierProfileFormProps> = ({ formData, onC
   const handleMultiSelectChange = (field: keyof SettingsFormData, selectedValue: string) => {
     const currentValues = (formData[field] as string[] || []) as Array<SwissCanton | SupportedLanguage | string>;
     let newValues: Array<SwissCanton | SupportedLanguage | string>;
-    if (currentValues.includes(selectedValue as any)) {
+    if (field === 'regionsServed') {
+      newValues = toggleMultiSelectWithAll(currentValues as string[], selectedValue);
+    } else if (currentValues.includes(selectedValue as any)) {
       newValues = currentValues.filter(v => v !== selectedValue);
     } else {
       newValues = [...currentValues, selectedValue as any];
@@ -162,7 +165,7 @@ const SupplierProfileForm: React.FC<SupplierProfileFormProps> = ({ formData, onC
             </label>
             <p className="text-xs text-gray-500 mb-3">{t('common:settingsCompanyProfile.cantonsHelpText', 'Select all cantons where your organization operates')}</p>
             <div className="flex flex-wrap gap-2">
-              {SWISS_CANTONS.map(canton => (
+              {SWISS_CANTONS_WITH_ALL.map(canton => (
                 <button
                   key={canton}
                   type="button"
@@ -173,7 +176,7 @@ const SupplierProfileForm: React.FC<SupplierProfileFormProps> = ({ formData, onC
                       : 'bg-white text-gray-700 border-gray-300 hover:border-swiss-teal'
                   }`}
                 >
-                  {canton}
+                  {canton === ALL_REGIONS_OPTION ? t('common:filters.all', 'All') : canton}
                 </button>
               ))}
             </div>

--- a/frontend/components/settings/sections/CompanyProfileSettings.tsx
+++ b/frontend/components/settings/sections/CompanyProfileSettings.tsx
@@ -1,7 +1,7 @@
 
 import React, { useMemo, useState, useRef } from 'react';
 import { SettingsFormData, UserRole, SwissCanton, SupportedLanguage } from '../../../types';
-import { STANDARD_INPUT_FIELD, SWISS_CANTONS, SUGGESTED_SERVICE_CATEGORIES, SUGGESTED_PRODUCT_CATEGORIES, PEDAGOGY_OPTIONS } from '../../../constants';
+import { STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL, ALL_REGIONS_OPTION, SUGGESTED_SERVICE_CATEGORIES, SUGGESTED_PRODUCT_CATEGORIES, PEDAGOGY_OPTIONS } from '../../../constants';
 import SettingsSectionWrapper from '../SettingsSectionWrapper';
 import ChipInput from '../../ui/ChipInput';
 import ImageCropperModal from '../../shared/ImageCropperModal';
@@ -23,6 +23,7 @@ import {
 } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../../../contexts/AppContext';
+import { toggleMultiSelectWithAll } from '../../../utils/regionSelection';
 
 interface CompanyProfileSettingsProps {
   settings: SettingsFormData;
@@ -85,7 +86,9 @@ const CompanyProfileSettings: React.FC<CompanyProfileSettingsProps> = ({ setting
   const handleMultiSelectChange = (field: keyof SettingsFormData, selectedValue: string) => {
     const currentValues = (settings[field] as string[] || []) as Array<SwissCanton | SupportedLanguage | string>;
     let newValues: Array<SwissCanton | SupportedLanguage | string>;
-    if (currentValues.includes(selectedValue as any)) {
+    if (field === 'regionsServed') {
+      newValues = toggleMultiSelectWithAll(currentValues as string[], selectedValue);
+    } else if (currentValues.includes(selectedValue as any)) {
       newValues = currentValues.filter(v => v !== selectedValue);
     } else {
       newValues = [...currentValues, selectedValue as any];
@@ -503,7 +506,7 @@ const CompanyProfileSettings: React.FC<CompanyProfileSettingsProps> = ({ setting
             <div className="form-input-container">
               <p className="text-xs text-gray-500 mb-2">{t('common:settingsCompanyProfile.cantonsHelpText', 'Select all cantons where your organization operates')}</p>
               <div className="flex flex-wrap gap-2">
-                {SWISS_CANTONS.map(canton => (
+                {SWISS_CANTONS_WITH_ALL.map(canton => (
                   <button
                     key={canton}
                     type="button"
@@ -514,7 +517,7 @@ const CompanyProfileSettings: React.FC<CompanyProfileSettingsProps> = ({ setting
                         : 'bg-white text-gray-700 border-gray-300 hover:border-swiss-teal'
                     }`}
                   >
-                    {canton}
+                    {canton === ALL_REGIONS_OPTION ? t('common:filters.all', 'All') : canton}
                   </button>
                 ))}
               </div>

--- a/frontend/components/settings/sections/EducatorProfileSettings.tsx
+++ b/frontend/components/settings/sections/EducatorProfileSettings.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { SettingsFormData, UserRole, WorkExperienceItem, EducationItem, CertificationItem } from '../../../types';
-import { STANDARD_INPUT_FIELD, SWISS_CANTONS } from '../../../constants';
+import { STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL, ALL_REGIONS_OPTION } from '../../../constants';
 import SettingsSectionWrapper from '../SettingsSectionWrapper';
 import ImageCropperModal from '../../shared/ImageCropperModal';
 import FileUploadZone from '../../ui/FileUploadZone';
@@ -520,9 +520,9 @@ const EducatorProfileSettings: React.FC<EducatorProfileSettingsProps> = ({ setti
                 required
               >
                 <option value="">{t('settings:educatorProfile.locationPlaceholder', 'Select a canton')}</option>
-                {SWISS_CANTONS.map((canton) => (
+                {SWISS_CANTONS_WITH_ALL.map((canton) => (
                   <option key={canton} value={canton}>
-                    {canton}
+                    {canton === ALL_REGIONS_OPTION ? t('common:filters.all', 'All') : canton}
                   </option>
                 ))}
               </select>

--- a/frontend/components/supplier/ProductUploadModal.tsx
+++ b/frontend/components/supplier/ProductUploadModal.tsx
@@ -10,13 +10,14 @@ import ChipInput from '../ui/ChipInput';
 import FileUploadZone from '../ui/FileUploadZone';
 import {
   STANDARD_INPUT_FIELD,
-  SWISS_CANTONS,
+  SWISS_CANTONS_WITH_ALL,
   SUGGESTED_PRODUCT_CATEGORIES,
   SUGGESTED_PRODUCT_COMPLIANCE_TAGS,
   SUGGESTED_PRODUCT_AGE_RANGES,
   SUGGESTED_PRODUCT_DELIVERY_METHODS,
 } from '../../constants';
 import { useCategories } from '../../hooks/useCategories';
+import { normalizeMultiSelectWithAll } from '../../utils/regionSelection';
 import {
   Product,
   ProductAvailabilityStatus,
@@ -314,9 +315,14 @@ const ProductUploadModal: React.FC<ProductUploadModalProps> = ({
     field: K,
     value: ProductFormState[K],
   ) => {
+    // Support sentinel "All" for canton coverage.
+    const normalizedValue =
+      field === 'supportedCantons' && Array.isArray(value)
+        ? (normalizeMultiSelectWithAll(value as string[]) as ProductFormState[K])
+        : value;
     setFormData((prev) => ({
       ...prev,
-      [field]: value,
+      [field]: normalizedValue,
     }));
   };
 
@@ -1151,7 +1157,7 @@ const ProductUploadModal: React.FC<ProductUploadModalProps> = ({
                     {renderChipInput(
                       formData.supportedCantons,
                       'supportedCantons',
-                      SWISS_CANTONS,
+                      SWISS_CANTONS_WITH_ALL,
                       true,
                       helper('cantonsPlaceholder', 'Add all cantons you cover'),
                     )}

--- a/frontend/components/supplier/ProductUploadModal.tsx
+++ b/frontend/components/supplier/ProductUploadModal.tsx
@@ -257,7 +257,7 @@ const ProductUploadModal: React.FC<ProductUploadModalProps> = ({
               : '',
           currency: fee.currency || product.priceCurrency || 'CHF',
         })) || [],
-      supportedCantons: product.supportedCantons || [],
+      supportedCantons: normalizeMultiSelectWithAll(product.supportedCantons),
       visibilityStart: product.visibilityStart || '',
       visibilityEnd: product.visibilityEnd || '',
       volumePricing:

--- a/frontend/constants.ts
+++ b/frontend/constants.ts
@@ -4,6 +4,12 @@ import { UserRole, User, Product, Service, JobListing, CandidateProfile, Partner
 // Re-export SWISS_CANTONS so it can be imported from this module
 export { SWISS_CANTONS, SERVICE_CATEGORIES, SERVICE_DELIVERY_TYPES };
 
+// Sentinel value meaning "applies to all regions/cantons".
+export const ALL_REGIONS_OPTION = 'All' as const;
+
+// Convenience list for selects where users can choose to cover all cantons.
+export const SWISS_CANTONS_WITH_ALL = [ALL_REGIONS_OPTION, ...SWISS_CANTONS] as const;
+
 export const APP_NAME = "Pro Crèche Solutions";
 
 // hCaptcha Configuration

--- a/frontend/pages/MarketplacePage.tsx
+++ b/frontend/pages/MarketplacePage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { Organization, Service, UserRole, Product, ServiceRequest, ServiceRequestStatus, OrganizationType } from '../types';
-import { STANDARD_INPUT_FIELD, ICON_INPUT_FIELD } from '../constants'; 
+import { STANDARD_INPUT_FIELD, ICON_INPUT_FIELD, ALL_REGIONS_OPTION } from '../constants'; 
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
 import Tabs from '../components/ui/Tabs';
@@ -286,13 +286,15 @@ const MarketplacePage: React.FC = () => {
   const allRegions = useMemo(() => {
     const regions = new Set<string>();
     [...productSuppliers, ...serviceProviders].forEach(org => {
-      if (org.region) regions.add(org.region);
-      if (org.canton) regions.add(org.canton);
+      if (org.region && org.region !== ALL_REGIONS_OPTION) regions.add(org.region);
+      if (org.canton && org.canton !== ALL_REGIONS_OPTION) regions.add(org.canton);
       if (org.regionsServed) {
-        org.regionsServed.forEach(r => regions.add(r));
+        org.regionsServed.forEach(r => {
+          if (r && r !== ALL_REGIONS_OPTION) regions.add(r);
+        });
       }
     });
-    return ['All', ...Array.from(regions).sort()];
+    return [ALL_REGIONS_OPTION, ...Array.from(regions).sort()];
   }, [productSuppliers, serviceProviders]);
 
   const currentCategories = activeTabIndex === 0 ? supplierProductCategories : serviceProviderCategories;

--- a/frontend/pages/ParentLeadFormPage.tsx
+++ b/frontend/pages/ParentLeadFormPage.tsx
@@ -266,7 +266,7 @@ const ParentLeadFormPage: React.FC = () => {
             </select>
           </div>
 
-          {formData.canton && (
+          {formData.canton && formData.canton !== ALL_REGIONS_OPTION && (
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">{t('parentLeadForm:labels.cities')}</label>
               <p className="text-xs text-gray-500 mb-2">{t('parentLeadForm:labels.citiesHelpText')}</p>

--- a/frontend/pages/ParentLeadFormPage.tsx
+++ b/frontend/pages/ParentLeadFormPage.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { useAppContext } from '../contexts/AppContext';
 import Button from '../components/ui/Button';
 import Card from '../components/ui/Card';
-import { APP_NAME, STANDARD_INPUT_FIELD, SWISS_CANTONS } from '../constants'; 
+import { APP_NAME, STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL, ALL_REGIONS_OPTION } from '../constants'; 
 import { ArrowLeftIcon, SquaresPlusIcon, PlusIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { useNavigate, Link } from 'react-router-dom'; // Import Link
 import { UserRole } from '../types'; 
@@ -258,7 +258,11 @@ const ParentLeadFormPage: React.FC = () => {
             <label htmlFor="canton" className="block text-sm font-medium text-gray-700 mb-1">{t('parentLeadForm:labels.canton')}</label>
             <select name="canton" id="canton" value={formData.canton} onChange={handleChange} required className={STANDARD_INPUT_FIELD}>
               <option value="">{t('parentLeadForm:placeholders.canton')}</option>
-              {SWISS_CANTONS.map(c => <option key={c} value={c}>{c}</option>)}
+              {SWISS_CANTONS_WITH_ALL.map(c => (
+                <option key={c} value={c}>
+                  {c === ALL_REGIONS_OPTION ? t('common:filters.all', 'All') : c}
+                </option>
+              ))}
             </select>
           </div>
 

--- a/frontend/pages/SignupPage.tsx
+++ b/frontend/pages/SignupPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate, Link, useLocation, useSearchParams } from 'react-router-do
 import { useTranslation } from 'react-i18next';
 import { useSignUp, useAuth, useUser } from '@clerk/clerk-react';
 import { SignupRole, SignupFormData, SwissCanton, SupportedLanguage, UserRole } from '../types';
-import { APP_NAME, STANDARD_INPUT_FIELD, SWISS_CANTONS, HCAPTCHA_SITE_KEY, HCAPTCHA_THEME, HCAPTCHA_SIZE } from '../constants';
+import { APP_NAME, STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL, HCAPTCHA_SITE_KEY, HCAPTCHA_THEME, HCAPTCHA_SIZE } from '../constants';
 import Button from '../components/ui/Button';
 import Card from '../components/ui/Card';
 import Captcha from '../components/ui/Captcha';
@@ -1003,7 +1003,7 @@ const SignupPage: React.FC = () => {
                     )}
                     
                       {requiresOrganizationDetails && renderField('phone', 'labels.phone', 'tel', true, 'placeholders.phone')}
-                      {requiresOrganizationDetails && renderField('canton', 'labels.canton', 'select', true, undefined, SWISS_CANTONS)}
+                      {requiresOrganizationDetails && renderField('canton', 'labels.canton', 'select', true, undefined, SWISS_CANTONS_WITH_ALL)}
 
                     {selectedRole === SignupRole.FOUNDATION && renderField('capacity', 'labels.capacity', 'number', true)}
                     {selectedRole === SignupRole.SUPPLIER && renderField('category', 'labels.category', 'text', true, 'placeholders.category')}

--- a/frontend/pages/SignupPage.tsx
+++ b/frontend/pages/SignupPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate, Link, useLocation, useSearchParams } from 'react-router-do
 import { useTranslation } from 'react-i18next';
 import { useSignUp, useAuth, useUser } from '@clerk/clerk-react';
 import { SignupRole, SignupFormData, SwissCanton, SupportedLanguage, UserRole } from '../types';
-import { APP_NAME, STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL, HCAPTCHA_SITE_KEY, HCAPTCHA_THEME, HCAPTCHA_SIZE } from '../constants';
+import { APP_NAME, STANDARD_INPUT_FIELD, SWISS_CANTONS, HCAPTCHA_SITE_KEY, HCAPTCHA_THEME, HCAPTCHA_SIZE } from '../constants';
 import Button from '../components/ui/Button';
 import Card from '../components/ui/Card';
 import Captcha from '../components/ui/Captcha';
@@ -1003,7 +1003,7 @@ const SignupPage: React.FC = () => {
                     )}
                     
                       {requiresOrganizationDetails && renderField('phone', 'labels.phone', 'tel', true, 'placeholders.phone')}
-                      {requiresOrganizationDetails && renderField('canton', 'labels.canton', 'select', true, undefined, SWISS_CANTONS_WITH_ALL)}
+                      {requiresOrganizationDetails && renderField('canton', 'labels.canton', 'select', true, undefined, SWISS_CANTONS)}
 
                     {selectedRole === SignupRole.FOUNDATION && renderField('capacity', 'labels.capacity', 'number', true)}
                     {selectedRole === SignupRole.SUPPLIER && renderField('category', 'labels.category', 'text', true, 'placeholders.category')}

--- a/frontend/pages/StatePoliciesPage.tsx
+++ b/frontend/pages/StatePoliciesPage.tsx
@@ -215,7 +215,8 @@ const StatePoliciesPage: React.FC = () => {
     fetchStatePolicies();
   }, [authenticatedRequest, i18n.language]);
 
-  const cantons = ['All', ...new Set(policyDocs.map(d => d.region).filter(Boolean) as string[])];
+  // Exclude sentinel "All" from the list; it's rendered as the dedicated first option.
+  const cantons = [...new Set(policyDocs.map(d => d.region).filter((r): r is string => Boolean(r && r !== 'All')))];
   const policyTypeOptions: Array<'All' | PolicyType> = ['All', ...POLICY_TYPES_ENUM];
   const policyCategoryOptions: Array<'All' | PolicyCategory> = ['All', ...POLICY_CATEGORIES];
 
@@ -252,7 +253,7 @@ const StatePoliciesPage: React.FC = () => {
       (isAdminOrSuperAdmin || doc.status === 'Published' || doc.status === 'Approved') && 
       (doc.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
        (doc.contentPreview && doc.contentPreview.toLowerCase().includes(searchTerm.toLowerCase()))) &&
-      (filterCanton === 'All' || doc.region === filterCanton) &&
+      (filterCanton === 'All' || doc.region === filterCanton || doc.region === 'All') &&
       (filterPolicyType === 'All' || doc.policyType === filterPolicyType) &&
       (filterCategory === 'All' || doc.category === filterCategory)
     );

--- a/frontend/pages/educator/EducatorJobBoardPage.tsx
+++ b/frontend/pages/educator/EducatorJobBoardPage.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { JobListing } from '../../types';
-import { STANDARD_INPUT_FIELD, ICON_INPUT_FIELD, SWISS_CANTONS } from '../../constants';
+import { STANDARD_INPUT_FIELD, ICON_INPUT_FIELD, SWISS_CANTONS_WITH_ALL, ALL_REGIONS_OPTION } from '../../constants';
 import Card from '../../components/ui/Card';
 import Button from '../../components/ui/Button';
 import { BriefcaseIcon, MapPinIcon, CalendarDaysIcon, MagnifyingGlassIcon, EyeIcon } from '@heroicons/react/24/outline';
@@ -89,7 +89,7 @@ const EducatorJobBoardPage: React.FC = () => {
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
   const [selectedJob, setSelectedJob] = useState<JobListing | null>(null);
 
-  const cantons = ['All', ...SWISS_CANTONS];
+  const cantons = SWISS_CANTONS_WITH_ALL;
   const contractTypes = ['All', 'CDI', 'CDD', 'INTERNSHIP', 'PART_TIME', 'FULL_TIME'];
 
   const fetchJobs = useCallback(async () => {
@@ -195,7 +195,7 @@ const EducatorJobBoardPage: React.FC = () => {
             <select id="filterCanton" value={filterCanton} onChange={(e) => setFilterCanton(e.target.value)} className={STANDARD_INPUT_FIELD}>
               {cantons.map((c) => (
                 <option key={c} value={c}>
-                  {c === 'All' ? t('common:filters.all') : c}
+                  {c === ALL_REGIONS_OPTION ? t('common:filters.all') : c}
                 </option>
               ))}
             </select>

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -518,6 +518,7 @@ export enum PolicyType {
     STANDARD = 'Standard',
     DIRECTIVE = 'Directive',
     LAW = 'Law',
+    COMPLIANCE_PROCEDURE = 'Compliance Procedure',
 }
 export const POLICY_TYPES_ENUM = Object.values(PolicyType);
 

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -519,6 +519,7 @@ export enum PolicyType {
     DIRECTIVE = 'Directive',
     LAW = 'Law',
     COMPLIANCE_PROCEDURE = 'Compliance Procedure',
+    ADMINISTRATIVE_PROCEDURE = 'Administrative Procedure',
 }
 export const POLICY_TYPES_ENUM = Object.values(PolicyType);
 

--- a/frontend/utils/regionSelection.ts
+++ b/frontend/utils/regionSelection.ts
@@ -1,0 +1,50 @@
+import { ALL_REGIONS_OPTION } from '../constants';
+
+/**
+ * Toggle helper for multi-select fields that support a special "All" sentinel.
+ *
+ * Rules:
+ * - Selecting "All" makes it the only selected value.
+ * - Selecting any specific region/canton removes "All" (if present) and toggles that value.
+ */
+export function toggleMultiSelectWithAll(
+  currentValues: readonly string[] | undefined,
+  selectedValue: string,
+): string[] {
+  const values = (Array.isArray(currentValues) ? currentValues : [])
+    .map(v => String(v))
+    .filter(Boolean);
+
+  const isAllSelectedValue = selectedValue === ALL_REGIONS_OPTION;
+  const hasAll = values.includes(ALL_REGIONS_OPTION);
+
+  if (isAllSelectedValue) {
+    return hasAll ? values.filter(v => v !== ALL_REGIONS_OPTION) : [ALL_REGIONS_OPTION];
+  }
+
+  const withoutAll = values.filter(v => v !== ALL_REGIONS_OPTION);
+  const hasSelected = withoutAll.includes(selectedValue);
+
+  if (hasSelected) {
+    return withoutAll.filter(v => v !== selectedValue);
+  }
+
+  return [...withoutAll, selectedValue];
+}
+
+/**
+ * Normalize persisted arrays so that if "All" is present, it becomes the sole value.
+ */
+export function normalizeMultiSelectWithAll(values: readonly string[] | undefined): string[] {
+  const list = (Array.isArray(values) ? values : [])
+    .map(v => String(v))
+    .filter(Boolean);
+
+  if (list.includes(ALL_REGIONS_OPTION)) {
+    return [ALL_REGIONS_OPTION];
+  }
+
+  // De-dupe while preserving order
+  return Array.from(new Set(list));
+}
+


### PR DESCRIPTION
Add "Compliance Procedure" and "Administrative Procedure" to Policy Type options and introduce a "Select all" option for region/canton selectors across the application to improve policy categorization and region targeting flexibility.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-86dba187-70ab-4e2a-a3ff-24e059bea7b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-86dba187-70ab-4e2a-a3ff-24e059bea7b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches region/canton filtering semantics across UI and API by introducing an `All` sentinel; mistakes could broaden or narrow query results. Changes are mostly additive but span multiple user flows (marketplace, leads matching, policy listing/alerts).
> 
> **Overview**
> Adds two new policy type values (*Compliance Procedure* and *Administrative Procedure*) across admin, frontend, and API enums, and updates policy review/upload UIs to expose them.
> 
> Introduces a shared `All` region/canton sentinel (`ALL_REGIONS_OPTION` and `SWISS_CANTONS_WITH_ALL`) across admin and frontend selectors, including new helpers in `frontend/utils/regionSelection.ts` to make multi-selects treat `All` as mutually exclusive.
> 
> Updates backend query logic to treat `All` as “no filter” when chosen and to include `All`-scoped records when filtering by a specific region (e.g., state policy search, policy alerts, org discovery, and lead-to-foundation matching), and adjusts frontend filtering lists to avoid duplicating the sentinel.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b0efa2a5e547e2e1fdbe9f6912de031cc05eb7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "All" option for region/canton selection across profile forms, policy uploads, and marketplace filters
  * Introduced two new policy types: Compliance Procedure and Administrative Procedure

* **Improvements**
  * Enhanced regional filtering to include policies and services marked as applicable to all regions when browsing by specific region
<!-- end of auto-generated comment: release notes by coderabbit.ai -->