### PR TITLE
Move user analytics to System Monitor Analytics tab; fix broken trans…

### DIFF
--- a/admin/src/pages/Dashboard.tsx
+++ b/admin/src/pages/Dashboard.tsx
@@ -23,7 +23,6 @@ import LoadingSpinner from '../components/ui/LoadingSpinner'
 import Card from '../components/design-system/Card'
 import Button from '../components/design-system/Button'
 import ContentUploadModal from '../components/ContentUploadModal'
-import UserAnalyticsSection from '../components/UserAnalyticsSection'
 import { useTranslation } from 'react-i18next'
 
 type ContentType = 'e-learning' | 'hr' | 'policy';
@@ -86,14 +85,6 @@ const Dashboard: React.FC = () => {
   })
 
   const staffingSignals = staffingSignalsResp as { openRequests: number; matchedRequests: number; filledRequests: number; replacementPoolSize: number } | null
-
-  const { data: clerkOverviewResp, isLoading: clerkOverviewLoading } = useQuery({
-    queryKey: ['admin-clerk-overview'],
-    queryFn: () => apiService.getClerkOverview(apiClient),
-    enabled: !!apiClient,
-    staleTime: 5 * 60 * 1000,
-    select: (res: any) => res?.data?.data ?? null,
-  })
 
   const staffingStats = [
     {
@@ -577,9 +568,6 @@ const Dashboard: React.FC = () => {
           </Card>
         </div>
       </Card>
-
-      {/* User Analytics */}
-      <UserAnalyticsSection data={clerkOverviewResp} isLoading={clerkOverviewLoading} />
 
       {/* Platform Summary */}
       <Card className="p-6">

--- a/admin/src/pages/SystemMonitor.tsx
+++ b/admin/src/pages/SystemMonitor.tsx
@@ -20,18 +20,14 @@ import {
   Trash2,
   Bell,
   BellOff,
-  BarChart3,
-  PieChart,
-  LineChart,
   AlertCircle,
-  Info,
   Zap,
-  Globe,
   Shield,
   Settings
 } from 'lucide-react'
-import { publicApi } from '../services/api'
+import { publicApi, useApiClient, apiService } from '../services/api'
 import LoadingSpinner from '../components/ui/LoadingSpinner'
+import UserAnalyticsSection from '../components/UserAnalyticsSection'
 import { LucideIcon } from 'lucide-react'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next';
@@ -40,7 +36,8 @@ const SystemMonitor: React.FC = () => {
   const [activeTab, setActiveTab] = useState<'overview' | 'metrics' | 'alerts' | 'logs' | 'analytics' | 'security'>('overview')
   const [logFilter, setLogFilter] = useState<'all' | 'error' | 'warning' | 'info'>('all')
   const queryClient = useQueryClient()
-  const { t } = useTranslation(['common', 'admin']);
+  const { t } = useTranslation(['common', 'admin'])
+  const apiClient = useApiClient()
 
   const { data: healthData, isLoading, error } = useQuery({
     queryKey: ['system-health'],
@@ -67,23 +64,18 @@ const SystemMonitor: React.FC = () => {
     refetchInterval: 10000, // Refresh every 10 seconds
   })
 
-  // Additional analytics queries
-  const { data: performanceMetrics, isLoading: performanceLoading } = useQuery({
-    queryKey: ['performance-metrics'],
-    queryFn: () => publicApi.get('/api/system-monitoring/performance'),
-    refetchInterval: 30000, // Refresh every 30 seconds
-  })
-
-  const { data: userAnalytics, isLoading: analyticsLoading } = useQuery({
-    queryKey: ['user-analytics'],
-    queryFn: () => publicApi.get('/api/system-monitoring/analytics'),
-    refetchInterval: 60000, // Refresh every minute
-  })
-
   const { data: securityMetrics, isLoading: securityLoading } = useQuery({
     queryKey: ['security-metrics'],
     queryFn: () => publicApi.get('/api/system-monitoring/security'),
     refetchInterval: 120000, // Refresh every 2 minutes
+  })
+
+  const { data: clerkOverviewResp, isLoading: clerkOverviewLoading } = useQuery({
+    queryKey: ['admin-clerk-overview'],
+    queryFn: () => apiService.getClerkOverview(apiClient),
+    enabled: !!apiClient,
+    staleTime: 5 * 60 * 1000,
+    select: (res: any) => res?.data?.data ?? null,
   })
 
   // Mutations
@@ -604,129 +596,7 @@ const SystemMonitor: React.FC = () => {
       )}
 
       {activeTab === 'analytics' && (
-        <div className="space-y-6">
-          {/* Performance Analytics */}
-          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-            <div className="flex items-center justify-between mb-6">
-              <h2 className="text-lg font-semibold text-gray-900 flex items-center">
-                <BarChart3 className="h-5 w-5 mr-2 text-swiss-teal" />
-                {t('admin:systemMonitor.analytics.performanceAnalytics', 'Performance Analytics')}
-              </h2>
-            </div>
-
-            {!performanceMetrics?.data && (
-              <div className="mb-4 p-4 bg-amber-50 border border-amber-200 rounded-lg">
-                <p className="text-sm text-amber-800">
-                  {t('admin:systemMonitor.analytics.requiresBackend', 'Performance analytics require backend monitoring infrastructure to be configured.')}
-                </p>
-              </div>
-            )}
-
-            {performanceLoading ? (
-              <div className="flex items-center justify-center py-8">
-                <LoadingSpinner size="large" />
-              </div>
-            ) : (
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-                <MetricCard
-                  title={t('common:titles.responsetime')}
-                  value={performanceMetrics?.data?.avgResponseTime ?? 'N/A'}
-                  unit={performanceMetrics?.data?.avgResponseTime ? 'ms' : ''}
-                  icon={Zap}
-                  color="blue"
-                />
-                <MetricCard
-                  title={t('common:titles.throughput')}
-                  value={performanceMetrics?.data?.requestsPerSecond ?? 'N/A'}
-                  unit={performanceMetrics?.data?.requestsPerSecond ? 'req/s' : ''}
-                  icon={TrendingUp}
-                  color="green"
-                />
-                <MetricCard
-                  title={t('common:errors.errorrate')}
-                  value={performanceMetrics?.data?.errorRate ?? 'N/A'}
-                  unit={performanceMetrics?.data?.errorRate !== undefined ? '%' : ''}
-                  icon={AlertCircle}
-                  color="red"
-                />
-                <MetricCard
-                  title={t('common:titles.uptime')}
-                  value={healthData?.data?.uptime ? `${Math.floor(healthData.data.uptime / 3600)}h ${Math.floor((healthData.data.uptime % 3600) / 60)}m` : 'N/A'}
-                  icon={CheckCircle}
-                  color="green"
-                />
-              </div>
-            )}
-          </div>
-
-          {/* User Analytics */}
-          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-            <div className="flex items-center justify-between mb-6">
-              <h2 className="text-lg font-semibold text-gray-900 flex items-center">
-                <Users className="h-5 w-5 mr-2 text-swiss-teal" />
-                {t('admin:systemMonitor.analytics.userAnalytics', 'User Analytics')}
-              </h2>
-            </div>
-
-            {!userAnalytics?.data && (
-              <div className="mb-4 p-4 bg-amber-50 border border-amber-200 rounded-lg">
-                <p className="text-sm text-amber-800">
-                  {t('admin:systemMonitor.analytics.requiresTracking', 'User analytics require tracking infrastructure to be configured. See the main Dashboard for available user statistics.')}
-                </p>
-              </div>
-            )}
-
-            {analyticsLoading ? (
-              <div className="flex items-center justify-center py-8">
-                <LoadingSpinner size="large" />
-              </div>
-            ) : (
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-                <MetricCard
-                  title={t('common:titles.activeusers')}
-                  value={userAnalytics?.data?.activeUsers ?? 'N/A'}
-                  icon={Users}
-                  color="blue"
-                />
-                <MetricCard
-                  title={t('common:titles.newuserstoday')}
-                  value={userAnalytics?.data?.newUsersToday ?? 'N/A'}
-                  icon={TrendingUp}
-                  color="green"
-                />
-                <MetricCard
-                  title={t('common:titles.sessionduration')}
-                  value={userAnalytics?.data?.avgSessionDuration ?? 'N/A'}
-                  unit={userAnalytics?.data?.avgSessionDuration ? 'min' : ''}
-                  icon={Clock}
-                  color="purple"
-                />
-                <MetricCard
-                  title={t('common:titles.pageviews')}
-                  value={userAnalytics?.data?.pageViews ?? 'N/A'}
-                  icon={Eye}
-                  color="yellow"
-                />
-              </div>
-            )}
-          </div>
-
-          {/* Geographic Analytics Notice */}
-          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-            <div className="flex items-center justify-between mb-6">
-              <h2 className="text-lg font-semibold text-gray-900 flex items-center">
-                <Globe className="h-5 w-5 mr-2 text-swiss-teal" />
-                {t('admin:systemMonitor.analytics.geographicDistribution', 'Geographic Distribution')}
-              </h2>
-            </div>
-
-            <div className="p-4 bg-gray-50 border border-gray-200 rounded-lg">
-              <p className="text-sm text-gray-600 text-center">
-                {t('admin:systemMonitor.analytics.requiresLocation', 'Geographic analytics require user location tracking to be implemented. This feature will display user distribution by region once the tracking infrastructure is configured.')}
-              </p>
-            </div>
-          </div>
-        </div>
+        <UserAnalyticsSection data={clerkOverviewResp} isLoading={clerkOverviewLoading} />
       )}
 
       {activeTab === 'security' && (

--- a/packages/translations/locales/de/common.json
+++ b/packages/translations/locales/de/common.json
@@ -599,6 +599,8 @@
     "tryAgain": "Erneut versuchen"
   },
   "errors": {
+    "errorrate": "Fehlerrate",
+    "errors": "Fehler",
     "deleteFailed": "Löschen failed",
     "deleteMessageFailed": "Löschen message failed",
     "downloadFailed": "download Failed",
@@ -2405,5 +2407,30 @@
     "Director": "Direktor/in",
     "CleaningStaff": "Reinigungspersonal",
     "Intern": "Praktikant/in"
+  },
+  "export": "Exportieren",
+  "info": "Info",
+  "warnings": "Warnungen",
+  "titles": {
+    "cpuusage": "CPU-Auslastung",
+    "memoryusage": "Speicherauslastung",
+    "diskusage": "Festplattenauslastung",
+    "uptime": "Betriebszeit",
+    "activealerts": "Aktive Warnungen",
+    "responsetime": "Antwortzeit",
+    "throughput": "Durchsatz",
+    "activeusers": "Aktive Benutzer",
+    "newuserstoday": "Neue Benutzer heute",
+    "sessionduration": "Ø Sitzungsdauer",
+    "pageviews": "Seitenaufrufe",
+    "activeconnections": "Aktive Verbindungen",
+    "avgquerytime": "Ø Abfragezeit",
+    "storageused": "Genutzter Speicher",
+    "connectionhealth": "Verbindungsstatus",
+    "requestsmin": "Anfragen / min",
+    "failedlogins": "Fehlgeschlagene Logins",
+    "blockedips": "Blockierte IPs",
+    "apihealth": "API-Status",
+    "lastscan": "Letzter Scan"
   }
 }

--- a/packages/translations/locales/en/common.json
+++ b/packages/translations/locales/en/common.json
@@ -623,6 +623,8 @@
     "tryAgain": "Try Again"
   },
   "errors": {
+    "errorrate": "Error Rate",
+    "errors": "Errors",
     "deleteFailed": "delete Failed",
     "deleteMessageFailed": "delete Message Failed",
     "downloadFailed": "download Failed",
@@ -2403,5 +2405,30 @@
     "Director": "Director",
     "CleaningStaff": "Cleaning Staff",
     "Intern": "Intern"
+  },
+  "export": "Export",
+  "info": "Info",
+  "warnings": "Warnings",
+  "titles": {
+    "cpuusage": "CPU Usage",
+    "memoryusage": "Memory Usage",
+    "diskusage": "Disk Usage",
+    "uptime": "Uptime",
+    "activealerts": "Active Alerts",
+    "responsetime": "Response Time",
+    "throughput": "Throughput",
+    "activeusers": "Active Users",
+    "newuserstoday": "New Users Today",
+    "sessionduration": "Avg Session Duration",
+    "pageviews": "Page Views",
+    "activeconnections": "Active Connections",
+    "avgquerytime": "Avg Query Time",
+    "storageused": "Storage Used",
+    "connectionhealth": "Connection Health",
+    "requestsmin": "Requests / min",
+    "failedlogins": "Failed Logins",
+    "blockedips": "Blocked IPs",
+    "apihealth": "API Health",
+    "lastscan": "Last Scan"
   }
 }

--- a/packages/translations/locales/fr/common.json
+++ b/packages/translations/locales/fr/common.json
@@ -593,6 +593,8 @@
     "tryAgain": "Réessayer"
   },
   "errors": {
+    "errorrate": "Taux d'erreur",
+    "errors": "Erreurs",
     "deleteFailed": "Supprimer failed",
     "deleteMessageFailed": "Supprimer message failed",
     "downloadFailed": "download Failed",
@@ -2403,5 +2405,30 @@
     "Director": "Directeur/Directrice",
     "CleaningStaff": "Personnel de nettoyage",
     "Intern": "Stagiaire"
+  },
+  "export": "Exporter",
+  "info": "Info",
+  "warnings": "Avertissements",
+  "titles": {
+    "cpuusage": "Utilisation CPU",
+    "memoryusage": "Utilisation mémoire",
+    "diskusage": "Utilisation disque",
+    "uptime": "Disponibilité",
+    "activealerts": "Alertes actives",
+    "responsetime": "Temps de réponse",
+    "throughput": "Débit",
+    "activeusers": "Utilisateurs actifs",
+    "newuserstoday": "Nouveaux utilisateurs aujourd'hui",
+    "sessionduration": "Durée moy. de session",
+    "pageviews": "Pages vues",
+    "activeconnections": "Connexions actives",
+    "avgquerytime": "Temps moy. de requête",
+    "storageused": "Stockage utilisé",
+    "connectionhealth": "Santé de connexion",
+    "requestsmin": "Requêtes / min",
+    "failedlogins": "Connexions échouées",
+    "blockedips": "IPs bloquées",
+    "apihealth": "Santé API",
+    "lastscan": "Dernier scan"
   }
 }


### PR DESCRIPTION
…lations

- SystemMonitor Analytics tab now renders the full UserAnalyticsSection (sign-up/sign-in charts, activity heatmap, cohort retention) instead of the placeholder cards that called a non-existent monitoring endpoint
- Added useApiClient + clerkOverview query to SystemMonitor; removed the dead performanceMetrics and userAnalytics stub queries
- Removed UserAnalyticsSection from Dashboard.tsx (canonical location is Settings → System Monitoring → Analytics)
- Added all missing common.json keys (en/de/fr): titles.cpuusage, titles.memoryusage, titles.diskusage, titles.uptime, titles.activealerts, titles.responsetime, titles.throughput, titles.activeusers, titles.newuserstoday, titles.sessionduration, titles.pageviews, titles.activeconnections, titles.avgquerytime, titles.storageused, titles.connectionhealth, titles.requestsmin, titles.failedlogins, titles.blockedips, titles.apihealth, titles.lastscan, errors.errorrate, errors.errors, export, info, warnings

https://claude.ai/code/session_01138xKVgBujyg9baPuyojyS