### PR TITLE
Fix blank Analytics tab: add error/idle states to UserAnalyticsSection

### DIFF
--- a/admin/src/components/UserAnalyticsSection.tsx
+++ b/admin/src/components/UserAnalyticsSection.tsx
@@ -30,6 +30,7 @@ interface ClerkOverviewData {
 interface Props {
   data: ClerkOverviewData | null | undefined
   isLoading: boolean
+  isError?: boolean
 }
 
 function formatWeek(isoDate: string) {
@@ -115,7 +116,7 @@ function retentionColor(pct: number) {
 const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 const DOW_LABELS = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
 
-export const UserAnalyticsSection: React.FC<Props> = ({ data, isLoading }) => {
+export const UserAnalyticsSection: React.FC<Props> = ({ data, isLoading, isError }) => {
   const { t } = useTranslation('admin')
   const signupsData = useMemo(() => fillWeeklySeries(data?.weeklySignups ?? []), [data])
   const signinsData = useMemo(() => fillWeeklySeries(data?.weeklySignins ?? []), [data])
@@ -157,7 +158,22 @@ export const UserAnalyticsSection: React.FC<Props> = ({ data, isLoading }) => {
     )
   }
 
-  if (!data) return null
+  if (isError || !data) {
+    return (
+      <Card className="p-6">
+        <div className="flex flex-col items-center justify-center h-40 gap-3 text-center">
+          <p className="text-sm font-medium text-gray-700">
+            {t('dashboard.userAnalytics.title')}
+          </p>
+          <p className="text-sm text-gray-400 max-w-sm">
+            {isError
+              ? t('dashboard.userAnalytics.errorState')
+              : t('dashboard.userAnalytics.emptyState')}
+          </p>
+        </div>
+      </Card>
+    )
+  }
 
   const { stats, cohortRetention } = data
   const currentWeek = combinedWeekly[combinedWeekly.length - 1]

--- a/admin/src/pages/SystemMonitor.tsx
+++ b/admin/src/pages/SystemMonitor.tsx
@@ -70,11 +70,12 @@ const SystemMonitor: React.FC = () => {
     refetchInterval: 120000, // Refresh every 2 minutes
   })
 
-  const { data: clerkOverviewResp, isLoading: clerkOverviewLoading } = useQuery({
+  const { data: clerkOverviewResp, isLoading: clerkOverviewLoading, isError: clerkOverviewError } = useQuery({
     queryKey: ['admin-clerk-overview'],
     queryFn: () => apiService.getClerkOverview(apiClient),
     enabled: !!apiClient,
     staleTime: 5 * 60 * 1000,
+    retry: 1,
     select: (res: any) => res?.data?.data ?? null,
   })
 
@@ -596,7 +597,11 @@ const SystemMonitor: React.FC = () => {
       )}
 
       {activeTab === 'analytics' && (
-        <UserAnalyticsSection data={clerkOverviewResp} isLoading={clerkOverviewLoading} />
+        <UserAnalyticsSection
+          data={clerkOverviewResp}
+          isLoading={clerkOverviewLoading || !apiClient}
+          isError={clerkOverviewError}
+        />
       )}
 
       {activeTab === 'security' && (

--- a/packages/translations/locales/de/admin.json
+++ b/packages/translations/locales/de/admin.json
@@ -625,7 +625,9 @@
         "subtitle": "% der Benutzer aus jeder Anmeldewoche, die in den Folgewochen aktiv waren (basierend auf der letzten Anmeldung)",
         "cohortWeek": "Kohortenwoche",
         "size": "Grösse"
-      }
+      },
+      "errorState": "Analyse konnte nicht geladen werden – stellen Sie sicher, dass die API den neuesten Code ausführt, und aktualisieren Sie die Seite.",
+      "emptyState": "Analysedaten sind noch nicht verfügbar."
     }
   },
   "contentUpload": {

--- a/packages/translations/locales/en/admin.json
+++ b/packages/translations/locales/en/admin.json
@@ -612,7 +612,9 @@
         "subtitle": "% of users from each sign-up week who were active in subsequent weeks (based on last sign-in)",
         "cohortWeek": "Cohort week",
         "size": "Size"
-      }
+      },
+      "errorState": "Could not load analytics — make sure the API is running the latest code and try refreshing.",
+      "emptyState": "Analytics data is not available yet."
     }
   },
   "contentUpload": {

--- a/packages/translations/locales/fr/admin.json
+++ b/packages/translations/locales/fr/admin.json
@@ -645,7 +645,9 @@
         "subtitle": "% d'utilisateurs de chaque semaine d'inscription actifs dans les semaines suivantes (basé sur la dernière connexion)",
         "cohortWeek": "Semaine de cohorte",
         "size": "Taille"
-      }
+      },
+      "errorState": "Impossible de charger les analyses — assurez-vous que l'API exécute le dernier code et actualisez la page.",
+      "emptyState": "Les données analytiques ne sont pas encore disponibles."
     }
   },
   "contentUpload": {


### PR DESCRIPTION
Previously the component silently returned null in two cases:
1. apiClient not yet initialized (query idle, isLoading=false, data=undefined)
2. API call failed (query error, isLoading=false, data=undefined)

Changes:
- UserAnalyticsSection now accepts isError prop and renders a visible card with a clear message when data is unavailable or the fetch fails
- SystemMonitor passes isLoading={clerkOverviewLoading || !apiClient} so the spinner shows while the API client is still initializing
- retry: 1 added to the query (was retrying 3x by default, causing delay)
- Added errorState and emptyState translation keys (en/de/fr)

https://claude.ai/code/session_01138xKVgBujyg9baPuyojyS