### PR TITLE
Fully decouple E-Learning from HR & Compliance in admin app

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -103,9 +103,9 @@ function App() {
           <Route path="intern-pool" element={<InternPoolPage />} />
           <Route path="parent-leads" element={<ParentLeadsPage />} />
           <Route path="orders" element={<OrdersPage />} />
+          <Route path="e-learning" element={<ELearningContentPage />} />
           <Route path="content" element={<ContentPage />}>
-            <Route index element={<Navigate to="/content/e-learning" replace />} />
-            <Route path="e-learning" element={<ELearningContentPage />} />
+            <Route index element={<Navigate to="/content/hr-documents" replace />} />
             <Route path="hr-documents" element={<HrDocumentsPage />} />
             <Route path="state-policies" element={<StatePoliciesPage />} />
           </Route>

--- a/admin/src/components/Sidebar.tsx
+++ b/admin/src/components/Sidebar.tsx
@@ -72,7 +72,7 @@ const navStructure: NavEntry[] = [
       { key: 'internPool',    href: '/intern-pool',  icon: GraduationCap },
     ],
   },
-  { type: 'single', key: 'eLearning', href: '/content/e-learning', icon: GraduationCap },
+  { type: 'single', key: 'eLearning', href: '/e-learning', icon: GraduationCap },
   {
     type: 'group', key: 'hrCompliance', icon: FileText,
     items: [

--- a/admin/src/pages/Content.tsx
+++ b/admin/src/pages/Content.tsx
@@ -22,12 +22,6 @@ export default function Content() {
         <div className="p-4 border-b border-gray-200">
           <div className="flex gap-2 overflow-x-auto">
             <NavLink
-              to="e-learning"
-              className={({ isActive }) => `${tabBase} ${isActive ? tabActive : tabInactive}`}
-            >
-              {t('admin:content.eLearning.title', 'E-Learning')}
-            </NavLink>
-            <NavLink
               to="hr-documents"
               className={({ isActive }) => `${tabBase} ${isActive ? tabActive : tabInactive}`}
             >


### PR DESCRIPTION
- Add standalone /e-learning route rendering ELearningContentPage directly (no ContentPage wrapper), completely separate from the /content nested routes
- Remove E-Learning tab from ContentPage so it only manages HR Documents and State Policies; default tab is now HR Documents
- Update admin sidebar E-Learning link from /content/e-learning to /e-learning

https://claude.ai/code/session_01Mgb7TFJrobXkf6byG6tvLW