### PR TITLE
Switch maintenance gif to assets folder import

### DIFF
--- a/frontend/pages/MaintenancePage.tsx
+++ b/frontend/pages/MaintenancePage.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import maintenanceGif from '../assets/maintenance.gif';
 
 const MaintenancePage: React.FC = () => {
   return (
     <div className="min-h-screen bg-page-bg flex flex-col items-center justify-center px-4">
       <div className="max-w-lg w-full text-center">
         <img
-          src="/maintenance.gif"
+          src={maintenanceGif}
           alt="Site under maintenance"
           className="w-80 h-auto mx-auto mb-8"
         />

--- a/frontend/vite-env.d.ts
+++ b/frontend/vite-env.d.ts
@@ -10,7 +10,12 @@ interface ImportMetaEnv {
   readonly VITE_NODE_ENV: string;
   readonly VITE_E2E_TEST?: string;
   readonly VITE_USE_BUNDLED_TRANSLATIONS?: string;
-  // Add other env variables here as needed
+  readonly VITE_MAINTENANCE_MODE?: string;
+}
+
+declare module '*.gif' {
+  const src: string;
+  export default src;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
References maintenance.gif from frontend/assets/ via Vite module import instead of the public directory which doesn't exist in the project. Also adds GIF module declaration and VITE_MAINTENANCE_MODE to vite-env.d.ts.

Place the gif at frontend/assets/maintenance.gif to activate.

https://claude.ai/code/session_019mXTgKYLePUfqYdTJ8SPvf