### PR TITLE
Admin dashboard settings display

### DIFF
--- a/admin/src/components/AdminLayout.tsx
+++ b/admin/src/components/AdminLayout.tsx
@@ -35,11 +35,11 @@ export const AdminLayout: React.FC<Props> = ({ children }) => {
   }, [location.pathname])
 
   return (
-    <div className="flex min-h-dvh">
+    <div className="flex min-h-dvh overflow-x-hidden">
       <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
-      <div className="flex-1 flex flex-col lg:pl-72">
+      <div className="min-w-0 flex-1 flex flex-col lg:pl-72">
         <Header setSidebarOpen={setSidebarOpen} />
-        <main className="flex-1 bg-page-bg p-4">{children ?? <Outlet />}</main>
+        <main className="min-w-0 flex-1 bg-page-bg p-4 overflow-x-hidden">{children ?? <Outlet />}</main>
       </div>
     </div>
   );

--- a/admin/src/components/settings/SettingsLayout.tsx
+++ b/admin/src/components/settings/SettingsLayout.tsx
@@ -86,10 +86,10 @@ function classNames(...classes: string[]) {
                   key={tab.key}
                   className={({ selected }) =>
                     classNames(
-                      'py-4 px-1 border-b-2 font-medium text-sm transition-colors duration-200 whitespace-nowrap',
+                      'my-2 px-3 py-1.5 rounded-md font-medium text-sm transition-colors duration-200 whitespace-nowrap',
                       selected
-                        ? 'border-swiss-teal text-swiss-teal'
-                        : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                        ? 'bg-swiss-teal text-white'
+                        : 'text-gray-600 hover:bg-gray-100 hover:text-swiss-charcoal'
                     )
                   }
                 >

--- a/admin/src/components/settings/SettingsLayout.tsx
+++ b/admin/src/components/settings/SettingsLayout.tsx
@@ -33,12 +33,12 @@ const SettingsLayout: React.FC = () => {
       component: SystemMonitorPage,
     },
     {
-      name: t('admin:designSystem', { defaultValue: 'Design System' }),
+      name: t('admin:settings.tabs.designSystem', { defaultValue: 'Design System' }),
       key: 'designSystem',
       component: DesignSystemPage,
     },
     {
-      name: t('admin:translations', { defaultValue: 'Translations' }),
+      name: t('admin:settings.tabs.translations', { defaultValue: 'Translations' }),
       key: 'translations',
       component: TranslationsPage,
     },
@@ -80,7 +80,7 @@ function classNames(...classes: string[]) {
       <div className="bg-white rounded-card shadow-soft border border-gray-200">
         <Tab.Group selectedIndex={selectedIndex} onChange={handleTabChange}>
           <div className="border-b border-gray-200">
-            <Tab.List className="flex space-x-8 px-6 overflow-x-auto whitespace-nowrap">
+            <Tab.List className="flex flex-wrap gap-x-8 gap-y-2 px-6">
               {tabs.map((tab) => (
                 <Tab
                   key={tab.key}

--- a/admin/src/pages/EmailNotificationPage.tsx
+++ b/admin/src/pages/EmailNotificationPage.tsx
@@ -465,53 +465,55 @@ export default function EmailNotificationPage() {
               </AdminButton>
             </div>
             
-            <AdminTable>
-              <AdminTableHeader>
-                <AdminTableRow>
-                  <AdminTableHeaderCell>{t('admin:settings.emailNotifications.templates.tableHeaders.name')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.emailNotifications.templates.tableHeaders.event')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.emailNotifications.templates.tableHeaders.category')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.emailNotifications.templates.tableHeaders.subject')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.emailNotifications.templates.tableHeaders.status')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.emailNotifications.templates.tableHeaders.updated')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.emailNotifications.templates.tableHeaders.actions')}</AdminTableHeaderCell>
-                </AdminTableRow>
-              </AdminTableHeader>
-              <AdminTableBody>
-                {templates.map((template) => (
-                  <AdminTableRow key={template.id}>
-                    <AdminTableCell>{template.name}</AdminTableCell>
-                    <AdminTableCell>
-                      <code className="text-xs bg-gray-100 px-2 py-1 rounded">{template.event}</code>
-                    </AdminTableCell>
-                    <AdminTableCell>
-                      <AdminBadge variant={getCategoryColor(template.category)}>
-                        {template.category}
-                      </AdminBadge>
-                    </AdminTableCell>
-                    <AdminTableCell>{template.subject}</AdminTableCell>
-                    <AdminTableCell>
-                      <AdminBadge variant={template.isActive ? 'low' : 'medium'}>
-                        {template.isActive ? t('admin:settings.emailNotifications.templates.status.active') : t('admin:settings.emailNotifications.templates.status.inactive')}
-                      </AdminBadge>
-                    </AdminTableCell>
-                    <AdminTableCell>
-                      {new Date(template.updatedAt).toLocaleDateString()}
-                    </AdminTableCell>
-                    <AdminTableCell>
-                      <div className="flex gap-2">
-                        <AdminButton variant="outline" size="sm" onClick={() => openEditTemplate(template)}>
-                          {t('admin:settings.emailNotifications.templates.buttons.edit')}
-                        </AdminButton>
-                        <AdminButton variant="secondary" size="sm" onClick={() => openPreviewTemplate(template)}>
-                          {t('admin:settings.emailNotifications.templates.buttons.preview')}
-                        </AdminButton>
-                      </div>
-                    </AdminTableCell>
+            <div className="overflow-x-auto">
+              <AdminTable>
+                <AdminTableHeader>
+                  <AdminTableRow>
+                    <AdminTableHeaderCell>{t('admin:settings.emailNotifications.templates.tableHeaders.name')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.emailNotifications.templates.tableHeaders.event')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.emailNotifications.templates.tableHeaders.category')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.emailNotifications.templates.tableHeaders.subject')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.emailNotifications.templates.tableHeaders.status')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.emailNotifications.templates.tableHeaders.updated')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.emailNotifications.templates.tableHeaders.actions')}</AdminTableHeaderCell>
                   </AdminTableRow>
-                ))}
-              </AdminTableBody>
-            </AdminTable>
+                </AdminTableHeader>
+                <AdminTableBody>
+                  {templates.map((template) => (
+                    <AdminTableRow key={template.id}>
+                      <AdminTableCell>{template.name}</AdminTableCell>
+                      <AdminTableCell>
+                        <code className="text-xs bg-gray-100 px-2 py-1 rounded">{template.event}</code>
+                      </AdminTableCell>
+                      <AdminTableCell>
+                        <AdminBadge variant={getCategoryColor(template.category)}>
+                          {template.category}
+                        </AdminBadge>
+                      </AdminTableCell>
+                      <AdminTableCell>{template.subject}</AdminTableCell>
+                      <AdminTableCell>
+                        <AdminBadge variant={template.isActive ? 'low' : 'medium'}>
+                          {template.isActive ? t('admin:settings.emailNotifications.templates.status.active') : t('admin:settings.emailNotifications.templates.status.inactive')}
+                        </AdminBadge>
+                      </AdminTableCell>
+                      <AdminTableCell>
+                        {new Date(template.updatedAt).toLocaleDateString()}
+                      </AdminTableCell>
+                      <AdminTableCell>
+                        <div className="flex gap-2">
+                          <AdminButton variant="outline" size="sm" onClick={() => openEditTemplate(template)}>
+                            {t('admin:settings.emailNotifications.templates.buttons.edit')}
+                          </AdminButton>
+                          <AdminButton variant="secondary" size="sm" onClick={() => openPreviewTemplate(template)}>
+                            {t('admin:settings.emailNotifications.templates.buttons.preview')}
+                          </AdminButton>
+                        </div>
+                      </AdminTableCell>
+                    </AdminTableRow>
+                  ))}
+                </AdminTableBody>
+              </AdminTable>
+            </div>
           </AdminCard>
         )}
 
