### PR TITLE
Restrict educator job roles to predefined list

### DIFF
--- a/admin/src/constants/design-system.ts
+++ b/admin/src/constants/design-system.ts
@@ -19,6 +19,10 @@ export const ALL_REGIONS_OPTION = 'All' as const;
 // Convenience list for selects where users can choose to cover all cantons.
 export const SWISS_CANTONS_WITH_ALL = [ALL_REGIONS_OPTION, ...SWISS_CANTONS] as const;
 
+// Restricted list of valid educator job roles.
+export const EDUCATOR_JOB_ROLES = ['Direction', 'EDE', 'ASE', 'Auxiliaire', 'Cleaning'] as const;
+export type EducatorJobRole = typeof EDUCATOR_JOB_ROLES[number];
+
 export const SERVICE_CATEGORIES = [
   'Legal', 'Catering', 'Cleaning', 'Workshops', 'IT_Support', 'Consulting', 
   'Maintenance', 'Photography', 'Staff_Training', 'Landscaping', 'Other'

--- a/admin/src/pages/AdminUserProfileEdit.tsx
+++ b/admin/src/pages/AdminUserProfileEdit.tsx
@@ -22,7 +22,7 @@ import Card from '../components/design-system/Card';
 import Button from '../components/design-system/Button';
 import ChipInput from '../components/design-system/ChipInput';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
-import { ALL_REGIONS_OPTION, STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL } from '../constants/design-system';
+import { ALL_REGIONS_OPTION, STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL, EDUCATOR_JOB_ROLES } from '../constants/design-system';
 import { UserRole } from '../types';
 
 interface UserProfile {
@@ -347,9 +347,10 @@ const AdminUserProfileEdit: React.FC = () => {
                   {t('admin:userProfile.cities', 'Cities')}
                 </label>
                 <ChipInput
-                  value={formData.cities || []}
+                  selectedChips={formData.cities || []}
                   onChange={(chips) => handleChange('cities', chips)}
                   placeholder={t('admin:userProfile.citiesPlaceholder', 'Add cities...')}
+                  allowCustomValues={true}
                 />
               </div>
             </div>
@@ -369,9 +370,10 @@ const AdminUserProfileEdit: React.FC = () => {
                   {t('admin:userProfile.jobRoles', 'Job Roles')}
                 </label>
                 <ChipInput
-                  value={formData.jobRoles || []}
+                  selectedChips={formData.jobRoles || []}
+                  availableOptions={[...EDUCATOR_JOB_ROLES]}
                   onChange={(chips) => handleChange('jobRoles', chips)}
-                  placeholder={t('admin:userProfile.jobRolesPlaceholder', 'e.g., Educator, Assistant')}
+                  placeholder={t('admin:userProfile.jobRolesPlaceholder', 'Select a role')}
                 />
               </div>
               <div>
@@ -426,9 +428,10 @@ const AdminUserProfileEdit: React.FC = () => {
                 {t('admin:userProfile.skills', 'Skills')}
               </h3>
               <ChipInput
-                value={formData.skills || []}
+                selectedChips={formData.skills || []}
                 onChange={(chips) => handleChange('skills', chips)}
                 placeholder={t('admin:userProfile.skillsPlaceholder', 'e.g., Montessori, Bilingual')}
+                allowCustomValues={true}
               />
             </Card>
 
@@ -438,9 +441,10 @@ const AdminUserProfileEdit: React.FC = () => {
                 {t('admin:userProfile.certifications', 'Certifications')}
               </h3>
               <ChipInput
-                value={formData.certifications || []}
+                selectedChips={formData.certifications || []}
                 onChange={(chips) => handleChange('certifications', chips)}
                 placeholder={t('admin:userProfile.certificationsPlaceholder', 'e.g., CPR Certified')}
+                allowCustomValues={true}
               />
             </Card>
 

--- a/api/src/admin/admin-profiles.controller.ts
+++ b/api/src/admin/admin-profiles.controller.ts
@@ -17,11 +17,13 @@ import {
   IsEmail,
   IsBoolean,
   IsArray,
+  IsIn,
   IsNumber,
   IsUrl,
   IsUUID,
   ValidateNested,
 } from 'class-validator';
+import { ALLOWED_JOB_ROLES } from '../settings/dto/educator-settings.dto';
 import { Type } from 'class-transformer';
 import { ClerkAuthGuard } from '../auth/guards/clerk-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -73,11 +75,12 @@ class AdminUpdateUserProfileDto {
 
   @IsOptional()
   @IsString()
+  @IsIn(ALLOWED_JOB_ROLES)
   jobRole?: string;
 
   @IsOptional()
   @IsArray()
-  @IsString({ each: true })
+  @IsIn(ALLOWED_JOB_ROLES, { each: true })
   jobRoles?: string[];
 
   @IsOptional()

--- a/api/src/settings/dto/educator-settings.dto.ts
+++ b/api/src/settings/dto/educator-settings.dto.ts
@@ -2,6 +2,7 @@ import {
   IsArray,
   IsBoolean,
   IsEmail,
+  IsIn,
   IsObject,
   IsOptional,
   IsString,
@@ -10,6 +11,8 @@ import {
   ValidateIf,
   ValidateNested,
 } from 'class-validator';
+
+export const ALLOWED_JOB_ROLES = ['Direction', 'EDE', 'ASE', 'Auxiliaire', 'Cleaning'] as const;
 import { Type } from 'class-transformer';
 import { EducatorAvailabilitySettingsDto } from './educator-availability.dto';
 
@@ -185,6 +188,7 @@ export class UpdateEducatorSettingsDto {
    */
   @IsOptional()
   @IsString()
+  @IsIn(ALLOWED_JOB_ROLES)
   jobRole?: string;
 
   /**
@@ -192,7 +196,7 @@ export class UpdateEducatorSettingsDto {
    */
   @IsOptional()
   @IsArray()
-  @IsString({ each: true })
+  @IsIn(ALLOWED_JOB_ROLES, { each: true })
   jobRoles?: string[];
 
   /**

--- a/frontend/components/profile/edit/EducatorProfileForm.tsx
+++ b/frontend/components/profile/edit/EducatorProfileForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { SettingsFormData, WorkExperienceItem, EducationItem, CertificationItem } from '../../../types';
-import { STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL, ALL_REGIONS_OPTION } from '../../../constants';
+import { STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL, ALL_REGIONS_OPTION, EDUCATOR_JOB_ROLES } from '../../../constants';
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../../../contexts/AppContext';
 import CoverImageSection from './shared/CoverImageSection';
@@ -269,12 +269,12 @@ const EducatorProfileForm: React.FC<EducatorProfileFormProps> = ({ formData, onC
             </label>
             <ChipInput
               selectedChips={jobRoles}
+              availableOptions={[...EDUCATOR_JOB_ROLES]}
               onChange={(roles) => {
                 onChange('jobRoles', roles);
                 onChange('jobRole', roles[0] || '');
               }}
-              placeholder={t('settings:educatorProfile.rolePlaceholder', 'e.g., Educator, Assistant')}
-              allowCustomValues={true}
+              placeholder={t('settings:educatorProfile.rolePlaceholder', 'Select a role')}
               onInputValueChange={setJobRoleDraft}
             />
             <p className="mt-1 text-xs text-gray-500">

--- a/frontend/components/settings/sections/EducatorProfileSettings.tsx
+++ b/frontend/components/settings/sections/EducatorProfileSettings.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { SettingsFormData, UserRole, WorkExperienceItem, EducationItem, CertificationItem } from '../../../types';
-import { STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL, ALL_REGIONS_OPTION } from '../../../constants';
+import { STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL, ALL_REGIONS_OPTION, EDUCATOR_JOB_ROLES } from '../../../constants';
 import SettingsSectionWrapper from '../SettingsSectionWrapper';
 import ImageCropperModal from '../../shared/ImageCropperModal';
 import FileUploadZone from '../../ui/FileUploadZone';
@@ -494,15 +494,18 @@ const EducatorProfileSettings: React.FC<EducatorProfileSettingsProps> = ({ setti
               {t('settings:educatorProfile.role', 'Role')} <span className="text-swiss-coral">*</span>
             </label>
             <div className="form-input-container">
-              <input
-                type="text"
+              <select
                 id="jobRole"
                 value={(profileData as any).jobRole}
                 onChange={(e) => handleFieldChange('jobRole', e.target.value)}
                 className={STANDARD_INPUT_FIELD}
-                placeholder={t('settings:educatorProfile.rolePlaceholder', 'e.g., Educator, Assistant')}
                 required
-              />
+              >
+                <option value="">{t('settings:educatorProfile.rolePlaceholder', 'Select a role')}</option>
+                {EDUCATOR_JOB_ROLES.map((role) => (
+                  <option key={role} value={role}>{role}</option>
+                ))}
+              </select>
             </div>
 
             <label htmlFor="region" className="form-label md:pt-2">

--- a/frontend/components/settings/sections/EducatorProfileSettings.tsx
+++ b/frontend/components/settings/sections/EducatorProfileSettings.tsx
@@ -497,7 +497,11 @@ const EducatorProfileSettings: React.FC<EducatorProfileSettingsProps> = ({ setti
               <select
                 id="jobRole"
                 value={(profileData as any).jobRole}
-                onChange={(e) => handleFieldChange('jobRole', e.target.value)}
+                onChange={(e) => {
+                  const role = e.target.value;
+                  handleFieldChange('jobRole', role);
+                  handleFieldChange('jobRoles', role ? [role] : []);
+                }}
                 className={STANDARD_INPUT_FIELD}
                 required
               >

--- a/frontend/constants.ts
+++ b/frontend/constants.ts
@@ -10,6 +10,10 @@ export const ALL_REGIONS_OPTION = 'All' as const;
 // Convenience list for selects where users can choose to cover all cantons.
 export const SWISS_CANTONS_WITH_ALL = [ALL_REGIONS_OPTION, ...SWISS_CANTONS] as const;
 
+// Restricted list of valid educator job roles. No free-text input is allowed; users must pick from this list.
+export const EDUCATOR_JOB_ROLES = ['Direction', 'EDE', 'ASE', 'Auxiliaire', 'Cleaning'] as const;
+export type EducatorJobRole = typeof EDUCATOR_JOB_ROLES[number];
+
 export const APP_NAME = "Pro Crèche Solutions";
 
 // hCaptcha Configuration

--- a/frontend/pages/RecruitmentPage.tsx
+++ b/frontend/pages/RecruitmentPage.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { JobListing, CandidateProfile, UserRole, JobStatus, JobContractType, JobContractTypeValue, Application } from '../types';
-import { STANDARD_INPUT_FIELD, ICON_INPUT_FIELD } from '../constants';
+import { STANDARD_INPUT_FIELD, ICON_INPUT_FIELD, EDUCATOR_JOB_ROLES } from '../constants';
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
 import Tabs from '../components/ui/Tabs';
@@ -434,18 +434,7 @@ const RecruitmentPage: React.FC = () => {
     ],
   );
 
-  const candidateRoleOptions = useMemo(() => {
-    const roles = new Set<string>();
-    candidateProfiles.forEach((c) => {
-      const roleEntries = c.jobRoles && c.jobRoles.length > 0
-        ? c.jobRoles
-        : [c.currentRoleOrTitle ?? c.jobRole ?? ''].map(r => r.trim()).filter(Boolean);
-      roleEntries.forEach((role) => {
-        if (role) roles.add(role);
-      });
-    });
-    return Array.from(roles).sort((a, b) => a.localeCompare(b));
-  }, [candidateProfiles]);
+  const candidateRoleOptions = [...EDUCATOR_JOB_ROLES];
 
   const jobsTotalPages = useMemo(
     () => Math.max(1, Math.ceil(filteredJobs.length / Math.max(1, jobsPerPage))),


### PR DESCRIPTION
## Summary
This PR introduces a restricted list of valid educator job roles and updates all related components to use this predefined list instead of allowing free-text input. This ensures consistency and data quality across the application.

## Key Changes
- **New constant**: Added `EDUCATOR_JOB_ROLES` constant in both `admin/src/constants/design-system.ts` and `frontend/constants.ts` with the valid roles: Direction, EDE, ASE, Auxiliaire, and Cleaning
- **Admin User Profile Edit**: Updated ChipInput components to use the new constant and changed prop names from `value` to `selectedChips` for consistency
  - Job Roles field now uses `availableOptions` to restrict selections
  - Cities, Skills, and Certifications fields now support `allowCustomValues={true}` for flexibility
- **Recruitment Page**: Replaced dynamic role extraction logic with the static `EDUCATOR_JOB_ROLES` list for candidate filtering
- **Educator Profile Settings**: Converted the job role input from a free-text field to a dropdown select with predefined options

## Implementation Details
- The `EDUCATOR_JOB_ROLES` constant is exported as both a const array and a TypeScript type (`EducatorJobRole`) for type safety
- ChipInput components now differentiate between fields that allow custom values (cities, skills, certifications) and those that require selection from a predefined list (job roles)
- The recruitment page no longer dynamically builds role options from candidate profiles, ensuring consistency with the admin-defined list

https://claude.ai/code/session_011k5bzQpipqaEqQDLuJXBPg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Educator job role inputs now use standardized dropdown selection with predefined roles (Direction, EDE, ASE, Auxiliaire, Cleaning) instead of free-text entry.
  * Improved consistency across admin and frontend for educator profile and recruitment role management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->