### PR TITLE
docs(v2): staffing-first remodel plan + persistent notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,11 @@
 
 This file is maintained by Claude Code sessions to avoid re-investigating the same areas of the codebase. Update it as new findings are made.
 
+> **v2 staffing-first remodel:** there is a dedicated plan folder at `docs/v2-staffing-remodel/`.
+> Start any remodel-related task by reading `docs/v2-staffing-remodel/00-README.md` and
+> `docs/v2-staffing-remodel/01-current-state-inventory.md` **before** re-analysing the codebase.
+> The current-state inventory there is the canonical pre-remodel snapshot.
+
 ---
 
 ## Architecture Overview

--- a/docs/v2-staffing-remodel/00-README.md
+++ b/docs/v2-staffing-remodel/00-README.md
@@ -1,0 +1,55 @@
+# ProCrèche v2 — Staffing-First Remodel
+
+> **Important:** Before starting any analysis or implementation related to the v2 remodel,
+> **read these notes first**. They are the source of truth for the remodel so we do not
+> re-investigate the codebase from scratch every session.
+
+## Files in this folder
+
+| File | Purpose |
+|---|---|
+| `00-README.md` | You are here. Entry point. |
+| `01-current-state-inventory.md` | Full audit of what exists today: API modules, Prisma models, frontend pages, admin pages, email system, integrations. Keep this updated as the code evolves. |
+| `02-gap-analysis.md` | What is missing or stubbed relative to the v2 staffing-first strategy. |
+| `03-remodel-strategy.md` | Strategic direction, principles, information-architecture targets, acceptance criteria per feature area. |
+| `04-phased-plan.md` | Concrete phased work plan (what to restructure, refactor, add, deprecate). No calendar estimates — phases instead. |
+| `05-data-migration-and-preservation.md` | How to preserve live users and data through the remodel (nothing destructive). |
+| `06-email-and-notification-plan.md` | Staffing-centric transactional email + in-app notification plan that hooks into the existing `email-notification` module. |
+| `07-navigation-ia-target.md` | Final navigation, routes, and page layouts per role (foundation + admin). |
+| `08-open-decisions.md` | Questions that need product decisions before/while building. |
+
+## Scope recap (from the brief)
+
+- **Product pivot:** ProCrèche becomes a **staffing and recruitment system** for Swiss crèches, with everything else relegated to secondary support layers.
+- **Admin dashboard:** all existing roles' features stay, but staffing sits on top and drives alerts/notifications. Staffing-focused email flows (candidate matching, daycare application notifications) must be added.
+- **Foundation (daycare) dashboard:** remodelled around staffing.
+- **Parent / Product supplier / Service provider dashboards:** **unchanged** in role scope. They keep their existing feature set. No staffing content leaks into them.
+- **Do not rebuild** what is already working. Restructure, rename, re-prioritise, and fill gaps. Preserve live users and live data.
+
+## Hard navigation rule (from brief)
+
+Top-level navigation for the staffing-oriented roles (foundation + admin) must follow this order:
+
+1. **Overview** (staffing-first dashboard homepage)
+2. **Staffing**
+3. **HR & Compliance**
+4. **Parent Enquiries**
+5. **Suppliers & Services**
+
+**Admin-only variation** (per user follow-up): Overview → **Users** → then the order above. All other admin modules (billing, support, content moderation, system, translations, …) remain available but ranked below staffing-signal surfaces.
+
+## Feature acceptance test (apply to every proposed change)
+
+A change is in scope only if it makes at least one of these true:
+
+- Improves hiring speed.
+- Improves candidate visibility.
+- Reduces staffing pressure (especially replacement).
+- Simplifies operator workflow.
+
+Otherwise it is secondary support — allowed to stay, not allowed to drive IA.
+
+## Branch / PR convention for this effort
+
+- Planning / notes branch: `cursor/v2-staffing-remodel-plan-3032` (this PR).
+- Subsequent implementation branches should be scoped per phase (e.g. `cursor/v2-p1-ia-foundation-3032`, `cursor/v2-p2-replacement-domain-3032`) and reference this plan.

