### PR TITLE
fix: resolve build errors introduced in previous round

### DIFF
--- a/admin/src/pages/Users.tsx
+++ b/admin/src/pages/Users.tsx
@@ -1217,7 +1217,7 @@ const Users: React.FC = () => {
           t('admin:users.addUser.bulkAllFailed', `All ${failureCount} invitation(s) failed to send`, { failureCount }),
         )
       } else if (failureCount > 0) {
-        toast.warn(
+        toast.warning(
           t('admin:users.addUser.bulkPartialSuccess', `${successCount} sent, ${failureCount} failed`, {
             successCount,
             failureCount,

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -282,7 +282,7 @@ export class UsersController {
     };
 
     const CONCURRENCY = 5;
-    const results: Awaited<ReturnType<typeof sendOne>>[] = [];
+    const results = [] as { email?: string; success: boolean; error?: string; invitationId?: string }[];
     for (let i = 0; i < dto.invitations.length; i += CONCURRENCY) {
       const batch = dto.invitations.slice(i, i + CONCURRENCY);
       const settled = await Promise.allSettled(batch.map(sendOne));


### PR DESCRIPTION
api/users.controller.ts:
- Drop Awaited<ReturnType<typeof sendOne>>[] annotation on the results accumulator; the fallback object for rejected promises (no email field) was incompatible with that inferred type and caused a tsc error; replace with an explicit plain object type that matches both fulfilled and (theoretical) rejected shapes

admin/pages/Users.tsx:
- Change toast.warn → toast.warning; sonner v2 exposes .warning, not .warn; using the non-existent method caused a TypeScript error in the admin build

https://claude.ai/code/session_01BiMRk1PycQT72vhX863rxL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated notification display for bulk user invitation operations with mixed success and failure results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->