### PR TITLE
fix: correct migration SQL table name and make idempotent

### DIFF
--- a/api/prisma/migrations/20260509000000_add_educator_approval_status/migration.sql
+++ b/api/prisma/migrations/20260509000000_add_educator_approval_status/migration.sql
@@ -1,7 +1,49 @@
--- CreateEnum
-CREATE TYPE "EducatorApprovalStatus" AS ENUM ('PENDING_REVIEW', 'APPROVED', 'REJECTED');
+-- Migration: Add EducatorApprovalStatus enum and approval fields to users table
+-- Idempotent: safe to re-run if a prior attempt left partial state.
 
--- AlterTable
-ALTER TABLE "User" ADD COLUMN "approvalStatus" "EducatorApprovalStatus",
-ADD COLUMN "approvalNotes" TEXT,
-ADD COLUMN "approvedAt" TIMESTAMP(3);
+-- 1. Create EducatorApprovalStatus enum if it doesn't exist yet
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE t.typname = 'EducatorApprovalStatus' AND n.nspname = 'public'
+  ) THEN
+    CREATE TYPE "EducatorApprovalStatus" AS ENUM ('PENDING_REVIEW', 'APPROVED', 'REJECTED');
+  END IF;
+END $$;
+
+-- 2. Add approvalStatus column if it doesn't exist
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'users'
+      AND column_name = 'approvalStatus'
+  ) THEN
+    ALTER TABLE "users" ADD COLUMN "approvalStatus" "EducatorApprovalStatus";
+  END IF;
+END $$;
+
+-- 3. Add approvalNotes column if it doesn't exist
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'users'
+      AND column_name = 'approvalNotes'
+  ) THEN
+    ALTER TABLE "users" ADD COLUMN "approvalNotes" TEXT;
+  END IF;
+END $$;
+
+-- 4. Add approvedAt column if it doesn't exist
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'users'
+      AND column_name = 'approvedAt'
+  ) THEN
+    ALTER TABLE "users" ADD COLUMN "approvedAt" TIMESTAMP(3);
+  END IF;
+END $$;


### PR DESCRIPTION
The original migration used ALTER TABLE "User" but the Prisma model has @@map("users") so the actual PostgreSQL table is "users" (lowercase). This caused the migration to fail and lock the deploy pipeline.

Rewritten to:
- Use the correct "users" table name
- Wrap each statement in DO $$ IF NOT EXISTS ... END $$ blocks so the migration is safe to re-run after the prior failed attempt

https://claude.ai/code/session_01CfhdMGLuiL3Fxrd8r53N97