### PR TITLE
feat: set up graphify integration for graph-first navigation

### DIFF
--- a/.claude/hooks/pre-search-reminder.sh
+++ b/.claude/hooks/pre-search-reminder.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Remind Claude to check the graph report before broad searches.
+# Exit 0 = allow tool, output is shown as hook feedback.
+if [ -f "graphify-out/GRAPH_REPORT.md" ]; then
+  echo "[graph-first] Consult graphify-out/GRAPH_REPORT.md to identify the relevant module/path before searching broadly. Use a targeted path instead of repo-wide patterns."
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Glob|Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/pre-search-reminder.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/topics/architecture.md
+++ b/.claude/topics/architecture.md
@@ -11,7 +11,7 @@
 ## Request Lifecycle
 
 ```
-Client → Clerk JWT → NestJS JwtAuthGuard → RolesGuard (CASL)
+Client → Clerk JWT → NestJS ClerkAuthGuard → RolesGuard (CASL)
        → Controller → Service → Prisma (PostgreSQL)
                               → Redis (cache / queues)
                               → External APIs (Stripe, SendGrid, S3)
@@ -19,14 +19,14 @@ Client → Clerk JWT → NestJS JwtAuthGuard → RolesGuard (CASL)
 
 ## Role Model
 
-Roles are an enum in `@workspace/types`. Each role gets:
-- A dedicated page directory in `frontend/src/pages/<role>/`
-- CASL ability definitions in `api/src/modules/auth/`
-- Route guards in `frontend/src/App.tsx`
+Roles are defined as `UserRole` in Prisma's generated client. Each role gets:
+- Page files in `frontend/pages/` (route targets in `frontend/App.tsx`)
+- CASL ability definitions in `api/src/auth/ability/`
+- Route guards in `frontend/App.tsx`
 
 ## Module Dependency Rules
 
-- All API modules import from `mod-auth` (guards)
+- All API modules import `ClerkAuthGuard` from `api/src/auth/guards/`
 - `mod-marketplace` → `mod-billing` (subscription gating)
 - `mod-leads` → `mod-mailing` (notifications)
 - `mod-email-notification` → `mod-mailing` (transport)
@@ -43,8 +43,8 @@ typescript-config → eslint-config → types → translations → ui
 
 ## Key Files to Know
 
-- `frontend/src/App.tsx` — all routes + role guards (800+ lines)
-- `api/src/app.module.ts` — root NestJS module, imports all 51 modules
+- `frontend/App.tsx` — all routes + role guards
+- `api/src/app.module.ts` — root NestJS module, imports all modules
 - `api/prisma/schema.prisma` — full DB schema
 - `render.yaml` — production service definitions
 - `turbo.json` — build task graph & caching config

--- a/.claude/topics/architecture.md
+++ b/.claude/topics/architecture.md
@@ -1,0 +1,50 @@
+# Architecture
+
+## Apps & Responsibilities
+
+| App | URL | Audience |
+|---|---|---|
+| `frontend/` | / | End users (all 7 roles) |
+| `admin/` | /admin | SUPER_ADMIN, ADMIN |
+| `api/` | /api | Both frontends + webhooks |
+
+## Request Lifecycle
+
+```
+Client → Clerk JWT → NestJS JwtAuthGuard → RolesGuard (CASL)
+       → Controller → Service → Prisma (PostgreSQL)
+                              → Redis (cache / queues)
+                              → External APIs (Stripe, SendGrid, S3)
+```
+
+## Role Model
+
+Roles are an enum in `@workspace/types`. Each role gets:
+- A dedicated page directory in `frontend/src/pages/<role>/`
+- CASL ability definitions in `api/src/modules/auth/`
+- Route guards in `frontend/src/App.tsx`
+
+## Module Dependency Rules
+
+- All API modules import from `mod-auth` (guards)
+- `mod-marketplace` → `mod-billing` (subscription gating)
+- `mod-leads` → `mod-mailing` (notifications)
+- `mod-email-notification` → `mod-mailing` (transport)
+- `mod-dashboard` → `mod-analytics` (data source)
+- `mod-elearning` → `mod-content` (content storage)
+
+## Shared Packages Build Order
+
+```
+typescript-config → eslint-config → types → translations → ui
+                                                            ↓
+                                              frontend / admin / api
+```
+
+## Key Files to Know
+
+- `frontend/src/App.tsx` — all routes + role guards (800+ lines)
+- `api/src/app.module.ts` — root NestJS module, imports all 51 modules
+- `api/prisma/schema.prisma` — full DB schema
+- `render.yaml` — production service definitions
+- `turbo.json` — build task graph & caching config

--- a/.claude/topics/debugging.md
+++ b/.claude/topics/debugging.md
@@ -11,8 +11,8 @@
 
 ### Auth / 401
 - Clerk JWT expired or not forwarded — check `Authorization` header
-- User not synced to DB — check `api/src/modules/auth/` webhook handler
-- Missing CASL ability — check `auth/ability.factory.ts`
+- User not synced to DB — check `api/src/auth/` webhook handler
+- Missing CASL ability — check `api/src/auth/ability/ability.factory.ts`
 
 ### Role-based UI not showing
 - Route guard in `App.tsx` not matching the role enum value
@@ -20,8 +20,8 @@
 - Clerk user metadata missing `role` field
 
 ### i18n key missing / untranslated
-- Run `pnpm i18n:extract` then `pnpm i18n:check`
-- Check `frontend/src/i18n/locales/` for the key
+- Run `pnpm extract:i18n-keys` then `pnpm check:i18n-keys`
+- Check `frontend/i18n/locales/` for the key
 - Pre-commit hook will catch hardcoded strings
 
 ### API 500
@@ -30,18 +30,18 @@
 - Redis connection issues — check Bull queue setup
 
 ### WebSocket / messaging not connecting
-- Check `MessagingContext` — Socket.io client config
-- Check `api/src/modules/messaging/` for CORS & auth middleware
+- Check `frontend/contexts/MessagingContext.tsx` — Socket.io client config
+- Check `api/src/messaging/` for CORS & auth middleware
 
 ### Stripe webhook not processing
-- Check `api/src/modules/billing/` webhook controller
+- Check `api/src/billing/` webhook controller
 - Verify `STRIPE_WEBHOOK_SECRET` env var is set
 
 ## Debug Commands
 
 ```bash
 pnpm db:status          # Check migration state
-pnpm i18n:check         # Validate translation coverage
+pnpm check:i18n-keys    # Validate translation coverage
 pnpm type-check         # Catch TS errors across all packages
 pnpm lint               # ESLint across monorepo
 ```

--- a/.claude/topics/debugging.md
+++ b/.claude/topics/debugging.md
@@ -1,0 +1,47 @@
+# Debugging Patterns
+
+## General Flow
+
+1. Check `graphify-out/GRAPH_REPORT.md` to identify the module
+2. Read the specific module file — don't grep broadly
+3. Check the relevant context/hook in frontend if it's a UI bug
+4. Check Prisma schema if it's a data issue
+
+## Common Failure Modes
+
+### Auth / 401
+- Clerk JWT expired or not forwarded — check `Authorization` header
+- User not synced to DB — check `api/src/modules/auth/` webhook handler
+- Missing CASL ability — check `auth/ability.factory.ts`
+
+### Role-based UI not showing
+- Route guard in `App.tsx` not matching the role enum value
+- `AppContext` not hydrated yet (loading state not handled)
+- Clerk user metadata missing `role` field
+
+### i18n key missing / untranslated
+- Run `pnpm i18n:extract` then `pnpm i18n:check`
+- Check `frontend/src/i18n/locales/` for the key
+- Pre-commit hook will catch hardcoded strings
+
+### API 500
+- Check NestJS exception filter output in logs
+- Check if Prisma migration is out of sync (`pnpm db:status`)
+- Redis connection issues — check Bull queue setup
+
+### WebSocket / messaging not connecting
+- Check `MessagingContext` — Socket.io client config
+- Check `api/src/modules/messaging/` for CORS & auth middleware
+
+### Stripe webhook not processing
+- Check `api/src/modules/billing/` webhook controller
+- Verify `STRIPE_WEBHOOK_SECRET` env var is set
+
+## Debug Commands
+
+```bash
+pnpm db:status          # Check migration state
+pnpm i18n:check         # Validate translation coverage
+pnpm type-check         # Catch TS errors across all packages
+pnpm lint               # ESLint across monorepo
+```

--- a/.claude/topics/deployment.md
+++ b/.claude/topics/deployment.md
@@ -47,24 +47,29 @@ typescript-config → eslint-config → types → translations → ui
                                               frontend / admin / api
 ```
 
+## Render Build Commands (from render.yaml)
+
+```
+frontend:  pnpm run prebuild:render && cd frontend && pnpm install && pnpm run build:render
+api:       pnpm run prebuild:render && cd api && pnpm install && pnpm run build:render
+admin:     pnpm run prebuild:render && cd admin && pnpm install && pnpm run build
+```
+
+`pnpm run prebuild:render` runs `scripts/prebuild-lock-check.mjs` — a lock file
+validation only. The full API setup (DB migrations, seeds) happens inside `build:render`.
+
 ## Deploy Steps (manual)
 
 1. Push to `main` — Render auto-deploys on merge
-2. Run migrations: `pnpm db:migrate` (in API build command)
-3. Check `pnpm db:status` if migration is stuck
-
-## Render Build Commands
-
-- **API**: `pnpm install && pnpm build && pnpm db:migrate`
-- **Frontend**: `pnpm install && pnpm build`
-- **Admin**: `pnpm install && pnpm build`
+2. Migrations run automatically as part of `build:render` in the API service
+3. Check `pnpm db:status` if migration state is unclear
 
 ## Common Deploy Failures
 
 | Symptom | Check |
 |---|---|
-| API won't start | `DATABASE_URL` / `REDIS_URL` missing |
+| API won't start | `DATABASE_URL` / `REDIS_URL` missing or wrong |
 | Clerk 401 | `CLERK_SECRET_KEY` wrong or expired |
 | Stripe webhook 400 | `STRIPE_WEBHOOK_SECRET` mismatch |
-| Build fails | Run `pnpm prebuild:render` locally first |
+| Build fails at lock check | Run `pnpm install` locally to regenerate `pnpm-lock.yaml` |
 | Migration stuck | Check `api/prisma/migrations/` for conflicts |

--- a/.claude/topics/deployment.md
+++ b/.claude/topics/deployment.md
@@ -1,0 +1,70 @@
+# Deployment
+
+## Platform: Render.com
+
+All services are defined in `render.yaml`. Three services:
+- `api` — NestJS (web service)
+- `frontend` — React SPA (static site)
+- `admin` — Admin React SPA (static site)
+
+## Environment Variables
+
+### API required vars
+```
+DATABASE_URL          PostgreSQL connection string
+REDIS_URL             Redis connection string
+CLERK_SECRET_KEY      Clerk backend secret
+CLERK_WEBHOOK_SECRET  Clerk webhook signing secret
+STRIPE_SECRET_KEY     Stripe API key
+STRIPE_WEBHOOK_SECRET Stripe webhook signing secret
+```
+
+See `env-example-*.txt` files at repo root for full lists.
+
+### Frontend / Admin required vars
+```
+VITE_API_URL          API base URL
+VITE_CLERK_PUBLISHABLE_KEY  Clerk publishable key
+```
+
+## Docker (local dev)
+
+```bash
+docker-compose up         # Start all services + dependencies
+docker-compose up api     # Start only API
+```
+
+Config in `docker/` and `docker-compose.yml`.
+
+Override local config in `docker-compose.override.yml`.
+
+## Build Order
+
+Turborepo enforces this via `turbo.json`:
+```
+typescript-config → eslint-config → types → translations → ui
+                                                            ↓
+                                              frontend / admin / api
+```
+
+## Deploy Steps (manual)
+
+1. Push to `main` — Render auto-deploys on merge
+2. Run migrations: `pnpm db:migrate` (in API build command)
+3. Check `pnpm db:status` if migration is stuck
+
+## Render Build Commands
+
+- **API**: `pnpm install && pnpm build && pnpm db:migrate`
+- **Frontend**: `pnpm install && pnpm build`
+- **Admin**: `pnpm install && pnpm build`
+
+## Common Deploy Failures
+
+| Symptom | Check |
+|---|---|
+| API won't start | `DATABASE_URL` / `REDIS_URL` missing |
+| Clerk 401 | `CLERK_SECRET_KEY` wrong or expired |
+| Stripe webhook 400 | `STRIPE_WEBHOOK_SECRET` mismatch |
+| Build fails | Run `pnpm prebuild:render` locally first |
+| Migration stuck | Check `api/prisma/migrations/` for conflicts |

