### PR TITLE
Fix transaction handling for migrations with savepoints

### DIFF
--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -1823,11 +1823,25 @@ export class UsersService {
 
           // billing_transactions.subscriptionId has ON DELETE RESTRICT, so we must
           // delete billing transactions before we can delete the subscriptions themselves.
-          const userSubIds = await tx.subscription
-            .findMany({ where: { userId: profile.id }, select: { id: true } })
-            .then((rows) => rows.map((r) => r.id));
-          if (userSubIds.length > 0) {
-            await safeDeleteMany(tx.billingTransaction, { subscriptionId: { in: userSubIds } });
+          // The findMany is wrapped in its own SAVEPOINT so that a P2021 (table-not-found)
+          // on either subscriptions or billing_transactions in a partially-migrated
+          // environment does not abort the outer transaction (mirroring safeDeleteMany).
+          {
+            const sp = `sp_${Math.random().toString(36).slice(2, 10)}`;
+            await tx.$executeRawUnsafe(`SAVEPOINT "${sp}"`);
+            try {
+              const userSubIds = await tx.subscription
+                .findMany({ where: { userId: profile.id }, select: { id: true } })
+                .then((rows) => rows.map((r) => r.id));
+              if (userSubIds.length > 0) {
+                await safeDeleteMany(tx.billingTransaction, { subscriptionId: { in: userSubIds } });
+              }
+              await tx.$executeRawUnsafe(`RELEASE SAVEPOINT "${sp}"`);
+            } catch (error: any) {
+              await tx.$executeRawUnsafe(`ROLLBACK TO SAVEPOINT "${sp}"`);
+              if (error?.code !== 'P2021') throw error;
+              // subscriptions table absent; safeDeleteMany below will also skip gracefully
+            }
           }
           await safeDeleteMany(tx.subscription, { userId: profile.id });
 

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -1743,20 +1743,32 @@ export class UsersService {
       await this.prisma.$transaction(
         async (tx) => {
         // Helper: run a deleteMany that might target a table not yet migrated.
+        // Uses a SAVEPOINT so that a P2021 (table-not-found) error can be swallowed
+        // without leaving the PostgreSQL transaction in an aborted state — which
+        // would cause every subsequent statement to fail with error 25P02.
         const safeDeleteMany = async (model: any, where: any): Promise<void> => {
+          const sp = `sp_${Math.random().toString(36).slice(2, 10)}`;
+          await tx.$executeRawUnsafe(`SAVEPOINT "${sp}"`);
           try {
             await model.deleteMany({ where });
+            await tx.$executeRawUnsafe(`RELEASE SAVEPOINT "${sp}"`);
           } catch (error: any) {
-            if (error?.code === 'P2021') return; // table does not exist
+            await tx.$executeRawUnsafe(`ROLLBACK TO SAVEPOINT "${sp}"`);
+            if (error?.code === 'P2021') return; // table does not exist, skip safely
             throw error;
           }
         };
         // Helper: run an updateMany that might target a table not yet migrated.
+        // Uses the same SAVEPOINT pattern as safeDeleteMany.
         const safeUpdateMany = async (model: any, where: any, data: any): Promise<void> => {
+          const sp = `sp_${Math.random().toString(36).slice(2, 10)}`;
+          await tx.$executeRawUnsafe(`SAVEPOINT "${sp}"`);
           try {
             await model.updateMany({ where, data });
+            await tx.$executeRawUnsafe(`RELEASE SAVEPOINT "${sp}"`);
           } catch (error: any) {
-            if (error?.code === 'P2021') return; // table does not exist
+            await tx.$executeRawUnsafe(`ROLLBACK TO SAVEPOINT "${sp}"`);
+            if (error?.code === 'P2021') return; // table does not exist, skip safely
             throw error;
           }
         };
@@ -1808,6 +1820,15 @@ export class UsersService {
           await safeDeleteMany(tx.ticketResponse, { userId: profile.id });
           await safeDeleteMany(tx.supportTicket, { OR: [{ userId: profile.id }, { assignedTo: profile.id }] });
           await safeDeleteMany(tx.userSubscription, { userId: profile.id });
+
+          // billing_transactions.subscriptionId has ON DELETE RESTRICT, so we must
+          // delete billing transactions before we can delete the subscriptions themselves.
+          const userSubIds = await tx.subscription
+            .findMany({ where: { userId: profile.id }, select: { id: true } })
+            .then((rows) => rows.map((r) => r.id));
+          if (userSubIds.length > 0) {
+            await safeDeleteMany(tx.billingTransaction, { subscriptionId: { in: userSubIds } });
+          }
           await safeDeleteMany(tx.subscription, { userId: profile.id });
 
           // E-learning


### PR DESCRIPTION
## Summary
This PR fixes transaction handling in the user deletion flow to properly handle database migrations where tables may not yet exist. It implements PostgreSQL SAVEPOINT logic to prevent transaction abort errors and adds proper foreign key constraint handling for billing transactions.

## Key Changes
- **SAVEPOINT pattern for safe operations**: Both `safeDeleteMany` and `safeUpdateMany` now use PostgreSQL SAVEPOINTs to isolate operations that might fail due to missing tables (P2021 errors). This prevents the entire transaction from entering an aborted state (error 25P02) when a table doesn't exist yet.
  - Create a unique savepoint before each operation
  - Release the savepoint on success
  - Rollback to the savepoint on error, then safely ignore P2021 errors
  
- **Foreign key constraint handling**: Added explicit deletion of billing transactions before subscriptions, since `billing_transactions.subscriptionId` has an `ON DELETE RESTRICT` constraint. This prevents foreign key violation errors during user deletion.

## Implementation Details
- Savepoint names are generated using random strings to ensure uniqueness within the transaction
- The savepoint pattern allows P2021 errors to be caught and ignored without leaving the PostgreSQL transaction in an aborted state
- Billing transactions are now queried and deleted by subscription ID before attempting to delete the subscriptions themselves

https://claude.ai/code/session_01W6h3DQZYBujCeDri7qbBmF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of user deletion operations to avoid transaction failures during database migrations.
  * Enhanced cleanup of associated billing records and related data when users are permanently deleted.
  * Added safeguards so partial-migration environments no longer cause outer transactions to abort during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->