### PR TITLE
Add custom trial date configuration for subscription activation

### DIFF
--- a/admin/src/pages/Subscriptions.tsx
+++ b/admin/src/pages/Subscriptions.tsx
@@ -1573,6 +1573,268 @@ const DeclineRequestModal: React.FC<DeclineRequestModalProps> = ({
   );
 };
 
+// Activate Subscription Request Modal Component
+interface ActivateSubscriptionRequestModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  request: {
+    id: string;
+    contactName?: string;
+    plan?: { name: string };
+  };
+  onActivate: (data: {
+    startDate?: string;
+    periodMonths?: number;
+    includeTrial?: boolean;
+    trialStartDate?: string;
+    trialEndDate?: string;
+    sendEmail?: boolean;
+    notes?: string;
+  }) => Promise<void>;
+  isLoading: boolean;
+}
+
+const ActivateSubscriptionRequestModal: React.FC<ActivateSubscriptionRequestModalProps> = ({
+  isOpen,
+  onClose,
+  request,
+  onActivate,
+  isLoading,
+}) => {
+  const { t } = useTranslation(['admin', 'common']);
+
+  const today = new Date().toISOString().split('T')[0];
+  const thirtyDaysLater = (() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 30);
+    return d.toISOString().split('T')[0];
+  })();
+
+  const [startDate, setStartDate] = React.useState(today);
+  const [periodMonths, setPeriodMonths] = React.useState<number>(-1);
+  const [includeTrial, setIncludeTrial] = React.useState(false);
+  const [trialStartDate, setTrialStartDate] = React.useState(today);
+  const [trialEndDate, setTrialEndDate] = React.useState(thirtyDaysLater);
+  const [sendEmail, setSendEmail] = React.useState(true);
+  const [notes, setNotes] = React.useState('');
+
+  // Keep trial start in sync with subscription start date
+  React.useEffect(() => {
+    setTrialStartDate(startDate);
+    const d = new Date(startDate);
+    d.setDate(d.getDate() + 30);
+    setTrialEndDate(d.toISOString().split('T')[0]);
+  }, [startDate]);
+
+  React.useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) onClose();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const apply30DayPreset = () => {
+    const d = new Date(trialStartDate);
+    d.setDate(d.getDate() + 30);
+    setTrialEndDate(d.toISOString().split('T')[0]);
+  };
+
+  const isSubmitDisabled = isLoading || (!includeTrial && periodMonths === -1);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await onActivate({
+      startDate: startDate || undefined,
+      periodMonths: periodMonths >= 0 ? periodMonths : undefined,
+      includeTrial: includeTrial || undefined,
+      trialStartDate: includeTrial ? trialStartDate : undefined,
+      trialEndDate: includeTrial ? trialEndDate : undefined,
+      sendEmail,
+      notes: notes || undefined,
+    });
+  };
+
+  const periodOptions = [
+    { value: -1, label: t('admin:subscriptions.editSubscription.period.selectPeriod', 'Select a period...') },
+    { value: 0, label: t('admin:subscriptions.editSubscription.period.monthlyRecurring', 'Monthly Recurring') },
+    { value: 1, label: t('admin:subscriptions.editSubscription.period.oneMonth', '1 Month') },
+    { value: 3, label: t('admin:subscriptions.editSubscription.period.threeMonths', '3 Months') },
+    { value: 6, label: t('admin:subscriptions.editSubscription.period.sixMonths', '6 Months') },
+    { value: 12, label: t('admin:subscriptions.editSubscription.period.oneYear', '1 Year') },
+    { value: 24, label: t('admin:subscriptions.editSubscription.period.twoYears', '2 Years') },
+  ];
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[60]"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="bg-white rounded-lg p-6 w-full max-w-lg max-h-[90vh] overflow-y-auto">
+        <div className="flex justify-between items-center mb-6">
+          <h3 className="text-lg font-semibold">
+            {t('admin:subscriptions.requests.activateModal.title', 'Activate Subscription')}
+          </h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {request.plan?.name && (
+          <div className="mb-4 p-3 bg-blue-50 rounded-lg text-sm text-blue-800">
+            {request.plan.name}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Start Date */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              {t('admin:subscriptions.requests.activateModal.startDate', 'Subscription Start Date')}
+            </label>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="w-full p-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          {/* Period */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              {t('admin:subscriptions.requests.activateModal.period', 'Subscription Period')}
+            </label>
+            <select
+              value={periodMonths}
+              onChange={(e) => setPeriodMonths(Number(e.target.value))}
+              className="w-full p-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
+            >
+              {periodOptions.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Include Trial Toggle */}
+          <div className="flex items-center gap-3 p-3 border rounded-lg">
+            <input
+              type="checkbox"
+              id="include-trial"
+              checked={includeTrial}
+              onChange={(e) => setIncludeTrial(e.target.checked)}
+              className="w-4 h-4 text-blue-600 rounded"
+            />
+            <label htmlFor="include-trial" className="text-sm font-medium text-gray-700 cursor-pointer select-none">
+              {t('admin:subscriptions.requests.activateModal.includeTrial', 'Include Trial Period')}
+            </label>
+          </div>
+
+          {/* Trial Date Controls */}
+          {includeTrial && (
+            <div className="pl-3 border-l-2 border-blue-200 space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-gray-700">
+                  {t('admin:subscriptions.requests.activateModal.trialDates', 'Trial Dates')}
+                </span>
+                <button
+                  type="button"
+                  onClick={apply30DayPreset}
+                  className="text-xs px-2 py-1 bg-blue-100 text-blue-700 rounded hover:bg-blue-200 font-medium"
+                >
+                  {t('admin:subscriptions.requests.activateModal.preset30Days', '30-day trial')}
+                </button>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-xs text-gray-600 mb-1">
+                    {t('admin:subscriptions.requests.activateModal.trialStart', 'Trial Start')}
+                  </label>
+                  <input
+                    type="date"
+                    value={trialStartDate}
+                    onChange={(e) => setTrialStartDate(e.target.value)}
+                    className="w-full p-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-gray-600 mb-1">
+                    {t('admin:subscriptions.requests.activateModal.trialEnd', 'Trial End')}
+                  </label>
+                  <input
+                    type="date"
+                    value={trialEndDate}
+                    min={trialStartDate}
+                    onChange={(e) => setTrialEndDate(e.target.value)}
+                    className="w-full p-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+              </div>
+              <p className="text-xs text-gray-500">
+                {t(
+                  'admin:subscriptions.requests.activateModal.trialHelp',
+                  'The subscription will stay in Trial status until the trial end date, then automatically become Active.',
+                )}
+              </p>
+            </div>
+          )}
+
+          {/* Notes */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              {t('admin:subscriptions.requests.activateModal.notes', 'Admin Notes (optional)')}
+            </label>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={2}
+              className="w-full p-2 border rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+            />
+          </div>
+
+          {/* Send Email */}
+          <div className="flex items-center gap-3">
+            <input
+              type="checkbox"
+              id="send-email"
+              checked={sendEmail}
+              onChange={(e) => setSendEmail(e.target.checked)}
+              className="w-4 h-4 text-blue-600 rounded"
+            />
+            <label htmlFor="send-email" className="text-sm text-gray-700 cursor-pointer select-none">
+              {t('admin:subscriptions.requests.activateModal.sendEmail', 'Send activation email to customer')}
+            </label>
+          </div>
+
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-gray-600 hover:text-gray-900"
+            >
+              {t('common:cancel', 'Cancel')}
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitDisabled}
+              className="flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50"
+            >
+              <CheckCircle className="w-4 h-4" />
+              {isLoading
+                ? t('common:saving', 'Saving...')
+                : t('admin:subscriptions.requests.activateModal.submit', 'Activate Subscription')}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
 // Subscription Settings Modal Component
 interface SubscriptionSettingsModalProps {
   isOpen: boolean;
@@ -1953,6 +2215,7 @@ const Subscriptions: React.FC = () => {
   const [cancellationStatusFilter, setCancellationStatusFilter] = useState<string>('');
   const [selectedRequest, setSelectedRequest] = useState<SubscriptionRequest | null>(null);
   const [isRequestDetailOpen, setIsRequestDetailOpen] = useState(false);
+  const [isActivateRequestModalOpen, setIsActivateRequestModalOpen] = useState(false);
   const [isInvoiceModalOpen, setIsInvoiceModalOpen] = useState(false);
   const [isPaymentModalOpen, setIsPaymentModalOpen] = useState(false);
   const [isDeclineModalOpen, setIsDeclineModalOpen] = useState(false);
@@ -2511,7 +2774,7 @@ const Subscriptions: React.FC = () => {
       data,
     }: {
       id: string;
-      data: { startDate?: string; periodMonths?: number; includeTrial?: boolean; sendEmail?: boolean; notes?: string };
+      data: { startDate?: string; periodMonths?: number; includeTrial?: boolean; trialStartDate?: string; trialEndDate?: string; sendEmail?: boolean; notes?: string };
     }) => subscriptionService.activateSubscriptionRequest(apiClient, id, data),
     onSuccess: (res: any) => {
       queryClient.invalidateQueries({ queryKey: ['subscription-requests'] });
@@ -3710,12 +3973,7 @@ const Subscriptions: React.FC = () => {
                   selectedRequest.status === SubscriptionRequestStatus.UNDER_REVIEW ||
                   selectedRequest.status === SubscriptionRequestStatus.INVOICE_SENT) && (
                   <button
-                    onClick={() => {
-                      activateRequestMutation.mutate({
-                        id: selectedRequest.id,
-                        data: { sendEmail: true },
-                      });
-                    }}
+                    onClick={() => setIsActivateRequestModalOpen(true)}
                     disabled={activateRequestMutation.isPending}
                     className="flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50"
                   >
@@ -3781,6 +4039,23 @@ const Subscriptions: React.FC = () => {
             });
           }}
           isLoading={declineRequestMutation.isPending}
+        />
+      )}
+
+      {/* Activate Subscription Request Modal */}
+      {isActivateRequestModalOpen && selectedRequest && (
+        <ActivateSubscriptionRequestModal
+          isOpen={isActivateRequestModalOpen}
+          onClose={() => setIsActivateRequestModalOpen(false)}
+          request={selectedRequest}
+          onActivate={async (data) => {
+            await activateRequestMutation.mutateAsync({
+              id: selectedRequest.id,
+              data,
+            });
+            setIsActivateRequestModalOpen(false);
+          }}
+          isLoading={activateRequestMutation.isPending}
         />
       )}
 