@@ -568,40 +570,42 @@ export default function EmailNotificationPage() {
               </AdminButton>
             </div>
             
-            <AdminTable>
-              <AdminTableHeader>
-                <AdminTableRow>
-                  <AdminTableHeaderCell>{t('admin:settings.emailNotifications.logs.tableHeaders.event')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.emailNotifications.logs.tableHeaders.recipient')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.emailNotifications.logs.tableHeaders.status')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.emailNotifications.logs.tableHeaders.sentAt')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.emailNotifications.logs.tableHeaders.error')}</AdminTableHeaderCell>
-                </AdminTableRow>
-              </AdminTableHeader>
-              <AdminTableBody>
-                {emailLogs.map((log) => (
-                  <AdminTableRow key={log.id}>
-                    <AdminTableCell>
-                      <code className="text-xs bg-gray-100 px-2 py-1 rounded">{log.event}</code>
-                    </AdminTableCell>
-                    <AdminTableCell>{log.recipient}</AdminTableCell>
-                    <AdminTableCell>
-                      <AdminBadge variant={getStatusColor(log.status)}>
-                        {log.status}
-                      </AdminBadge>
-                    </AdminTableCell>
-                    <AdminTableCell>
-                      {new Date(log.createdAt).toLocaleString()}
-                    </AdminTableCell>
-                    <AdminTableCell>
-                      {log.error ? (
-                        <span className="text-red-500 text-xs">{log.error}</span>
-                      ) : '-'}
-                    </AdminTableCell>
+            <div className="overflow-x-auto">
+              <AdminTable>
+                <AdminTableHeader>
+                  <AdminTableRow>
+                    <AdminTableHeaderCell>{t('admin:settings.emailNotifications.logs.tableHeaders.event')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.emailNotifications.logs.tableHeaders.recipient')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.emailNotifications.logs.tableHeaders.status')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.emailNotifications.logs.tableHeaders.sentAt')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.emailNotifications.logs.tableHeaders.error')}</AdminTableHeaderCell>
                   </AdminTableRow>
-                ))}
-              </AdminTableBody>
-            </AdminTable>
+                </AdminTableHeader>
+                <AdminTableBody>
+                  {emailLogs.map((log) => (
+                    <AdminTableRow key={log.id}>
+                      <AdminTableCell>
+                        <code className="text-xs bg-gray-100 px-2 py-1 rounded">{log.event}</code>
+                      </AdminTableCell>
+                      <AdminTableCell>{log.recipient}</AdminTableCell>
+                      <AdminTableCell>
+                        <AdminBadge variant={getStatusColor(log.status)}>
+                          {log.status}
+                        </AdminBadge>
+                      </AdminTableCell>
+                      <AdminTableCell>
+                        {new Date(log.createdAt).toLocaleString()}
+                      </AdminTableCell>
+                      <AdminTableCell>
+                        {log.error ? (
+                          <span className="text-red-500 text-xs">{log.error}</span>
+                        ) : '-'}
+                      </AdminTableCell>
+                    </AdminTableRow>
+                  ))}
+                </AdminTableBody>
+              </AdminTable>
+            </div>
           </AdminCard>
         )}
 

