### PR TITLE
fix: add missing commas after userProfileEdit block in EN/FR/DE admin…

### DIFF
--- a/packages/translations/locales/de/admin.json
+++ b/packages/translations/locales/de/admin.json
@@ -2451,6 +2451,7 @@
       "hint": "PDF, DOC, DOCX — max. 5 MB",
       "uploadFailed": "CV-Upload fehlgeschlagen. Bitte erneut versuchen."
     }
+  },
   "orgProfile": {
     "editTitle": "Organisationsprofil bearbeiten",
     "basicInfo": "Allgemeine Informationen",

--- a/packages/translations/locales/en/admin.json
+++ b/packages/translations/locales/en/admin.json
@@ -2451,6 +2451,7 @@
       "hint": "PDF, DOC, DOCX — max 5 MB",
       "uploadFailed": "CV upload failed. Please try again."
     }
+  },
   "orgProfile": {
     "editTitle": "Edit Organization Profile",
     "basicInfo": "Basic Information",

--- a/packages/translations/locales/fr/admin.json
+++ b/packages/translations/locales/fr/admin.json
@@ -2476,6 +2476,7 @@
       "hint": "PDF, DOC, DOCX — 5 Mo max",
       "uploadFailed": "Échec du téléchargement du CV. Veuillez réessayer."
     }
+  },
   "orgProfile": {
     "editTitle": "Modifier le profil de l'organisation",
     "basicInfo": "Informations générales",


### PR DESCRIPTION
….json

The closing brace of userProfileEdit.cv was not followed by a comma before the orgProfile key, causing invalid JSON and a Vite build failure.

https://claude.ai/code/session_01CMVMgpQ58fp6fSJSvMhg7m

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected JSON structure in translation files for German, English, and French to ensure proper parsing of localized content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->