### PR TITLE
Disable Sentry Session Replay on Safari to fix signup freeze

### DIFF
--- a/frontend/sentry.config.ts
+++ b/frontend/sentry.config.ts
@@ -4,13 +4,21 @@ import * as Sentry from '@sentry/react';
 // Session Replay integration, particularly around input/focus events on
 // password fields, which can cause the browser to freeze with a spinning
 // cursor. Detect Safari and skip the Replay integration there.
+//
+// Apple requires every iOS browser to use WebKit, so Firefox iOS, Edge iOS,
+// Chrome iOS, etc. hit the same bug as Safari and must also be opted out.
 function isSafariBrowser(): boolean {
   if (typeof navigator === 'undefined') return false;
   const ua = navigator.userAgent;
-  const isChromium = /Chrome|Chromium|CriOS|EdgiOS|FxiOS|OPR\//.test(ua);
-  const isSafariUA = /Safari/.test(ua) && !isChromium;
-  const isIOSWebKit = /iPad|iPhone|iPod/.test(ua) && !isChromium;
-  return isSafariUA || isIOSWebKit;
+
+  // Any iOS browser is WebKit under the hood, regardless of branding.
+  const isIOS = /iPad|iPhone|iPod/.test(ua);
+  if (isIOS) return true;
+
+  // Desktop: real Safari is the only Safari-branded UA that isn't also a
+  // Chromium variant (Chrome, Edge, Opera, etc. all include "Safari").
+  const isDesktopChromium = /Chrome\/|Chromium\/|Edg\/|OPR\//.test(ua);
+  return /Safari\//.test(ua) && !isDesktopChromium;
 }
 
 export function initSentry() {

--- a/frontend/sentry.config.ts
+++ b/frontend/sentry.config.ts
@@ -1,9 +1,22 @@
 import * as Sentry from '@sentry/react';
 
+// Safari (including iOS WebKit) has known performance issues with Sentry's
+// Session Replay integration, particularly around input/focus events on
+// password fields, which can cause the browser to freeze with a spinning
+// cursor. Detect Safari and skip the Replay integration there.
+function isSafariBrowser(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent;
+  const isChromium = /Chrome|Chromium|CriOS|EdgiOS|FxiOS|OPR\//.test(ua);
+  const isSafariUA = /Safari/.test(ua) && !isChromium;
+  const isIOSWebKit = /iPad|iPhone|iPod/.test(ua) && !isChromium;
+  return isSafariUA || isIOSWebKit;
+}
+
 export function initSentry() {
   const dsn = import.meta.env.VITE_SENTRY_DSN;
   const environment = import.meta.env.MODE || 'development';
-  
+
   // Debug logging for Sentry initialization (only show protocol prefix for security)
   console.info('[Sentry] Initialization check:', {
     hasDsn: !!dsn,
@@ -11,7 +24,7 @@ export function initSentry() {
     environment,
     mode: import.meta.env.MODE,
   });
-  
+
   // Only initialize Sentry if DSN is provided
   if (!dsn) {
     console.warn('[Sentry] VITE_SENTRY_DSN not configured. Skipping Sentry initialization.');
@@ -19,34 +32,45 @@ export function initSentry() {
     return;
   }
 
-  Sentry.init({
-    dsn,
-    environment,
-    integrations: [
-      Sentry.browserTracingIntegration(),
+  const skipReplay = isSafariBrowser();
+  if (skipReplay) {
+    console.info('[Sentry] Safari detected — skipping Session Replay integration to avoid password-field freeze.');
+  }
+
+  const integrations: Parameters<typeof Sentry.init>[0]['integrations'] = [
+    Sentry.browserTracingIntegration(),
+    Sentry.feedbackIntegration({
+      colorScheme: 'light',
+      showBranding: false,
+      isNameRequired: true,
+      isEmailRequired: true,
+      formTitle: 'Report an Issue',
+      submitButtonLabel: 'Send Feedback',
+      messagePlaceholder: 'Describe what happened...',
+      successMessageText: 'Thank you for your feedback!',
+    }),
+  ];
+
+  if (!skipReplay) {
+    integrations.push(
       Sentry.replayIntegration({
         maskAllText: true,
         blockAllMedia: true,
       }),
-      Sentry.feedbackIntegration({
-        // Display the Sentry feedback widget
-        colorScheme: 'light',
-        showBranding: false,
-        isNameRequired: true,
-        isEmailRequired: true,
-        formTitle: 'Report an Issue',
-        submitButtonLabel: 'Send Feedback',
-        messagePlaceholder: 'Describe what happened...',
-        successMessageText: 'Thank you for your feedback!',
-      }),
-    ],
-    
+    );
+  }
+
+  Sentry.init({
+    dsn,
+    environment,
+    integrations,
+
     // Performance Monitoring
     tracesSampleRate: environment === 'production' ? 0.1 : 1.0, // Capture 10% of transactions in production
-    
-    // Session Replay
-    replaysSessionSampleRate: 0.1, // Sample 10% of sessions
-    replaysOnErrorSampleRate: 1.0, // Sample 100% of sessions with errors
+
+    // Session Replay (effectively disabled on Safari since the integration is omitted there)
+    replaysSessionSampleRate: skipReplay ? 0 : 0.1,
+    replaysOnErrorSampleRate: skipReplay ? 0 : 1.0,
     
     // Release tracking
     release: import.meta.env.VITE_SENTRY_RELEASE,


### PR DESCRIPTION
Sentry's Session Replay integration uses rrweb to record DOM and input events. It has documented Safari performance issues that manifest most visibly on password fields — focusing the field triggers a spinning cursor and the page becomes unresponsive. The previous autocomplete fix was necessary but not sufficient because Replay's buffer recording runs on every session (replaysOnErrorSampleRate: 1.0 keeps a rolling 60s buffer even for the 90% of sessions that are not Replay-sampled).

Detect Safari via UA (excluding Chromium-based browsers that include Safari in their UA string) and omit the Replay integration there. Chrome, Firefox, and Edge keep full Replay coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled Session Replay on Safari browsers (including iOS WebKit) to improve compatibility. All other Sentry monitoring features remain active across all browsers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/One-S-Digital/PC-Solutions-Platform/pull/631?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->