### PR TITLE
Login incomplete error

### DIFF
--- a/admin/src/components/auth/AdminCustomLoginFormNew.tsx
+++ b/admin/src/components/auth/AdminCustomLoginFormNew.tsx
@@ -59,22 +59,37 @@ export default function AdminCustomLoginForm() {
       }
 
       const result = await signIn.create({
+        strategy: 'password',
         identifier: formData.email,
         password: formData.password,
       });
 
-      if (result.status === 'complete') {
-        // User signed in successfully, activate session and redirect to admin dashboard
+      const activateSession = async (sessionId: string | null) => {
         try {
-          // Immediately activate session and navigate - no re-render in between
-          await setActive({ session: result.createdSessionId });
+          await setActive({ session: sessionId });
           navigate('/dashboard');
         } catch (setActiveError: any) {
           console.error('Session activation failed:', setActiveError);
           setError(t('auth:errors.sessionActivationFailed'));
         }
+      };
+
+      if (result.status === 'complete') {
+        await activateSession(result.createdSessionId);
       } else if (result.status === 'needs_first_factor') {
-        // Handle 2FA if needed
+        const firstFactorResult = await signIn.attemptFirstFactor({
+          strategy: 'password',
+          password: formData.password,
+        });
+
+        if (firstFactorResult.status === 'complete') {
+          await activateSession(firstFactorResult.createdSessionId);
+        } else if (firstFactorResult.status === 'needs_second_factor') {
+          setError(t('auth:errors.twoFactorRequired'));
+        } else {
+          setError(t('auth:errors.twoFactorRequired'));
+        }
+      } else if (result.status === 'needs_second_factor') {
         setError(t('auth:errors.twoFactorRequired'));
       }
     } catch (err: any) {

--- a/frontend/pages/LoginPage.tsx
+++ b/frontend/pages/LoginPage.tsx
@@ -109,22 +109,37 @@ const LoginPage: React.FC = () => {
 
     try {
       const result = await signIn.create({
+        strategy: 'password',
         identifier: email,
         password: password,
       });
 
-      if (result.status === 'complete') {
+      const activateSession = async (sessionId: string | null) => {
         try {
-          // Immediately activate session and navigate - no re-render in between
-          await setActive({ session: result.createdSessionId });
-          
-          // Navigate immediately - proper render gating prevents Active Session UI from showing
+          await setActive({ session: sessionId });
           navigate('/dashboard', { replace: true });
         } catch (setActiveError: any) {
           console.error('Session activation failed:', setActiveError);
           setError(t('common:loginPage.sessionActivationFailed'));
         }
+      };
+
+      if (result.status === 'complete') {
+        await activateSession(result.createdSessionId);
       } else if (result.status === 'needs_first_factor') {
+        const firstFactorResult = await signIn.attemptFirstFactor({
+          strategy: 'password',
+          password: password,
+        });
+
+        if (firstFactorResult.status === 'complete') {
+          await activateSession(firstFactorResult.createdSessionId);
+        } else if (firstFactorResult.status === 'needs_second_factor') {
+          setError(t('common:loginPage.twoFactorRequired'));
+        } else {
+          setError(t('common:loginPage.loginIncomplete'));
+        }
+      } else if (result.status === 'needs_second_factor') {
         setError(t('common:loginPage.twoFactorRequired'));
       } else {
         setError(t('common:loginPage.loginIncomplete'));

--- a/frontend/pages/LoginPage.tsx
+++ b/frontend/pages/LoginPage.tsx
@@ -114,6 +114,15 @@ const LoginPage: React.FC = () => {
         password: password,
       });
 
+      console.log('[Login Debug] signIn.create result:', {
+        status: result.status,
+        supportedFirstFactors: result.supportedFirstFactors,
+        supportedSecondFactors: result.supportedSecondFactors,
+        firstFactorVerification: result.firstFactorVerification,
+        createdSessionId: result.createdSessionId,
+        identifier: result.identifier,
+      });
+
       const activateSession = async (sessionId: string | null) => {
         try {
           await setActive({ session: sessionId });
@@ -127,9 +136,16 @@ const LoginPage: React.FC = () => {
       if (result.status === 'complete') {
         await activateSession(result.createdSessionId);
       } else if (result.status === 'needs_first_factor') {
+        console.log('[Login Debug] Attempting first factor with password strategy');
         const firstFactorResult = await signIn.attemptFirstFactor({
           strategy: 'password',
           password: password,
+        });
+
+        console.log('[Login Debug] attemptFirstFactor result:', {
+          status: firstFactorResult.status,
+          createdSessionId: firstFactorResult.createdSessionId,
+          supportedSecondFactors: firstFactorResult.supportedSecondFactors,
         });
 
         if (firstFactorResult.status === 'complete') {
@@ -142,10 +158,15 @@ const LoginPage: React.FC = () => {
       } else if (result.status === 'needs_second_factor') {
         setError(t('common:loginPage.twoFactorRequired'));
       } else {
+        console.warn('[Login Debug] Unexpected sign-in status:', result.status);
         setError(t('common:loginPage.loginIncomplete'));
       }
     } catch (err: any) {
-      console.error('Login error:', err);
+      console.error('[Login Debug] signIn.create threw error:', err, {
+        errors: err.errors,
+        message: err.message,
+        status: err.status,
+      });
 
       let errorMessage = t('common:errors.unknown');
       let errorCode = 'unknown';


### PR DESCRIPTION
Fixes login by explicitly setting the password strategy for Clerk's `signIn.create()` method.

Clerk v5's `signIn.create()` API uses discriminated union types, requiring `strategy: 'password'` to be explicitly passed for password-based authentication. Without it, the `password` field was ignored, preventing the sign-in from completing and leading to a generic "Login incomplete" error. This PR also adds proper handling for `needs_first_factor` and `needs_second_factor` statuses.

---
<p><a href="https://cursor.com/agents?id=bc-60748439-db79-444e-8de9-ec60d93c22ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60748439-db79-444e-8de9-ec60d93c22ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