--- a/.claude/topics/patterns.md
+++ b/.claude/topics/patterns.md
@@ -1,0 +1,66 @@
+# Patterns
+
+## NestJS Conventions
+
+### Module structure (`api/src/<module>/`)
+```
+<module>/
+├── <module>.module.ts      — NestJS module definition
+├── <module>.controller.ts  — HTTP routes
+├── <module>.service.ts     — Business logic
+├── dto/                    — Request/response DTOs (class-validator)
+└── guards/                 — Module-specific guards (if any)
+```
+
+### Guards order
+Always apply in this order on controllers:
+1. `@UseGuards(JwtAuthGuard)` — validates Clerk JWT
+2. `@UseGuards(RolesGuard)` — CASL role check
+3. `@Roles(Role.ADMIN, ...)` — specify allowed roles
+
+### DTOs
+- Use `class-validator` decorators (`@IsString()`, `@IsOptional()`, etc.)
+- Use `class-transformer` (`@Type(() => Number)`) for nested types
+- Always use `@ApiProperty()` for Swagger docs
+
+### Services
+- Inject `PrismaService` for DB access
+- Inject other services directly (NestJS handles DI)
+- Throw `NotFoundException`, `ForbiddenException` from `@nestjs/common`
+
+## React Conventions
+
+### File structure (`frontend/src/` and `admin/src/`)
+```
+components/<domain>/
+  <ComponentName>.tsx       — component file
+  <ComponentName>.test.tsx  — co-located tests (Vitest)
+hooks/
+  use<HookName>.ts          — custom hooks
+```
+
+### Data fetching
+- Use `@tanstack/react-query` (`useQuery`, `useMutation`)
+- API calls go in `services/` files, not inline in components
+- Wrap with `QueryClientProvider` at app root
+
+### Translations
+- Always use `useTranslation()` from `react-i18next`
+- Never hardcode user-visible strings — use `t('key')`
+- Pre-commit hook enforces this
+
+### Role-based rendering
+- Check role from `AppContext` (frontend) or session (admin)
+- Use route guards in `App.tsx` — don't duplicate in components
+
+## Shared Package Patterns
+
+### @workspace/types
+- All cross-app interfaces live here
+- Import with `import type { ... } from '@workspace/types'`
+- Enum: `Role` — use everywhere, never re-define locally
+
+### @repo/ui
+- Shared primitive components (Button, Input, Card, etc.)
+- Import with `import { ... } from '@repo/ui'`
+- Do not duplicate these in app-level `components/`

--- a/.claude/topics/patterns.md
+++ b/.claude/topics/patterns.md
@@ -14,9 +14,12 @@
 
 ### Guards order
 Always apply in this order on controllers:
-1. `@UseGuards(JwtAuthGuard)` — validates Clerk JWT
-2. `@UseGuards(RolesGuard)` — CASL role check
-3. `@Roles(Role.ADMIN, ...)` — specify allowed roles
+1. `@UseGuards(ClerkAuthGuard, RolesGuard)` — auth then RBAC
+2. `@Roles(UserRole.ADMIN, ...)` — specify allowed roles
+
+Where `ClerkAuthGuard` is from `../auth/guards/clerk-auth.guard` and
+`RolesGuard` is from `../auth/guards/roles.guard`. The `UserRole` enum
+comes from Prisma's generated client (not `@workspace/types`).
 
 ### DTOs
 - Use `class-validator` decorators (`@IsString()`, `@IsOptional()`, etc.)
@@ -30,13 +33,16 @@ Always apply in this order on controllers:
 
 ## React Conventions
 
-### File structure (`frontend/src/` and `admin/src/`)
+### File structure
+
 ```
-components/<domain>/
-  <ComponentName>.tsx       — component file
-  <ComponentName>.test.tsx  — co-located tests (Vitest)
-hooks/
-  use<HookName>.ts          — custom hooks
+frontend/
+├── pages/        Page-level components (route targets)
+├── components/   Feature-domain component directories
+├── contexts/     React context providers (AppContext, etc.)
+├── hooks/        Custom hooks
+├── services/     API fetchers
+└── App.tsx       All routes + role guards
 ```
 
 ### Data fetching
@@ -58,7 +64,6 @@ hooks/
 ### @workspace/types
 - All cross-app interfaces live here
 - Import with `import type { ... } from '@workspace/types'`
