### PR TITLE
Expand educator job roles and add i18n translations

### DIFF
--- a/admin/src/constants/design-system.ts
+++ b/admin/src/constants/design-system.ts
@@ -20,7 +20,7 @@ export const ALL_REGIONS_OPTION = 'All' as const;
 export const SWISS_CANTONS_WITH_ALL = [ALL_REGIONS_OPTION, ...SWISS_CANTONS] as const;
 
 // Restricted list of valid educator job roles.
-export const EDUCATOR_JOB_ROLES = ['Direction', 'EDE', 'ASE', 'Auxiliaire', 'Cleaning'] as const;
+export const EDUCATOR_JOB_ROLES = ['Direction', 'EDE', 'ASE', 'Auxiliaire', 'Cleaning', 'Director', 'Cleaning Staff', 'Intern'] as const;
 export type EducatorJobRole = typeof EDUCATOR_JOB_ROLES[number];
 
 export const SERVICE_CATEGORIES = [

--- a/api/src/settings/dto/educator-settings.dto.ts
+++ b/api/src/settings/dto/educator-settings.dto.ts
@@ -12,7 +12,7 @@ import {
   ValidateNested,
 } from 'class-validator';
 
-export const ALLOWED_JOB_ROLES = ['Direction', 'EDE', 'ASE', 'Auxiliaire', 'Cleaning'] as const;
+export const ALLOWED_JOB_ROLES = ['Direction', 'EDE', 'ASE', 'Auxiliaire', 'Cleaning', 'Director', 'Cleaning Staff', 'Intern'] as const;
 import { Type } from 'class-transformer';
 import { EducatorAvailabilitySettingsDto } from './educator-availability.dto';
 

--- a/frontend/components/profile/edit/EducatorProfileForm.tsx
+++ b/frontend/components/profile/edit/EducatorProfileForm.tsx
@@ -281,7 +281,7 @@ const EducatorProfileForm: React.FC<EducatorProfileFormProps> = ({ formData, onC
             >
               <option value="">{t('settings:educatorProfile.rolePlaceholder', 'Select a role')}</option>
               {EDUCATOR_JOB_ROLES.map((role) => (
-                <option key={role} value={role}>{role}</option>
+                <option key={role} value={role}>{t(`common:educatorJobRoles.${role.replace(/\s+/g, '')}`, role)}</option>
               ))}
             </select>
           </div>

--- a/frontend/components/signup/EducatorProfileStep.tsx
+++ b/frontend/components/signup/EducatorProfileStep.tsx
@@ -11,11 +11,7 @@ import {
 } from '@heroicons/react/24/outline';
 import Button from '../ui/Button';
 import FileUploadZone from '../ui/FileUploadZone';
-import { STANDARD_INPUT_FIELD, SWISS_CANTONS } from '../../constants';
-
-// Only the three profile types relevant to this signup step
-const EDUCATOR_PROFILE_ROLES = ['EDE', 'ASE', 'Auxiliaire'] as const;
-type EducatorProfileRole = typeof EDUCATOR_PROFILE_ROLES[number];
+import { STANDARD_INPUT_FIELD, SWISS_CANTONS, EDUCATOR_JOB_ROLES, type EducatorJobRole } from '../../constants';
 
 export interface EducatorProfileStepData {
   firstName: string;
@@ -28,7 +24,7 @@ export interface EducatorProfileStepData {
   professionalExperience: string;
   cvUrl: string;
   cvAssetId: string;
-  jobRole: EducatorProfileRole | '';
+  jobRole: EducatorJobRole | '';
 }
 
 interface EducatorProfileStepErrors {
@@ -239,8 +235,8 @@ const EducatorProfileStep: React.FC<EducatorProfileStepProps> = ({
         <p className="text-xs text-gray-500">
           {t('signup:educatorProfile.profileTypeHint', 'Select the qualification that best describes your role')}
         </p>
-        <div className="grid grid-cols-3 gap-3">
-          {EDUCATOR_PROFILE_ROLES.map(role => (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {EDUCATOR_JOB_ROLES.map(role => (
             <button
               key={role}
               type="button"
@@ -251,7 +247,7 @@ const EducatorProfileStep: React.FC<EducatorProfileStepProps> = ({
                   : 'border-gray-300 bg-white text-gray-600 hover:border-swiss-mint hover:bg-gray-50'
               }`}
             >
-              {role}
+              {t(`common:educatorJobRoles.${role.replace(/\s+/g, '')}`, role)}
             </button>
           ))}
         </div>

--- a/frontend/constants.ts
+++ b/frontend/constants.ts
@@ -11,7 +11,7 @@ export const ALL_REGIONS_OPTION = 'All' as const;
 export const SWISS_CANTONS_WITH_ALL = [ALL_REGIONS_OPTION, ...SWISS_CANTONS] as const;
 
 // Restricted list of valid educator job roles. No free-text input is allowed; users must pick from this list.
-export const EDUCATOR_JOB_ROLES = ['Direction', 'EDE', 'ASE', 'Auxiliaire', 'Cleaning'] as const;
+export const EDUCATOR_JOB_ROLES = ['Direction', 'EDE', 'ASE', 'Auxiliaire', 'Cleaning', 'Director', 'Cleaning Staff', 'Intern'] as const;
 export type EducatorJobRole = typeof EDUCATOR_JOB_ROLES[number];
 
 export const APP_NAME = "Pro Crèche Solutions";

--- a/packages/translations/locales/de/common.json
+++ b/packages/translations/locales/de/common.json
@@ -2397,5 +2397,15 @@
     "selectAll": "Alle auswählen",
     "deselectAll": "Auswahl aufheben",
     "confirmBulkDelete": "{{count}} Element(e) dauerhaft löschen? Dies kann nicht rückgängig gemacht werden."
+  },
+  "educatorJobRoles": {
+    "Direction": "Direktion",
+    "EDE": "EDE",
+    "ASE": "ASE",
+    "Auxiliaire": "Hilfskraft",
+    "Cleaning": "Reinigung",
+    "Director": "Direktor/in",
+    "CleaningStaff": "Reinigungspersonal",
+    "Intern": "Praktikant/in"
   }
 }

--- a/packages/translations/locales/en/common.json
+++ b/packages/translations/locales/en/common.json
@@ -2395,5 +2395,15 @@
     "selectAll": "Select all",
     "deselectAll": "Deselect all",
     "confirmBulkDelete": "Permanently delete {{count}} item(s)? This cannot be undone."
+  },
+  "educatorJobRoles": {
+    "Direction": "Direction",
+    "EDE": "EDE",
+    "ASE": "ASE",
+    "Auxiliaire": "Auxiliaire",
+    "Cleaning": "Cleaning",
+    "Director": "Director",
+    "CleaningStaff": "Cleaning Staff",
+    "Intern": "Intern"
   }
 }

--- a/packages/translations/locales/fr/common.json
+++ b/packages/translations/locales/fr/common.json
@@ -2395,5 +2395,15 @@
     "selectAll": "Tout sélectionner",
     "deselectAll": "Tout désélectionner",
     "confirmBulkDelete": "Supprimer définitivement {{count}} élément(s) ? Cette action est irréversible."
+  },
+  "educatorJobRoles": {
+    "Direction": "Direction",
+    "EDE": "EDE",
+    "ASE": "ASE",
+    "Auxiliaire": "Auxiliaire",
+    "Cleaning": "Nettoyage",
+    "Director": "Directeur/Directrice",
+    "CleaningStaff": "Personnel de nettoyage",
+    "Intern": "Stagiaire"
   }
 }


### PR DESCRIPTION
## Summary
This PR expands the list of available educator job roles and adds comprehensive internationalization (i18n) support for role display across the application. The changes centralize role definitions and ensure consistent, translated role labels throughout the UI.

## Key Changes
- **Expanded educator job roles**: Added three new roles (`Director`, `Cleaning Staff`, `Intern`) to the existing list (`Direction`, `EDE`, `ASE`, `Auxiliaire`, `Cleaning`)
- **Centralized role definitions**: Moved `EDUCATOR_JOB_ROLES` constant to shared constants file and removed local duplicate definitions
- **Added i18n translations**: Created `educatorJobRoles` translation keys in English, French, and German locales with appropriate role labels
- **Updated UI components**: 
  - `EducatorProfileStep`: Changed grid layout from 3 columns to responsive 2/4 columns and implemented translated role labels
  - `EducatorProfileForm`: Added translation support for role dropdown options
- **Updated backend validation**: Extended `ALLOWED_JOB_ROLES` in the API DTO to match the expanded role list
- **Consistent type usage**: Replaced local `EducatorProfileRole` type with shared `EducatorJobRole` type from constants

## Implementation Details
- Role labels are now dynamically translated using the pattern `common:educatorJobRoles.${role}` with whitespace normalization
- All three supported languages (EN, FR, DE) have been updated with appropriate translations
- The responsive grid layout improvement makes the role selection more accessible on smaller screens

https://claude.ai/code/session_011n8WFsFGpfPUk9xDkEdeGt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded educator job role options to include Director, Cleaning Staff, and Intern roles for selection in educator profiles.

* **Improvements**
  * Updated role selection interface with improved layout for better usability.
  * Educator job role labels now display in localized languages (English, German, and French) for enhanced user experience across regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->