--- a/docs/v2-staffing-remodel/01-current-state-inventory.md
+++ b/docs/v2-staffing-remodel/01-current-state-inventory.md
@@ -1,0 +1,366 @@
+# Current State Inventory (pre-remodel)
+
+> **Do not re-audit the codebase if this file already answers your question.** Update it
+> when things change. All file paths are repo-relative to `/workspace`.
+
+---
+
+## 1. Monorepo layout
+
+| App | Path | Stack |
+|---|---|---|
+| User SPA | `frontend/` | React + Vite + TypeScript, Tailwind, React Router v6, Clerk, i18next |
+| Admin SPA | `admin/` | Same stack, separate Vite config (dev port 5174) |
+| API | `api/` | NestJS + Prisma + PostgreSQL |
+
+Shared: `packages/`, `docs/`.
+
+---
+
+## 2. User roles (Prisma `User.role`)
+
+`PARENT`, `EDUCATOR`, `FOUNDATION`, `PRODUCT_SUPPLIER`, `SERVICE_PROVIDER`, `ADMIN`, `SUPER_ADMIN`.
+
+Role → primary dashboard URL (`frontend/App.tsx` `RoleBasedDashboardRedirect`, lines ~151–171):
+
+| Role | Redirect |
+|---|---|
+| `PRODUCT_SUPPLIER` | `/supplier/dashboard` |
+| `SERVICE_PROVIDER` | `/service-provider/dashboard` |
+| `FOUNDATION` | `/foundation/dashboard` |
+| `EDUCATOR` | `/educator/dashboard` |
+| `PARENT` | `/parent/dashboard` |
+| `ADMIN` / `SUPER_ADMIN` | `/admin/content-dashboard` *(note: bug smell — should be `/dashboard` or a true admin home; see §9)* |
+
+---
+
+## 3. Recruitment / staffing (the thing being elevated)
+
+### 3.1 API — `api/src/recruitment/`
+
+Files: `recruitment.controller.ts`, `recruitment.service.ts`, `recruitment.module.ts`, `dto/*`.
+Guarded by `ClerkAuthGuard` + `RolesGuard`. Controller base path: `recruitment`.
+
+Endpoints (abbreviated):
+
+| Method | Path | Roles | Notes |
+|---|---|---|---|
+| POST | `job-listings` | FOUNDATION, ADMIN, SUPER_ADMIN | `foundationId` from `req.user.organizationId`. |
+| GET | `job-listings` | all auth | educators/parents/suppliers → `publishedOnly` forced. Filters: `foundationId`, `status`, `location`, `search`, `contractType`, `employmentType`, `lang`. |
+| GET | `job-listings/:id` | all auth | translations applied when `lang ≠ en`. |
+| PATCH / DELETE | `job-listings/:id` | FOUNDATION (own org), ADMIN, SUPER_ADMIN | |
+| GET | `job-listings/:id/applications` | FOUNDATION (own org), ADMIN, SUPER_ADMIN | |
+| POST | `applications` | EDUCATOR, ADMIN, SUPER_ADMIN | `candidateId = req.user.id`. |
+| GET | `applications` | all auth (no `@Roles`) | **Audit**: missing role gate. |
+| GET | `applications/my` | EDUCATOR, ADMIN, SUPER_ADMIN | |
+| GET | `applications/job/:id` | FOUNDATION (own org), ADMIN, SUPER_ADMIN | |
+| GET | `applications/:id` | all auth | |
+| PATCH | `applications/:id` | FOUNDATION, ADMIN, SUPER_ADMIN | Status transitions. |
+| DELETE | `applications/:id` | EDUCATOR, ADMIN, SUPER_ADMIN | |
+| GET | `candidates` | FOUNDATION, ADMIN, SUPER_ADMIN | Filters: `role`, `skills` (csv), `location`, `search`. Admins see opted-out educators. |
+| GET | `candidates/:id` | all auth (no `@Roles`) | Non-admins only if `candidatePoolVisible=true`. **Audit**. |
+| GET | `job-listings/:id/matching-candidates` | FOUNDATION, ADMIN, SUPER_ADMIN | Stub: returns all pool-visible educators minus those who already applied. No skill / region / availability scoring. |
+| GET | `stats` | ADMIN, SUPER_ADMIN | Aggregate counts. |
+
+**No email side effects** in any recruitment endpoint.
+
+### 3.2 Prisma (`api/prisma/schema.prisma`)
+
+Dedicated recruitment models:
+
+- `JobListing` — `title`, `description`, `requirements[]`, `benefits[]`, `responsibilities[]`, `qualifications[]`, `location`, `salary`, `salaryRange`, `contractType` (enum), `employmentType` (enum), `workSchedule` (`Json?`), `startDate`, `status` (`DRAFT|PUBLISHED|CLOSED|FILLED`), `foundationId`, `publishedAt`. Relation: `applications[]`.
+- `JobApplication` — `jobListingId`, `candidateId (User.id)`, `coverLetter`, `cvUrl`, `cvAssetId`, `status` (`PENDING|REVIEWED|ACCEPTED|REJECTED`). Unique `(jobListingId, candidateId)`.
+
+Enums: `JobStatus`, `JobContractType {FULL_TIME, PART_TIME, CDI, CDD, INTERNSHIP, REPLACEMENT, TEMPORARY, FREELANCE}`, `JobEmploymentType {FULL_TIME, PART_TIME, REPLACEMENT}`, `ApplicationStatus`.
+
+Candidate identity lives on `User` (no dedicated `Candidate` / `EducatorProfile` table):
+
+- `skills[]`, `certifications[]`, `availability: String?` (legacy), `availabilitySettings: Json?` (structured, per `docs/EDUCATOR_AVAILABILITY_SYSTEM_DESIGN.md`), `cvUrl`, `shortBio`, `candidatePoolVisible`, `region`, `jobRole`, `jobRoles[]`, `cities[]`, `isActive`, plus `EducatorWorkExperience`, `EducatorEducation`, `EducatorCertification` child tables.
+
+**Missing models:** `Shortlist`, `SavedCandidate`, `Match`, `ReplacementRequest`, `UrgentShift`, `Assignment`, dedicated `EducatorAvailability` (lives as JSON on `User` today).
+
+### 3.3 Frontend staffing UI
+
+- `frontend/pages/RecruitmentPage.tsx` (foundation + admin) — tabs: jobs vs candidate pool. Uses `JobPostModal` and `ViewApplicantsModal`. Favourites are `localStorage` only. No persisted shortlist, no application status pipeline UI.
+- `frontend/pages/educator/EducatorJobBoardPage.tsx` — filter dropdown omits `REPLACEMENT`, `TEMPORARY`, `FREELANCE`. Placeholder foundation avatars from `picsum.photos`.
+- `frontend/pages/educator/EducatorApplicationsPage.tsx` — "View details" is `alert(...)` stub.
+- `frontend/pages/foundation/FoundationDashboardPage.tsx` — 3-column grid (quick stats / today / recent activity / quick actions / quick message). Uses real API via `foundationDashboardService`. Only one staffing hook: a "Post job" quick action link to `/recruitment`.
+- `frontend/pages/candidate/CandidateProfilePage.tsx` — candidate detail view.
+
+### 3.4 Admin staffing UI
+
+- `admin/src/pages/JobListings.tsx` — list, search, status filter (`PUBLISHED|DRAFT|CLOSED` — **no `FILLED`**), create/edit via `AddJobListingModal`, delete.
+- `admin/src/pages/Candidates.tsx` — list + search + availability string filter. Edit modal; delete menu item has **no `onClick`** (dead button).
+- `admin/src/components/AddJobListingModal.tsx` — **missing `employmentType`, `workSchedule`, `startDate`, `salaryRange`** vs. foundation `JobPostModal`.
+- `admin/src/components/AddCandidateModal.tsx` — legacy `availability` dropdown, not structured `availabilitySettings`.
+
+### 3.5 Replacement staffing state (critical finding)
+
+Replacement exists only as a **label**:
+
+- `JobContractType.REPLACEMENT` and `JobEmploymentType.REPLACEMENT` enum values.
+- `workSchedule` JSON on the listing for part-time / replacement roles.
+- Recruitment service maps `REPLACEMENT` contract type → `REPLACEMENT` employment type.
+
+There is **no**:
+
+- `ReplacementRequest` entity.
+- Urgency / SLA flagging.
+- Shift-level model (start time, end time, days).
+- Dynamic availability matching.
+- Fulfilment state machine (requested → offered → accepted → filled).
+- Direct assignment of a candidate to a shift without a job listing + application.
+
+**In effect: replacement staffing is not a feature. It is an enum tag on the existing "post a job" flow.**
+
+### 3.6 Availability system (`docs/EDUCATOR_AVAILABILITY_SYSTEM_DESIGN.md`)
+
+Designed (Calendly-style weekly schedule + overrides + employment type). Partially implemented:
+
+- Prisma field `User.availabilitySettings: Json?` exists.
+- DTOs in `api/src/settings/dto/educator-availability.dto.ts`.
+- Frontend `AvailabilityScheduler`, `types/availability.ts`.
+- Candidate pool date filter uses `isDateTimeAvailable` when settings present; falls back for legacy profiles.
+
+Not implemented:
+
+- Dedicated "available on date/time" search API across educators.
+- Availability-driven matching in `findMatchingCandidates`.
+- Structured availability in admin `AddCandidateModal`.
+
+---
+
+## 4. Peripheral modules (secondary under v2)
+
+### 4.1 Parent leads (`api/src/leads/`)
+
+- Prisma: `ParentLead`, `FoundationLeadResponse`. Real data.
+- Controller: public `POST /parent-leads`, foundation/admin listing & updates, parent `/parent/my-leads`, foundation `/foundation/my-leads`, matching, assign, distribution, notify, stats.
+- Scheduler `LeadsSchedulerService`: cron-driven lead distribution; auto-disables if `FRONTEND_URL` unset.
+- Frontend: `FoundationLeadsPage`, `ParentEnquiriesPage`, `ParentLeadFormPage` — all real API.
+- Admin: `ParentLeads.tsx` — real API.
+
+**Remodel verdict:** keep as-is; downgrade in IA ranking. Emits `new_lead` + `parent_lead_confirmation` emails already.
+
+### 4.2 HR / compliance
+
+- Prisma: `Asset` (with `category` / `contentCategory` / crawler fields), `OrganizationDocument`, `Canton`, `CantonSource`, `PolicyCrawlHistory`, `PolicyAlert`.
+- API: `policy-alerts`, `content` (HR / e-learning / state-policies), `admin/crawler` (env-gated on `CRAWLER_ENABLED`), `organization-documents`.
+- Frontend: `HRProceduresPage`, `StatePoliciesPage`.
+- Admin: `Cantons`, `CantonDetail`, `PolicyCrawler`, `PolicyReview`.
+
+**Remodel verdict:** keep. Move behind "HR & Compliance" as position 3 in the nav order.
+
+### 4.3 Marketplace / suppliers / service providers
+
+- Prisma: `Product`, `Catalog`, `Service`, `ServiceProvider`, `Order`, `OrderItem`, `ServiceRequest`, `Inquiry`, `PromoCode`, `Partner`.
+- API: `marketplace`, `partners`.
+- Frontend: `MarketplacePage`, `supplier/*` (7 pages), `service-provider/*` (7 pages).
+- Admin: `Products`, `Services`, `Orders`, `Partners`.
+
+**Remodel verdict:** keep. Supplier + service-provider role dashboards **remain untouched** per the brief. Foundation-side marketplace drops to nav position 5.
+
+### 4.4 E-learning / content
+
+- Prisma: full LMS graph (`Course`, `CourseModule`, `CourseLesson`, `CourseEnrollment`, `LessonProgress`, `CourseQuiz`, `QuizQuestion`, `QuizAnswer`, `QuizAttempt`, `Certificate`, `CourseDiscussion`, `DiscussionReply`) + `ContentItem`, `ContentCategory` + `ContentModeration`, `ModerationAction`.
+- API: `elearning`, `content`, `content-management`, `content-moderation` (automated rules endpoints are **stubs returning static data** — `content-moderation.service.ts` `getAutomatedRules` / `updateAutomatedRule`).
+- Frontend: `ELearningPage`, `FileGalleryPage`, `admin/ContentManagementDashboardPage`.
+- Admin: `Content.tsx` (tabs shell), `content/e-learning`, `content/hr-documents`, `content/state-policies`.
+
+**Remodel verdict:** keep, minimal. Per brief, e-learning is minimal support.
+
+### 4.5 Subscription / billing
+
+- Prisma (dual stack): `Subscription`, `SubscriptionPlan`, `SubscriptionRequest`, `SubscriptionCancellationRequest`, `SubscriptionSettings`, `SubscriptionAction`, `SubscriptionSchedule`, `SubscriptionNote`, `BillingTransaction`, `PricingTier`, `DynamicPricingRule`, `FeatureFlag` — plus legacy Stripe-direct `Plan`, `PlanPrice`, `UserSubscription`, `License`.
+- API: `billing` (Stripe + `GET /billing/plans`), `subscription-management` (large admin surface + public `GET /subscriptions/plans`).
+- Frontend: `PricingPage` (mixes static `pricingService` data + live `/subscriptions/plans` fetch).
+- Admin: `Subscriptions`, `DiscountTerminations` (vendor-clients API).
+
+**Remodel verdict:** keep. Entitlements may gate staffing features in v2 (out of scope here — tracked as open decision).
+
+### 4.6 Support
+
+- Prisma: `SupportTicket`, `TicketResponse`.
+- API: `support`.
+- Admin: `Support.tsx`, `SupportTicket.tsx`.
+
+**Remodel verdict:** keep. Admin nav rank: low.
+
+### 4.7 Messaging
+
+- Prisma: `Conversation`, `ConversationParticipant`, `Message`.
+- API: `messaging` REST + `messaging.gateway.ts` WebSocket (`/messaging` namespace).
+- Frontend: `MessagesPage` (`MessagingContext` + `useMessagingSocket`).
+- Admin: `Messaging.tsx` (has `unreadCount: 0 // TODO` placeholder).
+
+**Remodel verdict:** keep; deepen for recruiter ↔ candidate comms. Already cross-role.
+
+---
+
+## 5. Email / notification stack
+
+### 5.1 Engine — `api/src/email-notification/`
+
+- `email-notification.service.ts` — `sendNotification(event, recipient, payload, bypassPreferences?, allowUnknownRecipient?)` pipeline:
+  1. Look up user + `notificationPreferences`.
+  2. Check preferences (unless bypassed). Mandatory events always send.
+  3. Resolve template via `EmailTemplateService.getTemplate(event)` — DB first, then `getDefaultTemplate(event)` code fallback.
+  4. Send via `MailingTransportService` (SMTP → Mailgun → SendGrid).
+  5. Log to `EmailLog` (`sent` / `failed`; no delivered/opened/clicked wiring yet).
+- `scheduleNotification()` + `@Cron('0 * * * * *')` `processScheduledEmails()` — drains `ScheduledEmail` rows.
+- `sendBulkNotification()` **ignores `scheduledAt`** — pass-through to immediate send. Only `scheduleNotification()` + cron defers.
+- Analytics endpoint groups `EmailLog` by `status` and `event` — metrics beyond `sent`/`failed` are currently always 0.
+
+### 5.2 Seeded templates (`email-template.service.ts` `getStarterTemplates()`)
+
+| eventKey | category | vars |
+|---|---|---|
+| `account_verification` | authentication | `firstName`, `verificationUrl` |
+| `password_reset` | authentication | `firstName`, `resetUrl` |
+| `welcome_email` | userManagement | `firstName`, `dashboardUrl` |
+| `new_message` | messaging | `firstName`, `senderName`, `messagePreview`, `messageUrl` |
+| `new_lead` | leadManagement | `foundationName`, `parentName`, `childAge`, `location`, `message`, `leadUrl` |
+| `parent_lead_confirmation` | leadManagement | `parentName`, `enquiryReference`, `submittedAt`, `childAge`, `location`, `message`, `accountSetupUrl`, `enquiriesUrl` |
+
+In-code defaults exist for more keys but **billing-critical** events `payment_reminder` and `subscription_payment_failed` have **no fallback** — they fail silently if no DB row is seeded (known issue).
+
+Preference categories (`UserNotificationPreferences`): authentication, userManagement, **jobRecruitment**, messaging, marketplace, leadManagement, subscription, contentModeration, systemAdmin, marketing, plus `mailingListOptOut`, `frequency`, `quietHoursEnabled/Start/End`. `frequency` and quiet hours are **stored but not enforced**.
+
+### 5.3 Current trigger sites
+
+| Where | Event | Trigger |
+|---|---|---|
+| `clerk-webhook.controller.ts` | `welcome_email` | webhook, fire-and-forget, bypass prefs |
+| `leads.service.ts` | `parent_lead_confirmation` | on lead creation |
+| `leads-scheduler.service.ts` | `new_lead` | cron every 10 min (to foundation emails) |
+| `billing.service.ts` | `payment_reminder`, `subscription_payment_failed` | admin-triggered controllers |
+| `maintenance-mode.service.ts` | `system_maintenance` | on toggle / scheduled |
+| Cron (every minute) | any | `processScheduledEmails` |
+
+**Recruitment sends zero emails today.** No call site for `job_application_received`, `application_status_update`, `job_match`, or any replacement-related event.
+
+### 5.4 Mailing (campaigns) — `api/src/mailing/`
+
+- Transports: `smtp.transport.ts`, `mailgun.transport.ts`, `sendgrid.transport.ts`, resolved in `mailing-transport.service.ts`.
+- Service: segments, custom lists, CSV/XLSX export, batch-sending with cursor + rate-limit + HMAC unsubscribe.
+- Controller: full admin surface `/admin/mailing/*`.
+- Admin UI: `admin/src/pages/MailingList.tsx` (Build/Lists/Segments/Campaigns tabs) + `MailingCampaignDetail.tsx`.
+
+### 5.5 In-app notifications
+
+- No `Notification` Prisma model. No `api/src/notifications` module.
+- `frontend/pages/NotificationsPage.tsx` reads from `NotificationContext` (in-memory state, max 5, lost on refresh).
+- WebSockets: `MessagingGateway` for chat; `MaintenanceGateway` (+ admin `websocket.service.ts` on `/platform`) for maintenance + settings broadcasts. **No recruitment / staffing socket channel.**
+
+---
+
+## 6. Frontend navigation (`frontend/components/layout/Sidebar.tsx`)
+
+`navItems` is a single array filtered by `currentUser.role`. Full config at lines 62–141. Per-role flat order:
+
+- **PARENT:** Dashboard home, Browse foundations, Home find crèche, My requests, Messages, Support FAQ, Settings.
+- **EDUCATOR:** Dashboard, Job board, My profile, Applications, File gallery, Messages, Support.
+- **FOUNDATION:** Dashboard, Marketplace (Products / Services), Orders & appointments, Parent leads, **Recruitment** (Job listings / Candidate pool), HR procedures, E-learning, State policies, Analytics, Messages, Organisation profile, Support.
+- **PRODUCT_SUPPLIER:** Dashboard, Orders, Product marketplace, Analytics, Messages, Organisation profile, Support.
+- **SERVICE_PROVIDER:** Dashboard, My requests, Service marketplace, Analytics, Messages, Organisation profile, Support, Settings.
+- **ADMIN / SUPER_ADMIN:** Dashboard, (also filtered-in: Marketplace, Recruitment, E-learning, Messages), Users subtree, Content subtree, Discount terminations, Partners, Admin support, Design system, Settings.
+
+**Issues identified:**
+
+- Admin `/partners` nav points to the **public** `PublicPartnersPage` (public route registered first in `App.tsx`); authenticated partner directory is `/partners-directory`.
+- `MainLayout.tsx` calls `useTranslation` inside a callback (`toggleMobileSidebar`) — should be lifted to component top level; easy fix during layout refactor.
+
+---
+
+## 7. Admin navigation (`admin/src/components/Sidebar.tsx`)
+
+```
+dashboard, users, foundations (/organizations), partners, products, services,
+jobListings, candidatePool, parentLeads, ordersAppointments, content, messages,
+support, discountTerminations, subscriptions, mailingLists, policyCrawler, settings
+```
+
+Admin dashboard (`admin/src/pages/Dashboard.tsx`) sections:
+
+1. Header + welcome.
+2. System status card (health + policy crawler).
+3. Stats grid (4 cards: users / foundations / products / parent leads).
+4. Job stats (2 cards: job listings count / applications count).
+5. Content management block (E-learning / HR docs / state policies).
+6. Quick actions grid (Users / Organizations / Orders / Analytics).
+7. Platform summary bullets.
+8. `ContentUploadModal`.
+
+**Settings page hosts (as tabs):** `emailTemplates` (`EmailNotificationPage`), `systemMonitoring` (`SystemMonitor`), `translations`, `designSystem`. Redirect routes `/system`, `/translations`, `/design-system` all forward to the relevant settings tab.
+
+---
+
+## 8. Routing map
+
+### 8.1 User SPA (`frontend/App.tsx`)
+
+Public: `/login`, `/signup`, `/pricing`, `/partners`, `/parent-lead-form`, `/reset-password`, `/sso-callback`.
+
+Protected (wrapped in `ProtectedLayout` → `MainLayout`):
+
+- Shared: `/dashboard`, `/dashboard/details/:detailType`, `/marketplace`, `/recruitment`, `/candidate/:id`, `/messages`, `/hr-procedures`, `/state-policies`, `/e-learning`, `/partners-directory`, `/partner/:id`, `/profile`, `/profile/organization/:id`, `/profile/educator/:id`, `/settings`, `/settings/profile`, `/settings/service-provider`, `/file-gallery`, `/notifications`.
+- Admin-only subset under protected: `/admin/content-dashboard`, `/admin/discount-terminations`, `/admin/system-monitoring`, `/admin/support`, `/design-system`, `/users/*`.
+- Role pages: `/supplier/*` (7), `/service-provider/*` (7), `/foundation/*` (6), `/educator/*` (5), `/parent/*` (4).
+
+### 8.2 Admin SPA (`admin/src/App.tsx`)
+
+Public: `/login`, `/signup`, `/reset-password`, `/access-denied`.
+
+Protected (`AdminProtectedRoute` → `AdminLayout`): `/dashboard`, `/users`, `/users/:id/profile`, `/organizations`, `/organizations/:id/profile`, `/partners`, `/products`, `/services`, `/job-listings`, `/candidates`, `/parent-leads`, `/orders`, `/content`, `/content/e-learning`, `/content/hr-documents`, `/content/state-policies`, `/messaging`, `/support`, `/support/tickets/:id`, `/discount-terminations`, `/subscriptions`, `/mailing`, `/mailing/campaigns/:id`, `/policy-crawler/*`, `/settings`, + legacy redirects `/system`, `/translations`, `/design-system`.
+
+---
+
+## 9. Known bugs / smells caught during audit
+
+| Area | Issue |
+|---|---|
+| `App.tsx:168` | Admin default redirect points to `/admin/content-dashboard` (content-centric). In v2 this should be a staffing-centric admin home. |
+| `App.tsx` route order | `/partners` is public, but admin sidebar entry also uses `/partners` — admins clicking the sidebar may hit the public page. Should target `/partners-directory`. |
+| `MainLayout.tsx` | `useTranslation` called inside a callback rather than component body. |
+| `admin/src/pages/Candidates.tsx:~400-408` | Delete menu item has no `onClick` handler. |
+| `admin/src/pages/JobListings.tsx` | Status filter lacks `FILLED`. |
+| `admin/src/components/AddJobListingModal.tsx` | Missing `employmentType`, `workSchedule`, `startDate`, `salaryRange` vs. foundation modal. |
+| `admin/src/components/AddCandidateModal.tsx` | Uses legacy string availability, not `availabilitySettings`. |
+| `admin/src/pages/Messaging.tsx:~56` | Hard-coded `unreadCount: 0`. |
+| `EducatorApplicationsPage.tsx:~55` | `alert()` stub for "View details". |
+| `EducatorJobBoardPage.tsx` | Contract-type filter omits `REPLACEMENT`, `TEMPORARY`, `FREELANCE`. |
+| `RecruitmentPage.tsx` | Favourites are `localStorage`; no persistence → not a real shortlist feature. |
+| `recruitment.controller.ts` | `GET applications` and `GET candidates/:id` lack `@Roles` — behaviour depends on `RolesGuard` default. Audit. |
+| `recruitment.service.ts` `findMatchingCandidates` | Not real matching — just all pool-visible educators minus applicants. |
+| `email-notification.service.ts` | `frequency` and `quietHours` stored but not enforced; `sendBulkNotification` `scheduledAt` is ignored; only `sent`/`failed` statuses written. |
+| `content-moderation.service.ts:374-408` | `getAutomatedRules` / `updateAutomatedRule` return static stubs. |
+
+---
+
+## 10. Environment / deploy
+
+- `CRAWLER_ENABLED=false` by default (crawler turns off).
+- `MALWARE_SCANNING_ENABLED=false` by default.
+- `FRONTEND_URL` / `APP_URL` required for lead distribution and invite redirect URLs.
+- Redis optional (`REDIS_URL` / `REDIS_HOST`) — queues disabled if absent.
+- Mailing transport env vars documented in `CLAUDE.md`.
+- Stripe keys required for billing (production only).
+
+---
+
+## 11. Live-data reality check (for migration planning)
+
+Tables that **are in production use** and must be preserved end-to-end through the remodel:
+
+- `User`, `Organization`, `UserNotificationPreferences`.
+- `JobListing`, `JobApplication`.
+- `ParentLead`, `FoundationLeadResponse`.
+- `Product`, `Service`, `Order`, `OrderItem`, `ServiceRequest`, `Inquiry`, `Partner`.
+- `Conversation`, `ConversationParticipant`, `Message`.
+- `SupportTicket`, `TicketResponse`.
+- `Subscription`, `SubscriptionPlan`, `BillingTransaction` (+ legacy Stripe-direct `UserSubscription`, `Plan`, `PlanPrice`).
+- `EmailTemplate`, `EmailLog`, `ScheduledEmail`, `MailingSegment`, `MailingCampaign`, `MailingCustomList`, `MailingCustomListMember`.
+- `Asset`, `OrganizationDocument`, `Canton`, `CantonSource`, `PolicyCrawlHistory`, `PolicyAlert`.
+- LMS: `Course`, `CourseModule`, `CourseLesson`, `CourseEnrollment`, `LessonProgress`, `Certificate`.
+
+No destructive migration is planned.

