### PR TITLE
Remove duplicate Direction and Cleaning job roles

### DIFF
--- a/admin/src/constants/design-system.ts
+++ b/admin/src/constants/design-system.ts
@@ -20,7 +20,7 @@ export const ALL_REGIONS_OPTION = 'All' as const;
 export const SWISS_CANTONS_WITH_ALL = [ALL_REGIONS_OPTION, ...SWISS_CANTONS] as const;
 
 // Restricted list of valid educator job roles.
-export const EDUCATOR_JOB_ROLES = ['Direction', 'EDE', 'ASE', 'Auxiliaire', 'Cleaning', 'Director', 'Cleaning Staff', 'Intern'] as const;
+export const EDUCATOR_JOB_ROLES = ['EDE', 'ASE', 'Auxiliaire', 'Director', 'Cleaning Staff', 'Intern'] as const;
 export type EducatorJobRole = typeof EDUCATOR_JOB_ROLES[number];
 
 export const SERVICE_CATEGORIES = [

--- a/api/src/settings/dto/educator-settings.dto.ts
+++ b/api/src/settings/dto/educator-settings.dto.ts
@@ -12,7 +12,7 @@ import {
   ValidateNested,
 } from 'class-validator';
 
-export const ALLOWED_JOB_ROLES = ['Direction', 'EDE', 'ASE', 'Auxiliaire', 'Cleaning', 'Director', 'Cleaning Staff', 'Intern'] as const;
+export const ALLOWED_JOB_ROLES = ['EDE', 'ASE', 'Auxiliaire', 'Director', 'Cleaning Staff', 'Intern'] as const;
 import { Type } from 'class-transformer';
 import { EducatorAvailabilitySettingsDto } from './educator-availability.dto';
 

--- a/frontend/constants.ts
+++ b/frontend/constants.ts
@@ -11,7 +11,7 @@ export const ALL_REGIONS_OPTION = 'All' as const;
 export const SWISS_CANTONS_WITH_ALL = [ALL_REGIONS_OPTION, ...SWISS_CANTONS] as const;
 
 // Restricted list of valid educator job roles. No free-text input is allowed; users must pick from this list.
-export const EDUCATOR_JOB_ROLES = ['Direction', 'EDE', 'ASE', 'Auxiliaire', 'Cleaning', 'Director', 'Cleaning Staff', 'Intern'] as const;
+export const EDUCATOR_JOB_ROLES = ['EDE', 'ASE', 'Auxiliaire', 'Director', 'Cleaning Staff', 'Intern'] as const;
 export type EducatorJobRole = typeof EDUCATOR_JOB_ROLES[number];
 
 export const APP_NAME = "Pro Crèche Solutions";

--- a/packages/translations/locales/de/common.json
+++ b/packages/translations/locales/de/common.json
@@ -2399,11 +2399,9 @@
     "confirmBulkDelete": "{{count}} Element(e) dauerhaft löschen? Dies kann nicht rückgängig gemacht werden."
   },
   "educatorJobRoles": {
-    "Direction": "Direktion",
     "EDE": "EDE",
     "ASE": "ASE",
     "Auxiliaire": "Hilfskraft",
-    "Cleaning": "Reinigung",
     "Director": "Direktor/in",
     "CleaningStaff": "Reinigungspersonal",
     "Intern": "Praktikant/in"

--- a/packages/translations/locales/en/common.json
+++ b/packages/translations/locales/en/common.json
@@ -2397,11 +2397,9 @@
     "confirmBulkDelete": "Permanently delete {{count}} item(s)? This cannot be undone."
   },
   "educatorJobRoles": {
-    "Direction": "Direction",
     "EDE": "EDE",
     "ASE": "ASE",
     "Auxiliaire": "Auxiliaire",
-    "Cleaning": "Cleaning",
     "Director": "Director",
     "CleaningStaff": "Cleaning Staff",
     "Intern": "Intern"

--- a/packages/translations/locales/fr/common.json
+++ b/packages/translations/locales/fr/common.json
@@ -2397,11 +2397,9 @@
     "confirmBulkDelete": "Supprimer définitivement {{count}} élément(s) ? Cette action est irréversible."
   },
   "educatorJobRoles": {
-    "Direction": "Direction",
     "EDE": "EDE",
     "ASE": "ASE",
     "Auxiliaire": "Auxiliaire",
-    "Cleaning": "Nettoyage",
     "Director": "Directeur/Directrice",
     "CleaningStaff": "Personnel de nettoyage",
     "Intern": "Stagiaire"


### PR DESCRIPTION
Direction and Director are the same role; Cleaning and Cleaning Staff are the same role. Kept the English names and removed the French duplicates from all role lists and translation files.

https://claude.ai/code/session_011n8WFsFGpfPUk9xDkEdeGt