### PR TITLE
fix: add roleTags translations to signup locale files (en/fr/de)

### DIFF
--- a/packages/translations/locales/de/signup.json
+++ b/packages/translations/locales/de/signup.json
@@ -295,6 +295,13 @@
   "roleSubtitle": {
     "educator": "Job finden"
   },
+  "roleTags": {
+    "EDE": "EDE",
+    "ASE": "ASE",
+    "Auxiliaire": "Auxiliaire",
+    "Intern": "Praktikant/in",
+    "Cleaning_Staff": "Reinigungspersonal"
+  },
   "role": {
     "productSupplier": "Produktlieferant",
     "serviceProvider": "Dienstleister",

--- a/packages/translations/locales/en/signup.json
+++ b/packages/translations/locales/en/signup.json
@@ -295,6 +295,13 @@
   "roleSubtitle": {
     "educator": "Find Job"
   },
+  "roleTags": {
+    "EDE": "EDE",
+    "ASE": "ASE",
+    "Auxiliaire": "Auxiliary",
+    "Intern": "Intern",
+    "Cleaning_Staff": "Cleaning Staff"
+  },
   "role": {
     "productSupplier": "Product Supplier",
     "serviceProvider": "Service Provider",

--- a/packages/translations/locales/fr/signup.json
+++ b/packages/translations/locales/fr/signup.json
@@ -295,6 +295,13 @@
   "roleSubtitle": {
     "educator": "Trouver un emploi"
   },
+  "roleTags": {
+    "EDE": "EDE",
+    "ASE": "ASE",
+    "Auxiliaire": "Auxiliaire",
+    "Intern": "Stagiaire",
+    "Cleaning_Staff": "Personnel d'entretien"
+  },
   "role": {
     "productSupplier": "Fournisseur de produits",
     "serviceProvider": "Prestataire de services",


### PR DESCRIPTION
The educator card role tags (EDE, ASE, Auxiliaire, Intern, Cleaning Staff) were falling back to English on all locales because the roleTags section was missing from all three translation files. Adds the section to each:
- EN: EDE, ASE, Auxiliary, Intern, Cleaning Staff
- FR: EDE, ASE, Auxiliaire, Stagiaire, Personnel d'entretien
- DE: EDE, ASE, Auxiliaire, Praktikant/in, Reinigungspersonal

https://claude.ai/code/session_01VFsG7Fh3YQcq2xz9DicjHS