--- a/admin/src/pages/SystemConfigurationPage.tsx
+++ b/admin/src/pages/SystemConfigurationPage.tsx
@@ -530,58 +530,59 @@ export default function SystemConfigurationPage() {
                 {t('admin:settings.systemConfig.systemSettings.createSetting')}
               </AdminButton>
             </div>
-            
-            <AdminTable>
-              <AdminTableHeader>
-                <AdminTableRow>
-                  <AdminTableHeaderCell>{t('admin:settings.systemConfig.systemSettings.tableHeaders.key')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.systemConfig.systemSettings.tableHeaders.value')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.systemConfig.systemSettings.tableHeaders.category')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.systemConfig.systemSettings.tableHeaders.type')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.systemConfig.systemSettings.tableHeaders.actions')}</AdminTableHeaderCell>
-                </AdminTableRow>
-              </AdminTableHeader>
-              <AdminTableBody>
-                {settings.map((setting) => (
-                  <AdminTableRow key={setting.id}>
-                    <AdminTableCell>
-                      <div>
-                        <div className="font-medium text-admin-text">{setting.key}</div>
-                        <div className="text-sm text-admin-muted">{setting.description}</div>
-                      </div>
-                    </AdminTableCell>
-                    <AdminTableCell>
-                      <div className="text-sm text-admin-text">
-                        {typeof setting.value === 'string' ? setting.value : JSON.stringify(setting.value)}
-                      </div>
-                    </AdminTableCell>
-                    <AdminTableCell>
-                      <AdminBadge variant="low">{setting.category}</AdminBadge>
-                    </AdminTableCell>
-                    <AdminTableCell>
-                      <div className="flex gap-1">
-                        {setting.isEncrypted && <AdminBadge variant="high">{t('admin:settings.systemConfig.systemSettings.badges.encrypted')}</AdminBadge>}
-                        {setting.isPublic && <AdminBadge variant="medium">{t('admin:settings.systemConfig.systemSettings.badges.public')}</AdminBadge>}
-                      </div>
-                    </AdminTableCell>
-                    <AdminTableCell>
-                      <div className="flex gap-2">
-                        <AdminButton 
-                          variant="outline" 
-                          size="sm"
-                          onClick={() => handleEditSetting(setting)}
-                        >
-                          {t('admin:settings.systemConfig.systemSettings.buttons.edit')}
-                        </AdminButton>
-                        <AdminButton variant="secondary" size="sm">
-                          {t('admin:settings.systemConfig.systemSettings.buttons.view')}
-                        </AdminButton>
-                      </div>
-                    </AdminTableCell>
+            <div className="overflow-x-auto">
+              <AdminTable>
+                <AdminTableHeader>
+                  <AdminTableRow>
+                    <AdminTableHeaderCell>{t('admin:settings.systemConfig.systemSettings.tableHeaders.key')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.systemConfig.systemSettings.tableHeaders.value')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.systemConfig.systemSettings.tableHeaders.category')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.systemConfig.systemSettings.tableHeaders.type')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.systemConfig.systemSettings.tableHeaders.actions')}</AdminTableHeaderCell>
                   </AdminTableRow>
-                ))}
-              </AdminTableBody>
-            </AdminTable>
+                </AdminTableHeader>
+                <AdminTableBody>
+                  {settings.map((setting) => (
+                    <AdminTableRow key={setting.id}>
+                      <AdminTableCell>
+                        <div>
+                          <div className="font-medium text-admin-text">{setting.key}</div>
+                          <div className="text-sm text-admin-muted">{setting.description}</div>
+                        </div>
+                      </AdminTableCell>
+                      <AdminTableCell>
+                        <div className="text-sm text-admin-text">
+                          {typeof setting.value === 'string' ? setting.value : JSON.stringify(setting.value)}
+                        </div>
+                      </AdminTableCell>
+                      <AdminTableCell>
+                        <AdminBadge variant="low">{setting.category}</AdminBadge>
+                      </AdminTableCell>
+                      <AdminTableCell>
+                        <div className="flex gap-1">
+                          {setting.isEncrypted && <AdminBadge variant="high">{t('admin:settings.systemConfig.systemSettings.badges.encrypted')}</AdminBadge>}
+                          {setting.isPublic && <AdminBadge variant="medium">{t('admin:settings.systemConfig.systemSettings.badges.public')}</AdminBadge>}
+                        </div>
+                      </AdminTableCell>
+                      <AdminTableCell>
+                        <div className="flex gap-2">
+                          <AdminButton 
+                            variant="outline" 
+                            size="sm"
+                            onClick={() => handleEditSetting(setting)}
+                          >
+                            {t('admin:settings.systemConfig.systemSettings.buttons.edit')}
+                          </AdminButton>
+                          <AdminButton variant="secondary" size="sm">
+                            {t('admin:settings.systemConfig.systemSettings.buttons.view')}
+                          </AdminButton>
+                        </div>
+                      </AdminTableCell>
+                    </AdminTableRow>
+                  ))}
+                </AdminTableBody>
+              </AdminTable>
+            </div>
 
             {/* Edit Setting Modal */}
             {showEditSetting && editingSetting && (
@@ -674,54 +675,55 @@ export default function SystemConfigurationPage() {
                 {t('admin:settings.systemConfig.integrations.createIntegration')}
               </AdminButton>
             </div>
-            
-            <AdminTable>
-              <AdminTableHeader>
-                <AdminTableRow>
-                  <AdminTableHeaderCell>{t('admin:settings.systemConfig.integrations.tableHeaders.name')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.systemConfig.integrations.tableHeaders.type')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.systemConfig.integrations.tableHeaders.provider')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.systemConfig.integrations.tableHeaders.status')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.systemConfig.integrations.tableHeaders.lastSync')}</AdminTableHeaderCell>
-                  <AdminTableHeaderCell>{t('admin:settings.systemConfig.integrations.tableHeaders.actions')}</AdminTableHeaderCell>
-                </AdminTableRow>
-              </AdminTableHeader>
-              <AdminTableBody>
-                {integrations.map((integration) => (
-                  <AdminTableRow key={integration.id}>
-                    <AdminTableCell>
-                      <div className="font-medium text-admin-text">{integration.name}</div>
-                    </AdminTableCell>
-                    <AdminTableCell>
-                      <AdminBadge variant="low">{integration.type}</AdminBadge>
-                    </AdminTableCell>
-                    <AdminTableCell>
-                      <div className="text-admin-text">{integration.provider}</div>
-                    </AdminTableCell>
-                    <AdminTableCell>
-                      <AdminBadge variant={integration.isActive ? 'low' : 'medium'}>
-                        {integration.isActive ? t('admin:settings.systemConfig.integrations.status.active') : t('admin:settings.systemConfig.integrations.status.inactive')}
-                      </AdminBadge>
-                    </AdminTableCell>
-                    <AdminTableCell>
-                      <div className="text-sm text-admin-text">
-                        {integration.lastSyncAt ? new Date(integration.lastSyncAt).toLocaleString() : t('admin:settings.systemConfig.integrations.status.never')}
-                      </div>
-                    </AdminTableCell>
-                    <AdminTableCell>
-                      <div className="flex gap-2">
-                        <AdminButton variant="outline" size="sm">
-                          {t('admin:settings.systemConfig.integrations.buttons.test')}
-                        </AdminButton>
-                        <AdminButton variant="secondary" size="sm">
-                          {t('admin:settings.systemConfig.integrations.buttons.sync')}
-                        </AdminButton>
-                      </div>
-                    </AdminTableCell>
+            <div className="overflow-x-auto">
+              <AdminTable>
+                <AdminTableHeader>
+                  <AdminTableRow>
+                    <AdminTableHeaderCell>{t('admin:settings.systemConfig.integrations.tableHeaders.name')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.systemConfig.integrations.tableHeaders.type')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.systemConfig.integrations.tableHeaders.provider')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.systemConfig.integrations.tableHeaders.status')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.systemConfig.integrations.tableHeaders.lastSync')}</AdminTableHeaderCell>
+                    <AdminTableHeaderCell>{t('admin:settings.systemConfig.integrations.tableHeaders.actions')}</AdminTableHeaderCell>
                   </AdminTableRow>
-                ))}
-              </AdminTableBody>
-            </AdminTable>
+                </AdminTableHeader>
+                <AdminTableBody>
+                  {integrations.map((integration) => (
+                    <AdminTableRow key={integration.id}>
+                      <AdminTableCell>
+                        <div className="font-medium text-admin-text">{integration.name}</div>
+                      </AdminTableCell>
+                      <AdminTableCell>
+                        <AdminBadge variant="low">{integration.type}</AdminBadge>
+                      </AdminTableCell>
+                      <AdminTableCell>
+                        <div className="text-admin-text">{integration.provider}</div>
+                      </AdminTableCell>
+                      <AdminTableCell>
+                        <AdminBadge variant={integration.isActive ? 'low' : 'medium'}>
+                          {integration.isActive ? t('admin:settings.systemConfig.integrations.status.active') : t('admin:settings.systemConfig.integrations.status.inactive')}
+                        </AdminBadge>
+                      </AdminTableCell>
+                      <AdminTableCell>
+                        <div className="text-sm text-admin-text">
+                          {integration.lastSyncAt ? new Date(integration.lastSyncAt).toLocaleString() : t('admin:settings.systemConfig.integrations.status.never')}
+                        </div>
+                      </AdminTableCell>
+                      <AdminTableCell>
+                        <div className="flex gap-2">
+                          <AdminButton variant="outline" size="sm">
+                            {t('admin:settings.systemConfig.integrations.buttons.test')}
+                          </AdminButton>
+                          <AdminButton variant="secondary" size="sm">
+                            {t('admin:settings.systemConfig.integrations.buttons.sync')}
+                          </AdminButton>
+                        </div>
+                      </AdminTableCell>
+                    </AdminTableRow>
+                  ))}
+                </AdminTableBody>
+              </AdminTable>
+            </div>
           </AdminCard>
         )}
 