--- a/docs/v2-staffing-remodel/02-gap-analysis.md
+++ b/docs/v2-staffing-remodel/02-gap-analysis.md
@@ -1,0 +1,76 @@
+# Gap Analysis — v2 strategy vs. current code
+
+Filter: only gaps that affect the staffing-first pivot. Peripheral module stubs are noted in `01-current-state-inventory.md`.
+
+## A. Replacement staffing (Priority 3 in the brief)
+
+| Requirement (brief) | Reality today | Gap size |
+|---|---|---|
+| Directors must be able to signal urgent needs | Only by creating a `JobListing` with `contractType = REPLACEMENT`. No urgency flag, no SLA, no shift window. | **Build**: dedicated `ReplacementRequest` entity + workflow. |
+| Candidates matched quickly | `findMatchingCandidates` is a stub (pool-visible educators minus applicants). | **Refactor to real match**: skills + region + availability scoring. |
+| Dynamic availability | `availabilitySettings` JSON exists; matching doesn't use it. Educator UI exists; admin form doesn't. | **Integrate + consolidate**. |
+| Immediate-operational-support feel | No UI for it. Replacement is hidden behind the generic `RecruitmentPage`. | **Build**: dedicated "Find replacement staff" screen in foundation dashboard + admin alert rail. |
+
+## B. Staffing core (Priority 1)
+
+| Requirement | Reality | Gap |
+|---|---|---|
+| "Post a job" fast and simple | `JobPostModal` in `RecruitmentPage.tsx`. Functional. | **Refactor** into action-first framing; simplify fields, surface defaults, expose from dashboard home. |
+| "Find candidates" easy | `candidate-pool` tab; `localStorage` favourites only. | **Refactor**: persist shortlist (`SavedCandidate`), saved-searches, better filters. |
+| "Fill a position" clear | Application list has no status pipeline UI, no cover-letter drill-in, no message-from-list. Educator detail button is `alert()`. | **Build** pipeline modal (stages: new / reviewing / shortlisted / interview / offer / hired / rejected). |
+| Hiring flow not complex | Reasonable; remove friction, not add. | Light refactor. |
+
+## C. Candidate side (Priority 2)
+
+| Requirement | Reality | Gap |
+|---|---|---|
+| Structured, fast profile | `EducatorProfilePage` + related tables in Prisma. Real API. | Keep, light polish. |
+| Easy discovery | Candidate pool page exists. Matching is naive. | **Refactor** matching service. |
+| Clearly-defined availability | Designed, partially implemented. | **Finish** per `docs/EDUCATOR_AVAILABILITY_SYSTEM_DESIGN.md`. |
+| Replacement availability visible | Not differentiated from general availability. | **Add** "available for replacement" flag + filter, or reuse availability slots tagged as short-notice. |
+
+## D. Admin dashboard
+
+| Requirement | Reality | Gap |
+|---|---|---|
+| All roles' features stay, staffing on top | True for functionality; false for IA (sidebar is flat, no staffing hero). | **Restructure** admin homepage + sidebar order. |
+| Staffing-focused alerts (urgent replacements, applications to review, low-pool) | Admin Dashboard has a generic stats grid + crawler card. No alert concept. | **Build**: `StaffingSignals` service aggregating urgent state; expose on admin home + in-app notification feed. |
+| Default admin landing is staffing-centric | Currently `/admin/content-dashboard` per `App.tsx:168`. | **Fix**: redirect to admin SPA home; keep user-facing content dashboard as a separate tool. |
+| Users page remains second | Sidebar order is `dashboard, users, foundations, partners, products, …` — already close. | **Reorder** remaining entries around staffing. |
+
+## E. Email & notifications
+
+| Requirement | Reality | Gap |
+|---|---|---|
+| Candidate-matching emails on new job post | No recruitment email sites exist. | **Build**: new event `job_match`; fan-out to matching educators on job publish. |
+| Daycare emails on new application | Same. | **Build**: event `new_application`; to foundation members. |
+| Application status change emails to candidate | Same. | **Build**: event `application_status_update`. |
+| Replacement-specific urgency comms | Same. | **Build**: events `replacement_requested_match` + `replacement_confirmed`. |
+| In-app notifications | Purely in-memory (`NotificationContext`) | **Build**: `Notification` Prisma model + service + socket push (extend `/messaging` gateway or introduce `/notifications`). |
+
+## F. Foundation dashboard homepage (new Overview)
+
+| Element | Exists? | Gap |
+|---|---|---|
+| Staffing snapshot (open positions, applications awaiting review, urgent replacements) | Partial KPIs via `foundationDashboardService`, but not staffing-oriented. | **Refactor** to staffing-first overview with three primary widgets + secondary panels. |
+| Quick actions (Post job, Find replacement staff, Find candidates) | One "Post job" action link. | **Add**. |
+| Secondary panels (parent enquiries, HR alerts, supplier offers) | Scattered across nav. | **Reorganise** under fold. |
+
+## G. Navigation / IA
+
+| Target (brief) | Current | Gap |
+|---|---|---|
+| Overview → Staffing → HR & Compliance → Parent Enquiries → Suppliers & Services | For FOUNDATION: Dashboard → Marketplace → Orders → Parent leads → Recruitment → HR → E-learning → State policies → Analytics → Messages → Org profile → Support. Order does not match. | **Reorder** + **rename** to action-based labels. Group `recruitment` children under "Staffing" top entry. |
+| Admin: Overview → Users → Staffing stack → Other role features → Support | Current admin order is close for first three but splits staffing (`jobListings`, `candidatePool` separate). | **Group under "Staffing"** parent nav with sub-items. |
+| Action-based labels ("Post a job", "Find replacement staff") | Current labels are module-named ("Recruitment", "Candidate pool"). | **Rename** sub-items. |
+
+## H. Minor fixes blocking a clean remodel
+
+- `App.tsx:168` admin redirect target.
+- `MainLayout.tsx` `useTranslation` mis-placement.
+- `Candidates.tsx` dead Delete button.
+- Admin `AddJobListingModal` field parity with foundation modal.
+- `EducatorJobBoardPage` contract-type filter.
+- `JobListings.tsx` missing `FILLED` status filter.
+- Duplicate `UpdateJobApplicationDto` in `create-job-application.dto.ts` and `update-job-application.dto.ts`.
+- `recruitment.controller.ts` missing `@Roles` on 2 endpoints.

