### PR TITLE
refactor(admin): move CV upload to dedicated 'CV & Documents' tab in …

### DIFF
--- a/admin/src/pages/AdminUserProfileEdit.tsx
+++ b/admin/src/pages/AdminUserProfileEdit.tsx
@@ -707,7 +707,23 @@ const AdminUserProfileEdit: React.FC = () => {
             allowCustomValues={true}
           />
         </Card>
+      </div>
+    </PermissionGate>
+  );
 
+  const documentsTab = (
+    <PermissionGate
+      role={UserRole.SUPER_ADMIN}
+      fallback={
+        <Card className="p-6 opacity-60">
+          <div className="flex items-center gap-2">
+            <Lock className="h-4 w-4 text-amber-400" />
+            <span className="text-sm text-gray-500">Super Admin required to manage documents.</span>
+          </div>
+        </Card>
+      }
+    >
+      <div className="space-y-6">
         <Card className="p-6">
           <h3 className="mb-4 flex items-center text-base font-semibold text-gray-900">
             <FileText className="mr-2 h-5 w-5 text-swiss-teal" />
@@ -820,6 +836,7 @@ const AdminUserProfileEdit: React.FC = () => {
         { label: 'Professional', icon: Briefcase, content: professionalTab },
         { label: 'Experience & Education', icon: GraduationCap, content: experienceTab },
         { label: 'Skills', icon: Award, content: skillsTab },
+        { label: 'CV & Documents', icon: FileText, content: documentsTab },
       ]}
     />
   );


### PR DESCRIPTION
…educator profile

Previously the CV upload was bundled inside the 'Skills' tab, making it hard to discover. It now has its own 'CV & Documents' tab (5th tab, FileText icon) in the educator profile editor, while Skills retains only the skills chip input.

https://claude.ai/code/session_01CMVMgpQ58fp6fSJSvMhg7m

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "CV & Documents" tab to the Super Admin educator profile view, consolidating CV upload, replacement, and removal capabilities in one organized section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->