### PR TITLE
Restrict educator job roles to 5 predefined values & fix admin edit blank page

### DIFF
--- a/frontend/components/profile/edit/EducatorProfileForm.tsx
+++ b/frontend/components/profile/edit/EducatorProfileForm.tsx
@@ -28,7 +28,6 @@ interface EducatorProfileFormProps {
 const EducatorProfileForm: React.FC<EducatorProfileFormProps> = ({ formData, onChange }) => {
   const { t } = useTranslation(['common', 'settings']);
   const { currentUser } = useAppContext();
-  const [jobRoleDraft, setJobRoleDraft] = useState('');
   const [citiesDraft, setCitiesDraft] = useState('');
 
   const handleSkillsChange = (newSkills: string[]) => {
@@ -185,7 +184,6 @@ const EducatorProfileForm: React.FC<EducatorProfileFormProps> = ({ formData, onC
         ? [formData.jobRole]
         : [];
   const cities = Array.isArray(formData.cities) ? formData.cities : [];
-  const hasUnconfirmedJobRole = jobRoleDraft.trim().length > 0;
   const hasUnconfirmedCity = citiesDraft.trim().length > 0;
 
   return (
@@ -267,28 +265,22 @@ const EducatorProfileForm: React.FC<EducatorProfileFormProps> = ({ formData, onC
             <label htmlFor="jobRole" className="block text-sm font-medium text-gray-700 mb-1">
               {t('settings:educatorProfile.role', 'Role')} <span className="text-swiss-coral">*</span>
             </label>
-            <ChipInput
-              selectedChips={jobRoles}
-              availableOptions={[...EDUCATOR_JOB_ROLES]}
-              onChange={(roles) => {
-                onChange('jobRoles', roles);
-                onChange('jobRole', roles[0] || '');
+            <select
+              id="jobRole"
+              value={jobRoles[0] || ''}
+              onChange={(e) => {
+                const role = e.target.value;
+                onChange('jobRole', role);
+                onChange('jobRoles', role ? [role] : []);
               }}
-              placeholder={t('settings:educatorProfile.rolePlaceholder', 'Select a role')}
-              onInputValueChange={setJobRoleDraft}
-            />
-            <p className="mt-1 text-xs text-gray-500">
-              {t('settings:educatorProfile.roleHint', 'Add one or more roles to improve matching.')}
-            </p>
-            <p
-              className={`mt-1 text-xs ${hasUnconfirmedJobRole ? 'text-swiss-coral' : 'text-gray-500'}`}
+              className={STANDARD_INPUT_FIELD}
+              required
             >
-              {hasUnconfirmedJobRole && <span className="text-swiss-coral">*</span>}{' '}
-              {t(
-                'settings:educatorProfile.rolePressEnterHint',
-                'Type a role and press Enter to add it.',
-              )}
-            </p>
+              <option value="">{t('settings:educatorProfile.rolePlaceholder', 'Select a role')}</option>
+              {EDUCATOR_JOB_ROLES.map((role) => (
+                <option key={role} value={role}>{role}</option>
+              ))}
+            </select>
           </div>
 
           <div>

--- a/frontend/components/profile/edit/EducatorProfileForm.tsx
+++ b/frontend/components/profile/edit/EducatorProfileForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { SettingsFormData, WorkExperienceItem, EducationItem, CertificationItem } from '../../../types';
 import { STANDARD_INPUT_FIELD, SWISS_CANTONS_WITH_ALL, ALL_REGIONS_OPTION, EDUCATOR_JOB_ROLES } from '../../../constants';
 import { useTranslation } from 'react-i18next';
@@ -29,6 +29,14 @@ const EducatorProfileForm: React.FC<EducatorProfileFormProps> = ({ formData, onC
   const { t } = useTranslation(['common', 'settings']);
   const { currentUser } = useAppContext();
   const [citiesDraft, setCitiesDraft] = useState('');
+
+  // Normalize legacy multi-role data to a single role on mount so the submit
+  // payload always matches what the select displays, even if untouched.
+  useEffect(() => {
+    if (Array.isArray(formData.jobRoles) && formData.jobRoles.length > 1) {
+      onChange('jobRoles', [formData.jobRoles[0]]);
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSkillsChange = (newSkills: string[]) => {
     onChange('skills', newSkills);


### PR DESCRIPTION
## Summary

- **Restrict job roles** to 5 values only: `Direction`, `EDE`, `ASE`, `Auxiliaire`, `Cleaning` — replaces all free-text inputs with `<select>` dropdowns in both `EducatorProfileForm.tsx` and `EducatorProfileSettings.tsx`
- **Fix admin edit user blank page** — `AdminUserProfileEdit.tsx` was passing `value` prop to `ChipInput` which expects `selectedChips`; calling `.map()` on `undefined` crashed the render tree silently
- **Restrict candidate pool role filter** in `RecruitmentPage.tsx` to the static list instead of dynamically deriving from candidate data
- **Backend validation** — added `@IsIn(ALLOWED_JOB_ROLES)` to `jobRole` and `jobRoles` fields in both `UpdateEducatorSettingsDto` and `AdminUpdateUserProfileDto` so direct API calls with invalid roles get a 400

## Files changed

| File | Change |
|---|---|
| `frontend/constants.ts` | Add `EDUCATOR_JOB_ROLES` constant |
| `admin/src/constants/design-system.ts` | Add `EDUCATOR_JOB_ROLES` constant |
| `frontend/components/settings/sections/EducatorProfileSettings.tsx` | `<input>` → `<select>`, syncs `jobRoles[]` on change |
| `frontend/components/profile/edit/EducatorProfileForm.tsx` | ChipInput → `<select>`, removes unused `jobRoleDraft` state |
| `admin/src/pages/AdminUserProfileEdit.tsx` | Fix `value` → `selectedChips` on all 4 ChipInput usages; restrict `jobRoles` to predefined list |
| `frontend/pages/RecruitmentPage.tsx` | Static role filter options |
| `api/src/settings/dto/educator-settings.dto.ts` | Export `ALLOWED_JOB_ROLES`, add `@IsIn` validators |
| `api/src/admin/admin-profiles.controller.ts` | Import `ALLOWED_JOB_ROLES`, add `@IsIn` validators |

## Existing users with invalid job roles

No DB migration — existing out-of-range data is not deleted. Use the now-fixed admin edit user page (`/users/:id/profile`) to manually correct each user's job role to a valid value.

## Test plan

- [ ] Educator profile settings page shows a dropdown with exactly 5 options
- [ ] Educator profile form (public-facing) shows a dropdown with exactly 5 options
- [ ] Admin edit user page loads without blank page for any user
- [ ] Admin job roles field only allows selecting from the 5 predefined values
- [ ] Candidate pool role filter dropdown shows the 5 static roles
- [ ] API rejects `PATCH /settings/educator` with an invalid `jobRole` value (400)
- [ ] API rejects `PATCH /admin/users/:id/profile` with an invalid `jobRole` value (400)

https://claude.ai/code/session_011k5bzQpipqaEqQDLuJXBPg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Job role selection simplified to a single required dropdown with placeholder and predefined options.
* **Bug Fixes**
  * Legacy multi-value job role entries are automatically normalized to a single selection.
  * Removed obsolete “unconfirmed job role” UI and related guidance for entering roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->