### PR TITLE
Add contact email display to organization public profile

### DIFF
--- a/api/src/profiles/profiles.controller.ts
+++ b/api/src/profiles/profiles.controller.ts
@@ -651,6 +651,7 @@ export class ProfileController {
         },
         logoAsset: true,
         coverAsset: true,
+        contactInfo: true,
         members: {
           include: {
             user: {
@@ -667,9 +668,13 @@ export class ProfileController {
       throw new NotFoundException('Organization not found');
     }
 
+    const { contactInfo, ...orgRest } = organization as any;
     return {
       success: true,
-      data: organization,
+      data: {
+        ...orgRest,
+        contactEmail: contactInfo?.contactEmail ?? null,
+      },
     };
   }
 

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -25,6 +25,7 @@ const userProfileInclude = {
         include: {
           logoAsset: true,
           coverAsset: true,
+          contactInfo: true,
           products: {
             include: {
               imageAsset: true,
@@ -464,6 +465,7 @@ export class UsersService {
         description: org.description,
         vatNumber: org.vatNumber,
         contactPerson: org.contactPerson,
+        contactEmail: (org as any).contactInfo?.contactEmail ?? null,
         phoneNumber: org.phoneNumber,
         canton: org.canton,
         regionsServed: org.regionsServed ?? (org.canton ? [org.canton] : []),

--- a/frontend/components/profile/OrganizationPublicProfile.tsx
+++ b/frontend/components/profile/OrganizationPublicProfile.tsx
@@ -212,6 +212,23 @@ const OrganizationPublicProfile: React.FC<OrganizationPublicProfileProps> = ({
 
               <div>
                 <p className="text-xs text-gray-500 mb-1 font-medium">
+                  {t('profile:organization.contactEmail', { defaultValue: 'Contact Email' })}
+                </p>
+                {organization.contactEmail ? (
+                  <a
+                    href={`mailto:${organization.contactEmail}`}
+                    className="text-swiss-mint hover:text-swiss-teal flex items-center gap-2"
+                  >
+                    <EnvelopeIcon className="w-4 h-4" />
+                    {organization.contactEmail}
+                  </a>
+                ) : (
+                  <p className="text-gray-400 italic text-xs">{t('profile:organization.notProvided', { defaultValue: 'Not provided' })}</p>
+                )}
+              </div>
+
+              <div>
+                <p className="text-xs text-gray-500 mb-1 font-medium">
                   {t('profile:organization.phone', { defaultValue: 'Phone' })}
                 </p>
                 {organization.phoneNumber ? (

--- a/frontend/pages/profile/OrganizationProfileViewPage.tsx
+++ b/frontend/pages/profile/OrganizationProfileViewPage.tsx
@@ -55,6 +55,7 @@ const OrganizationProfileViewPage: React.FC = () => {
             description: orgData.description,
             vatNumber: orgData.vatNumber,
             contactPerson: orgData.contactPerson,
+            contactEmail: orgData.contactEmail ?? null,
             phoneNumber: orgData.phoneNumber,
             canton: orgData.canton,
             regionsServed: Array.isArray(orgData.regionsServed) ? orgData.regionsServed : (orgData.canton ? [orgData.canton] : []),

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -88,6 +88,7 @@ export interface Organization {
   
   // Additional organization fields
   contactPerson?: string;
+  contactEmail?: string;
   phoneNumber?: string;
   canton?: string; // Legacy single canton field
   city?: string; // City where the organization is located


### PR DESCRIPTION
## Summary
Added a new contact email section to the organization public profile page, allowing organizations to display their contact email address with a clickable mailto link.

## Key Changes
- Added a new contact email field display section in the organization profile
- Implemented conditional rendering to show the email as a clickable mailto link when available
- Added fallback text ("Not provided") when contact email is not provided
- Included an envelope icon for visual consistency with other contact information
- Applied consistent styling with existing profile sections (text colors, spacing, typography)
- Added i18n support with translation keys for both the label and "not provided" message

## Implementation Details
- The contact email is displayed as a clickable link with `mailto:` protocol
- Uses the `EnvelopeIcon` component for visual indication of email contact
- Styled with the swiss-mint color scheme matching the design system
- Positioned between the organization description and phone number sections
- Includes proper accessibility with semantic HTML (`<a>` tag for links)

https://claude.ai/code/session_019M12acfsqwTn6hibQL359y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization public profiles now show a contact email in the Contact Information section. When present, the email is a clickable mailto link; when absent, a localized "Not provided" placeholder appears.
  * Organization profile data now includes a contactEmail field so profile pages and related views can display this information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->