### PR TITLE
Make organization contactEmail migration idempotent and resilient

### DIFF
--- a/api/prisma/migrations/20260511000000_add_contact_email_to_organization/migration.sql
+++ b/api/prisma/migrations/20260511000000_add_contact_email_to_organization/migration.sql
@@ -12,7 +12,7 @@ BEGIN
     UPDATE "organizations" o
     SET "contactEmail" = oci."contactEmail"
     FROM "organization_contact_infos" oci
-    WHERE oci."organization_id" = o."id"
+    WHERE oci."organizationId" = o."id"
       AND oci."contactEmail" IS NOT NULL;
 
     -- Drop the now-redundant contact-info table

--- a/api/prisma/migrations/20260511000000_add_contact_email_to_organization/migration.sql
+++ b/api/prisma/migrations/20260511000000_add_contact_email_to_organization/migration.sql
@@ -1,12 +1,21 @@
 -- Add contactEmail directly to organizations table (camelCase matches schema convention)
-ALTER TABLE "organizations" ADD COLUMN "contactEmail" TEXT;
+-- Uses IF NOT EXISTS so this is safe to re-run after a failed attempt
+ALTER TABLE "organizations" ADD COLUMN IF NOT EXISTS "contactEmail" TEXT;
 
--- Migrate existing data from the separate contact-info table
-UPDATE "organizations" o
-SET "contactEmail" = oci."contactEmail"
-FROM "organization_contact_infos" oci
-WHERE oci."organization_id" = o."id"
-  AND oci."contactEmail" IS NOT NULL;
+-- Migrate existing data from the separate contact-info table (only when it still exists)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'organization_contact_infos'
+  ) THEN
+    UPDATE "organizations" o
+    SET "contactEmail" = oci."contactEmail"
+    FROM "organization_contact_infos" oci
+    WHERE oci."organization_id" = o."id"
+      AND oci."contactEmail" IS NOT NULL;
 
--- Drop the now-redundant contact-info table
-DROP TABLE "organization_contact_infos";
+    -- Drop the now-redundant contact-info table
+    DROP TABLE "organization_contact_infos";
+  END IF;
+END $$;

--- a/api/scripts/prebuild-complete-db-setup.mjs
+++ b/api/scripts/prebuild-complete-db-setup.mjs
@@ -191,7 +191,6 @@ const verifyCriticalTables = () => {
     // Separate contact email storage (must exist for profile settings updates)
     'user_contact_infos',
     'organizations',
-    'organization_contact_infos',
     'assets',
     // Policy crawler (feature-flagged, but schema must exist once migrations run)
     'cantons',

--- a/api/scripts/prebuild-db-setup.mjs
+++ b/api/scripts/prebuild-db-setup.mjs
@@ -1103,7 +1103,7 @@ BEGIN
     UPDATE "organizations" o
     SET "contactEmail" = oci."contactEmail"
     FROM "organization_contact_infos" oci
-    WHERE oci."organization_id" = o."id"
+    WHERE oci."organizationId" = o."id"
       AND oci."contactEmail" IS NOT NULL;
 
     DROP TABLE "organization_contact_infos";

--- a/api/scripts/prebuild-db-setup.mjs
+++ b/api/scripts/prebuild-db-setup.mjs
@@ -1084,6 +1084,38 @@ CREATE UNIQUE INDEX IF NOT EXISTS "mt_cost_tracking_date_provider_sourceLang_tar
   log('✅ Translation infrastructure verified.');
 };
 
