### PR TITLE
Block login/signup for non-admins during maintenance mode

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,7 +1,7 @@
 
 
 import React from 'react';
-import { Routes, Route, Navigate, useLocation, useNavigate, useSearchParams, Link } from 'react-router-dom';
+import { Routes, Route, Navigate, useLocation, useNavigate, Link } from 'react-router-dom';
 import { useAuth, useUser, useClerk, AuthenticateWithRedirectCallback } from '@clerk/clerk-react';
 import MainLayout from './components/layout/MainLayout';
 import DashboardPage from './pages/DashboardPage'; // This will be the Foundation default dashboard
@@ -104,15 +104,6 @@ import PricingPage from './pages/PricingPage';
 import ResetPasswordPage from './pages/ResetPasswordPage';
 import MaintenancePage from './pages/MaintenancePage';
 
-
-const LoginRouteGuard: React.FC<{ isMaintenanceMode: boolean }> = ({ isMaintenanceMode }) => {
-  const [searchParams] = useSearchParams();
-  const adminBypass = searchParams.get('admin') === '1';
-  if (isMaintenanceMode && !adminBypass) {
-    return <Navigate to="/maintenance" replace />;
-  }
-  return <LoginPage />;
-};
 
 const ProtectedRoute: React.FC<{ children: React.ReactElement; roles: UserRole[] }> = ({ children, roles }): React.ReactElement | null => {
   const { currentUser } = useAppContext();
@@ -697,7 +688,7 @@ const App: React.FC = () => {
             <SubscriptionProvider>
               <Routes>
                 <Route path="/maintenance" element={<MaintenancePage />} />
-                <Route path="/login" element={<LoginRouteGuard isMaintenanceMode={isMaintenanceMode} />} />
+                <Route path="/login" element={<LoginPage />} />
                 <Route path="/signup" element={isMaintenanceMode ? <Navigate to="/maintenance" replace /> : <SignupPage />} />
                 <Route path="/pricing" element={<PricingPage />} />
                 <Route path="/partners" element={<PublicPartnersPage />} />

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,7 +1,7 @@
 
 
 import React from 'react';
-import { Routes, Route, Navigate, useLocation, useNavigate, Link } from 'react-router-dom';
+import { Routes, Route, Navigate, useLocation, useNavigate, useSearchParams, Link } from 'react-router-dom';
 import { useAuth, useUser, useClerk, AuthenticateWithRedirectCallback } from '@clerk/clerk-react';
 import MainLayout from './components/layout/MainLayout';
 import DashboardPage from './pages/DashboardPage'; // This will be the Foundation default dashboard
@@ -104,6 +104,15 @@ import PricingPage from './pages/PricingPage';
 import ResetPasswordPage from './pages/ResetPasswordPage';
 import MaintenancePage from './pages/MaintenancePage';
 
+
+const LoginRouteGuard: React.FC<{ isMaintenanceMode: boolean }> = ({ isMaintenanceMode }) => {
+  const [searchParams] = useSearchParams();
+  const adminBypass = searchParams.get('admin') === '1';
+  if (isMaintenanceMode && !adminBypass) {
+    return <Navigate to="/maintenance" replace />;
+  }
+  return <LoginPage />;
+};
 
 const ProtectedRoute: React.FC<{ children: React.ReactElement; roles: UserRole[] }> = ({ children, roles }): React.ReactElement | null => {
   const { currentUser } = useAppContext();
@@ -648,6 +657,7 @@ const FrontendSettingsManager: React.FC = () => {
 
 const App: React.FC = () => {
   const isE2E = import.meta.env.MODE === 'e2e' || import.meta.env.VITE_E2E_TEST === 'true';
+  const isMaintenanceMode = import.meta.env.VITE_MAINTENANCE_MODE === 'true';
 
   // E2E mode: avoid external dependencies (Clerk/backend) and keep routes deterministic for Playwright.
   if (isE2E) {
@@ -686,8 +696,9 @@ const App: React.FC = () => {
           <MessagingProvider>
             <SubscriptionProvider>
               <Routes>
-                <Route path="/login" element={<LoginPage />} />
-                <Route path="/signup" element={<SignupPage />} />
+                <Route path="/maintenance" element={<MaintenancePage />} />
+                <Route path="/login" element={<LoginRouteGuard isMaintenanceMode={isMaintenanceMode} />} />
+                <Route path="/signup" element={isMaintenanceMode ? <Navigate to="/maintenance" replace /> : <SignupPage />} />
                 <Route path="/pricing" element={<PricingPage />} />
                 <Route path="/partners" element={<PublicPartnersPage />} />
                 <Route path="/parent-lead-form" element={<ParentLeadFormPage />} />

--- a/frontend/pages/MaintenancePage.tsx
+++ b/frontend/pages/MaintenancePage.tsx
@@ -19,7 +19,7 @@ const MaintenancePage: React.FC = () => {
         </p>
       </div>
       <p className="absolute bottom-6 text-xs text-gray-300">
-        <Link to="/login?admin=1" className="hover:text-gray-400 transition-colors">
+        <Link to="/login" className="hover:text-gray-400 transition-colors">
           Administrator login
         </Link>
       </p>

--- a/frontend/pages/MaintenancePage.tsx
+++ b/frontend/pages/MaintenancePage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import maintenanceGif from '../assets/maintenance.gif';
 
 const MaintenancePage: React.FC = () => {
@@ -17,6 +18,11 @@ const MaintenancePage: React.FC = () => {
           Site will be live again soon
         </p>
       </div>
+      <p className="absolute bottom-6 text-xs text-gray-300">
+        <Link to="/login?admin=1" className="hover:text-gray-400 transition-colors">
+          Administrator login
+        </Link>
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
- /login and /signup now redirect to /maintenance when VITE_MAINTENANCE_MODE=true
- Admins bypass via /login?admin=1, linked from a subtle footer on the maintenance page
- MaintenancePage gains react-router Link import and the admin bypass link
- LoginRouteGuard component reads the ?admin=1 param to allow admin access

https://claude.ai/code/session_019mXTgKYLePUfqYdTJ8SPvf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced maintenance mode functionality to control user access during scheduled system maintenance periods.
  * Added a dedicated maintenance page displayed to users when the system is in maintenance mode.
  * Administrators can bypass maintenance mode restrictions and maintain system access using a special query parameter in the login process.
  * User sign-up page now redirects to the maintenance page when maintenance mode is active.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/One-S-Digital/PC-Solutions-Platform/pull/620)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->