### PR TITLE
Add contact email to PartnerDetailPage contact info card

### DIFF
--- a/frontend/pages/partner/PartnerDetailPage.tsx
+++ b/frontend/pages/partner/PartnerDetailPage.tsx
@@ -381,9 +381,17 @@ const PartnerDetailPage: React.FC = () => {
                   {`${partner.region || partner.canton}, Switzerland`}
                 </p>
               )}
+              {partner.contactEmail && (
+                <p className="flex items-center">
+                  <EnvelopeIcon className="w-5 h-5 mr-2 text-gray-400" />
+                  <a href={`mailto:${partner.contactEmail}`} className="hover:text-swiss-mint truncate">
+                    {partner.contactEmail}
+                  </a>
+                </p>
+              )}
               {partner.phoneNumber && (
                 <p className="flex items-center">
-                  <PhoneIcon className="w-5 h-5 mr-2 text-gray-400" /> 
+                  <PhoneIcon className="w-5 h-5 mr-2 text-gray-400" />
                   <a href={`tel:${partner.phoneNumber}`} className="hover:text-swiss-mint">
                     {partner.phoneNumber}
                   </a>


### PR DESCRIPTION
The contact information card in PartnerDetailPage was rendering location, phone, contactPerson, and website but had no email field at all, even though EnvelopeIcon was already imported and the Organization type includes contactEmail. Added the mailto link row between location and phone.

https://claude.ai/code/session_01RRzufKhrGUkQfSp1MLLnbL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Partner detail pages now display contact email addresses as clickable links for direct email access.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/One-S-Digital/PC-Solutions-Platform/pull/613)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->