+/**
+ * Ensure organizations.contactEmail exists and organization_contact_infos is dropped.
+ * Matches migration `20260511000000_add_contact_email_to_organization`.
+ */
+const ensureOrganizationContactEmail = () => {
+  const sql = `
+-- Add contactEmail to organizations if missing
+ALTER TABLE "organizations" ADD COLUMN IF NOT EXISTS "contactEmail" TEXT;
+
+-- Migrate data and drop source table only if it still exists
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'organization_contact_infos'
+  ) THEN
+    UPDATE "organizations" o
+    SET "contactEmail" = oci."contactEmail"
+    FROM "organization_contact_infos" oci
+    WHERE oci."organization_id" = o."id"
+      AND oci."contactEmail" IS NOT NULL;
+
+    DROP TABLE "organization_contact_infos";
+  END IF;
+END $$;
+`;
+
+  log('Ensuring organizations.contactEmail exists and organization_contact_infos is cleaned up...');
+  runSql(sql);
+  log('✅ Organization contactEmail schema verified.');
+};
+
 const main = async () => {
   log(`Using schema: ${SCHEMA_PATH}`);
   log(`Using Prisma CLI: ${PRISMA_BIN ? PRISMA_BIN : 'npx prisma (fallback)'}`);
@@ -1244,6 +1276,35 @@ const main = async () => {
     try {
       forceMarkMigrationRolledBack('20260211090000_link_parent_leads_to_users');
       ensureParentLeadAccountLink();
+    } catch (e2) {
+      error(`❌ Could not prepare for migration: ${e2.message}`);
+    }
+  }
+
+  // Add contactEmail to organizations + drop organization_contact_infos
+  // Strategy:
+  // 1. Clear failed migration state so Prisma can re-run it
+  // 2. Pre-apply changes idempotently so the re-run succeeds even on a drifted DB
+  try {
+    log('🔧 Preparing for add_contact_email_to_organization migration...');
+
+    let cleared = await resolveMigration('rolled-back', '20260511000000_add_contact_email_to_organization');
+    if (!cleared) {
+      log('⚠️  Standard resolve failed, force-marking as rolled-back...');
+      cleared = forceMarkMigrationRolledBack('20260511000000_add_contact_email_to_organization');
+    }
+    if (cleared) {
+      log('✅ Migration cleared from failed state. Prisma will re-run it.');
+    }
+
+    ensureOrganizationContactEmail();
+    log('✅ Organization contactEmail schema prepared.');
+    log('📋 Prisma migrate deploy will now run this migration and mark it complete.');
+  } catch (e) {
+    warn(`⚠️  Organization contactEmail preparation failed: ${e.message}`);
+    try {
+      forceMarkMigrationRolledBack('20260511000000_add_contact_email_to_organization');
+      ensureOrganizationContactEmail();
     } catch (e2) {
       error(`❌ Could not prepare for migration: ${e2.message}`);
     }


### PR DESCRIPTION
## Summary
This PR makes the `add_contact_email_to_organization` migration idempotent and resilient to failed migration states by adding conditional checks and pre-applying schema changes in the prebuild setup script.

## Key Changes
- **Migration SQL**: Updated `20260511000000_add_contact_email_to_organization` to use `IF NOT EXISTS` for column addition and wrapped the data migration and table drop in a conditional block that only executes if `organization_contact_infos` table exists
- **Prebuild Setup**: Added `ensureOrganizationContactEmail()` function that idempotently applies the same schema changes before Prisma runs the migration
- **Migration Recovery**: Implemented migration state recovery logic that clears failed migration state and pre-applies changes, allowing Prisma to successfully re-run the migration even on drifted databases
- **Table Verification**: Removed `organization_contact_infos` from the critical tables list in `prebuild-complete-db-setup.mjs` since it's being dropped by the migration

## Implementation Details
- The migration now safely handles scenarios where it may have partially executed or the source table was already dropped
- The prebuild script attempts standard migration resolution first, with a fallback to force-mark as rolled-back if needed
- Error handling includes a retry mechanism that force-marks the migration as rolled-back and re-applies the schema changes
- All changes are wrapped in try-catch blocks to prevent the entire setup from failing if this specific migration encounters issues

https://claude.ai/code/session_01J8k1TqcGW6wnavX5BCQRh2