### PR TITLE
revert: remove invalid ignoreDeprecations "6.0" from tsconfig

### DIFF
--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -10,7 +10,6 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
-    "ignoreDeprecations": "6.0",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": false,


### PR DESCRIPTION
TypeScript 5.9.2 (what Render installs via pnpm-lock.yaml) does not recognise "6.0" as a valid ignoreDeprecations value and fails with TS5103, blocking the nest build.

The previous commit was diagnosing using the global tsc 6.0.2 which does emit TS5101 for baseUrl. However, Render uses the lockfile-pinned 5.9.2, where baseUrl is deprecated (warning only) not a hard error. Removing the bad override restores a compilable tsconfig.

https://claude.ai/code/session_019m5CsfKDRPSJrtQqBipesj