### PR TITLE
Fix admin recruitment pages and restore original content page links

### DIFF
--- a/admin/src/components/Sidebar.tsx
+++ b/admin/src/components/Sidebar.tsx
@@ -76,9 +76,8 @@ const navStructure: NavEntry[] = [
   {
     type: 'group', key: 'hrCompliance', icon: FileText,
     items: [
-      { key: 'hrDocuments',   href: '/content/hr-documents',   icon: FileText },
-      { key: 'statePolicies', href: '/content/state-policies', icon: FileSearch },
-      { key: 'policyCrawler', href: '/policy-crawler',         icon: FileSearch },
+      { key: 'content',       href: '/content',        icon: FileText },
+      { key: 'policyCrawler', href: '/policy-crawler', icon: FileSearch },
     ],
   },
   { type: 'single', key: 'parentLeads', href: '/parent-leads', icon: Heart },

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -533,10 +533,10 @@ const ProtectedLayout: React.FC = () => {
           <SubscriptionGatedRoute roles={[UserRole.FOUNDATION]}><FoundationAnalyticsPage /></SubscriptionGatedRoute>
         } />
         <Route path="/foundation/replacements" element={
-          <SubscriptionGatedRoute roles={[UserRole.FOUNDATION]}><FoundationReplacementsPage /></SubscriptionGatedRoute>
+          <SubscriptionGatedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN]}><FoundationReplacementsPage /></SubscriptionGatedRoute>
         } />
         <Route path="/foundation/intern-pool" element={
-          <SubscriptionGatedRoute roles={[UserRole.FOUNDATION]}><FoundationInternPoolPage /></SubscriptionGatedRoute>
+          <SubscriptionGatedRoute roles={[UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN]}><FoundationInternPoolPage /></SubscriptionGatedRoute>
         } />
         {/* Profile/Support routes don't require subscription */}
         <Route path="/foundation/organisation-profile" element={

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -113,8 +113,11 @@ const Sidebar: React.FC<SidebarProps> = ({ onLinkClick, isMobileView }) => {
     {
       path: '/recruitment', nameKey: 'sidebar.recruitment', icon: BriefcaseIcon, roles: [UserRole.ADMIN, UserRole.SUPER_ADMIN],
       subItems: [
-        { path: '/recruitment/job-listings',   nameKey: 'sidebar.jobListings',   icon: ListBulletIcon, roles: [UserRole.ADMIN, UserRole.SUPER_ADMIN] },
-        { path: '/recruitment/candidate-pool', nameKey: 'sidebar.candidatePool', icon: UserGroupIcon,  roles: [UserRole.ADMIN, UserRole.SUPER_ADMIN] },
+        { path: '/staffing/jobs',           nameKey: 'sidebar.postJob',            icon: ListBulletIcon,            roles: [UserRole.ADMIN, UserRole.SUPER_ADMIN] },
+        { path: '/staffing/candidates',     nameKey: 'sidebar.findCandidates',     icon: UserGroupIcon,             roles: [UserRole.ADMIN, UserRole.SUPER_ADMIN] },
+        { path: '/staffing/applications',   nameKey: 'sidebar.reviewApplications', icon: ClipboardDocumentListIcon, roles: [UserRole.ADMIN, UserRole.SUPER_ADMIN] },
+        { path: '/foundation/replacements', nameKey: 'sidebar.replacements',       icon: ArrowPathIcon,             roles: [UserRole.ADMIN, UserRole.SUPER_ADMIN] },
+        { path: '/foundation/intern-pool',  nameKey: 'sidebar.internPool',         icon: AcademicCapIcon,           roles: [UserRole.ADMIN, UserRole.SUPER_ADMIN] },
       ],
     },
     { path: '/e-learning', nameKey: 'sidebar.eLearning', icon: AcademicCapIcon, roles: [UserRole.ADMIN, UserRole.SUPER_ADMIN] },


### PR DESCRIPTION
- Admin app sidebar: revert hrCompliance group back to single /content link so the original ContentPage tabbed view (HR docs + state policies) is preserved unchanged; E-Learning standalone link points to /content/e-learning as a direct entry point
- Frontend sidebar (Admin/Super Admin): expand Recruitment group to match Foundation's comprehensive view — postJob, findCandidates, reviewApplications, replacements, internPool — replacing the old 2-item group that only had job-listings/candidate-pool
- Frontend routes: open /foundation/replacements and /foundation/intern-pool to ADMIN/SUPER_ADMIN so admin users can access those pages from the frontend sidebar

https://claude.ai/code/session_01Mgb7TFJrobXkf6byG6tvLW