--- a/admin/src/pages/Subscriptions.tsx
+++ b/admin/src/pages/Subscriptions.tsx
@@ -1648,7 +1648,7 @@ const ActivateSubscriptionRequestModal: React.FC<ActivateSubscriptionRequestModa
     e.preventDefault();
     await onActivate({
       startDate: startDate || undefined,
-      periodMonths: periodMonths >= 0 ? periodMonths : undefined,
+      periodMonths: periodMonths > 0 ? periodMonths : undefined,
       includeTrial: includeTrial || undefined,
       trialStartDate: includeTrial ? trialStartDate : undefined,
       trialEndDate: includeTrial ? trialEndDate : undefined,

--- a/admin/src/services/subscriptionService.ts
+++ b/admin/src/services/subscriptionService.ts
@@ -320,6 +320,8 @@ export const subscriptionService = {
     startDate?: string;
     periodMonths?: number;
     includeTrial?: boolean;
+    trialStartDate?: string;
+    trialEndDate?: string;
     sendEmail?: boolean;
     notes?: string;
   }) =>

--- a/admin/src/types/subscription.ts
+++ b/admin/src/types/subscription.ts
@@ -176,6 +176,8 @@ export interface CreateSubscriptionDto {
   startDate?: string;
   durationMonths?: number;
   includeTrial?: boolean;
+  trialStartDate?: string;
+  trialEndDate?: string;
   notes?: string;
 }
 

--- a/api/src/subscription-management/dto/subscription-request.dto.ts
+++ b/api/src/subscription-management/dto/subscription-request.dto.ts
@@ -178,6 +178,14 @@ export class ActivateFromRequestDto {
   includeTrial?: boolean;
 
   @IsOptional()
+  @IsDateString()
+  trialStartDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  trialEndDate?: string;
+
+  @IsOptional()
   @IsBoolean()
   sendEmail?: boolean;
 

--- a/api/src/subscription-management/dto/subscription.dto.ts
+++ b/api/src/subscription-management/dto/subscription.dto.ts
@@ -46,6 +46,14 @@ export class CreateSubscriptionDto {
   includeTrial?: boolean;
 
   @IsOptional()
+  @IsDateString()
+  trialStartDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  trialEndDate?: string;
+
+  @IsOptional()
   @IsString()
   notes?: string;
 }

--- a/api/src/subscription-management/subscription-management.service.ts
+++ b/api/src/subscription-management/subscription-management.service.ts
@@ -555,11 +555,19 @@ export class SubscriptionManagementService {
       let trialEnd: Date | null = null;
       let status: SubscriptionStatus = 'PENDING';
 
-      if (data.includeTrial && plan.trialDays > 0) {
-        trialStart = startDate;
-        trialEnd = new Date(startDate);
-        trialEnd.setDate(trialEnd.getDate() + plan.trialDays);
-        status = 'TRIAL';
+      if (data.includeTrial) {
+        if (data.trialStartDate && data.trialEndDate) {
+          // Admin provided explicit trial dates
+          trialStart = new Date(data.trialStartDate);
+          trialEnd = new Date(data.trialEndDate);
+          status = 'TRIAL';
+        } else if (plan.trialDays > 0) {
+          // Fall back to plan's default trialDays
+          trialStart = startDate;
+          trialEnd = new Date(startDate);
+          trialEnd.setDate(trialEnd.getDate() + plan.trialDays);
+          status = 'TRIAL';
+        }
       }
 
       const subscription = await this.prisma.subscription.create({

--- a/api/src/subscription-management/subscription-request.service.ts
+++ b/api/src/subscription-management/subscription-request.service.ts
@@ -546,21 +546,27 @@ export class SubscriptionRequestService {
           startDate: data.startDate,
           durationMonths: data.periodMonths,
           includeTrial: data.includeTrial,
+          trialStartDate: data.trialStartDate,
+          trialEndDate: data.trialEndDate,
           notes: data.notes || `Created from subscription request ${id}`,
         },
         performedBy,
       );
 
-      // Activate the subscription
-      await this.subscriptionService.activateSubscription(
-        subscription.id,
-        {
-          startDate: data.startDate,
-          periodMonths: data.periodMonths,
-          notes: data.notes,
-        },
-        performedBy,
-      );
+      // If a trial was started, leave the subscription in TRIAL status — the scheduled
+      // cron job will transition it to ACTIVE when the trial period ends.
+      // For non-trial activations, move directly to ACTIVE now.
+      if (subscription.status !== 'TRIAL') {
+        await this.subscriptionService.activateSubscription(
+          subscription.id,
+          {
+            startDate: data.startDate,
+            periodMonths: data.periodMonths,
+            notes: data.notes,
+          },
+          performedBy,
+        );
+      }
 
       // Update the request
       const updated = await this.prisma.subscriptionRequest.update({

--- a/api/src/subscription-management/subscription-request.service.ts
+++ b/api/src/subscription-management/subscription-request.service.ts
@@ -566,6 +566,23 @@ export class SubscriptionRequestService {
           },
           performedBy,
         );
+      } else {
+        // Record who initiated the trial so audit fields are never null.
+        await this.prisma.subscription.update({
+          where: { id: subscription.id },
+          data: { activatedBy: performedBy, activatedAt: new Date() },
+        });
+        await this.prisma.subscriptionAction.create({
+          data: {
+            subscriptionId: subscription.id,
+            action: 'ACTIVATE',
+            previousStatus: 'PENDING',
+            newStatus: 'TRIAL',
+            reason: 'Trial activated from subscription request',
+            notes: data.notes,
+            performedBy,
+          },
+        });
       }
 
       // Update the request

--- a/packages/translations/locales/de/admin.json
+++ b/packages/translations/locales/de/admin.json
@@ -2157,6 +2157,20 @@
         "notes": "Interne Notizen (optional)",
         "sendEmailNotification": "E-Mail-Benachrichtigung an den Kunden senden",
         "decline": "Anfrage ablehnen"
+      },
+      "activateModal": {
+        "title": "Abonnement aktivieren",
+        "startDate": "Abonnement-Startdatum",
+        "period": "Abonnementzeitraum",
+        "includeTrial": "Testzeitraum einschließen",
+        "trialDates": "Testdaten",
+        "trialStart": "Testbeginn",
+        "trialEnd": "Testende",
+        "preset30Days": "30-Tage-Test",
+        "sendEmail": "Aktivierungs-E-Mail an den Kunden senden",
+        "notes": "Admin-Notizen (optional)",
+        "submit": "Abonnement aktivieren",
+        "trialHelp": "Das Abonnement bleibt im Teststatus bis zum Enddatum des Tests und wird dann automatisch aktiv."
       }
     },
     "cancellations": {

--- a/packages/translations/locales/en/admin.json
+++ b/packages/translations/locales/en/admin.json
@@ -2137,6 +2137,20 @@
         "notes": "Internal Notes (optional)",
         "sendEmailNotification": "Send email notification to customer",
         "decline": "Decline Request"
+      },
+      "activateModal": {
+        "title": "Activate Subscription",
+        "startDate": "Subscription Start Date",
+        "period": "Subscription Period",
+        "includeTrial": "Include Trial Period",
+        "trialDates": "Trial Dates",
+        "trialStart": "Trial Start",
+        "trialEnd": "Trial End",
+        "preset30Days": "30-day trial",
+        "sendEmail": "Send activation email to customer",
+        "notes": "Admin Notes (optional)",
+        "submit": "Activate Subscription",
+        "trialHelp": "The subscription will stay in Trial status until the trial end date, then automatically become Active."
       }
     },
     "cancellations": {

--- a/packages/translations/locales/fr/admin.json
+++ b/packages/translations/locales/fr/admin.json
@@ -2152,6 +2152,20 @@
         "notes": "Notes internes (optionnel)",
         "sendEmailNotification": "Envoyer une notification par email au client",
         "decline": "Refuser la demande"
+      },
+      "activateModal": {
+        "title": "Activer l'abonnement",
+        "startDate": "Date de début de l'abonnement",
+        "period": "Période d'abonnement",
+        "includeTrial": "Inclure une période d'essai",
+        "trialDates": "Dates d'essai",
+        "trialStart": "Début de l'essai",
+        "trialEnd": "Fin de l'essai",
+        "preset30Days": "Essai 30 jours",
+        "sendEmail": "Envoyer un email d'activation au client",
+        "notes": "Notes administrateur (optionnel)",
+        "submit": "Activer l'abonnement",
+        "trialHelp": "L'abonnement restera en statut Essai jusqu'à la date de fin d'essai, puis deviendra automatiquement Actif."
       }
     },
     "cancellations": {


### PR DESCRIPTION
## Summary
This PR adds a new modal dialog for activating subscription requests with enhanced trial period configuration. Admins can now specify custom trial start and end dates when activating subscriptions, rather than relying solely on plan defaults.

## Key Changes

- **New ActivateSubscriptionRequestModal component**: A comprehensive modal form that allows admins to:
  - Set a custom subscription start date
  - Select subscription period (monthly recurring, 1-24 months)
  - Optionally include a trial period with custom dates
  - Apply a quick 30-day trial preset
  - Add admin notes
  - Choose whether to send activation email to customer

- **Backend enhancements**:
  - Updated `ActivateFromRequestDto` and `CreateSubscriptionDto` to accept `trialStartDate` and `trialEndDate` fields
  - Modified subscription creation logic to use admin-provided trial dates when available, falling back to plan defaults
  - Updated activation flow to keep subscriptions in TRIAL status when a trial period is configured, allowing scheduled jobs to transition to ACTIVE automatically

- **Frontend improvements**:
  - Replaced simple one-click activation with modal-based workflow
  - Trial start date automatically syncs with subscription start date
  - Trial end date has minimum validation to prevent invalid date ranges
  - Form validation ensures either a trial or subscription period is selected

- **Internationalization**: Added translation keys for the new modal in English, French, and German

## Implementation Details

- Trial dates are optional and only used when `includeTrial` is true
- If custom trial dates are provided, they take precedence over plan's default `trialDays`
- Subscriptions with trial periods remain in TRIAL status until the trial end date, then transition to ACTIVE via scheduled job
- Non-trial activations proceed directly to ACTIVE status
- Modal includes keyboard escape handling and click-outside-to-close functionality

https://claude.ai/code/session_014iupNMWgTSrLaVkkVtBF8p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated modal to activate subscription requests with fields for start date, trial start/end, period, email and notes.
  * 30-day trial preset and Escape-key closing supported; modal closes after activation.

* **Behavior Changes**
  * When explicit trial dates are provided, the activation records TRIAL status and does not immediately flip to ACTIVE (non-trial activations still activate immediately).

* **Localization**
  * Added activation UI translations for English, German, and French.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->