### PR TITLE
fix: add educator approval status handler to prebuild-db-setup script

### DIFF
--- a/api/scripts/prebuild-db-setup.mjs
+++ b/api/scripts/prebuild-db-setup.mjs
@@ -1169,6 +1169,56 @@ END $$;
   log('✅ Enum urgency/compensation schema verified.');
 };
 
+/**
+ * Ensure EducatorApprovalStatus enum and approval columns exist on the users table.
+ * Matches migration `20260509000000_add_educator_approval_status`.
+ * Idempotent: each step is guarded so it is safe to re-run.
+ */
+const ensureEducatorApprovalStatus = () => {
+  const sql = `
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE t.typname = 'EducatorApprovalStatus' AND n.nspname = 'public'
+  ) THEN
+    CREATE TYPE "EducatorApprovalStatus" AS ENUM ('PENDING_REVIEW', 'APPROVED', 'REJECTED');
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'approvalStatus'
+  ) THEN
+    ALTER TABLE "users" ADD COLUMN "approvalStatus" "EducatorApprovalStatus";
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'approvalNotes'
+  ) THEN
+    ALTER TABLE "users" ADD COLUMN "approvalNotes" TEXT;
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'approvedAt'
+  ) THEN
+    ALTER TABLE "users" ADD COLUMN "approvedAt" TIMESTAMP(3);
+  END IF;
+END $$;
+`;
+
+  log('Ensuring EducatorApprovalStatus enum and approval columns exist...');
+  runSql(sql);
+  log('✅ EducatorApprovalStatus schema verified.');
+};
+
 const main = async () => {
   log(`Using schema: ${SCHEMA_PATH}`);
   log(`Using Prisma CLI: ${PRISMA_BIN ? PRISMA_BIN : 'npx prisma (fallback)'}`);
@@ -1358,6 +1408,35 @@ const main = async () => {
     try {
       forceMarkMigrationRolledBack('20260507020000_enum_urgency_compensation');
       ensureEnumUrgencyCompensation();
+    } catch (e2) {
+      error(`❌ Could not prepare for migration: ${e2.message}`);
+    }
+  }
+
+  // EducatorApprovalStatus enum + approval columns on users table
+  // The migration SQL is idempotent (DO $$ blocks guard each step). This handler
+  // clears any failed-state record from the first deploy attempt, pre-applies the
+  // schema directly, then lets Prisma mark it complete via migrate deploy.
+  try {
+    log('🔧 Preparing for add_educator_approval_status migration...');
+
+    let cleared = await resolveMigration('rolled-back', '20260509000000_add_educator_approval_status');
+    if (!cleared) {
+      log('⚠️  Standard resolve failed, force-marking as rolled-back...');
+      cleared = forceMarkMigrationRolledBack('20260509000000_add_educator_approval_status');
+    }
+    if (cleared) {
+      log('✅ Migration cleared from failed state. Prisma will re-run it.');
+    }
+
+    ensureEducatorApprovalStatus();
+    log('✅ EducatorApprovalStatus schema prepared.');
+    log('📋 Prisma migrate deploy will now run this migration and mark it complete.');
+  } catch (e) {
+    warn(`⚠️  add_educator_approval_status preparation failed: ${e.message}`);
+    try {
+      forceMarkMigrationRolledBack('20260509000000_add_educator_approval_status');
+      ensureEducatorApprovalStatus();
     } catch (e2) {
       error(`❌ Could not prepare for migration: ${e2.message}`);
     }


### PR DESCRIPTION
The migration is marked failed in _prisma_migrations from the first deploy attempt. Prisma refuses to run any migrations while a failed one exists.

Add an ensureEducatorApprovalStatus() handler that follows the same pattern as the existing enum_urgency_compensation handler:
1. Resolve/force-mark the failed migration as rolled-back
2. Pre-apply the schema idempotently via direct SQL
3. Let prisma migrate deploy re-run the migration and mark it applied

https://claude.ai/code/session_01CfhdMGLuiL3Fxrd8r53N97