### PR TITLE
fix: remove stale Organization.contactInfo include from admin-profile…

### DIFF
--- a/api/src/admin/admin-profiles.controller.ts
+++ b/api/src/admin/admin-profiles.controller.ts
@@ -358,7 +358,6 @@ export class AdminProfilesController {
                 include: {
                   logoAsset: true,
                   coverAsset: true,
-                  contactInfo: true,
                 },
               },
             },
@@ -390,7 +389,6 @@ export class AdminProfilesController {
               include: {
                 logoAsset: true,
                 coverAsset: true,
-                contactInfo: true,
               },
             },
           },


### PR DESCRIPTION
…s controller

The 20260511000000_add_contact_email_to_organization migration dropped the organization_contact_infos table, removing the contactInfo relation from the Organization Prisma model. Two Prisma include blocks in getUserProfile still referenced that relation, causing four TypeScript errors at nest build time:
- TS2353: contactInfo does not exist in OrganizationInclude (x2)
- TS2339: organizations property missing due to cascading type failure (x2)

The Organization.contactEmail field is now a direct column on the model so no include is needed. User.contactInfo (UserContactInfo) remains intact.

https://claude.ai/code/session_01J8k1TqcGW6wnavX5BCQRh2