### PR TITLE
fix: resolve two TypeScript compilation errors failing nest build

### DIFF
--- a/api/src/recruitment/recruitment.service.ts
+++ b/api/src/recruitment/recruitment.service.ts
@@ -891,7 +891,7 @@ export class RecruitmentService {
     if (!foundationId) return;
     const members = await this.prisma.user.findMany({
       where: {
-        organizationId: foundationId,
+        organizations: { some: { organizationId: foundationId } },
         role: { in: ['FOUNDATION' as any, 'ADMIN' as any, 'SUPER_ADMIN' as any] },
         isActive: { not: false },
       },

--- a/api/src/replacements/dto/update-replacement-request.dto.ts
+++ b/api/src/replacements/dto/update-replacement-request.dto.ts
@@ -1,5 +1,5 @@
 import { IsEnum, IsOptional, IsString } from 'class-validator';
-import { ReplacementRequestStatus } from '@prisma/client';
+import { ReplacementRequestStatus, UrgencyLevel } from '@prisma/client';
 
 export class UpdateReplacementRequestDto {
   @IsOptional()
@@ -11,6 +11,6 @@ export class UpdateReplacementRequestDto {
   description?: string;
 
   @IsOptional()
-  @IsString()
-  urgency?: string;
+  @IsEnum(UrgencyLevel)
+  urgency?: UrgencyLevel;
 }


### PR DESCRIPTION
1. recruitment.service.ts:894 — User model has no direct organizationId field; filter by the junction relation instead: organizations: { some: { organizationId: foundationId } }

2. replacements dto — urgency typed as string but Prisma requires the UrgencyLevel enum; switch decorator to @IsEnum(UrgencyLevel) and the field type to UrgencyLevel.

https://claude.ai/code/session_019m5CsfKDRPSJrtQqBipesj