-- Enum: `Role` — use everywhere, never re-define locally
 
 ### @repo/ui
 - Shared primitive components (Button, Input, Card, etc.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# PC-Solutions-Platform
+
+## Graph-First Navigation
+
+Before any broad repo exploration, **read `graphify-out/GRAPH_REPORT.md`** first.
+Use it to identify the relevant module/path, then do targeted reads only.
+
+## Working Rules
+
+- Read graph report → identify module → targeted `Read`/`Grep` on that path
+- Avoid repo-wide `Glob`/`Grep` unless the graph is missing or stale
+- Summarize command output; do not paste full logs
+- Keep edits scoped to the task; do not touch unrelated files
+- For architecture questions, consult `graphify-out/GRAPH_REPORT.md` first
+- Load `.claude/topics/` files only when the task explicitly needs them
+
+## Search Lanes
+
+| Issue area | Start here |
+|---|---|
+| UI / frontend pages | `frontend/src/pages/` |
+| Frontend components | `frontend/src/components/` |
+| Frontend state / hooks | `frontend/src/contexts/`, `frontend/src/hooks/` |
+| Admin dashboard | `admin/src/` |
+| API modules | `api/src/<module-name>/` |
+| Auth / sessions / RBAC | `api/src/auth/`, `frontend/src/contexts/` |
+| Billing / Stripe | `api/src/billing/` |
+| Real-time messaging | `api/src/messaging/` |
+| i18n / translations | `packages/translations/`, `frontend/src/i18n/` |
+| Shared types | `packages/types/src/` |
+| Shared UI components | `packages/ui/src/` |
+| Database / migrations | `api/prisma/` |
+| Config / build / deploy | `turbo.json`, `render.yaml`, `docker/` |
+| Tests | `**/*.spec.ts`, `frontend/tests/` |
+| Scripts / automation | `scripts/` |
+
+## Tech Stack (quick ref)
+
+- **Monorepo**: Turborepo + pnpm 9
+- **Frontend**: React 19 + Vite + Tailwind + React Query + react-router-dom 7
+- **Admin**: React 19 + Vite (separate app, same auth)
+- **API**: NestJS 11 + Prisma 6 + PostgreSQL + Redis + Socket.io
+- **Auth**: Clerk (JWT + webhook sync to DB)
+- **Roles**: SUPER_ADMIN · ADMIN · FOUNDATION · PRODUCT_SUPPLIER · SERVICE_PROVIDER · EDUCATOR · PARENT
+
+## Topic Files (load only when relevant)
+
+- `.claude/topics/architecture.md` — system design, data flow, role model, module map
+- `.claude/topics/debugging.md` — debugging patterns, common failure modes
+- `.claude/topics/patterns.md` — NestJS/React conventions, file structure rules
+- `.claude/topics/deployment.md` — Render.com deploy, env vars, Docker setup

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,0 +1,244 @@
+# PC-Solutions-Platform — Graph Report
+
+Generated: 2026-04-18 | Tool: graphify v1.0 (static analysis)
+
+---
+
+## Module Map
+
+```
+pc-solutions-platform/
+├── frontend/          React 19 SPA — 7-role marketplace UI
+├── admin/             React 19 SPA — back-office dashboard
+├── api/               NestJS — centralized REST + WebSocket API
+└── packages/
+    ├── eslint-config/
+    ├── translations/
+    ├── types/
+    ├── typescript-config/
+    ├── ui/
+```
+
+---
+
+## API Modules (43 modules under `api/src/`)
+
+| Module | Key responsibility | Notable deps |
+|---|---|---|
+| `admin` | Back-office ops, role management | auth |
+| `analytics` | User behaviour tracking | — |
+| `auth` | JWT validation, Clerk sync, CASL RBAC | Clerk, Passport, CASL |
+| `billing` | Stripe subscriptions + payments | Stripe SDK |
+| `categories` | Product/service taxonomy | — |
+| `content` | CMS-style content management | — |
+| `content-management` | CMS content CRUD | content |
+| `content-moderation` | Content review & moderation | content |
+| `crawler` | Web content crawling & classification | — |
+| `dashboard` | Aggregated stats per role | analytics |
+| `elearning` | Learning content, courses | content |
+| `email-notification` | Transactional notifications | mailing |
+| `frontend-settings` | Feature flags, per-role config | — |
+| `health` | Health check endpoint | — |
+| `leads` | Lead capture & CRM pipeline | mailing |
+| `mailing` | Email campaigns | SendGrid, Mailgun |
+| `maintenance` | Maintenance mode controls | — |
+| `marketplace` | Product catalog, ordering, search | billing, categories |
+| `messaging` | Real-time chat (Socket.io) | Redis |
+| `metrics` | Platform metrics & health | — |
+| `organization-documents` | Org document storage | upload |
+| `partners` | Partner integrations | — |
+| `platform-settings` | Global platform configuration | — |
+| `policy-alerts` | Policy change alerts | mailing |
+| `principal` | Principal/org entity management | — |
+| `profiles` | User profile data | auth |
+| `promo-codes` | Promotional code management | billing |
+| `recruitment` | Job/candidate matching | — |
+| `security` | Security audit logging | — |
+| `settings` | Per-user settings | — |
+| `static-translation` | Static i18n string delivery | — |
+| `subscription-management` | Subscription lifecycle ops | billing |
+| `support` | Support tickets | — |
+| `sync` | Data sync jobs | — |
+| `system-configuration` | System-level config | — |
+| `system-monitoring` | System health monitoring | metrics |
+| `translation` | Dynamic translation management | — |
+| `translation-errors` | Translation error tracking | — |
+| `upload` | File upload & S3 storage | — |
+| `user-management` | Admin user management ops | auth |
+| `users` | User account management | auth |
+| `vendor-clients` | Third-party vendor client wrappers | — |
+| `webhooks` | Incoming webhook handlers (Clerk, Stripe) | auth, billing |
+
+---
+
+## Frontend Pages (`frontend/src/pages/`)
+
+```
+pages/
+*(none found)*
+```
+
+**Main router**: `frontend/src/App.tsx` — contains all role-based route guards.
+
+---
+
+## Admin App (`admin/src/`)
+
+### Pages
+- `AccessDenied`
+- `AdminOrganizationProfileEdit`
+- `AdminUserProfileEdit`
+- `Candidates`
+- `CantonDetail`
+- `Cantons`
+- `Content`
+- `Dashboard`
+- `DesignSystem`
+- `DiscountTerminations`
+- `EmailNotificationPage`
+- `JobListings`
+- `MailingCampaignDetail`
+- `MailingList`
+- `Messaging`
+- `Orders`
+- `Organizations`
+- `ParentLeads`
+- `Partners`
+- `PolicyCrawler`
+- `PolicyReview`
+- `Products`
+- `ResetPassword`
+- `Services`
+- `Settings`
+- `Subscriptions`
+- `Support`
+- `SupportTicket`
+- `SystemConfigurationPage`
+- `SystemMonitor`
+- `Translations`
+- `Users`
+
+### Component Directories
+- `auth/`
+- `design-system/`
+- `forms/`
+- `mailing/`
+- `messaging/`
+- `products/`
+- `services/`
+- `settings/`
+- `support/`
+- `ui/`
+
+---
+
+## Frontend Component Domains (`frontend/src/components/`)
+
+| Directory | Contains |
+|---|---|
+| `verification/` | — |
+
+---
+
+## Context Providers (`frontend/src/contexts/`)
+
+| Context | Purpose |
+|---|---|
+| *(none found)* | — |
+
+---
+
+## Shared Packages
+
+| Package | Import path | Use case |
+|---|---|---|
+| `@repo/eslint-config` | `@repo/eslint-config` | — |
+| `@workspace/translations` | `@workspace/translations` | — |
+| `@workspace/types` | `@workspace/types` | — |
+| `@repo/typescript-config` | `@repo/typescript-config` | — |
+| `@repo/ui` | `@repo/ui` | — |
+
+---
+
+## Data Flow: Typical Request
+
+```
+Browser
+  └── Clerk JWT (Authorization header)
+        └── NestJS API Gateway
+              ├── JwtAuthGuard (validates Clerk token)
+              ├── RolesGuard (CASL ability check)
+              └── Module Controller
+                    ├── Service (business logic)
+                    ├── Prisma ORM → PostgreSQL
+                    ├── Redis (cache / Bull job queue)
+                    └── External: Stripe / SendGrid / S3
+```
+
+---
+
+## Auth & Role Model
+
+- **Provider**: Clerk (hosted auth UI + JWT)
+- **Sync**: Clerk webhooks → `api/src/auth/` → Prisma User record
+- **RBAC**: CASL `ability` definitions scoped per role
+- **Roles** (enum in `@workspace/types`):
+  - `SUPER_ADMIN` — full platform access
+  - `ADMIN` — managed admin access (uses `/admin` app)
+  - `FOUNDATION` — grant/program management
+  - `PRODUCT_SUPPLIER` — product catalog & orders
+  - `SERVICE_PROVIDER` — service listings & leads
+  - `EDUCATOR` — availability, elearning, parent-facing profile
+  - `PARENT` — marketplace browsing, child management
+
+---
+
+## Key Entry Points
+
+| File | Role |
+|---|---|
+| `frontend/src/main.tsx` | Frontend SPA entry |
+| `frontend/src/App.tsx` | All frontend routes + role guards |
+| `admin/src/main.tsx` | Admin SPA entry |
+| `api/src/main.ts` | NestJS bootstrap |
+| `api/src/app.module.ts` | Root NestJS module (imports all modules) |
+| `api/prisma/schema.prisma` | Full DB schema |
+| `turbo.json` | Build task graph |
+| `render.yaml` | Production deployment spec |
+
+---
+
+## Dependency Graph (inter-module)
+
+```
+frontend  ──imports──▶  @repo/ui, @workspace/types, @workspace/translations
+admin     ──imports──▶  @repo/ui, @workspace/types, @workspace/translations
+api       ──imports──▶  @workspace/types, @workspace/translations
+
+api/auth    ◀── guards ── all other api modules
+api/billing ◀── checks ── marketplace, elearning, leads
+api/mailing ◀── sends  ── email-notification, leads, auth
+api/messaging ◀── socket ── frontend
+```
+
+---
+
+## Build & Scripts
+
+| Script | Purpose |
+|---|---|
+| `pnpm build` | Turborepo build all apps |
+| `pnpm dev` | Dev servers for all apps |
+| `pnpm lint` / `lint:fix` | ESLint across all packages |
+| `pnpm type-check` | TS check across all packages |
+| `pnpm test` | Vitest + Playwright |
+| `pnpm db:migrate` | Prisma migrate deploy |
+| `pnpm graphify` | Regenerate this graph report |
+
+---
+
+## Maintenance Notes
+
+- Regenerate this report after major structural changes: `pnpm graphify`
+- Update `graph.json` is regenerated automatically by the same command
+- Report path: `graphify-out/GRAPH_REPORT.md`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -27,7 +27,7 @@ pc-solutions-platform/
 |---|---|---|
 | `admin` | Back-office ops, role management | auth |
 | `analytics` | User behaviour tracking | — |
-| `auth` | JWT validation, Clerk sync, CASL RBAC | Clerk, Passport, CASL |
+| `auth` | Clerk auth, CASL RBAC, guard definitions | Clerk, Passport, CASL |
 | `billing` | Stripe subscriptions + payments | Stripe SDK |
 | `categories` | Product/service taxonomy | — |
 | `content` | CMS-style content management | — |
@@ -71,20 +71,55 @@ pc-solutions-platform/
 
 ---
 
-## Frontend Pages (`frontend/src/pages/`)
+## Frontend Pages (`frontend/pages/`)
 
 ```
 pages/
-*(none found)*
+├── admin/
+├── candidate/
+├── educator/
+├── foundation/
+├── parent/
+├── partner/
+├── profile/
+├── service-provider/
+├── supplier/
+├── DashboardDetailPage.tsx
+├── DashboardPage.tsx
+├── DesignSystemPage.tsx
+├── ELearningPage.tsx
+├── FileGalleryPage.tsx
+├── FoundationLeadsPage.tsx
+├── HRProceduresPage.tsx
+├── LoginPage.tsx
+├── LoginPageE2E.tsx
+├── MarketplacePage.tsx
+├── MessagesPage.tsx
+├── NotificationsPage.tsx
+├── ParentEnquiriesPage.tsx
+├── ParentLeadFormPage.tsx
+├── PartnersPage.tsx
+├── PricingPage.tsx
+├── ProfileEditPage.tsx
+├── ProfilePage.tsx
+├── PublicPartnersPage.tsx
+├── RecruitmentPage.tsx
+├── ResetPasswordPage.tsx
+├── ServiceProviderSettingsPage.tsx
+├── SettingsPage.tsx
+├── SignupPage.tsx
+├── SignupPageE2E.tsx
+├── StatePoliciesPage.tsx
+├── UsersPage.tsx
 ```
 
-**Main router**: `frontend/src/App.tsx` — contains all role-based route guards.
+**Main router**: `frontend/App.tsx` — contains all role-based route guards.
 
 ---
 
 ## Admin App (`admin/src/`)
 
-### Pages
+### Pages (36 total)
 - `AccessDenied`
 - `AdminOrganizationProfileEdit`
 - `AdminUserProfileEdit`
@@ -117,6 +152,10 @@ pages/
 - `SystemMonitor`
 - `Translations`
 - `Users`
+- `content/ContentShared`
+- `content/ELearningContentPage`
+- `content/HrDocumentsPage`
+- `content/StatePoliciesPage`
 
 ### Component Directories
 - `auth/`
@@ -132,19 +171,39 @@ pages/
 
 ---
 
-## Frontend Component Domains (`frontend/src/components/`)
+## Frontend Component Domains (`frontend/components/`)
 
 | Directory | Contains |
 |---|---|
-| `verification/` | — |
+| `admin/` | — |
+| `availability/` | — |
+| `cart/` | — |
+| `foundation/` | — |
+| `help/` | — |
+| `icons/` | — |
+| `layout/` | — |
+| `marketplace/` | — |
+| `messaging/` | — |
+| `profile/` | — |
+| `recruitment/` | — |
+| `service-provider/` | — |
+| `settings/` | — |
+| `shared/` | — |
+| `supplier/` | — |
+| `support/` | — |
+| `ui/` | — |
 
 ---
 
-## Context Providers (`frontend/src/contexts/`)
+## Context Providers (`frontend/contexts/`)
 
 | Context | Purpose |
 |---|---|
-| *(none found)* | — |
+| `AppContext` | — |
+| `CartContext` | — |
+| `MessagingContext` | — |
+| `NotificationContext` | — |
+| `SubscriptionContext` | — |
 
 ---
 
@@ -166,7 +225,7 @@ pages/
 Browser
   └── Clerk JWT (Authorization header)
         └── NestJS API Gateway
-              ├── JwtAuthGuard (validates Clerk token)
+              ├── ClerkAuthGuard (validates Clerk token)
               ├── RolesGuard (CASL ability check)
               └── Module Controller
                     ├── Service (business logic)
@@ -181,7 +240,8 @@ Browser
 
 - **Provider**: Clerk (hosted auth UI + JWT)
 - **Sync**: Clerk webhooks → `api/src/auth/` → Prisma User record
-- **RBAC**: CASL `ability` definitions scoped per role
+- **RBAC**: CASL `ability` definitions in `api/src/auth/ability/`
+- **Guards**: `ClerkAuthGuard` + `RolesGuard` (from `api/src/auth/guards/`)
 - **Roles** (enum in `@workspace/types`):
   - `SUPER_ADMIN` — full platform access
   - `ADMIN` — managed admin access (uses `/admin` app)
@@ -197,8 +257,8 @@ Browser
 
 | File | Role |
 |---|---|
-| `frontend/src/main.tsx` | Frontend SPA entry |
-| `frontend/src/App.tsx` | All frontend routes + role guards |
+| `frontend/index.tsx` | Frontend SPA entry |
+| `frontend/App.tsx` | All frontend routes + role guards |
 | `admin/src/main.tsx` | Admin SPA entry |
 | `api/src/main.ts` | NestJS bootstrap |
 | `api/src/app.module.ts` | Root NestJS module (imports all modules) |
@@ -240,5 +300,5 @@ api/messaging ◀── socket ── frontend
 ## Maintenance Notes
 
 - Regenerate this report after major structural changes: `pnpm graphify`
-- Update `graph.json` is regenerated automatically by the same command
+- `graph.json` is regenerated automatically by the same command
 - Report path: `graphify-out/GRAPH_REPORT.md`

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1,0 +1,343 @@
+{
+  "version": "1.0",
+  "generated": "2026-04-18",
+  "repo": "pc-solutions-platform",
+  "type": "monorepo",
+  "nodes": [
+    {
+      "id": "frontend",
+      "type": "app",
+      "path": "frontend/",
+      "tech": "React 19 + Vite + Tailwind",
+      "entry": "frontend/src/main.tsx"
+    },
+    {
+      "id": "admin",
+      "type": "app",
+      "path": "admin/",
+      "tech": "React 19 + Vite",
+      "entry": "admin/src/main.tsx"
+    },
+    {
+      "id": "api",
+      "type": "app",
+      "path": "api/",
+      "tech": "NestJS",
+      "entry": "api/src/main.ts"
+    },
+    {
+      "id": "pkg-eslint-config",
+      "type": "package",
+      "path": "packages/eslint-config/",
+      "name": "@repo/eslint-config"
+    },
+    {
+      "id": "pkg-translations",
+      "type": "package",
+      "path": "packages/translations/",
+      "name": "@workspace/translations"
+    },
+    {
+      "id": "pkg-types",
+      "type": "package",
+      "path": "packages/types/",
+      "name": "@workspace/types"
+    },
+    {
+      "id": "pkg-typescript-config",
+      "type": "package",
+      "path": "packages/typescript-config/",
+      "name": "@repo/typescript-config"
+    },
+    {
+      "id": "pkg-ui",
+      "type": "package",
+      "path": "packages/ui/",
+      "name": "@repo/ui"
+    },
+    {
+      "id": "mod-admin",
+      "type": "api-module",
+      "path": "api/src/admin/"
+    },
+    {
+      "id": "mod-analytics",
+      "type": "api-module",
+      "path": "api/src/analytics/"
+    },
+    {
+      "id": "mod-auth",
+      "type": "api-module",
+      "path": "api/src/auth/"
+    },
+    {
+      "id": "mod-billing",
+      "type": "api-module",
+      "path": "api/src/billing/"
+    },
+    {
+      "id": "mod-categories",
+      "type": "api-module",
+      "path": "api/src/categories/"
+    },
+    {
+      "id": "mod-content",
+      "type": "api-module",
+      "path": "api/src/content/"
+    },
+    {
+      "id": "mod-content-management",
+      "type": "api-module",
+      "path": "api/src/content-management/"
+    },
+    {
+      "id": "mod-content-moderation",
+      "type": "api-module",
+      "path": "api/src/content-moderation/"
+    },
+    {
+      "id": "mod-crawler",
+      "type": "api-module",
+      "path": "api/src/crawler/"
+    },
+    {
+      "id": "mod-dashboard",
+      "type": "api-module",
+      "path": "api/src/dashboard/"
+    },
+    {
+      "id": "mod-elearning",
+      "type": "api-module",
+      "path": "api/src/elearning/"
+    },
+    {
+      "id": "mod-email-notification",
+      "type": "api-module",
+      "path": "api/src/email-notification/"
+    },
+    {
+      "id": "mod-frontend-settings",
+      "type": "api-module",
+      "path": "api/src/frontend-settings/"
+    },
+    {
+      "id": "mod-health",
+      "type": "api-module",
+      "path": "api/src/health/"
+    },
+    {
+      "id": "mod-leads",
+      "type": "api-module",
+      "path": "api/src/leads/"
+    },
+    {
+      "id": "mod-mailing",
+      "type": "api-module",
+      "path": "api/src/mailing/"
+    },
+    {
+      "id": "mod-maintenance",
+      "type": "api-module",
+      "path": "api/src/maintenance/"
+    },
+    {
+      "id": "mod-marketplace",
+      "type": "api-module",
+      "path": "api/src/marketplace/"
+    },
+    {
+      "id": "mod-messaging",
+      "type": "api-module",
+      "path": "api/src/messaging/"
+    },
+    {
+      "id": "mod-metrics",
+      "type": "api-module",
+      "path": "api/src/metrics/"
+    },
+    {
+      "id": "mod-organization-documents",
+      "type": "api-module",
+      "path": "api/src/organization-documents/"
+    },
+    {
+      "id": "mod-partners",
+      "type": "api-module",
+      "path": "api/src/partners/"
+    },
+    {
+      "id": "mod-platform-settings",
+      "type": "api-module",
+      "path": "api/src/platform-settings/"
+    },
+    {
+      "id": "mod-policy-alerts",
+      "type": "api-module",
+      "path": "api/src/policy-alerts/"
+    },
+    {
+      "id": "mod-principal",
+      "type": "api-module",
+      "path": "api/src/principal/"
+    },
+    {
+      "id": "mod-profiles",
+      "type": "api-module",
+      "path": "api/src/profiles/"
+    },
+    {
+      "id": "mod-promo-codes",
+      "type": "api-module",
+      "path": "api/src/promo-codes/"
+    },
+    {
+      "id": "mod-recruitment",
+      "type": "api-module",
+      "path": "api/src/recruitment/"
+    },
+    {
+      "id": "mod-security",
+      "type": "api-module",
+      "path": "api/src/security/"
+    },
+    {
+      "id": "mod-settings",
+      "type": "api-module",
+      "path": "api/src/settings/"
+    },
+    {
+      "id": "mod-static-translation",
+      "type": "api-module",
+      "path": "api/src/static-translation/"
+    },
+    {
+      "id": "mod-subscription-management",
+      "type": "api-module",
+      "path": "api/src/subscription-management/"
+    },
+    {
+      "id": "mod-support",
+      "type": "api-module",
+      "path": "api/src/support/"
+    },
+    {
+      "id": "mod-sync",
+      "type": "api-module",
+      "path": "api/src/sync/"
+    },
+    {
+      "id": "mod-system-configuration",
+      "type": "api-module",
+      "path": "api/src/system-configuration/"
+    },
+    {
+      "id": "mod-system-monitoring",
+      "type": "api-module",
+      "path": "api/src/system-monitoring/"
+    },
+    {
+      "id": "mod-translation",
+      "type": "api-module",
+      "path": "api/src/translation/"
+    },
+    {
+      "id": "mod-translation-errors",
+      "type": "api-module",
+      "path": "api/src/translation-errors/"
+    },
+    {
+      "id": "mod-upload",
+      "type": "api-module",
+      "path": "api/src/upload/"
+    },
+    {
+      "id": "mod-user-management",
+      "type": "api-module",
+      "path": "api/src/user-management/"
+    },
+    {
+      "id": "mod-users",
+      "type": "api-module",
+      "path": "api/src/users/"
+    },
+    {
+      "id": "mod-vendor-clients",
+      "type": "api-module",
+      "path": "api/src/vendor-clients/"
+    },
+    {
+      "id": "mod-webhooks",
+      "type": "api-module",
+      "path": "api/src/webhooks/"
+    },
+    {
+      "id": "fc-verification",
+      "type": "frontend-component-dir",
+      "path": "frontend/src/components/verification/"
+    }
+  ],
+  "edges": [
+    {
+      "from": "frontend",
+      "to": "pkg-ui"
+    },
+    {
+      "from": "frontend",
+      "to": "pkg-types"
+    },
+    {
+      "from": "frontend",
+      "to": "pkg-translations"
+    },
+    {
+      "from": "admin",
+      "to": "pkg-ui"
+    },
+    {
+      "from": "admin",
+      "to": "pkg-types"
+    },
+    {
+      "from": "admin",
+      "to": "pkg-translations"
+    },
+    {
+      "from": "api",
+      "to": "pkg-types"
+    },
+    {
+      "from": "api",
+      "to": "pkg-translations"
+    },
+    {
+      "from": "mod-marketplace",
+      "to": "mod-billing"
+    },
+    {
+      "from": "mod-marketplace",
+      "to": "mod-categories"
+    },
+    {
+      "from": "mod-leads",
+      "to": "mod-mailing"
+    },
+    {
+      "from": "mod-email-notification",
+      "to": "mod-mailing"
+    },
+    {
+      "from": "mod-dashboard",
+      "to": "mod-analytics"
+    },
+    {
+      "from": "mod-elearning",
+      "to": "mod-content"
+    }
+  ],
+  "meta": {
+    "apiModuleCount": 43,
+    "packageCount": 5,
+    "adminPageCount": 32,
+    "frontendComponentDirCount": 1
+  }
+}

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "type": "app",
       "path": "frontend/",
       "tech": "React 19 + Vite + Tailwind",
-      "entry": "frontend/src/main.tsx"
+      "entry": "frontend/index.tsx"
     },
     {
       "id": "admin",
@@ -58,222 +58,780 @@
     {
       "id": "mod-admin",
       "type": "api-module",
-      "path": "api/src/admin/"
+      "path": "api/src/admin/",
+      "desc": "Back-office ops, role management"
     },
     {
       "id": "mod-analytics",
       "type": "api-module",
-      "path": "api/src/analytics/"
+      "path": "api/src/analytics/",
+      "desc": "User behaviour tracking"
     },
     {
       "id": "mod-auth",
       "type": "api-module",
-      "path": "api/src/auth/"
+      "path": "api/src/auth/",
+      "desc": "Clerk auth, CASL RBAC, guard definitions"
     },
     {
       "id": "mod-billing",
       "type": "api-module",
-      "path": "api/src/billing/"
+      "path": "api/src/billing/",
+      "desc": "Stripe subscriptions + payments"
     },
     {
       "id": "mod-categories",
       "type": "api-module",
-      "path": "api/src/categories/"
+      "path": "api/src/categories/",
+      "desc": "Product/service taxonomy"
     },
     {
       "id": "mod-content",
       "type": "api-module",
-      "path": "api/src/content/"
+      "path": "api/src/content/",
+      "desc": "CMS-style content management"
     },
     {
       "id": "mod-content-management",
       "type": "api-module",
-      "path": "api/src/content-management/"
+      "path": "api/src/content-management/",
+      "desc": "CMS content CRUD"
     },
     {
       "id": "mod-content-moderation",
       "type": "api-module",
-      "path": "api/src/content-moderation/"
+      "path": "api/src/content-moderation/",
+      "desc": "Content review & moderation"
     },
     {
       "id": "mod-crawler",
       "type": "api-module",
-      "path": "api/src/crawler/"
+      "path": "api/src/crawler/",
+      "desc": "Web content crawling & classification"
     },
     {
       "id": "mod-dashboard",
       "type": "api-module",
-      "path": "api/src/dashboard/"
+      "path": "api/src/dashboard/",
+      "desc": "Aggregated stats per role"
     },
     {
       "id": "mod-elearning",
       "type": "api-module",
-      "path": "api/src/elearning/"
+      "path": "api/src/elearning/",
+      "desc": "Learning content, courses"
     },
     {
       "id": "mod-email-notification",
       "type": "api-module",
-      "path": "api/src/email-notification/"
+      "path": "api/src/email-notification/",
+      "desc": "Transactional notifications"
     },
     {
       "id": "mod-frontend-settings",
       "type": "api-module",
-      "path": "api/src/frontend-settings/"
+      "path": "api/src/frontend-settings/",
+      "desc": "Feature flags, per-role config"
     },
     {
       "id": "mod-health",
       "type": "api-module",
-      "path": "api/src/health/"
+      "path": "api/src/health/",
+      "desc": "Health check endpoint"
     },
     {
       "id": "mod-leads",
       "type": "api-module",
-      "path": "api/src/leads/"
+      "path": "api/src/leads/",
+      "desc": "Lead capture & CRM pipeline"
     },
     {
       "id": "mod-mailing",
       "type": "api-module",
-      "path": "api/src/mailing/"
+      "path": "api/src/mailing/",
+      "desc": "Email campaigns"
     },
     {
       "id": "mod-maintenance",
       "type": "api-module",
-      "path": "api/src/maintenance/"
+      "path": "api/src/maintenance/",
+      "desc": "Maintenance mode controls"
     },
     {
       "id": "mod-marketplace",
       "type": "api-module",
-      "path": "api/src/marketplace/"
+      "path": "api/src/marketplace/",
+      "desc": "Product catalog, ordering, search"
     },
     {
       "id": "mod-messaging",
       "type": "api-module",
-      "path": "api/src/messaging/"
+      "path": "api/src/messaging/",
+      "desc": "Real-time chat (Socket.io)"
     },
     {
       "id": "mod-metrics",
       "type": "api-module",
-      "path": "api/src/metrics/"
+      "path": "api/src/metrics/",
+      "desc": "Platform metrics & health"
     },
     {
       "id": "mod-organization-documents",
       "type": "api-module",
-      "path": "api/src/organization-documents/"
+      "path": "api/src/organization-documents/",
+      "desc": "Org document storage"
     },
     {
       "id": "mod-partners",
       "type": "api-module",
-      "path": "api/src/partners/"
+      "path": "api/src/partners/",
+      "desc": "Partner integrations"
     },
     {
       "id": "mod-platform-settings",
       "type": "api-module",
-      "path": "api/src/platform-settings/"
+      "path": "api/src/platform-settings/",
+      "desc": "Global platform configuration"
     },
     {
       "id": "mod-policy-alerts",
       "type": "api-module",
-      "path": "api/src/policy-alerts/"
+      "path": "api/src/policy-alerts/",
+      "desc": "Policy change alerts"
     },
     {
       "id": "mod-principal",
       "type": "api-module",
-      "path": "api/src/principal/"
+      "path": "api/src/principal/",
+      "desc": "Principal/org entity management"
     },
     {
       "id": "mod-profiles",
       "type": "api-module",
-      "path": "api/src/profiles/"
+      "path": "api/src/profiles/",
+      "desc": "User profile data"
     },
     {
       "id": "mod-promo-codes",
       "type": "api-module",
-      "path": "api/src/promo-codes/"
+      "path": "api/src/promo-codes/",
+      "desc": "Promotional code management"
     },
     {
       "id": "mod-recruitment",
       "type": "api-module",
-      "path": "api/src/recruitment/"
+      "path": "api/src/recruitment/",
+      "desc": "Job/candidate matching"
     },
     {
       "id": "mod-security",
       "type": "api-module",
-      "path": "api/src/security/"
+      "path": "api/src/security/",
+      "desc": "Security audit logging"
     },
     {
       "id": "mod-settings",
       "type": "api-module",
-      "path": "api/src/settings/"
+      "path": "api/src/settings/",
+      "desc": "Per-user settings"
     },
     {
       "id": "mod-static-translation",
       "type": "api-module",
-      "path": "api/src/static-translation/"
+      "path": "api/src/static-translation/",
+      "desc": "Static i18n string delivery"
     },
     {
       "id": "mod-subscription-management",
       "type": "api-module",
-      "path": "api/src/subscription-management/"
+      "path": "api/src/subscription-management/",
+      "desc": "Subscription lifecycle ops"
     },
     {
       "id": "mod-support",
       "type": "api-module",
-      "path": "api/src/support/"
+      "path": "api/src/support/",
+      "desc": "Support tickets"
     },
     {
       "id": "mod-sync",
       "type": "api-module",
-      "path": "api/src/sync/"
+      "path": "api/src/sync/",
+      "desc": "Data sync jobs"
     },
     {
       "id": "mod-system-configuration",
       "type": "api-module",
-      "path": "api/src/system-configuration/"
+      "path": "api/src/system-configuration/",
+      "desc": "System-level config"
     },
     {
       "id": "mod-system-monitoring",
       "type": "api-module",
-      "path": "api/src/system-monitoring/"
+      "path": "api/src/system-monitoring/",
+      "desc": "System health monitoring"
     },
     {
       "id": "mod-translation",
       "type": "api-module",
-      "path": "api/src/translation/"
+      "path": "api/src/translation/",
+      "desc": "Dynamic translation management"
     },
     {
       "id": "mod-translation-errors",
       "type": "api-module",
-      "path": "api/src/translation-errors/"
+      "path": "api/src/translation-errors/",
+      "desc": "Translation error tracking"
     },
     {
       "id": "mod-upload",
       "type": "api-module",
-      "path": "api/src/upload/"
+      "path": "api/src/upload/",
+      "desc": "File upload & S3 storage"
     },
     {
       "id": "mod-user-management",
       "type": "api-module",
-      "path": "api/src/user-management/"
+      "path": "api/src/user-management/",
+      "desc": "Admin user management ops"
     },
     {
       "id": "mod-users",
       "type": "api-module",
-      "path": "api/src/users/"
+      "path": "api/src/users/",
+      "desc": "User account management"
     },
     {
       "id": "mod-vendor-clients",
       "type": "api-module",
-      "path": "api/src/vendor-clients/"
+      "path": "api/src/vendor-clients/",
+      "desc": "Third-party vendor client wrappers"
     },
     {
       "id": "mod-webhooks",
       "type": "api-module",
-      "path": "api/src/webhooks/"
+      "path": "api/src/webhooks/",
+      "desc": "Incoming webhook handlers (Clerk, Stripe)"
     },
     {
-      "id": "fc-verification",
+      "id": "fc-admin",
       "type": "frontend-component-dir",
-      "path": "frontend/src/components/verification/"
+      "path": "frontend/components/admin/"
+    },
+    {
+      "id": "fc-availability",
+      "type": "frontend-component-dir",
+      "path": "frontend/components/availability/"
+    },
+    {
+      "id": "fc-cart",
+      "type": "frontend-component-dir",
+      "path": "frontend/components/cart/"
+    },
+    {
+      "id": "fc-foundation",
+      "type": "frontend-component-dir",
+      "path": "frontend/components/foundation/"
+    },
+    {
+      "id": "fc-help",
+      "type": "frontend-component-dir",
+      "path": "frontend/components/help/"
+    },
+    {
+      "id": "fc-icons",
+      "type": "frontend-component-dir",
+      "path": "frontend/components/icons/"
+    },
+    {
+      "id": "fc-layout",
+      "type": "frontend-component-dir",
+      "path": "frontend/components/layout/"
+    },
+    {
+      "id": "fc-marketplace",
+      "type": "frontend-component-dir",
+      "path": "frontend/components/marketplace/"
+    },
+    {
+      "id": "fc-messaging",
+      "type": "frontend-component-dir",
+      "path": "frontend/components/messaging/"
+    },
+    {
+      "id": "fc-profile",
+      "type": "frontend-component-dir",
+      "path": "frontend/components/profile/"
+    },
+    {
+      "id": "fc-recruitment",
+      "type": "frontend-component-dir",
+      "path": "frontend/components/recruitment/"
+    },
+    {
+      "id": "fc-service-provider",
+      "type": "frontend-component-dir",
+      "path": "frontend/components/service-provider/"
+    },
+    {
+      "id": "fc-settings",
+      "type": "frontend-component-dir",
+      "path": "frontend/components/settings/"
+    },
+    {
+      "id": "fc-shared",
+      "type": "frontend-component-dir",
+      "path": "frontend/components/shared/"
+    },
+    {
+      "id": "fc-supplier",
+      "type": "frontend-component-dir",
+      "path": "frontend/components/supplier/"
+    },
+    {
+      "id": "fc-support",
+      "type": "frontend-component-dir",
+      "path": "frontend/components/support/"
+    },
+    {
+      "id": "fc-ui",
+      "type": "frontend-component-dir",
+      "path": "frontend/components/ui/"
+    },
+    {
+      "id": "fp-admin",
+      "type": "frontend-page",
+      "path": "frontend/pages/admin/"
+    },
+    {
+      "id": "fp-candidate",
+      "type": "frontend-page",
+      "path": "frontend/pages/candidate/"
+    },
+    {
+      "id": "fp-educator",
+      "type": "frontend-page",
+      "path": "frontend/pages/educator/"
+    },
+    {
+      "id": "fp-foundation",
+      "type": "frontend-page",
+      "path": "frontend/pages/foundation/"
+    },
+    {
+      "id": "fp-parent",
+      "type": "frontend-page",
+      "path": "frontend/pages/parent/"
+    },
+    {
+      "id": "fp-partner",
+      "type": "frontend-page",
+      "path": "frontend/pages/partner/"
+    },
+    {
+      "id": "fp-profile",
+      "type": "frontend-page",
+      "path": "frontend/pages/profile/"
+    },
+    {
+      "id": "fp-service-provider",
+      "type": "frontend-page",
+      "path": "frontend/pages/service-provider/"
+    },
+    {
+      "id": "fp-supplier",
+      "type": "frontend-page",
+      "path": "frontend/pages/supplier/"
+    },
+    {
+      "id": "fp-DashboardDetailPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/DashboardDetailPage.tsx"
+    },
+    {
+      "id": "fp-DashboardPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/DashboardPage.tsx"
+    },
+    {
+      "id": "fp-DesignSystemPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/DesignSystemPage.tsx"
+    },
+    {
+      "id": "fp-ELearningPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/ELearningPage.tsx"
+    },
+    {
+      "id": "fp-FileGalleryPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/FileGalleryPage.tsx"
+    },
+    {
+      "id": "fp-FoundationLeadsPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/FoundationLeadsPage.tsx"
+    },
+    {
+      "id": "fp-HRProceduresPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/HRProceduresPage.tsx"
+    },
+    {
+      "id": "fp-LoginPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/LoginPage.tsx"
+    },
+    {
+      "id": "fp-LoginPageE2E",
+      "type": "frontend-page",
+      "path": "frontend/pages/LoginPageE2E.tsx"
+    },
+    {
+      "id": "fp-MarketplacePage",
+      "type": "frontend-page",
+      "path": "frontend/pages/MarketplacePage.tsx"
+    },
+    {
+      "id": "fp-MessagesPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/MessagesPage.tsx"
+    },
+    {
+      "id": "fp-NotificationsPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/NotificationsPage.tsx"
+    },
+    {
+      "id": "fp-ParentEnquiriesPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/ParentEnquiriesPage.tsx"
+    },
+    {
+      "id": "fp-ParentLeadFormPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/ParentLeadFormPage.tsx"
+    },
+    {
+      "id": "fp-PartnersPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/PartnersPage.tsx"
+    },
+    {
+      "id": "fp-PricingPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/PricingPage.tsx"
+    },
+    {
+      "id": "fp-ProfileEditPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/ProfileEditPage.tsx"
+    },
+    {
+      "id": "fp-ProfilePage",
+      "type": "frontend-page",
+      "path": "frontend/pages/ProfilePage.tsx"
+    },
+    {
+      "id": "fp-PublicPartnersPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/PublicPartnersPage.tsx"
+    },
+    {
+      "id": "fp-RecruitmentPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/RecruitmentPage.tsx"
+    },
+    {
+      "id": "fp-ResetPasswordPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/ResetPasswordPage.tsx"
+    },
+    {
+      "id": "fp-ServiceProviderSettingsPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/ServiceProviderSettingsPage.tsx"
+    },
+    {
+      "id": "fp-SettingsPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/SettingsPage.tsx"
+    },
+    {
+      "id": "fp-SignupPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/SignupPage.tsx"
+    },
+    {
+      "id": "fp-SignupPageE2E",
+      "type": "frontend-page",
+      "path": "frontend/pages/SignupPageE2E.tsx"
+    },
+    {
+      "id": "fp-StatePoliciesPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/StatePoliciesPage.tsx"
+    },
+    {
+      "id": "fp-UsersPage",
+      "type": "frontend-page",
+      "path": "frontend/pages/UsersPage.tsx"
+    },
+    {
+      "id": "ctx-AppContext",
+      "type": "context",
+      "path": "frontend/contexts/AppContext.tsx"
+    },
+    {
+      "id": "ctx-CartContext",
+      "type": "context",
+      "path": "frontend/contexts/CartContext.tsx"
+    },
+    {
+      "id": "ctx-MessagingContext",
+      "type": "context",
+      "path": "frontend/contexts/MessagingContext.tsx"
+    },
+    {
+      "id": "ctx-NotificationContext",
+      "type": "context",
+      "path": "frontend/contexts/NotificationContext.tsx"
+    },
+    {
+      "id": "ctx-SubscriptionContext",
+      "type": "context",
+      "path": "frontend/contexts/SubscriptionContext.tsx"
+    },
+    {
+      "id": "ap-AccessDenied",
+      "type": "admin-page",
+      "path": "admin/src/pages/AccessDenied.tsx"
+    },
+    {
+      "id": "ap-AdminOrganizationProfileEdit",
+      "type": "admin-page",
+      "path": "admin/src/pages/AdminOrganizationProfileEdit.tsx"
+    },
+    {
+      "id": "ap-AdminUserProfileEdit",
+      "type": "admin-page",
+      "path": "admin/src/pages/AdminUserProfileEdit.tsx"
+    },
+    {
+      "id": "ap-Candidates",
+      "type": "admin-page",
+      "path": "admin/src/pages/Candidates.tsx"
+    },
+    {
+      "id": "ap-CantonDetail",
+      "type": "admin-page",
+      "path": "admin/src/pages/CantonDetail.tsx"
+    },
+    {
+      "id": "ap-Cantons",
+      "type": "admin-page",
+      "path": "admin/src/pages/Cantons.tsx"
+    },
+    {
+      "id": "ap-Content",
+      "type": "admin-page",
+      "path": "admin/src/pages/Content.tsx"
+    },
+    {
+      "id": "ap-Dashboard",
+      "type": "admin-page",
+      "path": "admin/src/pages/Dashboard.tsx"
+    },
+    {
+      "id": "ap-DesignSystem",
+      "type": "admin-page",
+      "path": "admin/src/pages/DesignSystem.tsx"
+    },
+    {
+      "id": "ap-DiscountTerminations",
+      "type": "admin-page",
+      "path": "admin/src/pages/DiscountTerminations.tsx"
+    },
+    {
+      "id": "ap-EmailNotificationPage",
+      "type": "admin-page",
+      "path": "admin/src/pages/EmailNotificationPage.tsx"
+    },
+    {
+      "id": "ap-JobListings",
+      "type": "admin-page",
+      "path": "admin/src/pages/JobListings.tsx"
+    },
+    {
+      "id": "ap-MailingCampaignDetail",
+      "type": "admin-page",
+      "path": "admin/src/pages/MailingCampaignDetail.tsx"
+    },
+    {
+      "id": "ap-MailingList",
+      "type": "admin-page",
+      "path": "admin/src/pages/MailingList.tsx"
+    },
+    {
+      "id": "ap-Messaging",
+      "type": "admin-page",
+      "path": "admin/src/pages/Messaging.tsx"
+    },
+    {
+      "id": "ap-Orders",
+      "type": "admin-page",
+      "path": "admin/src/pages/Orders.tsx"
+    },
+    {
+      "id": "ap-Organizations",
+      "type": "admin-page",
+      "path": "admin/src/pages/Organizations.tsx"
+    },
+    {
+      "id": "ap-ParentLeads",
+      "type": "admin-page",
+      "path": "admin/src/pages/ParentLeads.tsx"
+    },
+    {
+      "id": "ap-Partners",
+      "type": "admin-page",
+      "path": "admin/src/pages/Partners.tsx"
+    },
+    {
+      "id": "ap-PolicyCrawler",
+      "type": "admin-page",
+      "path": "admin/src/pages/PolicyCrawler.tsx"
+    },
+    {
+      "id": "ap-PolicyReview",
+      "type": "admin-page",
+      "path": "admin/src/pages/PolicyReview.tsx"
+    },
+    {
+      "id": "ap-Products",
+      "type": "admin-page",
+      "path": "admin/src/pages/Products.tsx"
+    },
+    {
+      "id": "ap-ResetPassword",
+      "type": "admin-page",
+      "path": "admin/src/pages/ResetPassword.tsx"
+    },
+    {
+      "id": "ap-Services",
+      "type": "admin-page",
+      "path": "admin/src/pages/Services.tsx"
+    },
+    {
+      "id": "ap-Settings",
+      "type": "admin-page",
+      "path": "admin/src/pages/Settings.tsx"
+    },
+    {
+      "id": "ap-Subscriptions",
+      "type": "admin-page",
+      "path": "admin/src/pages/Subscriptions.tsx"
+    },
+    {
+      "id": "ap-Support",
+      "type": "admin-page",
+      "path": "admin/src/pages/Support.tsx"
+    },
+    {
+      "id": "ap-SupportTicket",
+      "type": "admin-page",
+      "path": "admin/src/pages/SupportTicket.tsx"
+    },
+    {
+      "id": "ap-SystemConfigurationPage",
+      "type": "admin-page",
+      "path": "admin/src/pages/SystemConfigurationPage.tsx"
+    },
+    {
+      "id": "ap-SystemMonitor",
+      "type": "admin-page",
+      "path": "admin/src/pages/SystemMonitor.tsx"
+    },
+    {
+      "id": "ap-Translations",
+      "type": "admin-page",
+      "path": "admin/src/pages/Translations.tsx"
+    },
+    {
+      "id": "ap-Users",
+      "type": "admin-page",
+      "path": "admin/src/pages/Users.tsx"
+    },
+    {
+      "id": "ap-content-ContentShared",
+      "type": "admin-page",
+      "path": "admin/src/pages/content/ContentShared.tsx"
+    },
+    {
+      "id": "ap-content-ELearningContentPage",
+      "type": "admin-page",
+      "path": "admin/src/pages/content/ELearningContentPage.tsx"
+    },
+    {
+      "id": "ap-content-HrDocumentsPage",
+      "type": "admin-page",
+      "path": "admin/src/pages/content/HrDocumentsPage.tsx"
+    },
+    {
+      "id": "ap-content-StatePoliciesPage",
+      "type": "admin-page",
+      "path": "admin/src/pages/content/StatePoliciesPage.tsx"
+    },
+    {
+      "id": "acd-auth",
+      "type": "admin-component-dir",
+      "path": "admin/src/components/auth/"
+    },
+    {
+      "id": "acd-design-system",
+      "type": "admin-component-dir",
+      "path": "admin/src/components/design-system/"
+    },
+    {
+      "id": "acd-forms",
+      "type": "admin-component-dir",
+      "path": "admin/src/components/forms/"
+    },
+    {
+      "id": "acd-mailing",
+      "type": "admin-component-dir",
+      "path": "admin/src/components/mailing/"
+    },
+    {
+      "id": "acd-messaging",
+      "type": "admin-component-dir",
+      "path": "admin/src/components/messaging/"
+    },
+    {
+      "id": "acd-products",
+      "type": "admin-component-dir",
+      "path": "admin/src/components/products/"
+    },
+    {
+      "id": "acd-services",
+      "type": "admin-component-dir",
+      "path": "admin/src/components/services/"
+    },
+    {
+      "id": "acd-settings",
+      "type": "admin-component-dir",
+      "path": "admin/src/components/settings/"
+    },
+    {
+      "id": "acd-support",
+      "type": "admin-component-dir",
+      "path": "admin/src/components/support/"
+    },
+    {
+      "id": "acd-ui",
+      "type": "admin-component-dir",
+      "path": "admin/src/components/ui/"
     }
   ],
   "edges": [
@@ -337,7 +895,9 @@
   "meta": {
     "apiModuleCount": 43,
     "packageCount": 5,
-    "adminPageCount": 32,
-    "frontendComponentDirCount": 1
+    "adminPageCount": 36,
+    "frontendComponentDirCount": 17,
+    "frontendPageCount": 36,
+    "frontendContextCount": 5
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "i18n:full-check": "npm run extract:i18n-keys && npm run check:i18n-keys && npm run generate:i18n-types",
     "i18n:pipeline": "node scripts/i18n-pipeline.mjs",
     "i18n:pipeline:ci": "node scripts/i18n-pipeline.mjs --ci",
-    "prepare": "node scripts/run-husky.js"
+    "prepare": "node scripts/run-husky.js",
+    "graphify": "node scripts/graphify.mjs"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",

--- a/scripts/graphify.mjs
+++ b/scripts/graphify.mjs
@@ -1,0 +1,415 @@
+#!/usr/bin/env node
+/**
+ * graphify v1.0 — static analysis for PC-Solutions-Platform
+ *
+ * Scans the monorepo and (re)generates:
+ *   graphify-out/graph.json        machine-readable dependency graph
+ *   graphify-out/GRAPH_REPORT.md   human/Claude-readable report
+ *
+ * Run:  node scripts/graphify.mjs
+ */
+
+import { existsSync, readdirSync, statSync, writeFileSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const OUT = join(ROOT, 'graphify-out');
+
+// Directories under api/src that are NestJS infrastructure, not feature modules
+const API_INFRA_DIRS = new Set(['common', 'compat', 'prisma', 'types', 'utils', 'platform', 'src']);
+
+// Known module descriptions — add new entries as modules evolve
+const MODULE_DESCRIPTIONS = {
+  auth:                   ['JWT validation, Clerk sync, CASL RBAC', 'Clerk, Passport, CASL'],
+  admin:                  ['Back-office ops, role management', 'auth'],
+  marketplace:            ['Product catalog, ordering, search', 'billing, categories'],
+  billing:                ['Stripe subscriptions + payments', 'Stripe SDK'],
+  messaging:              ['Real-time chat (Socket.io)', 'Redis'],
+  leads:                  ['Lead capture & CRM pipeline', 'mailing'],
+  elearning:              ['Learning content, courses', 'content'],
+  mailing:                ['Email campaigns', 'SendGrid, Mailgun'],
+  'email-notification':   ['Transactional notifications', 'mailing'],
+  categories:             ['Product/service taxonomy', '—'],
+  content:                ['CMS-style content management', '—'],
+  analytics:              ['User behaviour tracking', '—'],
+  dashboard:              ['Aggregated stats per role', 'analytics'],
+  crawler:                ['Web content crawling & classification', '—'],
+  'frontend-settings':    ['Feature flags, per-role config', '—'],
+  profiles:               ['User profile data', 'auth'],
+  users:                  ['User account management', 'auth'],
+  'user-management':      ['Admin user management ops', 'auth'],
+  recruitment:            ['Job/candidate matching', '—'],
+  support:                ['Support tickets', '—'],
+  upload:                 ['File upload & S3 storage', '—'],
+  webhooks:               ['Incoming webhook handlers (Clerk, Stripe)', 'auth, billing'],
+  settings:               ['Per-user settings', '—'],
+  'subscription-management': ['Subscription lifecycle ops', 'billing'],
+  'content-management':   ['CMS content CRUD', 'content'],
+  'content-moderation':   ['Content review & moderation', 'content'],
+  maintenance:            ['Maintenance mode controls', '—'],
+  metrics:                ['Platform metrics & health', '—'],
+  security:               ['Security audit logging', '—'],
+  sync:                   ['Data sync jobs', '—'],
+  translation:            ['Dynamic translation management', '—'],
+  'static-translation':   ['Static i18n string delivery', '—'],
+  'translation-errors':   ['Translation error tracking', '—'],
+  'organization-documents': ['Org document storage', 'upload'],
+  partners:               ['Partner integrations', '—'],
+  'platform-settings':    ['Global platform configuration', '—'],
+  'policy-alerts':        ['Policy change alerts', 'mailing'],
+  principal:              ['Principal/org entity management', '—'],
+  'promo-codes':          ['Promotional code management', 'billing'],
+  'system-configuration': ['System-level config', '—'],
+  'system-monitoring':    ['System health monitoring', 'metrics'],
+  'vendor-clients':       ['Third-party vendor client wrappers', '—'],
+  health:                 ['Health check endpoint', '—'],
+};
+
+function subdirs(dir) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter((n) => statSync(join(dir, n)).isDirectory());
+}
+
+function files(dir, ext) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter((n) => n.endsWith(ext));
+}
+
+function hasFile(dir, ext) {
+  if (!existsSync(dir)) return false;
+  return readdirSync(dir).some((n) => n.endsWith(ext));
+}
+
+// ─── Scan API modules ────────────────────────────────────────────────────────
+
+function scanApiModules() {
+  const srcDir = join(ROOT, 'api', 'src');
+  return subdirs(srcDir)
+    .filter((name) => !API_INFRA_DIRS.has(name) && hasFile(join(srcDir, name), '.module.ts'))
+    .map((name) => {
+      const [desc, deps] = MODULE_DESCRIPTIONS[name] || ['—', '—'];
+      return { id: `mod-${name}`, name, path: `api/src/${name}/`, desc, deps };
+    });
+}
+
+// ─── Scan frontend ───────────────────────────────────────────────────────────
+
+function scanFrontendComponents() {
+  const dir = join(ROOT, 'frontend', 'src', 'components');
+  return subdirs(dir).map((name) => ({ name, path: `frontend/src/components/${name}/` }));
+}
+
+function scanFrontendPages() {
+  const dir = join(ROOT, 'frontend', 'src', 'pages');
+  return subdirs(dir).map((name) => ({ name, path: `frontend/src/pages/${name}/` }));
+}
+
+function scanFrontendContexts() {
+  const dir = join(ROOT, 'frontend', 'src', 'contexts');
+  return files(dir, '.tsx')
+    .concat(files(dir, '.ts'))
+    .map((f) => ({ name: f.replace(/\.(tsx?|jsx?)$/, ''), path: `frontend/src/contexts/${f}` }));
+}
+
+// ─── Scan admin ──────────────────────────────────────────────────────────────
+
+function scanAdminPages() {
+  const dir = join(ROOT, 'admin', 'src', 'pages');
+  return readdirSync(dir)
+    .filter((n) => n.endsWith('.tsx') || n.endsWith('.ts'))
+    .map((n) => n.replace(/\.(tsx?)$/, ''));
+}
+
+function scanAdminComponentDirs() {
+  const dir = join(ROOT, 'admin', 'src', 'components');
+  return subdirs(dir);
+}
+
+import { readFileSync } from 'fs';
+
+function scanPackagesSync() {
+  const dir = join(ROOT, 'packages');
+  return subdirs(dir).map((name) => {
+    const pkgJson = join(dir, name, 'package.json');
+    let pkgName = `@repo/${name}`;
+    if (existsSync(pkgJson)) {
+      try { pkgName = JSON.parse(readFileSync(pkgJson, 'utf8')).name || pkgName; } catch { /* ignore */ }
+    }
+    return { name, path: `packages/${name}/`, pkgName };
+  });
+}
+
+// ─── Generate graph.json ─────────────────────────────────────────────────────
+
+function buildGraph(apiModules, packages, frontendComponents, frontendPages, frontendContexts, adminPages, adminComponentDirs) {
+  const now = new Date().toISOString().slice(0, 10);
+
+  const nodes = [
+    { id: 'frontend', type: 'app', path: 'frontend/', tech: 'React 19 + Vite + Tailwind', entry: 'frontend/src/main.tsx' },
+    { id: 'admin', type: 'app', path: 'admin/', tech: 'React 19 + Vite', entry: 'admin/src/main.tsx' },
+    { id: 'api', type: 'app', path: 'api/', tech: 'NestJS', entry: 'api/src/main.ts' },
+    ...packages.map((p) => ({ id: `pkg-${p.name}`, type: 'package', path: p.path, name: p.pkgName })),
+    ...apiModules.map((m) => ({ id: m.id, type: 'api-module', path: m.path })),
+    ...frontendComponents.map((c) => ({ id: `fc-${c.name}`, type: 'frontend-component-dir', path: c.path })),
+    ...frontendPages.map((pg) => ({ id: `fp-${pg.name}`, type: 'frontend-page-dir', path: pg.path })),
+    ...frontendContexts.map((ctx) => ({ id: `ctx-${ctx.name}`, type: 'context', path: ctx.path })),
+  ];
+
+  const edges = [
+    { from: 'frontend', to: 'pkg-ui' },
+    { from: 'frontend', to: 'pkg-types' },
+    { from: 'frontend', to: 'pkg-translations' },
+    { from: 'admin', to: 'pkg-ui' },
+    { from: 'admin', to: 'pkg-types' },
+    { from: 'admin', to: 'pkg-translations' },
+    { from: 'api', to: 'pkg-types' },
+    { from: 'api', to: 'pkg-translations' },
+    { from: 'mod-marketplace', to: 'mod-billing' },
+    { from: 'mod-marketplace', to: 'mod-categories' },
+    { from: 'mod-leads', to: 'mod-mailing' },
+    { from: 'mod-email-notification', to: 'mod-mailing' },
+    { from: 'mod-dashboard', to: 'mod-analytics' },
+    { from: 'mod-elearning', to: 'mod-content' },
+  ].filter((e) => nodes.some((n) => n.id === e.from) && nodes.some((n) => n.id === e.to));
+
+  return {
+    version: '1.0',
+    generated: now,
+    repo: 'pc-solutions-platform',
+    type: 'monorepo',
+    nodes,
+    edges,
+    meta: {
+      apiModuleCount: apiModules.length,
+      packageCount: packages.length,
+      adminPageCount: adminPages.length,
+      frontendComponentDirCount: frontendComponents.length,
+    },
+  };
+}
+
+// ─── Generate GRAPH_REPORT.md ─────────────────────────────────────────────────
+
+function buildReport(graph, apiModules, packages, frontendComponents, frontendPages, frontendContexts, adminPages, adminComponentDirs) {
+  const date = graph.generated;
+
+  const modulesTable = apiModules
+    .map((m) => `| \`${m.name}\` | ${m.desc} | ${m.deps} |`)
+    .join('\n');
+
+  const componentsTable = frontendComponents
+    .map((c) => `| \`${c.name}/\` | — |`)
+    .join('\n');
+
+  const contextsTable = frontendContexts.length
+    ? frontendContexts.map((c) => `| \`${c.name}\` | — |`).join('\n')
+    : '| *(none found)* | — |';
+
+  const pagesSection = frontendPages.length
+    ? frontendPages.map((p) => `├── ${p.name}/`).join('\n')
+    : '*(none found)*';
+
+  const packagesTable = packages
+    .map((p) => `| \`${p.pkgName}\` | \`${p.pkgName}\` | — |`)
+    .join('\n');
+
+  const adminPagesList = adminPages.map((p) => `- \`${p}\``).join('\n');
+  const adminComponentList = adminComponentDirs.map((d) => `- \`${d}/\``).join('\n');
+
+  return `# PC-Solutions-Platform — Graph Report
+
+Generated: ${date} | Tool: graphify v1.0 (static analysis)
+
+---
+
+## Module Map
+
+\`\`\`
+pc-solutions-platform/
+├── frontend/          React 19 SPA — 7-role marketplace UI
+├── admin/             React 19 SPA — back-office dashboard
+├── api/               NestJS — centralized REST + WebSocket API
+└── packages/
+${packages.map((p) => `    ├── ${p.name}/`).join('\n')}
+\`\`\`
+
+---
+
+## API Modules (${apiModules.length} modules under \`api/src/\`)
+
+| Module | Key responsibility | Notable deps |
+|---|---|---|
+${modulesTable}
+
+---
+
+## Frontend Pages (\`frontend/src/pages/\`)
+
+\`\`\`
+pages/
+${pagesSection}
+\`\`\`
+
+**Main router**: \`frontend/src/App.tsx\` — contains all role-based route guards.
+
+---
+
+## Admin App (\`admin/src/\`)
+
+### Pages
+${adminPagesList}
+
+### Component Directories
+${adminComponentList}
+
+---
+
+## Frontend Component Domains (\`frontend/src/components/\`)
+
+| Directory | Contains |
+|---|---|
+${componentsTable}
+
+---
+
+## Context Providers (\`frontend/src/contexts/\`)
+
+| Context | Purpose |
+|---|---|
+${contextsTable}
+
+---
+
+## Shared Packages
+
+| Package | Import path | Use case |
+|---|---|---|
+${packagesTable}
+
+---
+
+## Data Flow: Typical Request
+
+\`\`\`
+Browser
+  └── Clerk JWT (Authorization header)
+        └── NestJS API Gateway
+              ├── JwtAuthGuard (validates Clerk token)
+              ├── RolesGuard (CASL ability check)
+              └── Module Controller
+                    ├── Service (business logic)
+                    ├── Prisma ORM → PostgreSQL
+                    ├── Redis (cache / Bull job queue)
+                    └── External: Stripe / SendGrid / S3
+\`\`\`
+
+---
+
+## Auth & Role Model
+
+- **Provider**: Clerk (hosted auth UI + JWT)
+- **Sync**: Clerk webhooks → \`api/src/auth/\` → Prisma User record
+- **RBAC**: CASL \`ability\` definitions scoped per role
+- **Roles** (enum in \`@workspace/types\`):
+  - \`SUPER_ADMIN\` — full platform access
+  - \`ADMIN\` — managed admin access (uses \`/admin\` app)
+  - \`FOUNDATION\` — grant/program management
+  - \`PRODUCT_SUPPLIER\` — product catalog & orders
+  - \`SERVICE_PROVIDER\` — service listings & leads
+  - \`EDUCATOR\` — availability, elearning, parent-facing profile
+  - \`PARENT\` — marketplace browsing, child management
+
+---
+
+## Key Entry Points
+
+| File | Role |
+|---|---|
+| \`frontend/src/main.tsx\` | Frontend SPA entry |
+| \`frontend/src/App.tsx\` | All frontend routes + role guards |
+| \`admin/src/main.tsx\` | Admin SPA entry |
+| \`api/src/main.ts\` | NestJS bootstrap |
+| \`api/src/app.module.ts\` | Root NestJS module (imports all modules) |
+| \`api/prisma/schema.prisma\` | Full DB schema |
+| \`turbo.json\` | Build task graph |
+| \`render.yaml\` | Production deployment spec |
+
+---
+
+## Dependency Graph (inter-module)
+
+\`\`\`
+frontend  ──imports──▶  @repo/ui, @workspace/types, @workspace/translations
+admin     ──imports──▶  @repo/ui, @workspace/types, @workspace/translations
+api       ──imports──▶  @workspace/types, @workspace/translations
+
+api/auth    ◀── guards ── all other api modules
+api/billing ◀── checks ── marketplace, elearning, leads
+api/mailing ◀── sends  ── email-notification, leads, auth
+api/messaging ◀── socket ── frontend
+\`\`\`
+
+---
+
+## Build & Scripts
+
+| Script | Purpose |
+|---|---|
+| \`pnpm build\` | Turborepo build all apps |
+| \`pnpm dev\` | Dev servers for all apps |
+| \`pnpm lint\` / \`lint:fix\` | ESLint across all packages |
+| \`pnpm type-check\` | TS check across all packages |
+| \`pnpm test\` | Vitest + Playwright |
+| \`pnpm db:migrate\` | Prisma migrate deploy |
+| \`pnpm graphify\` | Regenerate this graph report |
+
+---
+
+## Maintenance Notes
+
+- Regenerate this report after major structural changes: \`pnpm graphify\`
+- Update \`graph.json\` is regenerated automatically by the same command
+- Report path: \`graphify-out/GRAPH_REPORT.md\`
+`;
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+function main() {
+  console.log('graphify v1.0 — scanning monorepo…\n');
+
+  const apiModules = scanApiModules();
+  const packages = scanPackagesSync();
+  const frontendComponents = scanFrontendComponents();
+  const frontendPages = scanFrontendPages();
+  const frontendContexts = scanFrontendContexts();
+
+  let adminPages = [];
+  let adminComponentDirs = [];
+  try { adminPages = scanAdminPages(); } catch { /* admin may not exist */ }
+  try { adminComponentDirs = scanAdminComponentDirs(); } catch { /* admin may not exist */ }
+
+  console.log(`  API modules:       ${apiModules.length}`);
+  console.log(`  Packages:          ${packages.length}`);
+  console.log(`  Admin pages:       ${adminPages.length}`);
+  console.log(`  Frontend comp dirs:${frontendComponents.length}`);
+  console.log(`  Frontend page dirs:${frontendPages.length}`);
+  console.log(`  Frontend contexts: ${frontendContexts.length}`);
+  console.log('');
+
+  const graph = buildGraph(apiModules, packages, frontendComponents, frontendPages, frontendContexts, adminPages, adminComponentDirs);
+  const report = buildReport(graph, apiModules, packages, frontendComponents, frontendPages, frontendContexts, adminPages, adminComponentDirs);
+
+  if (!existsSync(OUT)) mkdirSync(OUT, { recursive: true });
+
+  writeFileSync(join(OUT, 'graph.json'), JSON.stringify(graph, null, 2) + '\n', 'utf8');
+  writeFileSync(join(OUT, 'GRAPH_REPORT.md'), report, 'utf8');
+
+  console.log('  graphify-out/graph.json       written');
+  console.log('  graphify-out/GRAPH_REPORT.md  written');
+  console.log('\nDone.');
+}
+
+main();

--- a/scripts/graphify.mjs
+++ b/scripts/graphify.mjs
@@ -9,7 +9,7 @@
  * Run:  node scripts/graphify.mjs
  */
 
-import { existsSync, readdirSync, statSync, writeFileSync, mkdirSync } from 'fs';
+import { existsSync, readdirSync, statSync, writeFileSync, mkdirSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -22,7 +22,7 @@ const API_INFRA_DIRS = new Set(['common', 'compat', 'prisma', 'types', 'utils', 
 
 // Known module descriptions — add new entries as modules evolve
 const MODULE_DESCRIPTIONS = {
-  auth:                   ['JWT validation, Clerk sync, CASL RBAC', 'Clerk, Passport, CASL'],
+  auth:                   ['Clerk auth, CASL RBAC, guard definitions', 'Clerk, Passport, CASL'],
   admin:                  ['Back-office ops, role management', 'auth'],
   marketplace:            ['Product catalog, ordering, search', 'billing, categories'],
   billing:                ['Stripe subscriptions + payments', 'Stripe SDK'],
@@ -72,9 +72,9 @@ function subdirs(dir) {
   return readdirSync(dir).filter((n) => statSync(join(dir, n)).isDirectory());
 }
 
-function files(dir, ext) {
+function tsxFiles(dir) {
   if (!existsSync(dir)) return [];
-  return readdirSync(dir).filter((n) => n.endsWith(ext));
+  return readdirSync(dir).filter((n) => n.endsWith('.tsx') || n.endsWith('.ts'));
 }
 
 function hasFile(dir, ext) {
@@ -97,29 +97,55 @@ function scanApiModules() {
 // ─── Scan frontend ───────────────────────────────────────────────────────────
 
 function scanFrontendComponents() {
-  const dir = join(ROOT, 'frontend', 'src', 'components');
-  return subdirs(dir).map((name) => ({ name, path: `frontend/src/components/${name}/` }));
+  // Components live at frontend/components/ (not under src/)
+  const dir = join(ROOT, 'frontend', 'components');
+  return subdirs(dir).map((name) => ({ name, path: `frontend/components/${name}/` }));
 }
 
 function scanFrontendPages() {
-  const dir = join(ROOT, 'frontend', 'src', 'pages');
-  return subdirs(dir).map((name) => ({ name, path: `frontend/src/pages/${name}/` }));
+  // Pages live at frontend/pages/ as .tsx files (not under src/)
+  const dir = join(ROOT, 'frontend', 'pages');
+  const pageFiles = tsxFiles(dir).map((f) => ({
+    name: f.replace(/\.(tsx?)$/, ''),
+    path: `frontend/pages/${f}`,
+    type: 'file',
+  }));
+  const pageDirs = subdirs(dir).map((name) => ({
+    name,
+    path: `frontend/pages/${name}/`,
+    type: 'dir',
+  }));
+  return [...pageDirs, ...pageFiles];
 }
 
 function scanFrontendContexts() {
-  const dir = join(ROOT, 'frontend', 'src', 'contexts');
-  return files(dir, '.tsx')
-    .concat(files(dir, '.ts'))
-    .map((f) => ({ name: f.replace(/\.(tsx?|jsx?)$/, ''), path: `frontend/src/contexts/${f}` }));
+  // Contexts live at frontend/contexts/ (not under src/)
+  const dir = join(ROOT, 'frontend', 'contexts');
+  return tsxFiles(dir).map((f) => ({
+    name: f.replace(/\.(tsx?)$/, ''),
+    path: `frontend/contexts/${f}`,
+  }));
 }
 
 // ─── Scan admin ──────────────────────────────────────────────────────────────
 
+function collectTsxRecursive(dir, base) {
+  if (!existsSync(dir)) return [];
+  const results = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const rel = base ? `${base}/${entry}` : entry;
+    if (statSync(full).isDirectory()) {
+      results.push(...collectTsxRecursive(full, rel));
+    } else if (entry.endsWith('.tsx') || entry.endsWith('.ts')) {
+      results.push(rel.replace(/\.(tsx?)$/, ''));
+    }
+  }
+  return results;
+}
+
 function scanAdminPages() {
-  const dir = join(ROOT, 'admin', 'src', 'pages');
-  return readdirSync(dir)
-    .filter((n) => n.endsWith('.tsx') || n.endsWith('.ts'))
-    .map((n) => n.replace(/\.(tsx?)$/, ''));
+  return collectTsxRecursive(join(ROOT, 'admin', 'src', 'pages'), '');
 }
 
 function scanAdminComponentDirs() {
@@ -127,7 +153,7 @@ function scanAdminComponentDirs() {
   return subdirs(dir);
 }
 
-import { readFileSync } from 'fs';
+// ─── Scan packages ───────────────────────────────────────────────────────────
 
 function scanPackagesSync() {
   const dir = join(ROOT, 'packages');
@@ -147,14 +173,16 @@ function buildGraph(apiModules, packages, frontendComponents, frontendPages, fro
   const now = new Date().toISOString().slice(0, 10);
 
   const nodes = [
-    { id: 'frontend', type: 'app', path: 'frontend/', tech: 'React 19 + Vite + Tailwind', entry: 'frontend/src/main.tsx' },
+    { id: 'frontend', type: 'app', path: 'frontend/', tech: 'React 19 + Vite + Tailwind', entry: 'frontend/index.tsx' },
     { id: 'admin', type: 'app', path: 'admin/', tech: 'React 19 + Vite', entry: 'admin/src/main.tsx' },
     { id: 'api', type: 'app', path: 'api/', tech: 'NestJS', entry: 'api/src/main.ts' },
     ...packages.map((p) => ({ id: `pkg-${p.name}`, type: 'package', path: p.path, name: p.pkgName })),
-    ...apiModules.map((m) => ({ id: m.id, type: 'api-module', path: m.path })),
+    ...apiModules.map((m) => ({ id: m.id, type: 'api-module', path: m.path, desc: m.desc })),
     ...frontendComponents.map((c) => ({ id: `fc-${c.name}`, type: 'frontend-component-dir', path: c.path })),
-    ...frontendPages.map((pg) => ({ id: `fp-${pg.name}`, type: 'frontend-page-dir', path: pg.path })),
+    ...frontendPages.map((pg) => ({ id: `fp-${pg.name}`, type: 'frontend-page', path: pg.path })),
     ...frontendContexts.map((ctx) => ({ id: `ctx-${ctx.name}`, type: 'context', path: ctx.path })),
+    ...adminPages.map((p) => ({ id: `ap-${p.replace(/\//g, '-')}`, type: 'admin-page', path: `admin/src/pages/${p}.tsx` })),
+    ...adminComponentDirs.map((d) => ({ id: `acd-${d}`, type: 'admin-component-dir', path: `admin/src/components/${d}/` })),
   ];
 
   const edges = [
@@ -186,6 +214,8 @@ function buildGraph(apiModules, packages, frontendComponents, frontendPages, fro
       packageCount: packages.length,
       adminPageCount: adminPages.length,
       frontendComponentDirCount: frontendComponents.length,
+      frontendPageCount: frontendPages.length,
+      frontendContextCount: frontendContexts.length,
     },
   };
 }
@@ -199,24 +229,28 @@ function buildReport(graph, apiModules, packages, frontendComponents, frontendPa
     .map((m) => `| \`${m.name}\` | ${m.desc} | ${m.deps} |`)
     .join('\n');
 
-  const componentsTable = frontendComponents
-    .map((c) => `| \`${c.name}/\` | — |`)
-    .join('\n');
+  const componentsTable = frontendComponents.length
+    ? frontendComponents.map((c) => `| \`${c.name}/\` | — |`).join('\n')
+    : '| *(none found)* | — |';
 
   const contextsTable = frontendContexts.length
     ? frontendContexts.map((c) => `| \`${c.name}\` | — |`).join('\n')
     : '| *(none found)* | — |';
 
   const pagesSection = frontendPages.length
-    ? frontendPages.map((p) => `├── ${p.name}/`).join('\n')
+    ? frontendPages.map((p) => `├── ${p.type === 'dir' ? p.name + '/' : p.name + '.tsx'}`).join('\n')
     : '*(none found)*';
 
   const packagesTable = packages
     .map((p) => `| \`${p.pkgName}\` | \`${p.pkgName}\` | — |`)
     .join('\n');
 
-  const adminPagesList = adminPages.map((p) => `- \`${p}\``).join('\n');
-  const adminComponentList = adminComponentDirs.map((d) => `- \`${d}/\``).join('\n');
+  const adminPagesList = adminPages.length
+    ? adminPages.map((p) => `- \`${p}\``).join('\n')
+    : '*(none found)*';
+  const adminComponentList = adminComponentDirs.length
+    ? adminComponentDirs.map((d) => `- \`${d}/\``).join('\n')
+    : '*(none found)*';
 
   return `# PC-Solutions-Platform — Graph Report
 
@@ -245,20 +279,20 @@ ${modulesTable}
 
 ---
 
-## Frontend Pages (\`frontend/src/pages/\`)
+## Frontend Pages (\`frontend/pages/\`)
 
 \`\`\`
 pages/
 ${pagesSection}
 \`\`\`
 
-**Main router**: \`frontend/src/App.tsx\` — contains all role-based route guards.
+**Main router**: \`frontend/App.tsx\` — contains all role-based route guards.
 
 ---
 
 ## Admin App (\`admin/src/\`)
 
-### Pages
+### Pages (${adminPages.length} total)
 ${adminPagesList}
 
 ### Component Directories
@@ -266,7 +300,7 @@ ${adminComponentList}
 
 ---
 
-## Frontend Component Domains (\`frontend/src/components/\`)
+## Frontend Component Domains (\`frontend/components/\`)
 
 | Directory | Contains |
 |---|---|
@@ -274,7 +308,7 @@ ${componentsTable}
 
 ---
 
-## Context Providers (\`frontend/src/contexts/\`)
+## Context Providers (\`frontend/contexts/\`)
 
 | Context | Purpose |
 |---|---|
@@ -296,7 +330,7 @@ ${packagesTable}
 Browser
   └── Clerk JWT (Authorization header)
         └── NestJS API Gateway
-              ├── JwtAuthGuard (validates Clerk token)
+              ├── ClerkAuthGuard (validates Clerk token)
               ├── RolesGuard (CASL ability check)
               └── Module Controller
                     ├── Service (business logic)
@@ -311,7 +345,8 @@ Browser
 
 - **Provider**: Clerk (hosted auth UI + JWT)
 - **Sync**: Clerk webhooks → \`api/src/auth/\` → Prisma User record
-- **RBAC**: CASL \`ability\` definitions scoped per role
+- **RBAC**: CASL \`ability\` definitions in \`api/src/auth/ability/\`
+- **Guards**: \`ClerkAuthGuard\` + \`RolesGuard\` (from \`api/src/auth/guards/\`)
 - **Roles** (enum in \`@workspace/types\`):
   - \`SUPER_ADMIN\` — full platform access
   - \`ADMIN\` — managed admin access (uses \`/admin\` app)
@@ -327,8 +362,8 @@ Browser
 
 | File | Role |
 |---|---|
-| \`frontend/src/main.tsx\` | Frontend SPA entry |
-| \`frontend/src/App.tsx\` | All frontend routes + role guards |
+| \`frontend/index.tsx\` | Frontend SPA entry |
+| \`frontend/App.tsx\` | All frontend routes + role guards |
 | \`admin/src/main.tsx\` | Admin SPA entry |
 | \`api/src/main.ts\` | NestJS bootstrap |
 | \`api/src/app.module.ts\` | Root NestJS module (imports all modules) |
@@ -370,7 +405,7 @@ api/messaging ◀── socket ── frontend
 ## Maintenance Notes
 
 - Regenerate this report after major structural changes: \`pnpm graphify\`
-- Update \`graph.json\` is regenerated automatically by the same command
+- \`graph.json\` is regenerated automatically by the same command
 - Report path: \`graphify-out/GRAPH_REPORT.md\`
 `;
 }
@@ -391,12 +426,12 @@ function main() {
   try { adminPages = scanAdminPages(); } catch { /* admin may not exist */ }
   try { adminComponentDirs = scanAdminComponentDirs(); } catch { /* admin may not exist */ }
 
-  console.log(`  API modules:       ${apiModules.length}`);
-  console.log(`  Packages:          ${packages.length}`);
-  console.log(`  Admin pages:       ${adminPages.length}`);
-  console.log(`  Frontend comp dirs:${frontendComponents.length}`);
-  console.log(`  Frontend page dirs:${frontendPages.length}`);
-  console.log(`  Frontend contexts: ${frontendContexts.length}`);
+  console.log(`  API modules:        ${apiModules.length}`);
+  console.log(`  Packages:           ${packages.length}`);
+  console.log(`  Admin pages:        ${adminPages.length}`);
+  console.log(`  Frontend comp dirs: ${frontendComponents.length}`);
+  console.log(`  Frontend pages:     ${frontendPages.length}`);
+  console.log(`  Frontend contexts:  ${frontendContexts.length}`);
   console.log('');
 
   const graph = buildGraph(apiModules, packages, frontendComponents, frontendPages, frontendContexts, adminPages, adminComponentDirs);


### PR DESCRIPTION
## Summary

- Adds `scripts/graphify.mjs` — a static analysis script that scans the monorepo and regenerates `graphify-out/GRAPH_REPORT.md` and `graphify-out/graph.json`. Run with `pnpm graphify` after structural changes (new modules, renamed dirs, new roles).
- Commits the Claude Code context that supports graph-first navigation: `CLAUDE.md`, `.claude/settings.json`, `.claude/hooks/pre-search-reminder.sh`, and `.claude/topics/` (architecture, debugging, patterns, deployment guides).
- Fixes `CLAUDE.md` search lanes to use the real path layout (`api/src/<module>/` not `api/src/modules/<module>/`).

### Review fixes (second commit)

- Scanner now reads correct frontend paths (`frontend/pages/`, `frontend/contexts/`, `frontend/components/` — not under `src/`), fixing the zero-page/context counts in the initial output.
- `scanFrontendPages()` collects both `.tsx` files and subdirs (36 pages found).
- `scanAdminPages()` recurses into nested subdirs (e.g. `pages/content/`), capturing all 36 admin pages.
- Admin page and component-dir nodes now included in `graph.json` so downstream consumers can navigate admin paths.
- Data flow diagram and guard documentation updated to `ClerkAuthGuard` (actual guard in `api/src/auth/guards/`).
- Topic files corrected: `api/src/modules/*` paths → `api/src/*`; `pnpm i18n:extract` → `pnpm extract:i18n-keys`; Render build commands reflect `render.yaml`; `prebuild:render` scope clarified.

## Test plan

- [ ] Run `pnpm graphify` — completes without errors and writes both output files
- [ ] `graphify-out/GRAPH_REPORT.md` shows correct counts (43 modules, 36 pages, 5 contexts, 36 admin pages)
- [ ] `graphify-out/graph.json` includes admin page and context nodes
- [ ] `.claude/hooks/pre-search-reminder.sh` fires on Glob/Grep tool use in a Claude Code session

https://claude.ai/code/session_01YcR74mgAm7HV9KaSLB4gSN