--- a/docs/v2-staffing-remodel/03-remodel-strategy.md
+++ b/docs/v2-staffing-remodel/03-remodel-strategy.md
@@ -1,0 +1,94 @@
+# Remodel Strategy
+
+## Guiding principle
+
+**Upgrade, don't rebuild.** The Prisma schema, NestJS modules, and React routing shell are all production and must stay. We remodel by:
+
+1. **Elevating** staffing to the top of the information architecture.
+2. **Renaming** modules to action-based labels.
+3. **Extending** (not replacing) the recruitment domain to cover replacement staffing properly.
+4. **Wiring** transactional email + in-app notifications into existing recruitment events.
+5. **Downgrading** secondary modules in navigation only — their data and APIs stay intact.
+
+## Non-negotiables (from the brief)
+
+- Foundation + admin dashboards are remodelled.
+- **Parent, Product Supplier, Service Provider dashboards are untouched.** Nothing staffing-related should leak into their UIs or their role dashboards.
+- Live users and data are preserved. All data-model changes are additive (new tables, new nullable fields, new enum values).
+- Nav order is fixed: Overview → Staffing → HR & Compliance → Parent Enquiries → Suppliers & Services (admin inserts Users between Overview and Staffing).
+- Feature acceptance test: a change is in scope only if it improves hiring speed, candidate visibility, replacement fulfilment, or operator workflow.
+
+## What stays the same
+
+- Auth (Clerk), role model, organisation model.
+- Billing / subscription plumbing.
+- Messaging, support tickets.
+- Marketplace, supplier, service-provider domains end-to-end.
+- Parent enquiries domain (leads service + scheduler).
+- HR / state policies / canton policies backends.
+- E-learning backend.
+- Mailing / campaign infrastructure.
+- Frontend design system, routing shell, Clerk SSO flow.
+
+## What changes (high level)
+
+1. **New domain extension: replacement staffing.**
+   - New Prisma models (all additive): `ReplacementRequest`, `SavedCandidate` (persisted shortlists), `StaffingAlert` (or generic `Notification`). Optional: `AvailabilitySlot` materialisation for fast search.
+   - New API module `api/src/staffing/` composing recruitment + new replacement pieces (or extend `recruitment` — see open decisions).
+   - Matching service upgrade: real scoring on skills, cities/region, availability-on-date, language, certifications.
+
+2. **Foundation dashboard remodel.**
+   - Sidebar renamed + reordered to action-first labels.
+   - Homepage (`/foundation/dashboard`) becomes a staffing overview.
+   - `/recruitment` rebranded to `/staffing` (keep `/recruitment/*` as redirects for preserved links and old deep-links).
+   - Replacement staffing gets its own surface: `/staffing/replacements` with urgency rail and quick-match.
+   - Secondary items (HR procedures, state policies, e-learning, marketplace, parent leads, analytics, org profile, support) are demoted in nav, not removed.
+
+3. **Admin dashboard remodel.**
+   - Sidebar reordered: Overview → Users → Staffing (Jobs / Candidates / Replacements / Applications) → HR & Compliance (Content, Policy crawler) → Parent Enquiries (Parent leads) → Suppliers & Services (Organizations, Partners, Products, Services, Orders) → Platform Ops (Subscriptions, Mailing, Support, Discount terminations, Settings).
+   - Admin homepage becomes a **staffing signals** page: urgent replacement requests, applications awaiting review, low-candidate-pool alerts, new-job-fanout status — with classic platform counters below.
+   - Fix the admin-default-redirect: ADMIN/SUPER_ADMIN land on the admin SPA, not the user SPA's `/admin/content-dashboard`.
+
+4. **Email & notification layer (staffing).**
+   - Seed new templates: `new_application`, `application_status_update`, `job_match`, `replacement_request_open`, `replacement_matched`, `replacement_confirmed`, `low_candidate_pool`.
+   - Wire triggers in `recruitment.service.ts` and new `staffing.service.ts`.
+   - Introduce a real in-app notification system (Prisma `Notification` model + service + socket push) — gated behind a feature flag in early phases so we can ship email first.
+
+5. **Candidate-side polish.**
+   - Finish the availability system per `docs/EDUCATOR_AVAILABILITY_SYSTEM_DESIGN.md`.
+   - Add "available for replacement" affordance (either a flag on `availabilitySettings` or an explicit `replacementAvailability` field).
+   - Replace `picsum.photos` placeholders with initials-avatar or real asset URL fallback.
+   - Replace `alert()` stub for educator application detail with a real modal / detail page.
+
+6. **Minor bugfix sweep** (listed in `02-gap-analysis.md §H`) — do these alongside the IA changes as they unblock the new navigation and admin actions.
+
+## What we will NOT do
+
+- We will not migrate `JobListing` → a new table. We extend it.
+- We will not re-key existing `EmailTemplate` rows. New flows use **new** event keys.
+- We will not change routes for parent / supplier / service-provider users.
+- We will not re-platform auth, billing, messaging, or marketplace.
+- We will not build "HR software" features beyond what already exists. HR & Compliance stays as the current content+policy set.
+
+## Principles driving UI redesign
+
+- **Action labels over module labels:** "Post a job", "Find replacement staff", "Find candidates", "Review applications".
+- **One action per screen primary.** If there are two, one must be clearly secondary.
+- **Urgent state surfaced at Overview level.** A foundation user should see "3 replacement requests open · 7 applications awaiting review · 2 candidates ready to hire" without navigating.
+- **No duplicate destinations.** Marketplace is `/marketplace` only; admin sidebar should not route admins to the user-facing public page by accident.
+- **Subscription gates stay.** Staffing core remains behind the same `SubscriptionGatedRoute` wrapper foundations already hit — entitlement model is unchanged (tracked as an open decision if plans need to be re-bundled).
+
+## Success metrics (what this remodel must improve)
+
+From the brief, measured via new dashboards (Phase 4):
+
+- Time to post a job.
+- Time to first candidate.
+- Time to hire.
+- Active candidate count.
+- Replacement request fulfilment speed.
+- Job fill rate.
+- Candidate profile completion.
+- Application rate.
+
+These metrics require the `Notification` + `StaffingSignals` plumbing, so they land in the later phases.

