### PR TITLE
Add custom list management features to mailing module

### DIFF
--- a/admin/src/components/mailing/CustomListMembersModal.tsx
+++ b/admin/src/components/mailing/CustomListMembersModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { X, Users, Trash2, ChevronLeft, ChevronRight } from 'lucide-react'
 import { toast } from 'sonner'
@@ -17,6 +17,9 @@ const CustomListMembersModal: React.FC<Props> = ({ isOpen, onClose, list }) => {
   const queryClient = useQueryClient()
   const [page, setPage] = useState(1)
   const PAGE_SIZE = 20
+
+  // Reset to page 1 whenever the targeted list changes
+  useEffect(() => { setPage(1) }, [list.id])
 
   const { data, isLoading } = useQuery({
     queryKey: ['custom-list-members', list.id, page],
@@ -48,15 +51,19 @@ const CustomListMembersModal: React.FC<Props> = ({ isOpen, onClose, list }) => {
     <div
       className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50"
       onClick={onClose}
+      role="presentation"
     >
       <div
         className="w-full max-w-2xl bg-white rounded-lg shadow-xl max-h-[85vh] flex flex-col"
         onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="custom-list-modal-title"
       >
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-gray-200">
           <div>
-            <h3 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+            <h3 id="custom-list-modal-title" className="text-lg font-semibold text-gray-900 flex items-center gap-2">
               <Users className="w-5 h-5 text-blue-600" />
               {list.name}
             </h3>
@@ -65,7 +72,7 @@ const CustomListMembersModal: React.FC<Props> = ({ isOpen, onClose, list }) => {
               {list.description && ` · ${list.description}`}
             </p>
           </div>
-          <button onClick={onClose} className="p-1 text-gray-400 hover:text-gray-600">
+          <button onClick={onClose} className="p-1 text-gray-400 hover:text-gray-600" aria-label="Close">
             <X className="w-5 h-5" />
           </button>
         </div>

--- a/admin/src/components/mailing/CustomListMembersModal.tsx
+++ b/admin/src/components/mailing/CustomListMembersModal.tsx
@@ -1,0 +1,154 @@
+import React, { useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { X, Users, Trash2, ChevronLeft, ChevronRight } from 'lucide-react'
+import { toast } from 'sonner'
+import { useApiClient, apiService } from '../../services/api'
+import { MailingCustomList, MailingCustomListMember } from '../../types/api'
+import LoadingSpinner from '../ui/LoadingSpinner'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  list: MailingCustomList
+}
+
+const CustomListMembersModal: React.FC<Props> = ({ isOpen, onClose, list }) => {
+  const apiClient = useApiClient()
+  const queryClient = useQueryClient()
+  const [page, setPage] = useState(1)
+  const PAGE_SIZE = 20
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['custom-list-members', list.id, page],
+    queryFn: async () => {
+      const res = await apiService.mailingGetCustomListMembers(apiClient, list.id, {
+        page,
+        pageSize: PAGE_SIZE,
+      })
+      return res.data
+    },
+    enabled: isOpen,
+  })
+
+  const handleRemove = async (userId: string, email: string) => {
+    if (!confirm(`Remove ${email} from this list?`)) return
+    try {
+      await apiService.mailingRemoveUsersFromList(apiClient, list.id, [userId])
+      toast.success(`Removed ${email} from list`)
+      queryClient.invalidateQueries({ queryKey: ['custom-list-members', list.id] })
+      queryClient.invalidateQueries({ queryKey: ['mailing-custom-lists'] })
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message || 'Failed to remove member')
+    }
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-2xl bg-white rounded-lg shadow-xl max-h-[85vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-gray-200">
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+              <Users className="w-5 h-5 text-blue-600" />
+              {list.name}
+            </h3>
+            <p className="text-sm text-gray-500 mt-0.5">
+              {data?.total ?? list._count?.members ?? 0} members
+              {list.description && ` · ${list.description}`}
+            </p>
+          </div>
+          <button onClick={onClose} className="p-1 text-gray-400 hover:text-gray-600">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto">
+          {isLoading ? (
+            <div className="flex justify-center py-12">
+              <LoadingSpinner />
+            </div>
+          ) : !data?.members?.length ? (
+            <div className="text-center py-12 text-gray-400">
+              <Users className="w-10 h-10 mx-auto mb-3 text-gray-300" />
+              <p>No members in this list</p>
+              <p className="text-sm mt-1 text-gray-400">
+                Select users in the Build tab and click "Add to List" to add members
+              </p>
+            </div>
+          ) : (
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50 sticky top-0">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Email</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Role</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Added</th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {data.members.map((member: MailingCustomListMember) => (
+                  <tr key={member.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 text-sm font-medium text-gray-900">
+                      {member.firstName} {member.lastName}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-600">{member.email}</td>
+                    <td className="px-4 py-3 text-sm text-gray-500 capitalize">{member.role?.toLowerCase()}</td>
+                    <td className="px-4 py-3 text-sm text-gray-500">
+                      {new Date(member.addedAt).toLocaleDateString()}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <button
+                        onClick={() => handleRemove(member.id, member.email)}
+                        className="p-1 text-gray-400 hover:text-red-600"
+                        title="Remove from list"
+                      >
+                        <Trash2 className="w-3.5 h-3.5" />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        {/* Pagination footer */}
+        {data && data.totalPages > 1 && (
+          <div className="flex items-center justify-between px-4 py-3 border-t border-gray-200 bg-gray-50">
+            <span className="text-sm text-gray-600">
+              Page {data.page} of {data.totalPages} · {data.total} total
+            </span>
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1}
+                className="p-1.5 text-gray-500 hover:text-gray-700 disabled:opacity-40 rounded hover:bg-gray-200"
+              >
+                <ChevronLeft className="w-4 h-4" />
+              </button>
+              <button
+                onClick={() => setPage((p) => Math.min(data.totalPages, p + 1))}
+                disabled={page === data.totalPages}
+                className="p-1.5 text-gray-500 hover:text-gray-700 disabled:opacity-40 rounded hover:bg-gray-200"
+              >
+                <ChevronRight className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default CustomListMembersModal

--- a/admin/src/pages/MailingList.tsx
+++ b/admin/src/pages/MailingList.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
-  Mail, Plus, Download, Send, Save, Trash2, RefreshCw, Users, BarChart3, List, UserPlus,
+  Mail, Plus, Download, Send, Save, Trash2, RefreshCw, Users, BarChart3, List, UserPlus, Pencil, Check, X,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
@@ -19,6 +19,7 @@ import ExportModal from '../components/mailing/ExportModal'
 import ComposeEmailModal from '../components/mailing/ComposeEmailModal'
 import SendProgressOverlay from '../components/mailing/SendProgressOverlay'
 import AddToListModal from '../components/mailing/AddToListModal'
+import CustomListMembersModal from '../components/mailing/CustomListMembersModal'
 
 type Tab = 'build' | 'segments' | 'campaigns' | 'lists'
 
@@ -75,6 +76,14 @@ const MailingListPage: React.FC = () => {
   const [sendingCampaignId, setSendingCampaignId] = useState<string | null>(null)
   const [actionLoading, setActionLoading] = useState(false)
   const [selectedUserIds, setSelectedUserIds] = useState<Set<string>>(new Set())
+
+  // Custom list action state
+  const [activeList, setActiveList] = useState<MailingCustomList | null>(null)
+  const [listMembersModalOpen, setListMembersModalOpen] = useState(false)
+  const [listComposeModalOpen, setListComposeModalOpen] = useState(false)
+  const [listExportModalOpen, setListExportModalOpen] = useState(false)
+  const [editingListId, setEditingListId] = useState<string | null>(null)
+  const [editingListName, setEditingListName] = useState('')
 
   const toggleSelectUser = useCallback((id: string) => {
     setSelectedUserIds((prev) => {
@@ -231,6 +240,66 @@ const MailingListPage: React.FC = () => {
     setFilters(segment.filtersJson)
     setActiveTab('build')
   }, [])
+
+  const handleCreateListCampaign = useCallback(async (subject: string, bodyHtml: string) => {
+    if (!activeList) return
+    setActionLoading(true)
+    try {
+      const res = await apiService.mailingCreateCampaign(apiClient, {
+        subject,
+        bodyHtml,
+        customListId: activeList.id,
+      })
+      const campaignId = res.data?.campaignId
+      toast.success('Campaign created')
+      setListComposeModalOpen(false)
+      if (campaignId) setSendingCampaignId(campaignId)
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message || 'Failed to create campaign')
+    } finally {
+      setActionLoading(false)
+    }
+  }, [apiClient, activeList])
+
+  const handleExportList = useCallback(async (format: 'csv' | 'xlsx', columns: string[]) => {
+    if (!activeList) return
+    setActionLoading(true)
+    try {
+      const res = await apiService.mailingExport(apiClient, {
+        customListId: activeList.id,
+        format,
+        columns,
+        deduplicateByEmail: true,
+      })
+      const blob = new Blob([res.data], {
+        type: format === 'csv' ? 'text/csv' : 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      })
+      const url = window.URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `${activeList.name.replace(/\s+/g, '_')}_export_${new Date().toISOString().slice(0, 10)}.${format}`
+      a.click()
+      window.URL.revokeObjectURL(url)
+      toast.success(`Exported ${activeList._count?.members || 0} members`)
+      setListExportModalOpen(false)
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message || 'Export failed')
+    } finally {
+      setActionLoading(false)
+    }
+  }, [apiClient, activeList])
+
+  const handleRenameList = useCallback(async (listId: string, newName: string) => {
+    if (!newName.trim()) return
+    try {
+      await apiService.mailingUpdateCustomList(apiClient, listId, { name: newName.trim() })
+      toast.success('List renamed')
+      setEditingListId(null)
+      queryClient.invalidateQueries({ queryKey: ['mailing-custom-lists'] })
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message || 'Failed to rename list')
+    }
+  }, [apiClient, queryClient])
 
   return (
     <div className="space-y-6">
@@ -536,28 +605,95 @@ const MailingListPage: React.FC = () => {
                     {customListsData.lists.map((list: MailingCustomList) => (
                       <tr key={list.id} className="hover:bg-gray-50">
                         <td className="px-4 py-3">
-                          <div className="text-sm font-medium text-gray-900">{list.name}</div>
-                          {list.description && <div className="text-xs text-gray-500 truncate max-w-xs">{list.description}</div>}
+                          {editingListId === list.id ? (
+                            <form
+                              className="flex items-center gap-2"
+                              onSubmit={(e) => { e.preventDefault(); handleRenameList(list.id, editingListName) }}
+                            >
+                              <input
+                                autoFocus
+                                value={editingListName}
+                                onChange={(e) => setEditingListName(e.target.value)}
+                                className="text-sm border border-blue-400 rounded px-2 py-0.5 focus:outline-none focus:ring-1 focus:ring-blue-500 w-48"
+                              />
+                              <button type="submit" className="p-1 text-green-600 hover:text-green-800">
+                                <Check className="w-3.5 h-3.5" />
+                              </button>
+                              <button type="button" onClick={() => setEditingListId(null)} className="p-1 text-gray-400 hover:text-gray-600">
+                                <X className="w-3.5 h-3.5" />
+                              </button>
+                            </form>
+                          ) : (
+                            <>
+                              <div className="text-sm font-medium text-gray-900">{list.name}</div>
+                              {list.description && <div className="text-xs text-gray-500 truncate max-w-xs">{list.description}</div>}
+                            </>
+                          )}
                         </td>
-                        <td className="px-4 py-3 text-sm text-gray-600">{(list._count?.members ?? 0).toLocaleString()}</td>
+                        <td className="px-4 py-3">
+                          <button
+                            onClick={() => { setActiveList(list); setListMembersModalOpen(true) }}
+                            className="text-sm text-blue-600 hover:underline"
+                            title="View members"
+                          >
+                            {(list._count?.members ?? 0).toLocaleString()} members
+                          </button>
+                        </td>
                         <td className="px-4 py-3 text-sm text-gray-500">{new Date(list.updatedAt).toLocaleDateString()}</td>
                         <td className="px-4 py-3 text-right">
-                          <button
-                            onClick={async () => {
-                              if (!confirm(t('admin:mailing.customLists.deleteConfirm', 'Delete this list?'))) return
-                              try {
-                                await apiService.mailingDeleteCustomList(apiClient, list.id)
-                                toast.success(t('admin:mailing.customLists.deleted', 'List deleted'))
-                                queryClient.invalidateQueries({ queryKey: ['mailing-custom-lists'] })
-                              } catch (err: any) {
-                                toast.error(err?.response?.data?.message || 'Failed to delete')
-                              }
-                            }}
-                            className="p-1 text-gray-400 hover:text-red-600"
-                            title="Delete"
-                          >
-                            <Trash2 className="w-3.5 h-3.5" />
-                          </button>
+                          <div className="flex items-center justify-end gap-1">
+                            {/* Send email / Create campaign */}
+                            <button
+                              onClick={() => { setActiveList(list); setListComposeModalOpen(true) }}
+                              disabled={(list._count?.members ?? 0) === 0}
+                              className="flex items-center gap-1 text-xs px-2 py-1 text-blue-600 hover:bg-blue-50 rounded disabled:opacity-40 disabled:cursor-not-allowed"
+                              title="Create mail campaign for this list"
+                            >
+                              <Send className="w-3 h-3" /> Send
+                            </button>
+                            {/* Export list */}
+                            <button
+                              onClick={() => { setActiveList(list); setListExportModalOpen(true) }}
+                              disabled={(list._count?.members ?? 0) === 0}
+                              className="flex items-center gap-1 text-xs px-2 py-1 text-gray-600 hover:bg-gray-100 rounded disabled:opacity-40 disabled:cursor-not-allowed"
+                              title="Export list members"
+                            >
+                              <Download className="w-3 h-3" /> Export
+                            </button>
+                            {/* View members */}
+                            <button
+                              onClick={() => { setActiveList(list); setListMembersModalOpen(true) }}
+                              className="flex items-center gap-1 text-xs px-2 py-1 text-gray-600 hover:bg-gray-100 rounded"
+                              title="View members"
+                            >
+                              <Users className="w-3 h-3" /> Members
+                            </button>
+                            {/* Rename */}
+                            <button
+                              onClick={() => { setEditingListId(list.id); setEditingListName(list.name) }}
+                              className="p-1 text-gray-400 hover:text-blue-600"
+                              title="Rename list"
+                            >
+                              <Pencil className="w-3.5 h-3.5" />
+                            </button>
+                            {/* Delete */}
+                            <button
+                              onClick={async () => {
+                                if (!confirm(t('admin:mailing.customLists.deleteConfirm', 'Delete this list?'))) return
+                                try {
+                                  await apiService.mailingDeleteCustomList(apiClient, list.id)
+                                  toast.success(t('admin:mailing.customLists.deleted', 'List deleted'))
+                                  queryClient.invalidateQueries({ queryKey: ['mailing-custom-lists'] })
+                                } catch (err: any) {
+                                  toast.error(err?.response?.data?.message || 'Failed to delete')
+                                }
+                              }}
+                              className="p-1 text-gray-400 hover:text-red-600"
+                              title="Delete list"
+                            >
+                              <Trash2 className="w-3.5 h-3.5" />
+                            </button>
+                          </div>
                         </td>
                       </tr>
                     ))}
@@ -612,6 +748,33 @@ const MailingListPage: React.FC = () => {
           }}
         />
       )}
+
+      {/* Custom list — view members */}
+      {activeList && (
+        <CustomListMembersModal
+          isOpen={listMembersModalOpen}
+          onClose={() => setListMembersModalOpen(false)}
+          list={activeList}
+        />
+      )}
+
+      {/* Custom list — compose campaign email */}
+      <ComposeEmailModal
+        isOpen={listComposeModalOpen}
+        onClose={() => setListComposeModalOpen(false)}
+        onSend={handleCreateListCampaign}
+        loading={actionLoading}
+        recipientCount={activeList?._count?.members ?? 0}
+      />
+
+      {/* Custom list — export members */}
+      <ExportModal
+        isOpen={listExportModalOpen}
+        onClose={() => setListExportModalOpen(false)}
+        onExport={handleExportList}
+        loading={actionLoading}
+        count={activeList?._count?.members ?? 0}
+      />
     </div>
   )
 }

--- a/admin/src/pages/MailingList.tsx
+++ b/admin/src/pages/MailingList.tsx
@@ -277,7 +277,8 @@ const MailingListPage: React.FC = () => {
       const url = window.URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = url
-      a.download = `${activeList.name.replace(/\s+/g, '_')}_export_${new Date().toISOString().slice(0, 10)}.${format}`
+      const sanitizedName = activeList.name.normalize('NFKD').replace(/[\u0300-\u036f]/g, '').replace(/[/\\:*?"<>|]+/g, '').replace(/\s+/g, '_').trim().slice(0, 100)
+      a.download = `${sanitizedName}_export_${new Date().toISOString().slice(0, 10)}.${format}`
       a.click()
       window.URL.revokeObjectURL(url)
       toast.success(`Exported ${activeList._count?.members || 0} members`)
@@ -288,6 +289,20 @@ const MailingListPage: React.FC = () => {
       setActionLoading(false)
     }
   }, [apiClient, activeList])
+
+  const handleDeleteCustomList = useCallback(async (listId: string) => {
+    if (!confirm(t('admin:mailing.customLists.deleteConfirm', 'Delete this list?'))) return
+    setActionLoading(true)
+    try {
+      await apiService.mailingDeleteCustomList(apiClient, listId)
+      toast.success(t('admin:mailing.customLists.deleted', 'List deleted'))
+      queryClient.invalidateQueries({ queryKey: ['mailing-custom-lists'] })
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message || 'Failed to delete')
+    } finally {
+      setActionLoading(false)
+    }
+  }, [apiClient, queryClient, t])
 
   const handleRenameList = useCallback(async (listId: string, newName: string) => {
     if (!newName.trim()) return
@@ -678,16 +693,7 @@ const MailingListPage: React.FC = () => {
                             </button>
                             {/* Delete */}
                             <button
-                              onClick={async () => {
-                                if (!confirm(t('admin:mailing.customLists.deleteConfirm', 'Delete this list?'))) return
-                                try {
-                                  await apiService.mailingDeleteCustomList(apiClient, list.id)
-                                  toast.success(t('admin:mailing.customLists.deleted', 'List deleted'))
-                                  queryClient.invalidateQueries({ queryKey: ['mailing-custom-lists'] })
-                                } catch (err: any) {
-                                  toast.error(err?.response?.data?.message || 'Failed to delete')
-                                }
-                              }}
+                              onClick={() => handleDeleteCustomList(list.id)}
                               className="p-1 text-gray-400 hover:text-red-600"
                               title="Delete list"
                             >

--- a/admin/src/services/api.ts
+++ b/admin/src/services/api.ts
@@ -1047,6 +1047,7 @@ export const apiService = {
   mailingExport: (apiClient: AxiosInstance, data: {
     filters?: any;
     segmentId?: string;
+    customListId?: string;
     format: 'csv' | 'xlsx';
     columns: string[];
     deduplicateByEmail?: boolean;
@@ -1061,6 +1062,7 @@ export const apiService = {
     bodyText?: string;
     filters?: any;
     segmentId?: string;
+    customListId?: string;
   }) => apiClient.post('/admin/mailing/campaigns', data),
 
   mailingListCampaigns: (apiClient: AxiosInstance, params?: { page?: number; pageSize?: number }) =>

--- a/api/src/mailing/dto/campaign.dto.ts
+++ b/api/src/mailing/dto/campaign.dto.ts
@@ -21,6 +21,10 @@ export class CreateCampaignDto {
   @IsOptional()
   @IsString()
   segmentId?: string;
+
+  @IsOptional()
+  @IsString()
+  customListId?: string;
 }
 
 export class SendBatchDto {

--- a/api/src/mailing/dto/export.dto.ts
+++ b/api/src/mailing/dto/export.dto.ts
@@ -12,6 +12,10 @@ export class ExportRequestDto {
   @IsString()
   segmentId?: string;
 
+  @IsOptional()
+  @IsString()
+  customListId?: string;
+
   @IsString()
   @IsIn(['csv', 'xlsx'])
   format: 'csv' | 'xlsx';

--- a/api/src/mailing/dto/mailing-filters.dto.ts
+++ b/api/src/mailing/dto/mailing-filters.dto.ts
@@ -1,10 +1,11 @@
-import { IsOptional, IsArray, IsBoolean, IsString, IsEnum } from 'class-validator';
+import { IsOptional, IsArray, IsBoolean, IsString, IsEnum, ArrayMaxSize } from 'class-validator';
 import { UserRole, SubscriptionStatus, SubscriptionTier } from '@prisma/client';
 
 export class MailingFiltersDto {
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
+  @ArrayMaxSize(2000)
   userIds?: string[];
   @IsOptional()
   @IsArray()

--- a/api/src/mailing/dto/mailing-filters.dto.ts
+++ b/api/src/mailing/dto/mailing-filters.dto.ts
@@ -4,6 +4,10 @@ import { UserRole, SubscriptionStatus, SubscriptionTier } from '@prisma/client';
 export class MailingFiltersDto {
   @IsOptional()
   @IsArray()
+  @IsString({ each: true })
+  userIds?: string[];
+  @IsOptional()
+  @IsArray()
   @IsEnum(UserRole, { each: true })
   roles?: UserRole[];
 

--- a/api/src/mailing/mailing.controller.ts
+++ b/api/src/mailing/mailing.controller.ts
@@ -26,6 +26,7 @@ import { CreateSegmentDto, UpdateSegmentDto } from './dto/segment.dto';
 import { CreateCampaignDto, SendBatchDto } from './dto/campaign.dto';
 import { ExportRequestDto } from './dto/export.dto';
 import { CreateCustomListDto, UpdateCustomListDto, ManageCustomListMembersDto } from './dto/custom-list.dto';
+import { MailingFiltersDto } from './dto/mailing-filters.dto';
 
 @ApiTags('admin/mailing')
 @Controller('admin/mailing')
@@ -134,8 +135,12 @@ export class MailingController {
   ) {
     const adminId = this.getAdminId(req);
 
+    if (body.customListId && body.segmentId) {
+      throw new BadRequestException('customListId and segmentId are mutually exclusive');
+    }
+
     // Resolve filters, accounting for custom list targeting
-    let filters: any;
+    let filters: MailingFiltersDto;
     if (body.customListId) {
       const memberIds = await this.mailingService.getAllCustomListMemberIds(body.customListId);
       if (memberIds.length === 0) {
@@ -151,7 +156,7 @@ export class MailingController {
       body.columns,
       body.deduplicateByEmail ?? true,
       adminId,
-      body.segmentId,
+      body.segmentId ?? body.customListId,
     );
 
     const filename = `mailing_export_${new Date().toISOString().slice(0, 10)}`;
@@ -227,7 +232,11 @@ export class MailingController {
   async createCampaign(@Body() body: CreateCampaignDto, @Request() req: any) {
     const adminId = this.getAdminId(req);
 
-    let filters = body.filters;
+    if (body.customListId && body.segmentId) {
+      throw new BadRequestException('customListId and segmentId are mutually exclusive');
+    }
+
+    let filters: MailingFiltersDto = body.filters;
 
     // If targeting a custom list, resolve the member user IDs and inject them into filters
     if (body.customListId) {
@@ -244,7 +253,7 @@ export class MailingController {
       body.bodyText,
       adminId,
       filters,
-      body.segmentId,
+      body.customListId ? undefined : body.segmentId,
     );
   }
 

--- a/api/src/mailing/mailing.controller.ts
+++ b/api/src/mailing/mailing.controller.ts
@@ -133,7 +133,18 @@ export class MailingController {
     @Res() res: Response,
   ) {
     const adminId = this.getAdminId(req);
-    const filters = await this.mailingService.resolveFilters(body.filters, body.segmentId);
+
+    // Resolve filters, accounting for custom list targeting
+    let filters: any;
+    if (body.customListId) {
+      const memberIds = await this.mailingService.getAllCustomListMemberIds(body.customListId);
+      if (memberIds.length === 0) {
+        throw new BadRequestException('Custom list has no members');
+      }
+      filters = { ...(body.filters || {}), userIds: memberIds };
+    } else {
+      filters = await this.mailingService.resolveFilters(body.filters, body.segmentId);
+    }
 
     const result = await this.mailingService.exportRecipients(
       filters,
@@ -215,12 +226,24 @@ export class MailingController {
   @ApiOperation({ summary: 'Create a campaign' })
   async createCampaign(@Body() body: CreateCampaignDto, @Request() req: any) {
     const adminId = this.getAdminId(req);
+
+    let filters = body.filters;
+
+    // If targeting a custom list, resolve the member user IDs and inject them into filters
+    if (body.customListId) {
+      const memberIds = await this.mailingService.getAllCustomListMemberIds(body.customListId);
+      if (memberIds.length === 0) {
+        throw new BadRequestException('Custom list has no members');
+      }
+      filters = { ...filters, userIds: memberIds };
+    }
+
     return this.mailingService.createCampaign(
       body.subject,
       body.bodyHtml,
       body.bodyText,
       adminId,
-      body.filters,
+      filters,
       body.segmentId,
     );
   }

--- a/api/src/mailing/mailing.service.ts
+++ b/api/src/mailing/mailing.service.ts
@@ -211,6 +211,7 @@ export class MailingService {
       });
       ids.push(...members.map((m) => m.userId));
       done = members.length < PAGE_SIZE;
+      if (ids.length >= MAX_EXPORT_ROWS) break;
       page++;
     }
     return ids;

--- a/api/src/mailing/mailing.service.ts
+++ b/api/src/mailing/mailing.service.ts
@@ -186,7 +186,34 @@ export class MailingService {
       });
     }
 
+    // H) Direct user ID restriction (e.g. from a custom list) -----
+    if (filters.userIds?.length) {
+      andConditions.push({ id: { in: filters.userIds } });
+    }
+
     return { AND: andConditions };
+  }
+
+  /** Fetch all member user IDs from a custom list (handles pagination). */
+  async getAllCustomListMemberIds(listId: string): Promise<string[]> {
+    const PAGE_SIZE = 500;
+    const ids: string[] = [];
+    let page = 1;
+    let done = false;
+    while (!done) {
+      const skip = (page - 1) * PAGE_SIZE;
+      const members = await this.prisma.mailingCustomListMember.findMany({
+        where: { listId },
+        skip,
+        take: PAGE_SIZE,
+        select: { userId: true },
+        orderBy: { userId: 'asc' },
+      });
+      ids.push(...members.map((m) => m.userId));
+      done = members.length < PAGE_SIZE;
+      page++;
+    }
+    return ids;
   }
 
   /* ================================================================ */


### PR DESCRIPTION
## Summary
Enhanced the mailing module with comprehensive custom list management capabilities, including the ability to view list members, send campaigns to specific lists, export list data, and rename lists inline.

## Key Changes

### Frontend (Admin UI)
- **New Modal Component**: Added `CustomListMembersModal` to display paginated list of members with ability to remove individual members
- **Enhanced Custom Lists Table**: 
  - Converted member count to clickable button that opens members modal
  - Added inline list renaming with edit/confirm/cancel UI
  - Reorganized action buttons (Send, Export, Members, Rename, Delete) in a compact button group
- **New State Management**: Added state for managing active list, modal visibility, and editing operations
- **New Handlers**:
  - `handleCreateListCampaign`: Create email campaigns targeting a specific custom list
  - `handleExportList`: Export custom list members to CSV/XLSX
  - `handleRenameList`: Rename custom lists with API persistence
- **Icon Additions**: Imported `Pencil`, `Check`, and `X` icons from lucide-react for edit UI
- **API Integration**: Updated `apiService.mailingExport` to support `customListId` parameter

### Backend (API)
- **Service Enhancement**: Added `getAllCustomListMemberIds()` method to fetch all member IDs from a custom list with pagination support (500 items per page)
- **Filter Resolution**: Updated campaign creation and export endpoints to resolve custom list targeting:
  - When `customListId` is provided, fetch all member IDs and inject them as `userIds` filter
  - Validates that custom list has members before proceeding
- **DTO Updates**:
  - Added `customListId` field to `CreateCampaignDto`
  - Added `customListId` field to `ExportRequestDto`
  - Added `userIds` field to `MailingFiltersDto` for direct user ID filtering
- **Controller Logic**: Updated `createCampaign` and export endpoints to handle custom list targeting with proper validation

## Implementation Details
- Custom list targeting works by resolving member IDs upfront and injecting them into the standard filter pipeline
- Member removal from lists triggers invalidation of both the members query and the custom lists summary query
- Pagination in members modal uses 20 items per page with navigation controls
- Inline editing uses form submission with confirm/cancel buttons for better UX
- All operations include proper error handling and user feedback via toast notifications

https://claude.ai/code/session_011ff9F3hPmfq4WKTEDjGJ1S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Member management modal for custom lists with pagination, member removal, counts, and confirmations.
  * Per-list actions: Send (create campaign), Export (CSV/XLSX), Members, Rename (inline edit), and Delete; last-updated timestamps shown.
  * Compose and Export flows now support targeting a specific custom list and surface success/error toasts.
  * Server-side support added for resolving custom-list members when exporting or creating list campaigns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->