### PR TITLE
Add CV asset support to educator settings

### DIFF
--- a/api/prisma/migrations/20260509000000_add_cv_asset_id_to_user/migration.sql
+++ b/api/prisma/migrations/20260509000000_add_cv_asset_id_to_user/migration.sql
@@ -1,0 +1,6 @@
+-- Add cvAssetId to users table so educators can link their CV upload asset
+ALTER TABLE "users" ADD COLUMN "cvAssetId" TEXT;
+
+ALTER TABLE "users"
+    ADD CONSTRAINT "users_cvAssetId_fkey"
+    FOREIGN KEY ("cvAssetId") REFERENCES "assets"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -224,6 +224,10 @@ model User {
   coverAssetId String?
   coverAsset   Asset?  @relation("UserCover", fields: [coverAssetId], references: [id])
 
+  // CV document asset relation (educator profile CV)
+  cvAssetId String?
+  cvAsset   Asset?  @relation("UserCV", fields: [cvAssetId], references: [id])
+
   // Stripe integration
   stripeCustomerId String? @unique
 
@@ -609,6 +613,7 @@ model Asset {
   // User asset relations
   userAvatars User[] @relation("UserAvatar")
   userCovers  User[] @relation("UserCover")
+  userCVs     User[] @relation("UserCV")
 
   // Product relations
   products Product[]

--- a/api/src/settings/dto/educator-settings.dto.ts
+++ b/api/src/settings/dto/educator-settings.dto.ts
@@ -172,6 +172,10 @@ export class UpdateEducatorSettingsDto {
 
   @IsOptional()
   @IsString()
+  cvAssetId?: string;
+
+  @IsOptional()
+  @IsString()
   avatarAssetId?: string;
 
   @IsOptional()

--- a/api/src/settings/settings.controller.ts
+++ b/api/src/settings/settings.controller.ts
@@ -397,6 +397,7 @@ export class SettingsController {
         skills: user.skills ?? [],
         availability: user.availability ?? '',
         cvUrl: user.cvUrl ?? '',
+        cvAssetId: (user as any).cvAssetId ?? '',
         shortBio: user.shortBio ?? '',
         candidatePoolVisible: !!(user as any).candidatePoolVisible,
         region: (user as any).region ?? '',
@@ -475,6 +476,13 @@ export class SettingsController {
         [AssetKind.COVER_IMAGE],
         'Cover image',
       );
+      await this.validateAssetForUsage(
+        tx,
+        settings.cvAssetId,
+        accountId,
+        [AssetKind.CV],
+        'CV',
+      );
 
       await tx.user.update({
         where: { id: profileId },
@@ -489,6 +497,7 @@ export class SettingsController {
           skills: settings.skills,
           availability: settings.availability,
           ...(settings.cvUrl !== undefined && { cvUrl: normalizedIncomingCvUrl }),
+          ...(settings.cvAssetId !== undefined && { cvAssetId: settings.cvAssetId || null }),
           shortBio: settings.shortBio,
           region: settings.region,
           ...(settings.cities !== undefined && { cities: settings.cities }),

--- a/api/src/settings/settings.controller.ts
+++ b/api/src/settings/settings.controller.ts
@@ -372,6 +372,7 @@ export class SettingsController {
     const { user } = await this.principal.getOrBootstrapAccountAndProfile(clerkUserId, {
       avatarAsset: true, // Include avatar asset relation
       coverAsset: true, // Include cover asset relation
+      cvAsset: true, // Include CV asset relation
       contactInfo: true,
       workExperienceItems: { orderBy: { sortOrder: 'asc' } },
       educationItems: { orderBy: { sortOrder: 'asc' } },
@@ -396,7 +397,7 @@ export class SettingsController {
         certificationItems: user.certificationItems ?? [],
         skills: user.skills ?? [],
         availability: user.availability ?? '',
-        cvUrl: user.cvUrl ?? '',
+        cvUrl: (user as any).cvAsset?.publicUrl ?? user.cvUrl ?? '',
         cvAssetId: (user as any).cvAssetId ?? '',
         shortBio: user.shortBio ?? '',
         candidatePoolVisible: !!(user as any).candidatePoolVisible,


### PR DESCRIPTION
## Summary
This PR adds support for managing CV files as assets in the educator settings, allowing users to upload and store their CV as an asset rather than just providing a URL.

## Key Changes
- Added `cvAssetId` field to the `UpdateEducatorSettingsDto` to accept CV asset identifiers
- Updated the settings controller to:
  - Include `cvAssetId` in the user profile response mapping
  - Validate CV assets using the existing `validateAssetForUsage` method with the `AssetKind.CV` type
  - Persist the `cvAssetId` to the database when provided in settings updates
- The implementation follows the same pattern as the existing cover image asset handling

## Implementation Details
- The `cvAssetId` field is optional and can be set to `null` when undefined
- Asset validation ensures the CV asset belongs to the account and is of the correct type
- The change maintains backward compatibility with the existing `cvUrl` field

https://claude.ai/code/session_01CygDUcYW2cQyH7weK9EANh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Educator profile settings now support managing CV through asset-based storage, providing users with flexible CV management options alongside URL-based settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/One-S-Digital/PC-Solutions-Platform/pull/601)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->