--- a/docs/v2-staffing-remodel/04-phased-plan.md
+++ b/docs/v2-staffing-remodel/04-phased-plan.md
@@ -1,0 +1,210 @@
+# Phased Implementation Plan
+
+> Phases are ordered by dependency. Nothing here is dated — promotion between phases is gated by the acceptance criteria at the end of each phase. Each phase should ship on its own branch + PR so the remodel is incremental and reversible.
+
+**Legend (per task):**
+`[Refactor]` = edit existing code. `[New]` = net-new code/data. `[Rename/IA]` = navigation, labels, routing. `[Fix]` = bug fix discovered during audit. `[Config]` = env / seed / migration.
+
+---
+
+## Phase 0 — Preparation (this PR)
+
+- `[New]` Land persistent notes + this plan under `docs/v2-staffing-remodel/`.
+- Register the branch and open a draft PR for visibility.
+
+Exit criteria: this folder exists on `Main` (or a merged PR). Future sessions start by reading `00-README.md`.
+
+---
+
+## Phase 1 — Foundation IA + admin IA restructure (low risk, high signal)
+
+Goal: navigation order and labels match v2 strategy **without changing any business logic**.
+
+Tasks:
+
+1. `[Refactor]` `frontend/components/layout/Sidebar.tsx`
+   - Reorder FOUNDATION items to: Overview (`/foundation/dashboard`), **Staffing** (`/staffing` with sub-items `Job listings`, `Candidate pool`, **`Replacements`** placeholder), **HR & Compliance** (HR procedures, State policies, E-learning), **Parent Enquiries** (existing `/foundation/leads`), **Suppliers & Services** (`/marketplace/products`, `/marketplace/services`), Messages, Analytics, Organisation profile, Support.
+   - Rename labels to action-based i18n keys (`sidebar.postJob`, `sidebar.findCandidates`, `sidebar.findReplacements`). Keep existing `nameKey` fallbacks to avoid missing translations during the transition.
+2. `[Rename/IA]` Register `/staffing` as an alias of `/recruitment` in `frontend/App.tsx` (both work during transition). Keep the existing `/recruitment/*` routes for 1 release cycle.
+3. `[Refactor]` `admin/src/components/Sidebar.tsx` reorder groups:
+   - Overview, Users, Staffing (Jobs, Candidates, Applications, **Replacements** placeholder), HR & Compliance (Content, Policy crawler), Parent Enquiries (Parent leads), Suppliers & Services (Organizations, Partners, Products, Services, Orders, Discount terminations), Platform Ops (Messaging, Subscriptions, Mailing, Support, Settings).
+   - Group `Staffing` children under a collapsible parent (admin Sidebar currently has no sub-items — add that pattern; mirror user frontend's `subItems` shape).
+4. `[Fix]` Admin default redirect. In `frontend/App.tsx:168` change `ADMIN`/`SUPER_ADMIN` landing to a staffing-oriented location. Options:
+   - (a) Send admins to the admin SPA URL if deployed separately (preferred — admins normally work there).
+   - (b) If admins routinely use the user SPA, send to `/users/all` (admin first task is user management anyway) and remove the content-dashboard shortcut from role default.
+   - Document the chosen URL in `07-navigation-ia-target.md`.
+5. `[Fix]` Admin sidebar `partners` target — change to `/partners-directory` (authenticated `PartnersPage`), or drop the admin partners entry if Admin SPA `PartnersPage` covers it.
+6. `[Fix]` `MainLayout.tsx` — lift `useTranslation` to component body.
+7. `[Rename/IA]` Breadcrumb / page titles updated to the new label set.
+
+Exit criteria: foundation sidebar order matches brief; admin sidebar order matches brief (with Users on top); no new features yet; **parent / supplier / service-provider sidebars untouched**; existing deep links still work.
+
+---
+
+## Phase 2 — Staffing core polish (under the hood, no new entity)
+
+Goal: make today's recruitment features actually usable for the new positioning.
+
+Tasks:
+
+1. `[Refactor]` Rewrite `recruitment.service.ts#findMatchingCandidates`:
+   - Score candidates on: region / canton match, city overlap, skills intersection, certifications, language, role match, and availability (reuse `isDateTimeAvailable` when `availabilitySettings` present; fall back to `availability` string).
+   - Exclude already-applied candidates. Return sorted + include `matchScore` + `matchedOn[]` breakdown.
+   - Add unit tests in `api/src/recruitment/`.
+2. `[Fix]` `recruitment.controller.ts` — add `@Roles(FOUNDATION, ADMIN, SUPER_ADMIN)` to `GET applications` (org-scope filter in service). Add `@Roles` to `GET candidates/:id` matching `GET candidates`.
+3. `[Fix]` Deduplicate `UpdateJobApplicationDto` (controller imports from `create-job-application.dto.ts`; delete the unused `update-job-application.dto.ts` or make it the canonical source).
+4. `[Refactor]` Application pipeline UI:
+   - Replace `ViewApplicantsModal` with a two-pane review screen: list + drill-in (cover letter, CV link, message button, status dropdown PATCH).
+   - Extend `ApplicationStatus` enum (see §5 for migration): add `SHORTLISTED`, `INTERVIEW`, `OFFER`, `HIRED` alongside existing `PENDING`, `REVIEWED`, `ACCEPTED`, `REJECTED`. Backfill: treat `ACCEPTED` as `HIRED` for display, keep enum member for BC.
+   - Replace `alert()` stub in `EducatorApplicationsPage.tsx` with a detail modal.
+5. `[Refactor]` Persistent shortlist. New Prisma model `SavedCandidate { id, foundationId, userId, candidateId, createdAt, notes? }`. Replace `localStorage` favourites in `RecruitmentPage.tsx`. Expose endpoints in `recruitment.controller.ts`.
+6. `[Refactor]` Foundation `JobPostModal` — expose `employmentType`, `workSchedule`, `startDate`, `salaryRange` already on the API; simplify defaults; keep the action label "Post a job" primary.
+7. `[Refactor]` Admin `AddJobListingModal` — field parity with foundation modal.
+8. `[Fix]` `JobListings.tsx` — add `FILLED` to status filter; add `FILLED` transition action.
+9. `[Fix]` `EducatorJobBoardPage.tsx` — contract-type filter aligned with `JobContractType` enum (include replacement/temporary/freelance).
+10. `[Fix]` `Candidates.tsx` delete menu wired to a proper API call (or removed if delete is not desired at admin level).
+11. `[Refactor]` Replace `picsum.photos` avatars with initials-avatar.
+
+Exit criteria: hiring an educator from a posted job is a clean end-to-end flow; admin mirrors foundation capability; shortlist persists; all listed bugs from `02-gap-analysis.md §H` resolved.
+
+---
+
+## Phase 3 — Replacement staffing as a first-class feature
+
+Goal: directors can post urgent replacement needs and see available educators in minutes.
+
+Tasks:
+
+1. `[New]` Prisma models (`api/prisma/schema.prisma`):
+   - `ReplacementRequest { id, foundationId, title, description?, startAt, endAt, requiredSkills[], requiredRole?, cities[], region?, urgency (enum LOW|MEDIUM|HIGH|CRITICAL), status (OPEN|MATCHED|CONFIRMED|FULFILLED|CANCELLED), createdAt, updatedAt, fulfilledByUserId?, notes? }`.
+   - `ReplacementMatch { id, requestId, candidateId, status (SUGGESTED|OFFERED|DECLINED|ACCEPTED), score, createdAt, respondedAt? }` — scoped unique per `(requestId, candidateId)`.
+   - Additive only. No changes to `JobListing` / `JobApplication`.
+   - Migration: `prisma migrate dev -n "v2_replacement_staffing"`.
+2. `[New]` `api/src/staffing/replacement/` module:
+   - Service: CRUD + `suggestMatches(requestId)` using the Phase 2 matching algorithm (weight availability on the date/time of the request).
+   - Controller:
+     - `POST /staffing/replacements` (FOUNDATION, ADMIN) — create request.
+     - `GET /staffing/replacements` (FOUNDATION own-org, ADMIN all) — filter by status, urgency.
+     - `GET /staffing/replacements/:id` — detail including matches.
+     - `PATCH /staffing/replacements/:id` — update / cancel.
+     - `POST /staffing/replacements/:id/offer/:candidateId` — change match status to `OFFERED`, email the candidate.
+     - `POST /staffing/replacements/:id/accept` (EDUCATOR) — candidate accepts.
+     - `POST /staffing/replacements/:id/confirm/:candidateId` (FOUNDATION) — confirm fulfilment.
+   - Guards: `ClerkAuthGuard` + `RolesGuard`; own-org enforcement in service.
+3. `[New]` Foundation UI:
+   - `/staffing/replacements` page — list + urgency badges + filters + "New replacement request" primary CTA.
+   - Detail page with suggested candidates (sorted by match score) and one-click "Offer" action.
+4. `[New]` Admin UI:
+   - `/staffing/replacements` (admin SPA) — cross-foundation view. Same detail surface.
+5. `[New]` Availability polish:
+   - Finish `docs/EDUCATOR_AVAILABILITY_SYSTEM_DESIGN.md` (finish the `/educators/available` search endpoint; use it for `suggestMatches`).
+   - Add `isOpenToReplacement: boolean` to `availabilitySettings` JSON, editable in `EducatorProfilePage`.
+6. `[New]` Candidate-side UI:
+   - `EducatorDashboardPage` gains a "Replacement opportunities" card (only when `isOpenToReplacement` is true).
+   - `EducatorApplicationsPage` gains a "Replacement offers" tab.
+7. `[Rename/IA]` Promote "Replacements" from the Phase 1 placeholder to a real sub-nav entry in both foundation and admin sidebars.
+
+Exit criteria: a foundation user can post a replacement need, see sorted matches, send an offer, and record fulfilment; educators can accept/decline; admin has cross-foundation visibility.
+
+---
+
+## Phase 4 — Emails + in-app notifications (staffing events)
+
+Goal: the platform talks to its users about staffing events.
+
+Tasks:
+
+1. `[New]` Seed new `EmailTemplate` rows in `email-template.service.ts#getStarterTemplates`:
+   - `new_application` → foundation members: `{foundationName, candidateName, jobTitle, applicationUrl}`.
+   - `application_status_update` → candidate: `{candidateName, jobTitle, foundationName, status, applicationUrl}`.
+   - `job_match` → candidate: `{candidateName, jobTitle, foundationName, location, jobUrl}`.
+   - `replacement_request_open` → matched candidates: `{candidateName, foundationName, startAt, endAt, cities, offerUrl}`.
+   - `replacement_matched` → foundation: `{foundationName, candidateName, requestTitle, requestUrl}`.
+   - `replacement_confirmed` → candidate and foundation: confirmation details.
+   - `low_candidate_pool` → admins (daily summary): `{region, openJobs, activeCandidates, gap}`.
+2. `[New]` Trigger sites:
+   - `recruitment.service.ts#createJobApplication` — emit `new_application` to foundation members.
+   - `recruitment.service.ts#updateJobApplication` — emit `application_status_update` on status change.
+   - `recruitment.service.ts#createJobListing` (on publish transition) — emit `job_match` to top-N matching candidates (use Phase 2 matcher; cap via env `STAFFING_MATCH_EMAIL_LIMIT`; respect `jobRecruitment` preference).
+   - `replacement.service.ts#create` — emit `replacement_request_open` to top matches.
+   - `replacement.service.ts#confirm` — emit `replacement_confirmed`.
+3. `[New]` Prisma `Notification` model + `api/src/notifications/` module:
+   - `Notification { id, userId, type, title, body, link, metadata Json?, readAt?, createdAt }`.
+   - REST endpoints: `GET /notifications`, `POST /notifications/mark-read`, `POST /notifications/mark-all-read`.
+   - Socket push: extend existing `/messaging` gateway with a `notification` event, or add a `/notifications` gateway (decision in `08-open-decisions.md`).
+4. `[Refactor]` `frontend/contexts/NotificationContext.tsx` — load from API, subscribe via socket, keep the in-memory fallback for transient toasts.
+5. `[New]` Admin "Staffing signals" panel on admin home:
+   - Cards: Open replacement requests (count + urgency breakdown), Applications awaiting review > 48h, Low-pool regions (0 active candidates for an active job's region), Candidate-pool growth (WoW), Jobs with 0 matches > 24h.
+   - Service `api/src/staffing/signals/` aggregates these counts for `ADMIN`/`SUPER_ADMIN`.
+6. `[New]` Admin daily digest email: reuse `scheduleNotification` with a generated payload → `low_candidate_pool` template. Or run a nightly cron in `staffing-signals.service.ts` posting to `/admin/mailing/custom-lists/admins`.
+7. `[Fix]` While here: fix the two known engine flaws — `sendBulkNotification` respecting `scheduledAt` (delegate to `scheduleNotification`), and seeding `payment_reminder` / `subscription_payment_failed` templates so billing flow doesn't fail silently.
+
+Exit criteria: emails on the 5 staffing events fire in production with log evidence; admin homepage surfaces staffing signals; in-app notifications have backing persistence and real-time delivery.
+
+---
+
+## Phase 5 — Foundation dashboard homepage (Overview)
+
+Goal: the foundation "Overview" page reflects staffing-first operational clarity.
+
+Tasks:
+
+1. `[Refactor]` `frontend/pages/foundation/FoundationDashboardPage.tsx`:
+   - Hero block: three KPI cards — **Open positions**, **Applications awaiting review**, **Open replacement requests** (each clickable).
+   - Primary CTA row: Post a job, Find replacement staff, Find candidates, Review applications.
+   - Below the fold: Recent activity (existing), today's calendar (existing), quick message (existing), plus a "Secondary" row with collapsed cards for Parent enquiries, HR alerts (from `policy-alerts`), Supplier promotions.
+   - Data loader: new `foundationStaffingOverviewService` combining existing `foundationDashboardService` with the new staffing counts.
+2. `[Refactor]` `educator` and `parent` dashboards: **no structural change**. Educators gain the "Replacement opportunities" card from Phase 3. Parents untouched.
+3. `[Refactor]` `supplier` and `service-provider` dashboards: **untouched**. Explicit test: no staffing labels appear on their routes.
+
+Exit criteria: a foundation user lands on `/foundation/dashboard` and immediately sees staffing state + three primary actions; the rest of the platform is reachable but visually secondary.
+
+---
+
+## Phase 6 — Admin homepage + user-management parity
+
+Goal: admin lands on a staffing signals page; user management stays one click away.
+
+Tasks:
+
+1. `[Refactor]` `admin/src/pages/Dashboard.tsx`:
+   - Top: **Staffing signals** cards (from Phase 4).
+   - Next: **Users quick actions** (manage users, invite, pending requests) — this enforces the "Users sits second" rule.
+   - Then: existing Jobs / Applications / Content / Platform counters.
+2. `[Refactor]` `admin/src/components/Sidebar.tsx` badge system — wire existing `useNotificationData` to the new `Notification` model for live counts (jobs awaiting moderation, urgent replacements, support tickets).
+3. `[New]` Admin email preferences — expose the `jobRecruitment` category explicitly on the admin profile so admins can opt in/out of staffing digests.
+
+Exit criteria: admin homepage shows operational signals first, user management second, everything else below. Badge counts are live.
+
+---
+
+## Phase 7 — Measurement & cleanup
+
+Goal: close the feedback loop and remove deprecated surfaces.
+
+Tasks:
+
+1. `[New]` Add metrics collection (all derived from existing tables, no new telemetry stack required):
+   - Time-to-first-candidate: `JobApplication.createdAt - JobListing.publishedAt`.
+   - Time-to-hire: `JobApplication.updatedAt (status=HIRED) - JobListing.publishedAt`.
+   - Replacement fulfilment speed: `ReplacementRequest.updatedAt (status=FULFILLED) - createdAt`.
+   - Expose on admin "Staffing signals" page as a rolling 30-day panel.
+2. `[Rename/IA]` Remove legacy `/recruitment/*` routes (keep a server-side redirect for 1 release).
+3. `[Rename/IA]` Retire the label "Recruitment" from user-facing nav; keep in the API module name (no reason to rename the Nest module).
+4. `[Fix]` `Messaging.tsx` `unreadCount` hard-coded `0` — compute properly.
+5. `[Config]` `CLAUDE.md` updated with v2 context pointer to this folder.
+
+Exit criteria: staffing KPIs visible, legacy paths retired, docs coherent.
+
+---
+
+## Out of scope (explicit)
+
+- Rebuilding billing, Stripe, Clerk, or messaging.
+- Reworking supplier / service-provider / parent UIs.
+- Deep automation (auto-offer AI, auto-match bots).
+- Video interviewing or scheduling integrations.
+- New marketplace features.
+- Standalone onboarding wizard.
+
+These may be revisited after the staffing core is proven (metrics from Phase 7).

--- a/docs/v2-staffing-remodel/05-data-migration-and-preservation.md
+++ b/docs/v2-staffing-remodel/05-data-migration-and-preservation.md
@@ -1,0 +1,69 @@
+# Data Migration & Preservation
+
+> Core promise: **no destructive migrations**. Live users and live data survive the remodel.
+
+## Principles
+
+1. All schema changes are **additive**: new tables, new nullable fields, new enum values. Never drop or rename existing columns in the same migration.
+2. Enum extensions are applied via `prisma migrate` and then exploited in code. Old enum values remain usable.
+3. API contracts: new routes are added; old routes are deprecated (not removed) for at least one release cycle. Frontends consume either.
+4. Deep links: `/recruitment/*` remains a working redirect target throughout Phase 1–6, removed only in Phase 7.
+5. i18n keys: new action-based keys are added; old keys remain until Phase 7 cleanup. No keys are deleted while still referenced.
+
+## Schema change log (proposed)
+
+| Phase | Table | Change | Migration name |
+|---|---|---|---|
+| 2 | `JobApplication` | Extend `ApplicationStatus` enum with `SHORTLISTED`, `INTERVIEW`, `OFFER`, `HIRED`. Existing values `PENDING`, `REVIEWED`, `ACCEPTED`, `REJECTED` preserved. `ACCEPTED` stays valid (legacy). | `v2_application_pipeline_stages` |
+| 2 | `SavedCandidate` (new) | `id`, `foundationId`, `userId` (admin who saved), `candidateId`, `createdAt`, `notes?`. Unique `(foundationId, candidateId)`. | `v2_saved_candidate` |
+| 3 | `ReplacementRequest` (new) | See `04-phased-plan.md §Phase 3`. | `v2_replacement_request` |
+| 3 | `ReplacementMatch` (new) | See `04-phased-plan.md §Phase 3`. | `v2_replacement_match` |
+| 3 | `User.availabilitySettings` | No schema change (JSON). Add `isOpenToReplacement: boolean` key at the service / DTO layer. | — |
+| 4 | `Notification` (new) | `id`, `userId`, `type`, `title`, `body`, `link?`, `metadata Json?`, `readAt?`, `createdAt`. | `v2_notification` |
+| 4 | `EmailTemplate` | Data-only: insert 7 new rows via `getStarterTemplates()` idempotent `createMany({ skipDuplicates: true })`. No schema change. | — |
+| 4 | `EmailLog` | Later opportunity to widen `status` enum to include `delivered`, `opened`, `clicked` when a transport webhook is wired. Not required for Phase 4 exit. | deferred |
+
+All Prisma migrations must be generated via `pnpm --filter api prisma migrate dev -n "<name>"` and reviewed before merging.
+
+## Data backfills
+
+- **`SavedCandidate`:** no backfill. Legacy `localStorage` favourites remain on the user's device until the user re-opens the candidate pool; they see the empty persisted list, can re-favourite. Optional: on first load, send any `localStorage` favourites to `POST /recruitment/shortlist/bulk` once (keyed by a one-shot localStorage flag).
+- **`ApplicationStatus.HIRED`:** not auto-backfilled. Foundations who previously marked an application `ACCEPTED` keep it as `ACCEPTED`. UI renders `ACCEPTED` and `HIRED` identically for 1 release, then new status transitions default to `HIRED`.
+- **`ReplacementRequest`:** no backfill. Jobs previously posted with `contractType=REPLACEMENT` remain as job listings. Optional migration later to convert open REPLACEMENT jobs into `ReplacementRequest` rows if the operator wants.
+- **`Notification`:** no backfill (empty table on migration day is fine).
+
+## Feature flags (to de-risk rollout)
+
+Reuse existing `FeatureFlag` model. Flags to introduce:
+
+- `v2_staffing_ia` — controls new nav labels + order. Default off on prod until Phase 1 is validated.
+- `v2_replacement_module` — hides replacement routes until Phase 3 is shipped.
+- `v2_staffing_emails` — master switch for new email events (per-event override optional via env `STAFFING_EMAIL_DISABLED_EVENTS=job_match,replacement_request_open`).
+- `v2_in_app_notifications` — gates the new `Notification` feed; falls back to `NotificationContext` transient toasts.
+
+Flags are read by `FrontendSettingsManager` on frontend and by `FeatureFlagService` (existing) on backend.
+
+## Email deliverability during rollout
+
+- New events rate-limited by `STAFFING_MATCH_EMAIL_LIMIT` (default 20) so a single job post cannot blast an entire pool.
+- All new templates respect `jobRecruitment` category preference; users who already opted out are not spammed.
+- Admins can preview templates in the existing admin `EmailNotificationPage` before flipping the feature flag.
+
+## Deep-link preservation map
+
+| Old | New | Status during phases 1–6 | After phase 7 |
+|---|---|---|---|
+| `/recruitment` | `/staffing` | Both work | Old → 301 redirect |
+| `/recruitment/job-listings` | `/staffing/jobs` | Both work | Old → 301 redirect |
+| `/recruitment/candidate-pool` | `/staffing/candidates` | Both work | Old → 301 redirect |
+| `/candidate/:id` | unchanged | — | — |
+| `/admin/content-dashboard` (as admin default landing) | admin SPA home | Keep the page; just stop defaulting admins to it | Keep page, no default |
+
+## Test plan for preservation
+
+- Before merging each phase: run the existing E2E suite (`frontend/tests`, admin/e2e if present). E2E login and role-redirect are already covered.
+- Manual smoke per role: log in as each of the 7 roles, confirm:
+  - PARENT / EDUCATOR / PRODUCT_SUPPLIER / SERVICE_PROVIDER: sidebar and dashboard are **byte-identical** to pre-remodel for non-`FOUNDATION`/`ADMIN` roles in Phases 1–2.
+  - FOUNDATION: sidebar order matches target; old URLs still resolve.
+  - ADMIN / SUPER_ADMIN: sidebar order matches target; admin SPA loads at login; user-facing `/admin/*` pages still reachable.
+- Prisma migration dry-run on a staging copy of prod DB before production.

--- a/docs/v2-staffing-remodel/06-email-and-notification-plan.md
+++ b/docs/v2-staffing-remodel/06-email-and-notification-plan.md
@@ -1,0 +1,121 @@
+# Staffing Email & Notification Plan
+
+Builds on the existing `api/src/email-notification/` + `api/src/mailing/` stack. All additions reuse the same pipeline — no new transport, no new auth, no new delivery infrastructure.
+
+## 1. New transactional events
+
+Each event has a DB template (seeded in `getStarterTemplates()`), an in-code default (for failure tolerance), and is gated by `UserNotificationPreferences.jobRecruitment` (except `welcome`-type ones).
+
+| eventKey | Category | Recipient | Trigger | Variables | Respects prefs? |
+|---|---|---|---|---|---|
+| `new_application` | jobRecruitment | Foundation members | `recruitment.service.createJobApplication` | `foundationName`, `candidateName`, `jobTitle`, `applicationUrl` | Yes |
+| `application_status_update` | jobRecruitment | Candidate | `recruitment.service.updateJobApplication` when `status` changes | `candidateName`, `jobTitle`, `foundationName`, `status`, `applicationUrl` | Yes |
+| `job_match` | jobRecruitment | Top-N matched candidates | `recruitment.service.updateJobListing` when transitioning `DRAFT → PUBLISHED`, and `recruitment.service.createJobListing` if created already `PUBLISHED` | `candidateName`, `jobTitle`, `foundationName`, `location`, `contractType`, `jobUrl` | Yes |
+| `replacement_request_open` | jobRecruitment | Top-N matched candidates with `isOpenToReplacement=true` | `replacement.service.create` (and on requalification) | `candidateName`, `foundationName`, `startAt`, `endAt`, `cities`, `offerUrl` | Yes |
+| `replacement_matched` | jobRecruitment | Foundation members | When a `ReplacementMatch` flips to `ACCEPTED` | `foundationName`, `candidateName`, `requestTitle`, `requestUrl` | Yes |
+| `replacement_confirmed` | jobRecruitment | Candidate + foundation | `replacement.service.confirm` | role-specific variables | Yes |
+| `low_candidate_pool` | systemAdmin | Admins | Nightly cron in `staffing-signals.service` | `region`, `openJobs`, `activeCandidates`, `gap`, `dashboardUrl` | Yes |
+
+## 2. Fan-out rules
+
+- Foundation-bound emails send to **every active user whose `organizationId` matches the foundation** (filter `role ∈ {FOUNDATION}` or `role = ADMIN` linked to that org). If there are none, fall back to the foundation's billing / primary contact email (already a field on `Organization`).
+- Candidate-bound emails go to the candidate's email on file (`User.email`), with the existing `sendNotification` preference gate.
+- Bulk match fan-out (`job_match`, `replacement_request_open`) is capped by `STAFFING_MATCH_EMAIL_LIMIT` (default 20). Candidates are selected by the Phase 2 matcher ranked by score.
+
+## 3. Wiring points (where code goes)
+
+- `api/src/recruitment/recruitment.service.ts`
+  - Inject `EmailNotificationService` (already exported from `email-notification.module`).
+  - After successful `prisma.jobApplication.create`, `await this.emailNotificationService.sendNotification({ event: 'new_application', recipient: <foundationMemberEmail>, payload })` — one per recipient; wrap in `Promise.allSettled` so one bad email doesn't abort the request.
+  - In `updateJobApplication`, compare `prevStatus` vs `newStatus` and emit `application_status_update` to the candidate.
+  - In `createJobListing` / `updateJobListing`, if status transitions to `PUBLISHED`, compute matches via the new matcher and call `sendNotification` per top-N candidate using event `job_match`.
+- `api/src/staffing/replacement/replacement.service.ts`
+  - On `create`: compute matches with availability scoring; fan-out `replacement_request_open`.
+  - On `accept`: emit `replacement_matched` to foundation.
+  - On `confirm`: emit `replacement_confirmed` to both sides.
+- `api/src/staffing/signals/staffing-signals.service.ts` (new)
+  - `@Cron('0 7 * * *')` daily at 07:00: compute low-pool by region, bulk-send `low_candidate_pool` to admins.
+
+## 4. Why `sendNotification` and not `mailing` campaigns
+
+Transactional staffing emails are:
+
+- Per-user, payload-driven (templated variables differ per recipient).
+- Preference-gated at the user level.
+- Log-critical (`EmailLog` ties back to `userId` for auditing).
+
+That's the `email-notification` pipeline, not the `mailing` (bulk campaign) pipeline. Campaigns stay reserved for marketing/newsletter use.
+
+## 5. In-app notifications
+
+New Prisma model `Notification`:
+
+```prisma
+model Notification {
+  id         String   @id @default(uuid())
+  userId     String
+  type       String
+  title      String
+  body       String?
+  link       String?
+  metadata   Json?
+  readAt     DateTime?
+  createdAt  DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, readAt, createdAt])
+  @@map("notifications")
+}
+```
+
+API (`api/src/notifications/`):
+
+- `GET /notifications?unread=true&limit=50` — current user's notifications.
+- `POST /notifications/:id/read`, `POST /notifications/read-all`.
+- Internal service method `createNotification({ userId, type, title, body, link, metadata })` called alongside every `sendNotification` site listed in §3.
+
+Socket push:
+
+- Extend existing `messaging.gateway.ts` (simpler than a second gateway) to relay `notification.created` events on the user's channel. Alternative: new `/notifications` namespace — see `08-open-decisions.md` for trade-offs.
+
+Frontend:
+
+- `frontend/contexts/NotificationContext.tsx` — rewrite to:
+  - Fetch `GET /notifications?unread=true` on mount.
+  - Subscribe to `notification.created` socket event.
+  - Expose `markRead` / `markAllRead`.
+  - Keep the existing transient-toast interface (add the `Notification` to in-memory toast list too).
+- `frontend/pages/NotificationsPage.tsx` — swap data source from context-only to the list returned by API + context merge.
+- `frontend/components/layout/Navbar.tsx` — unread badge count comes from `GET /notifications?unread=true&limit=0` (return count only) or from a new `/notifications/unread-count` endpoint.
+
+## 6. Admin staffing signals panel
+
+`GET /admin/staffing/signals` returns:
+
+```json
+{
+  "openReplacementRequests": { "total": number, "byUrgency": { "LOW": n, "MEDIUM": n, "HIGH": n, "CRITICAL": n } },
+  "applicationsAwaitingReview": { "total": number, "over48h": number },
+  "lowPoolRegions": [ { "region": string, "openJobs": n, "activeCandidates": n } ],
+  "zeroMatchJobs": [ { "jobId": string, "title": string, "hoursSincePosted": n } ],
+  "candidatePoolGrowth": { "weekOverWeekPct": number }
+}
+```
+
+Rendered as cards on `admin/src/pages/Dashboard.tsx` above the existing counters.
+
+## 7. Known issues to fix in the same effort
+
+- `email-notification.service.ts#sendBulkNotification` currently ignores `scheduledAt` — fix to forward to `scheduleNotification` when a future date is given.
+- Seed `payment_reminder` and `subscription_payment_failed` into `EmailTemplate` (already referenced by billing but not seeded).
+- `EmailLog.status` only ever becomes `sent` or `failed`. If SendGrid webhook is available, wire `delivered`/`opened`/`clicked` in a later pass — **deferred**.
+
+## 8. Acceptance checklist for the email/notification phase
+
+- [ ] All 7 new templates exist in DB after a fresh seed.
+- [ ] Unit tests: `recruitment.service.spec.ts` covers the 3 recruitment trigger points with a mocked `EmailNotificationService`.
+- [ ] Integration test: posting a job → matching candidates receive an email (or an `EmailLog` row is created; transport mocked).
+- [ ] Admin can opt-out of `low_candidate_pool` via existing preference UI.
+- [ ] `STAFFING_MATCH_EMAIL_LIMIT` enforced.
+- [ ] `v2_staffing_emails` feature flag toggles fan-out.

--- a/docs/v2-staffing-remodel/07-navigation-ia-target.md
+++ b/docs/v2-staffing-remodel/07-navigation-ia-target.md
@@ -1,0 +1,135 @@
+# Target Navigation & Information Architecture
+
+## Fixed ordering rule (all staffing-oriented roles)
+
+```
+Overview → Staffing → HR & Compliance → Parent Enquiries → Suppliers & Services → (everything else)
+```
+
+Admin-only variation:
+
+```
+Overview → Users → Staffing → HR & Compliance → Parent Enquiries → Suppliers & Services → Platform Ops
+```
+
+## 1. Foundation sidebar (target)
+
+| # | Label (user-visible) | i18n key | Path | Source of truth |
+|---|---|---|---|---|
+| 1 | Overview | `sidebar.overview` | `/foundation/dashboard` | `FoundationDashboardPage` |
+| 2 | Staffing | `sidebar.staffing` | `/staffing` (redirect to first sub) | — |
+| 2.1 | Post a job | `sidebar.postJob` | `/staffing/jobs` | `RecruitmentPage` jobs tab |
+| 2.2 | Find candidates | `sidebar.findCandidates` | `/staffing/candidates` | `RecruitmentPage` candidates tab |
+| 2.3 | Find replacement staff | `sidebar.findReplacements` | `/staffing/replacements` | *new page (Phase 3)* |
+| 2.4 | Review applications | `sidebar.reviewApplications` | `/staffing/applications` | *new cross-job list + detail* |
+| 3 | HR & Compliance | `sidebar.hrCompliance` | parent, no route | — |
+| 3.1 | HR procedures | `sidebar.hrProcedures` | `/hr-procedures` | existing page |
+| 3.2 | State policies | `sidebar.statePolicies` | `/state-policies` | existing page |
+| 3.3 | E-learning | `sidebar.eLearning` | `/e-learning` | existing page |
+| 4 | Parent enquiries | `sidebar.parentEnquiries` | `/foundation/leads` | existing `FoundationLeadsPage` |
+| 5 | Suppliers & Services | `sidebar.suppliersServices` | parent, no route | — |
+| 5.1 | Products | `sidebar.products` | `/marketplace/products` | existing |
+| 5.2 | Services | `sidebar.services` | `/marketplace/services` | existing |
+| 6 | Orders & appointments | `sidebar.ordersAppointments` | `/foundation/orders-appointments` | existing |
+| 7 | Analytics | `sidebar.analytics` | `/foundation/analytics` | existing |
+| 8 | Messages | `sidebar.messages` | `/messages` | existing |
+| 9 | Organisation profile | `sidebar.organisationProfile` | `/foundation/organisation-profile` | existing |
+| 10 | Support | `sidebar.support` | `/foundation/support` | existing |
+
+## 2. Admin sidebar (target)
+
+| # | Label | Path | Notes |
+|---|---|---|---|
+| 1 | Overview | `/dashboard` | Admin homepage (Staffing Signals first — see §4) |
+| 2 | Users | `/users` | Unchanged CRUD |
+| 3 | Staffing | parent | Collapsible group |
+| 3.1 | Job listings | `/job-listings` | existing |
+| 3.2 | Candidates | `/candidates` | existing |
+| 3.3 | Applications | `/applications` | *new admin page — cross-foundation* |
+| 3.4 | Replacement requests | `/replacements` | *new page (Phase 3)* |
+| 4 | HR & Compliance | parent | |
+| 4.1 | Content | `/content` | existing tabs shell |
+| 4.2 | Policy crawler | `/policy-crawler` | existing |
+| 5 | Parent enquiries | `/parent-leads` | existing |
+| 6 | Suppliers & Services | parent | |
+| 6.1 | Organizations | `/organizations` | existing |
+| 6.2 | Partners | `/partners` | existing |
+| 6.3 | Products | `/products` | existing |
+| 6.4 | Services | `/services` | existing |
+| 6.5 | Orders | `/orders` | existing |
+| 7 | Platform Ops | parent | |
+| 7.1 | Messaging | `/messaging` | existing |
+| 7.2 | Subscriptions | `/subscriptions` | existing |
+| 7.3 | Discount terminations | `/discount-terminations` | existing |
+| 7.4 | Mailing | `/mailing` | existing |
+| 7.5 | Support | `/support` | existing |
+| 7.6 | Settings | `/settings` | existing (hosts system monitoring, translations, email templates, design system tabs) |
+
+## 3. Unchanged sidebars (per brief)
+
+- **Parent** — unchanged (see `01-current-state-inventory.md §6`).
+- **Educator** — adds "Replacement opportunities" tab inside `EducatorApplicationsPage`, no sidebar change.
+- **Product Supplier** — unchanged.
+- **Service Provider** — unchanged.
+
+## 4. Foundation `Overview` page (target layout)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Staffing Snapshot (3 KPI cards — clickable)                │
+│  [Open positions] [Applications to review] [Replacements]   │
+├─────────────────────────────────────────────────────────────┤
+│  Primary actions                                            │
+│  [Post a job]  [Find replacement staff]                     │
+│  [Find candidates]  [Review applications]                   │
+├─────────────────────────────────────────────────────────────┤
+│  Activity & calendar (existing FoundationDashboardPage)     │
+├─────────────────────────────────────────────────────────────┤
+│  Secondary (collapsed by default)                           │
+│  • Parent enquiries waiting                                 │
+│  • HR / policy alerts                                       │
+│  • Suppliers & services offers                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## 5. Admin `Overview` page (target layout)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Staffing Signals (4 cards)                                 │
+│  [Urgent replacements] [Apps > 48h] [Low-pool regions]      │
+│  [Zero-match jobs]                                          │
+├─────────────────────────────────────────────────────────────┤
+│  Users Quick Actions                                        │
+│  [Manage users] [Invite user] [Pending role changes]        │
+├─────────────────────────────────────────────────────────────┤
+│  Platform counters (existing)                               │
+│  users / foundations / products / parent leads              │
+├─────────────────────────────────────────────────────────────┤
+│  System status + policy crawler (existing)                  │
+├─────────────────────────────────────────────────────────────┤
+│  Content management summary (existing — smaller)            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## 6. Route reorganisation (URL migrations)
+
+| From | To | Keep old as redirect? |
+|---|---|---|
+| `/recruitment` | `/staffing` | Yes (Phase 1–6), drop in Phase 7 |
+| `/recruitment/job-listings` | `/staffing/jobs` | Yes |
+| `/recruitment/candidate-pool` | `/staffing/candidates` | Yes |
+| (new) | `/staffing/replacements` | N/A |
+| (new) | `/staffing/applications` | N/A |
+| admin default redirect → `/admin/content-dashboard` | admin SPA home (or `/users/all`) | Replace outright |
+
+## 7. Language / label rules
+
+- Use action verbs: "Post a job" not "Recruitment".
+- Never expose the word "Module" or the i18n-key identifier to users.
+- Keep English as the canonical source. i18n sync runs on the existing `pnpm i18n:*` scripts.
+
+## 8. Responsive behaviour
+
+- Mobile: the Overview page collapses the KPI cards to a horizontal scroller; primary actions become a 2x2 grid; secondary section collapses behind a "Show secondary" toggle.
+- Admin sidebar: existing collapse/expand pattern remains; parent groups start expanded for ADMIN, collapsed for SUPER_ADMIN user preference (stored in localStorage — already implemented pattern).

--- a/docs/v2-staffing-remodel/08-open-decisions.md
+++ b/docs/v2-staffing-remodel/08-open-decisions.md
@@ -1,0 +1,82 @@
+# Open Decisions
+
+Points that need a product / business answer (or a deliberate deferral) before or during implementation. None of these block writing this plan; all of them affect a specific phase.
+
+## D1. Replacement as a new domain, or overloaded on `JobListing`?
+
+- **Recommendation in this plan:** new `ReplacementRequest` + `ReplacementMatch` tables (Phase 3).
+- **Alternative:** keep replacement as a `JobContractType.REPLACEMENT` with a new `urgency` field on `JobListing` and reuse `JobApplication` as the fulfilment state machine.
+- **Trade-off:** overloaded `JobListing` is simpler to migrate but forces the same 4-stage application lifecycle (`PENDING → REVIEWED → ACCEPTED → REJECTED`) onto time-sensitive replacement shifts. The plan's recommendation assumes replacement needs a **different**, much shorter workflow (matched → offered → confirmed → fulfilled). If the business wants "replacement is just an urgent job", pick the alternative.
+- **Who decides:** Product.
+
+## D2. Admin default landing URL
+
+- Today: `ADMIN` / `SUPER_ADMIN` land on user-facing `/admin/content-dashboard` (`frontend/App.tsx:168`).
+- Options:
+  - (a) Admin SPA URL — requires knowing the deploy URL (env `ADMIN_APP_URL`).
+  - (b) `/users/all` in the user SPA — pragmatic if admins mostly live in the user SPA.
+  - (c) New `/admin/staffing-signals` page in the user SPA mirroring the admin SPA page.
+- **Recommendation:** (a) if admin SPA is exposed to admins routinely; otherwise (c).
+- **Who decides:** Product + DevOps.
+
+## D3. Socket channel for notifications
+
+- Extend existing `messaging.gateway.ts` with a `notification.created` event on the user's socket, **or** introduce a new `/notifications` namespace.
+- **Trade-off:** reusing the messaging gateway is faster to ship; a dedicated namespace is cleaner long-term.
+- **Recommendation:** reuse `messaging.gateway.ts` for now; extract when/if we add other notification transports (mobile push, web push).
+
+## D4. How aggressive is the `job_match` fan-out?
+
+- `STAFFING_MATCH_EMAIL_LIMIT` default. Too high → spam perception, preference opt-outs; too low → candidates miss opportunities.
+- **Recommendation:** start at 20, monitor opt-out rates, adjust.
+- **Who decides:** Growth / Product.
+
+## D5. Subscription entitlements for staffing features
+
+- Staffing is behind `SubscriptionGatedRoute` today.
+- Questions:
+  - Is replacement staffing gated at a higher tier?
+  - Are admin "staffing signals" free for all admins or tied to enterprise?
+  - Should educators' "available for replacement" toggle be free?
+- **Plan assumption:** same gate as existing recruitment; no new tiers introduced.
+- **Who decides:** Business / Monetisation.
+
+## D6. Availability model finalisation
+
+- `docs/EDUCATOR_AVAILABILITY_SYSTEM_DESIGN.md` is partially implemented; admin still uses legacy string availability.
+- Decision needed: commit to the structured model and deprecate the `availability: String?` legacy field, OR keep both forever and pay the complexity.
+- **Recommendation:** commit to structured, write a read-only compatibility shim in the service, deprecate legacy in Phase 7.
+
+## D7. Do admins need their own `Notification` feed?
+
+- The plan introduces `Notification` model for all users.
+- **Implicit assumption:** admins also receive notifications (urgent replacement created, support SLA breached, moderation queue spike).
+- **Who decides:** Product.
+
+## D8. Messaging deepening for recruiter ↔ candidate
+
+- Conversations exist but are unscoped. Phase 2/3 surfaces "Message candidate" buttons.
+- Question: auto-create a conversation per `(foundation, candidate, jobListing)` context, or reuse the general messaging model?
+- **Recommendation:** reuse general model; add `metadata.contextType='staffing'` + `contextId` JSON hooks (no schema change).
+
+## D9. What happens to existing `RecruitmentPage.tsx`?
+
+- Option (a): keep it, mount at `/staffing/jobs` + `/staffing/candidates` (simple alias).
+- Option (b): split into `StaffingJobsPage` + `StaffingCandidatesPage` (separate files, clearer mental model).
+- **Recommendation:** (a) through Phase 2; revisit in Phase 5 if the file becomes unwieldy.
+
+## D10. E-learning priority
+
+- Brief: "Minimal." Today it is fully built with a LMS graph, enrollments, certificates.
+- Decision: **leave as-is** (cost of removing = huge, cost of keeping = 0). Just downgrade in nav.
+- Confirmed unless Product objects.
+
+---
+
+## Items intentionally deferred
+
+- SendGrid / Mailgun delivery webhook wiring (`EmailLog.status` enrichment).
+- Mobile push notifications.
+- Automated AI matching / scoring beyond the rule-based matcher proposed in Phase 2.
+- Redis-backed webhook idempotency (currently in-memory `Set`; listed as known issue in `CLAUDE.md`).
+- ClamAV malware scanning (env-gated off by default).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Platform pivot: ProCrèche becomes a **staffing & recruitment system for Swiss crèches**, with everything else (parent enquiries, HR & compliance, marketplace, e-learning) relegated to secondary support. The brief is clear that we should **upgrade, not rebuild**, preserve live data, and keep non-core roles (Parent / Product Supplier / Service Provider) untouched.

This PR does **no code changes** — it lands the strategic plan and the persistent pre-remodel snapshot so future sessions don't re-audit the codebase from scratch.

## What's in here

New folder: `docs/v2-staffing-remodel/`

| File | Purpose |
|---|---|
| `00-README.md` | Entry point. Scope recap, hard nav rule, feature acceptance test, branch convention. |
| `01-current-state-inventory.md` | Full audit: monorepo layout, roles + redirects, recruitment API + Prisma, frontend + admin UI, replacement state, availability status, parent leads, HR/compliance, marketplace, e-learning, subscription, support, messaging, email engine + seeded templates + trigger sites, in-app notifications, nav, routes, known bugs, env config, live tables to preserve. |
| `02-gap-analysis.md` | v2 requirements vs. reality, per area. |
| `03-remodel-strategy.md` | Guiding principles, non-negotiables, what stays, what changes, principles for UI redesign, success metrics. |
| `04-phased-plan.md` | 8 phases (0 Prep → 7 Measurement & Cleanup), each with concrete tasks tagged `[Refactor]` / `[New]` / `[Rename/IA]` / `[Fix]` / `[Config]` and exit criteria. No calendar dates — phases are dependency-ordered. |
| `05-data-migration-and-preservation.md` | Additive-only Prisma changes, feature flags, deep-link preservation map, per-role smoke test plan. |
| `06-email-and-notification-plan.md` | 7 new transactional events (`new_application`, `application_status_update`, `job_match`, `replacement_request_open`, `replacement_matched`, `replacement_confirmed`, `low_candidate_pool`), fan-out rules, wiring points, `Notification` model, admin staffing-signals panel. |
| `07-navigation-ia-target.md` | Final sidebars (foundation + admin), Overview page layouts, URL migration table. |
| `08-open-decisions.md` | 10 product/business decisions that need answers to unblock specific phases. |

Also updates `CLAUDE.md` to point future sessions to the new folder first.

## Key strategic calls documented in the plan

- **Nav order (fixed):** `Overview → Staffing → HR & Compliance → Parent Enquiries → Suppliers & Services`. Admin variation inserts `Users` between `Overview` and `Staffing`.
- **Replacement staffing as new domain:** adds `ReplacementRequest` + `ReplacementMatch` models (Phase 3). Rationale: its state machine (matched → offered → confirmed → fulfilled) is fundamentally different from `JobApplication`'s 4-stage pipeline. Overload on `JobListing` documented as alternative in `08-open-decisions.md D1`.
- **Email layer reuses existing `email-notification` module** — no new transport. 7 seeded templates + 5 wiring points in `recruitment.service.ts` and new `replacement.service.ts`.
- **In-app notifications** get a real `Notification` Prisma model; socket push piggybacks on the existing `messaging.gateway.ts` (alternative namespace noted in `08-open-decisions.md D3`).
- **No destructive migration.** All schema changes are additive. `ApplicationStatus` is extended, not rewritten. Legacy `/recruitment/*` routes redirect until Phase 7.
- **Non-core role dashboards (Parent / Supplier / Service Provider) are untouched.** Explicit test in Phase 1's exit criteria.

## Minor issues caught during the audit (listed for fixing in Phase 1–2)

- Admin default redirect lands on `/admin/content-dashboard` (content-centric) — should land on staffing.
- `frontend/components/layout/MainLayout.tsx` calls `useTranslation` inside a callback.
- `admin/src/pages/Candidates.tsx` Delete menu item has no `onClick`.
- `admin/src/components/AddJobListingModal.tsx` missing `employmentType`, `workSchedule`, `startDate`, `salaryRange` vs. foundation modal.
- `admin/src/pages/JobListings.tsx` status filter missing `FILLED`.
- `EducatorJobBoardPage.tsx` contract-type filter omits `REPLACEMENT`/`TEMPORARY`/`FREELANCE`.
- `EducatorApplicationsPage.tsx` "View details" is an `alert()` stub.
- `recruitment.service.ts#findMatchingCandidates` is a stub (no real scoring).
- `recruitment.controller.ts` missing `@Roles` on 2 endpoints.
- Duplicate `UpdateJobApplicationDto`.
- `email-notification.service.ts#sendBulkNotification` ignores `scheduledAt`; billing-critical templates (`payment_reminder`, `subscription_payment_failed`) not seeded.

## How to review this PR

Docs only — review by reading them in order: `00 → 03 → 04 → 07 → 06 → 05 → 02 → 01 → 08`. Files are self-contained, written to be durable against future code changes.

## Next step

After this lands, subsequent implementation work should open one PR per phase, each branched from `Main` and referencing the phase in `04-phased-plan.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83001630-df08-44f4-b23e-b19227d83032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83001630-df08-44f4-b23e-b19227d83032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive planning documentation for an upcoming staffing system remodel, including implementation strategy, phased roadmap, current state inventory, gap analysis, data migration approach, and navigation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->