### PR TITLE
Clerk auth origin domains

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -40,12 +40,6 @@ services:
         fromDatabase:
           name: pc-solutions-db
           property: connectionString
-      # Required for Clerk JWT token validation (azp claim)
-      - key: ADMIN_ORIGIN
-        value: https://devadmin.procrechesolutions.com
-      - key: APP_ORIGIN
-        value: https://dev.procrechesolutions.com
-        # Note: Update APP_ORIGIN if your frontend uses a different domain (e.g., dash.procrechesolutions.com)
 
   # Admin Panel Service
   - type: web

--- a/render.yaml
+++ b/render.yaml
@@ -42,9 +42,9 @@ services:
           property: connectionString
       # Required for Clerk JWT token validation (azp claim)
       - key: ADMIN_ORIGIN
-        value: https://admin.procrechesolutions.com
+        value: https://devadmin.procrechesolutions.com
       - key: APP_ORIGIN
-        value: https://app.procrechesolutions.com
+        value: https://dev.procrechesolutions.com
         # Note: Update APP_ORIGIN if your frontend uses a different domain (e.g., dash.procrechesolutions.com)
 
   # Admin Panel Service


### PR DESCRIPTION
Update Clerk auth origins in `render.yaml` to use dev domains.

The `ADMIN_ORIGIN` and `APP_ORIGIN` environment variables, used by the API's `ClerkAuthGuard` for Clerk JWT `azp` validation, were hardcoded to production domains in `render.yaml`. This PR updates them to the specified dev domains: `https://dev.procrechesolutions.com` for the frontend and `https://devadmin.procrechesolutions.com` for admin.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-5374067d-41f0-4fb1-87bd-dc45f87e6fd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5374067d-41f0-4fb1-87bd-dc45f87e6fd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

