### PR TITLE
Make maintenance page fully responsive and back button more visible

### DIFF
--- a/frontend/pages/MaintenancePage.tsx
+++ b/frontend/pages/MaintenancePage.tsx
@@ -8,20 +8,20 @@ const MaintenancePage: React.FC = () => {
   const navigate = useNavigate();
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-blue-50 flex flex-col items-center justify-center px-4 relative overflow-hidden">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-blue-50 flex flex-col items-center justify-center p-4 sm:p-6 lg:p-8 relative overflow-hidden">
       {/* Decorative blobs */}
       <div className="absolute -top-48 -right-48 w-96 h-96 bg-swiss-mint/20 rounded-full blur-3xl pointer-events-none" />
       <div className="absolute -bottom-48 -left-48 w-96 h-96 bg-swiss-teal/10 rounded-full blur-3xl pointer-events-none" />
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-blue-50/30 rounded-full blur-3xl pointer-events-none" />
 
-      <div className="relative w-full max-w-2xl">
+      <div className="relative w-full max-w-xs sm:max-w-md md:max-w-xl lg:max-w-2xl xl:max-w-3xl">
         {/* Back button */}
         <button
           onClick={() => navigate(-1)}
-          className="flex items-center gap-2 text-sm text-gray-400 hover:text-swiss-teal transition-colors mb-6 group"
+          className="inline-flex items-center gap-2 mb-4 sm:mb-6 px-4 py-2 rounded-xl bg-white border border-gray-200 shadow-sm text-sm font-medium text-swiss-charcoal hover:bg-swiss-teal hover:text-white hover:border-swiss-teal transition-all duration-200 group"
         >
           <svg
-            className="w-4 h-4 transition-transform group-hover:-translate-x-0.5"
+            className="w-4 h-4 flex-shrink-0 transition-transform group-hover:-translate-x-0.5"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -32,33 +32,33 @@ const MaintenancePage: React.FC = () => {
         </button>
 
         {/* Card */}
-        <div className="bg-white/80 backdrop-blur-md rounded-3xl shadow-soft border border-gray-100 px-8 py-12 text-center">
-          {/* GIF — doubled from w-80 (320px) to 640px */}
+        <div className="bg-white/80 backdrop-blur-md rounded-2xl sm:rounded-3xl shadow-soft border border-gray-100 px-5 py-8 sm:px-8 sm:py-10 lg:px-12 lg:py-14 text-center">
+          {/* GIF — fluid: 100% on small screens, up to 640px on large */}
           <img
             src={maintenanceGif}
             alt={t('maintenancePage.title')}
-            className="w-[640px] max-w-full h-auto mx-auto mb-8 drop-shadow-sm"
+            className="w-full max-w-[280px] sm:max-w-sm md:max-w-md lg:max-w-[640px] h-auto mx-auto mb-6 sm:mb-8 drop-shadow-sm"
           />
 
           {/* Status badge */}
-          <div className="inline-flex items-center gap-2 bg-amber-50 border border-amber-200 text-amber-700 text-xs font-medium px-4 py-1.5 rounded-full mb-6">
-            <span className="relative flex h-2 w-2">
+          <div className="inline-flex items-center gap-2 bg-amber-50 border border-amber-200 text-amber-700 text-xs font-medium px-3 py-1.5 sm:px-4 rounded-full mb-4 sm:mb-6">
+            <span className="relative flex h-2 w-2 flex-shrink-0">
               <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-400 opacity-75" />
               <span className="relative inline-flex rounded-full h-2 w-2 bg-amber-500" />
             </span>
             {t('maintenancePage.status')}
           </div>
 
-          <h1 className="text-4xl font-bold text-swiss-charcoal mb-4 tracking-tight">
+          <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-swiss-charcoal mb-3 sm:mb-4 tracking-tight">
             {t('maintenancePage.title')}
           </h1>
 
-          <p className="text-lg text-gray-500 max-w-md mx-auto leading-relaxed">
+          <p className="text-base sm:text-lg text-gray-500 max-w-sm sm:max-w-md mx-auto leading-relaxed">
             {t('maintenancePage.subtitle')}
           </p>
 
           {/* Divider */}
-          <div className="mt-10 pt-8 border-t border-gray-100">
+          <div className="mt-8 sm:mt-10 pt-6 sm:pt-8 border-t border-gray-100">
             <div className="flex items-center justify-center gap-3">
               <span className="w-2 h-2 rounded-full bg-swiss-mint" />
               <span className="w-2 h-2 rounded-full bg-swiss-sand" />
@@ -69,7 +69,7 @@ const MaintenancePage: React.FC = () => {
       </div>
 
       {/* Admin login link */}
-      <p className="absolute bottom-6 text-xs text-gray-300">
+      <p className="mt-6 text-xs text-gray-300 pb-2">
         <Link to="/login" className="hover:text-gray-400 transition-colors">
           {t('maintenancePage.adminLogin')}
         </Link>


### PR DESCRIPTION
Back button: now a solid pill (white bg, border, shadow) that fills with swiss-teal on hover — much more visible than the previous ghost text link.

Responsive layout:
- Container max-width scales through xs/sm/md/lg/xl breakpoints
- Card padding tightens on small screens (px-5 py-8 → lg:px-12 py-14)
- GIF width is fluid (max-w-[280px] → lg:max-w-[640px]) so it doubles on large viewports without overflowing on mobile
- Typography steps down on small screens (text-2xl → lg:text-4xl)
- Admin login link removed from absolute positioning so it doesn't overlap content on short viewports

https://claude.ai/code/session_01QEhkwqMXuUReJXuGyqv8HD