### PR TITLE
Track user last active timestamp on login

### DIFF
--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -490,6 +490,12 @@ export class UsersController {
     };
   }
 
+  @Patch('me/last-active')
+  async touchLastActive(@Request() request) {
+    await this.usersService.touchLastActive(request.user.clerkId);
+    return { success: true };
+  }
+
   @Patch('me')
   async updateCurrentUser(@Request() request, @Body() updateUserDto: UpdateUserDto) {
     const user = await this.usersService.updateByClerkId(request.user.clerkId, updateUserDto);

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -1190,6 +1190,14 @@ export class UsersService {
     return { success: true, removed: result.count > 0 };
   }
 
+  async touchLastActive(clerkId: string): Promise<void> {
+    const now = new Date();
+    await this.prisma.user.updateMany({
+      where: { clerkId },
+      data: { lastActiveAt: now },
+    });
+  }
+
   async updateByClerkId(clerkId: string, updateUserDto: UpdateUserDto) {
     console.log('🔄 [BACKEND UPDATE] Starting updateByClerkId');
     console.log('📝 UpdateUserDto received:', updateUserDto);

--- a/frontend/providers/AuthProvider.tsx
+++ b/frontend/providers/AuthProvider.tsx
@@ -351,7 +351,7 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
             fetch(`${apiService.apiBaseUrl}${API_ENDPOINTS.users.lastActive}`, {
               method: 'PATCH',
               headers: { Authorization: `Bearer ${token}` },
-            });
+            }).catch(() => {});
           }
         } catch {
           // Non-critical — do not block the login flow

--- a/frontend/providers/AuthProvider.tsx
+++ b/frontend/providers/AuthProvider.tsx
@@ -343,6 +343,19 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
           status: 'success',
           lastAttempt: Date.now(),
         };
+
+        // Stamp lastActiveAt on every successful login/session-restore
+        try {
+          const token = await getToken();
+          if (token) {
+            fetch(`${apiService.apiBaseUrl}${API_ENDPOINTS.users.lastActive}`, {
+              method: 'PATCH',
+              headers: { Authorization: `Bearer ${token}` },
+            });
+          }
+        } catch {
+          // Non-critical — do not block the login flow
+        }
         
       } catch (error) {
         if (cancelled) {

--- a/frontend/services/api-endpoints.ts
+++ b/frontend/services/api-endpoints.ts
@@ -15,6 +15,7 @@ export const API_ENDPOINTS = {
   users: {
     me: "/users/me",
     update: "/users/me",
+    lastActive: "/users/me/last-active",
     organization: "/users/organization",
     completeProfile: "/users/complete-profile",
   },


### PR DESCRIPTION
## Summary
This PR adds functionality to track when users last logged in or restored their session by updating a `lastActiveAt` timestamp on successful authentication.

## Key Changes
- **Frontend (AuthProvider)**: Added a non-blocking call to update the user's last active timestamp immediately after successful login or session restoration
- **Backend (UsersService)**: Implemented `touchLastActive()` method to update the `lastActiveAt` field for a user
- **Backend (UsersController)**: Added `PATCH /users/me/last-active` endpoint to handle last active timestamp updates
- **Frontend (API Endpoints)**: Added the new `lastActive` endpoint to the API endpoints configuration

## Implementation Details
- The frontend update is wrapped in a try-catch block and intentionally non-blocking to prevent authentication failures if the timestamp update fails
- The backend uses `updateMany()` to handle the update operation
- The timestamp is updated on every successful login/session-restore event, providing an accurate record of user activity
- The endpoint requires Bearer token authentication via the existing auth middleware

https://claude.ai/code/session_01VQ8K4YMRdpZcXt6XAyjtSr