### PR TITLE
Add state policy access control based on role permissions

### DIFF
--- a/api/src/upload/upload.service.ts
+++ b/api/src/upload/upload.service.ts
@@ -426,14 +426,20 @@ export class UploadService {
     // 2. User is SUPER_ADMIN or ADMIN
     // 3. File is linked to an active public organization document
     // 4. File is linked to an active catalog (PDF/CSV)
-    // 5. File is a state policy document (accessible to all authenticated users)
+    // 5. File is a state policy whose accessRoles permits the requesting user's role
+    //    (empty accessRoles means all authenticated users may access it)
     const isOwner = asset.uploadedById === appUserId;
     const isAdmin = requestingUser?.role === 'SUPER_ADMIN' || requestingUser?.role === 'ADMIN';
     const isOrganizationDocument = asset.organizationDocuments?.length > 0;
     const isCatalogAsset = catalogQueryFailed
       ? false
       : (asset.catalogPdfs?.length || 0) > 0 || (asset.catalogCsvs?.length || 0) > 0;
-    const isStatePolicyAsset = asset.category === 'STATE_POLICY';
+    const isStatePolicyAsset =
+      asset.category === 'STATE_POLICY' &&
+      (
+        !asset.accessRoles?.length ||
+        (requestingUser?.role && asset.accessRoles.includes(requestingUser.role))
+      );
 
     if (!isOwner && !isAdmin && !isOrganizationDocument && !isCatalogAsset && !isStatePolicyAsset) {
       this.logger.warn(

--- a/api/src/upload/upload.service.ts
+++ b/api/src/upload/upload.service.ts
@@ -426,16 +426,18 @@ export class UploadService {
     // 2. User is SUPER_ADMIN or ADMIN
     // 3. File is linked to an active public organization document
     // 4. File is linked to an active catalog (PDF/CSV)
+    // 5. File is a state policy document (accessible to all authenticated users)
     const isOwner = asset.uploadedById === appUserId;
     const isAdmin = requestingUser?.role === 'SUPER_ADMIN' || requestingUser?.role === 'ADMIN';
     const isOrganizationDocument = asset.organizationDocuments?.length > 0;
     const isCatalogAsset = catalogQueryFailed
       ? false
       : (asset.catalogPdfs?.length || 0) > 0 || (asset.catalogCsvs?.length || 0) > 0;
+    const isStatePolicyAsset = asset.category === 'STATE_POLICY';
 
-    if (!isOwner && !isAdmin && !isOrganizationDocument && !isCatalogAsset) {
+    if (!isOwner && !isAdmin && !isOrganizationDocument && !isCatalogAsset && !isStatePolicyAsset) {
       this.logger.warn(
-        `Access denied to file ${storageKey} for user ${appUserId} (owner=${isOwner}, admin=${isAdmin}, orgDoc=${isOrganizationDocument}, catalog=${isCatalogAsset})`,
+        `Access denied to file ${storageKey} for user ${appUserId} (owner=${isOwner}, admin=${isAdmin}, orgDoc=${isOrganizationDocument}, catalog=${isCatalogAsset}, statePolicy=${isStatePolicyAsset})`,
       );
       throw new ForbiddenException('Access denied to this file');
     }


### PR DESCRIPTION
## Summary
Added support for role-based access control to state policy files. Files categorized as `STATE_POLICY` can now be accessed by authenticated users whose roles are listed in the asset's `accessRoles`, or by any authenticated user if `accessRoles` is empty.

## Key Changes
- Added `isStatePolicyAsset` access check that validates:
  - File category is `STATE_POLICY`
  - Either `accessRoles` is empty (all authenticated users allowed) or the requesting user's role is in the `accessRoles` list
- Updated access denial logic to include state policy check alongside existing owner, admin, organization document, and catalog checks
- Enhanced logging to include state policy access status for better debugging

## Implementation Details
- State policy access is evaluated using the same pattern as other asset types (owner, admin, organization document, catalog)
- Empty `accessRoles` array acts as a permissive default, allowing any authenticated user to access the file
- Non-empty `accessRoles` requires an exact role match with the requesting user's role

https://claude.ai/code/session_01MWXfnfUWUiwVcosQeg3eV8