### PR TITLE
Suppress TypeScript 6.0 deprecation warnings in API

### DIFF
--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -10,6 +10,7 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
+    "ignoreDeprecations": "6.0",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": false,


### PR DESCRIPTION
## Summary
Added TypeScript deprecation suppression configuration to the API's tsconfig.json to handle breaking changes in TypeScript 6.0.

## Changes
- Added `"ignoreDeprecations": "6.0"` to the compiler options in `api/tsconfig.json`

## Details
This configuration option suppresses deprecation warnings related to TypeScript 6.0, allowing the project to continue building without warnings while using features or patterns that are deprecated in the latest TypeScript version. This provides a grace period for the codebase to be updated to align with TypeScript 6.0 standards.

https://claude.ai/code/session_019m5CsfKDRPSJrtQqBipesj