@@ -780,56 +782,57 @@ export default function SystemConfigurationPage() {
                   {t('admin:settings.systemConfig.maintenance.schedules.createSchedule')}
                 </AdminButton>
               </div>
-              
-              <AdminTable>
-                <AdminTableHeader>
-                  <AdminTableRow>
-                    <AdminTableHeaderCell>{t('admin:settings.systemConfig.maintenance.tableHeaders.name')}</AdminTableHeaderCell>
-                    <AdminTableHeaderCell>{t('admin:settings.systemConfig.maintenance.tableHeaders.description')}</AdminTableHeaderCell>
-                    <AdminTableHeaderCell>{t('admin:settings.systemConfig.maintenance.tableHeaders.scheduledStart')}</AdminTableHeaderCell>
-                    <AdminTableHeaderCell>{t('admin:settings.systemConfig.maintenance.tableHeaders.scheduledEnd')}</AdminTableHeaderCell>
-                    <AdminTableHeaderCell>{t('admin:settings.systemConfig.maintenance.tableHeaders.status')}</AdminTableHeaderCell>
-                    <AdminTableHeaderCell>{t('admin:settings.systemConfig.maintenance.tableHeaders.actions')}</AdminTableHeaderCell>
-                  </AdminTableRow>
-                </AdminTableHeader>
-                <AdminTableBody>
-                  {maintenanceSchedules.map((schedule) => (
-                    <AdminTableRow key={schedule.id}>
-                      <AdminTableCell>
-                        <div className="font-medium text-admin-text">{schedule.name}</div>
-                      </AdminTableCell>
-                      <AdminTableCell>
-                        <div className="text-sm text-admin-text">{schedule.description}</div>
-                      </AdminTableCell>
-                      <AdminTableCell>
-                        <div className="text-sm text-admin-text">
-                          {new Date(schedule.scheduledStart).toLocaleString()}
-                        </div>
-                      </AdminTableCell>
-                      <AdminTableCell>
-                        <div className="text-sm text-admin-text">
-                          {new Date(schedule.scheduledEnd).toLocaleString()}
-                        </div>
-                      </AdminTableCell>
-                      <AdminTableCell>
-                        <AdminBadge variant={schedule.isActive ? 'low' : 'medium'}>
-                          {schedule.isActive ? t('admin:settings.systemConfig.integrations.status.active') : t('admin:settings.systemConfig.integrations.status.inactive')}
-                        </AdminBadge>
-                      </AdminTableCell>
-                      <AdminTableCell>
-                        <div className="flex gap-2">
-                          <AdminButton variant="outline" size="sm">
-                            {t('admin:settings.systemConfig.systemSettings.buttons.edit')}
-                          </AdminButton>
-                          <AdminButton variant="secondary" size="sm">
-                            {t('admin:settings.systemConfig.systemSettings.buttons.view')}
-                          </AdminButton>
-                        </div>
-                      </AdminTableCell>
+              <div className="overflow-x-auto">
+                <AdminTable>
+                  <AdminTableHeader>
+                    <AdminTableRow>
+                      <AdminTableHeaderCell>{t('admin:settings.systemConfig.maintenance.tableHeaders.name')}</AdminTableHeaderCell>
+                      <AdminTableHeaderCell>{t('admin:settings.systemConfig.maintenance.tableHeaders.description')}</AdminTableHeaderCell>
+                      <AdminTableHeaderCell>{t('admin:settings.systemConfig.maintenance.tableHeaders.scheduledStart')}</AdminTableHeaderCell>
+                      <AdminTableHeaderCell>{t('admin:settings.systemConfig.maintenance.tableHeaders.scheduledEnd')}</AdminTableHeaderCell>
+                      <AdminTableHeaderCell>{t('admin:settings.systemConfig.maintenance.tableHeaders.status')}</AdminTableHeaderCell>
+                      <AdminTableHeaderCell>{t('admin:settings.systemConfig.maintenance.tableHeaders.actions')}</AdminTableHeaderCell>
                     </AdminTableRow>
-                  ))}
-                </AdminTableBody>
-              </AdminTable>
+                  </AdminTableHeader>
+                  <AdminTableBody>
+                    {maintenanceSchedules.map((schedule) => (
+                      <AdminTableRow key={schedule.id}>
+                        <AdminTableCell>
+                          <div className="font-medium text-admin-text">{schedule.name}</div>
+                        </AdminTableCell>
+                        <AdminTableCell>
+                          <div className="text-sm text-admin-text">{schedule.description}</div>
+                        </AdminTableCell>
+                        <AdminTableCell>
+                          <div className="text-sm text-admin-text">
+                            {new Date(schedule.scheduledStart).toLocaleString()}
+                          </div>
+                        </AdminTableCell>
+                        <AdminTableCell>
+                          <div className="text-sm text-admin-text">
+                            {new Date(schedule.scheduledEnd).toLocaleString()}
+                          </div>
+                        </AdminTableCell>
+                        <AdminTableCell>
+                          <AdminBadge variant={schedule.isActive ? 'low' : 'medium'}>
+                            {schedule.isActive ? t('admin:settings.systemConfig.integrations.status.active') : t('admin:settings.systemConfig.integrations.status.inactive')}
+                          </AdminBadge>
+                        </AdminTableCell>
+                        <AdminTableCell>
+                          <div className="flex gap-2">
+                            <AdminButton variant="outline" size="sm">
+                              {t('admin:settings.systemConfig.systemSettings.buttons.edit')}
+                            </AdminButton>
+                            <AdminButton variant="secondary" size="sm">
+                              {t('admin:settings.systemConfig.systemSettings.buttons.view')}
+                            </AdminButton>
+                          </div>
+                        </AdminTableCell>
+                      </AdminTableRow>
+                    ))}
+                  </AdminTableBody>
+                </AdminTable>
+              </div>
             </AdminCard>
           </div>
         )}


### PR DESCRIPTION
Fixes translation keys in the admin settings menu and prevents horizontal overflow on all admin settings pages.

The translation keys `designSystem (en)` and `translations (en)` were returning objects instead of strings, causing display issues in the settings menu. Additionally, admin settings pages were stretching beyond the viewport, requiring horizontal scrolling.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-014e4d3f-7179-41db-8034-59112af26d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-014e4d3f-7179-41db-8034-59112af26d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Settings tabs now wrap across multiple rows and use updated, more spacious rounded tab styling with clearer active/inactive states.
  * Data tables throughout the admin interface are wrapped in scrollable containers to improve horizontal scrolling and layout stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->