### PR TITLE
Add email notifications for replacement staffing & educator profile submission

### DIFF
--- a/api/src/auth/decorators/allow-pending-educator.decorator.ts
+++ b/api/src/auth/decorators/allow-pending-educator.decorator.ts
@@ -1,0 +1,9 @@
+import { SetMetadata } from '@nestjs/common';
+
+/**
+ * Decorator to mark routes that should be accessible to educators whose accounts
+ * are pending admin approval (PENDING_REVIEW status). Used on profile setup
+ * endpoints so educators can submit their profile before it is reviewed.
+ */
+export const ALLOW_PENDING_EDUCATOR_KEY = 'allowPendingEducator';
+export const AllowPendingEducator = () => SetMetadata(ALLOW_PENDING_EDUCATOR_KEY, true);

--- a/api/src/auth/guards/roles.guard.ts
+++ b/api/src/auth/guards/roles.guard.ts
@@ -4,6 +4,7 @@ import { UserRole, EducatorApprovalStatus } from '@prisma/client';
 import { ROLES_KEY } from '../decorators/roles.decorator';
 import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
 import { ALLOW_PENDING_KEY } from '../decorators/allow-pending.decorator';
+import { ALLOW_PENDING_EDUCATOR_KEY } from '../decorators/allow-pending-educator.decorator';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
@@ -11,24 +12,30 @@ export class RolesGuard implements CanActivate {
 
   canActivate(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest();
-    
+
     // 1. Allow OPTIONS requests (CORS preflight)
     if (request.method === 'OPTIONS') {
       return true;
     }
-    
+
     // 2. Check if route is marked as @Public()
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
       context.getHandler(),
       context.getClass(),
     ]);
-    
+
     if (isPublic) {
       return true;
     }
-    
+
     // 3. Check if route allows pending users via @AllowPending()
     const allowPending = this.reflector.getAllAndOverride<boolean>(ALLOW_PENDING_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    // 3b. Check if route allows educators with PENDING_REVIEW approval status
+    const allowPendingEducator = this.reflector.getAllAndOverride<boolean>(ALLOW_PENDING_EDUCATOR_KEY, [
       context.getHandler(),
       context.getClass(),
     ]);
@@ -69,7 +76,7 @@ export class RolesGuard implements CanActivate {
 
     // 7. Handle educators pending admin approval
     if (userContext.role === UserRole.EDUCATOR) {
-      if (userContext.approvalStatus === EducatorApprovalStatus.PENDING_REVIEW) {
+      if (userContext.approvalStatus === EducatorApprovalStatus.PENDING_REVIEW && !allowPendingEducator) {
         throw new ForbiddenException({
           message: 'Your educator profile is awaiting admin approval. You will be notified once reviewed.',
           code: 'EDUCATOR_PENDING_APPROVAL',

--- a/api/src/email-notification/email-template.service.ts
+++ b/api/src/email-notification/email-template.service.ts
@@ -304,7 +304,21 @@ export class EmailTemplateService {
             <p>Best regards,<br>The Pro Crèche Solutions Team</p>
           </div>
         `.trim(),
-        textContent: `Hello {{firstName}},\n\nYou have been proposed for a replacement shift.\n\nRole: {{role}} | Dates: {{startDate}} – {{endDate}} | Location: {{location}}\n\nView and respond: {{requestUrl}}\n\nBest regards,\nThe Pro Crèche Solutions Team`.trim(),
+        textContent: `
+          Hello {{firstName}},
+
+          You have been proposed for the following replacement shift:
+
+          Role: {{role}}
+          Dates: {{startDate}} – {{endDate}}
+          Location: {{location}}
+
+          Please log in to accept or decline this proposal:
+          {{requestUrl}}
+
+          Best regards,
+          The Pro Crèche Solutions Team
+        `.trim(),
         isActive: true,
       },
       {

--- a/api/src/email-notification/email-template.service.ts
+++ b/api/src/email-notification/email-template.service.ts
@@ -282,6 +282,32 @@ export class EmailTemplateService {
       },
       // ── Replacement Staffing ───────────────────────────────────────────────
       {
+        name: 'Replacement match proposed',
+        event: 'replacement_match_proposed',
+        subject: 'You have been proposed for a replacement shift',
+        category: 'jobRecruitment',
+        variables: ['firstName', 'role', 'startDate', 'endDate', 'location', 'requestUrl'],
+        htmlContent: `
+          <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+            <h2>Replacement shift proposed</h2>
+            <p>Hello {{firstName}},</p>
+            <p>You have been proposed for the following replacement shift:</p>
+            <ul>
+              <li><strong>Role:</strong> {{role}}</li>
+              <li><strong>Dates:</strong> {{startDate}} – {{endDate}}</li>
+              <li><strong>Location:</strong> {{location}}</li>
+            </ul>
+            <p>Please log in to accept or decline this proposal.</p>
+            <div style="text-align: center; margin: 24px 0;">
+              <a href="{{requestUrl}}" style="background-color: #14B8A6; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px;">View Proposal</a>
+            </div>
+            <p>Best regards,<br>The Pro Crèche Solutions Team</p>
+          </div>
+        `.trim(),
+        textContent: `Hello {{firstName}},\n\nYou have been proposed for a replacement shift.\n\nRole: {{role}} | Dates: {{startDate}} – {{endDate}} | Location: {{location}}\n\nView and respond: {{requestUrl}}\n\nBest regards,\nThe Pro Crèche Solutions Team`.trim(),
+        isActive: true,
+      },
+      {
         name: 'Replacement request posted',
         event: 'replacement_request_posted',
         subject: 'New replacement shift available',

--- a/api/src/replacements/replacements.module.ts
+++ b/api/src/replacements/replacements.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { PrismaModule } from '../prisma/prisma.module';
 import { AuthModule } from '../auth/auth.module';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { EmailNotificationModule } from '../email-notification/email-notification.module';
 import { ReplacementsController } from './replacements.controller';
 import { ReplacementsService } from './replacements.service';
 
 @Module({
-  imports: [PrismaModule, AuthModule, NotificationsModule],
+  imports: [PrismaModule, AuthModule, NotificationsModule, EmailNotificationModule],
   controllers: [ReplacementsController],
   providers: [ReplacementsService],
   exports: [ReplacementsService],

--- a/api/src/replacements/replacements.service.ts
+++ b/api/src/replacements/replacements.service.ts
@@ -30,6 +30,15 @@ export class ReplacementsService {
     return notification;
   }
 
+  private async isFeatureEnabled(flagKey: string): Promise<boolean> {
+    const flag = await this.prisma.featureFlag.findUnique({ where: { key: flagKey } });
+    return flag ? flag.isActive : true;
+  }
+
+  private resolveAppUrl(): string {
+    return this.configService.get<string>('APP_URL') || this.configService.get<string>('FRONTEND_URL') || '';
+  }
+
   // ── Requests ──────────────────────────────────────────────────────────────
 
   async createRequest(dto: CreateReplacementRequestDto, foundationId: string, userId: string) {
@@ -168,19 +177,22 @@ export class ReplacementsService {
     // Send email to educator (fire-and-forget — never block the response)
     const educator = match.educator;
     if (educator?.email) {
-      const appUrl = this.configService.get<string>('APP_URL') || this.configService.get<string>('FRONTEND_URL') || '';
-      this.emailNotificationService.sendNotification({
-        event: 'replacement_match_proposed',
-        recipient: educator.email,
-        recipientName: educator.firstName ?? undefined,
-        payload: {
-          firstName: educator.firstName ?? 'there',
-          role: request.role,
-          startDate: request.startDate.toLocaleDateString(),
-          endDate: request.endDate.toLocaleDateString(),
-          location: request.location ?? '',
-          requestUrl: `${appUrl}/educator/replacements`,
-        },
+      this.isFeatureEnabled('v2_staffing_emails').then(enabled => {
+        if (!enabled) return;
+        const appUrl = this.resolveAppUrl();
+        return this.emailNotificationService.sendNotification({
+          event: 'replacement_match_proposed',
+          recipient: educator.email!,
+          recipientName: educator.firstName ?? undefined,
+          payload: {
+            firstName: educator.firstName ?? 'there',
+            role: request.role,
+            startDate: request.startDate.toISOString().slice(0, 10),
+            endDate: request.endDate.toISOString().slice(0, 10),
+            location: request.location ?? '',
+            requestUrl: appUrl ? `${appUrl}/educator/replacements` : '',
+          },
+        });
       }).catch(() => {});
     }
 
@@ -245,18 +257,21 @@ export class ReplacementsService {
           : null;
 
     if (emailEvent && requester?.email) {
-      const appUrl = this.configService.get<string>('APP_URL') || this.configService.get<string>('FRONTEND_URL') || '';
-      this.emailNotificationService.sendNotification({
-        event: emailEvent,
-        recipient: requester.email,
-        recipientName: requester.firstName ?? undefined,
-        payload: {
-          firstName: requester.firstName ?? 'there',
-          role: match.request.role,
-          startDate: match.request.startDate.toLocaleDateString(),
-          endDate: match.request.endDate.toLocaleDateString(),
-          requestUrl: `${appUrl}/foundation/replacements`,
-        },
+      this.isFeatureEnabled('v2_staffing_emails').then(enabled => {
+        if (!enabled) return;
+        const appUrl = this.resolveAppUrl();
+        return this.emailNotificationService.sendNotification({
+          event: emailEvent!,
+          recipient: requester!.email!,
+          recipientName: requester!.firstName ?? undefined,
+          payload: {
+            firstName: requester!.firstName ?? 'there',
+            role: match.request.role,
+            startDate: match.request.startDate.toISOString().slice(0, 10),
+            endDate: match.request.endDate.toISOString().slice(0, 10),
+            requestUrl: appUrl ? `${appUrl}/foundation/replacements` : '',
+          },
+        });
       }).catch(() => {});
     }
 

--- a/api/src/replacements/replacements.service.ts
+++ b/api/src/replacements/replacements.service.ts
@@ -4,6 +4,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../prisma/prisma.service';
 import { NotificationType, ReplacementMatchStatus, ReplacementRequestStatus, UrgencyLevel, UserRole } from '@prisma/client';
 import { CreateReplacementRequestDto } from './dto/create-replacement-request.dto';
@@ -20,6 +21,7 @@ export class ReplacementsService {
     private notificationsService: NotificationsService,
     private notificationsGateway: NotificationsGateway,
     private emailNotificationService: EmailNotificationService,
+    private configService: ConfigService,
   ) {}
 
   private async notify(userId: string, type: NotificationType, title: string, body: string, link?: string) {
@@ -166,7 +168,7 @@ export class ReplacementsService {
     // Send email to educator (fire-and-forget — never block the response)
     const educator = match.educator;
     if (educator?.email) {
-      const appUrl = process.env.APP_URL || process.env.FRONTEND_URL || '';
+      const appUrl = this.configService.get<string>('APP_URL') || this.configService.get<string>('FRONTEND_URL') || '';
       this.emailNotificationService.sendNotification({
         event: 'replacement_match_proposed',
         recipient: educator.email,
@@ -233,7 +235,8 @@ export class ReplacementsService {
     );
 
     // Send email to the foundation's requester for accepted/declined responses
-    const requester = (match.request as any).requestedBy;
+    type Requester = { id: string; firstName: string | null; email: string | null } | null;
+    const requester = (match.request as typeof match.request & { requestedBy: Requester }).requestedBy;
     const emailEvent =
       dto.status === ReplacementMatchStatus.ACCEPTED
         ? 'replacement_match_accepted'
@@ -242,7 +245,7 @@ export class ReplacementsService {
           : null;
 
     if (emailEvent && requester?.email) {
-      const appUrl = process.env.APP_URL || process.env.FRONTEND_URL || '';
+      const appUrl = this.configService.get<string>('APP_URL') || this.configService.get<string>('FRONTEND_URL') || '';
       this.emailNotificationService.sendNotification({
         event: emailEvent,
         recipient: requester.email,

--- a/api/src/replacements/replacements.service.ts
+++ b/api/src/replacements/replacements.service.ts
@@ -11,6 +11,7 @@ import { UpdateReplacementRequestDto } from './dto/update-replacement-request.dt
 import { RespondMatchDto } from './dto/respond-match.dto';
 import { NotificationsService } from '../notifications/notifications.service';
 import { NotificationsGateway } from '../notifications/notifications.gateway';
+import { EmailNotificationService } from '../email-notification/email-notification.service';
 
 @Injectable()
 export class ReplacementsService {
@@ -18,6 +19,7 @@ export class ReplacementsService {
     private prisma: PrismaService,
     private notificationsService: NotificationsService,
     private notificationsGateway: NotificationsGateway,
+    private emailNotificationService: EmailNotificationService,
   ) {}
 
   private async notify(userId: string, type: NotificationType, title: string, body: string, link?: string) {
@@ -161,13 +163,36 @@ export class ReplacementsService {
       `/educator/replacements`,
     );
 
+    // Send email to educator (fire-and-forget — never block the response)
+    const educator = match.educator;
+    if (educator?.email) {
+      const appUrl = process.env.APP_URL || process.env.FRONTEND_URL || '';
+      this.emailNotificationService.sendNotification({
+        event: 'replacement_match_proposed',
+        recipient: educator.email,
+        recipientName: educator.firstName ?? undefined,
+        payload: {
+          firstName: educator.firstName ?? 'there',
+          role: request.role,
+          startDate: request.startDate.toLocaleDateString(),
+          endDate: request.endDate.toLocaleDateString(),
+          location: request.location ?? '',
+          requestUrl: `${appUrl}/educator/replacements`,
+        },
+      }).catch(() => {});
+    }
+
     return match;
   }
 
   async respondToMatch(matchId: string, dto: RespondMatchDto, educatorId: string, isAdmin: boolean) {
     const match = await this.prisma.replacementMatch.findUnique({
       where: { id: matchId },
-      include: { request: true },
+      include: {
+        request: {
+          include: { requestedBy: { select: { id: true, firstName: true, email: true } } },
+        },
+      },
     });
     if (!match) throw new NotFoundException('Match not found');
     if (!isAdmin && match.educatorId !== educatorId) {
@@ -206,6 +231,31 @@ export class ReplacementsService {
       `An educator has ${dto.status.toLowerCase()} your replacement request.`,
       `/foundation/replacements`,
     );
+
+    // Send email to the foundation's requester for accepted/declined responses
+    const requester = (match.request as any).requestedBy;
+    const emailEvent =
+      dto.status === ReplacementMatchStatus.ACCEPTED
+        ? 'replacement_match_accepted'
+        : dto.status === ReplacementMatchStatus.DECLINED
+          ? 'replacement_match_declined'
+          : null;
+
+    if (emailEvent && requester?.email) {
+      const appUrl = process.env.APP_URL || process.env.FRONTEND_URL || '';
+      this.emailNotificationService.sendNotification({
+        event: emailEvent,
+        recipient: requester.email,
+        recipientName: requester.firstName ?? undefined,
+        payload: {
+          firstName: requester.firstName ?? 'there',
+          role: match.request.role,
+          startDate: match.request.startDate.toLocaleDateString(),
+          endDate: match.request.endDate.toLocaleDateString(),
+          requestUrl: `${appUrl}/foundation/replacements`,
+        },
+      }).catch(() => {});
+    }
 
     return updated;
   }

--- a/api/src/settings/settings.controller.ts
+++ b/api/src/settings/settings.controller.ts
@@ -38,6 +38,8 @@ import { TranslationService } from '../translation/translation.service';
 import { FIELDS_BY_ENTITY } from '../translation/translation.config';
 import { normalizeRegionsServed } from '../common/utils/regions.util';
 import { AllowPendingEducator } from '../auth/decorators/allow-pending-educator.decorator';
+import { EmailNotificationService } from '../email-notification/email-notification.service';
+import { ConfigService } from '@nestjs/config';
 
 @ApiTags('settings')
 @Controller('settings')
@@ -50,6 +52,8 @@ export class SettingsController {
     private readonly principal: PrincipalService,
     private readonly translationService: TranslationService,
     private readonly uploadService: UploadService,
+    private readonly emailNotificationService: EmailNotificationService,
+    private readonly configService: ConfigService,
   ) {}
 
   /**
@@ -406,7 +410,7 @@ export class SettingsController {
     // 2) delete the underlying uploaded asset (best-effort)
     const existingCv = await this.prisma.user.findUnique({
       where: { id: profileId },
-      select: { cvUrl: true },
+      select: { cvUrl: true, shortBio: true, approvalStatus: true, email: true, firstName: true },
     });
     const previousCvUrl = existingCv?.cvUrl || '';
     const normalizedIncomingCvUrl =
@@ -582,6 +586,29 @@ export class SettingsController {
         // Do not fail settings update if deletion fails; leaving an orphaned file is preferable
         // to blocking the user from updating their profile.
       }
+    }
+
+    // Send "application received" email the first time an educator submits their profile.
+    // Condition: previously had no shortBio (blank profile) and is now submitting one,
+    // and their account is still PENDING_REVIEW (not yet reviewed by admin).
+    // This covers the email/password signup path; OAuth educators get it via completeProfile.
+    const isFirstSubmission =
+      !existingCv?.shortBio?.trim() &&
+      settings.shortBio?.trim() &&
+      existingCv?.approvalStatus === 'PENDING_REVIEW';
+
+    if (isFirstSubmission && existingCv?.email) {
+      const appUrl = this.configService.get<string>('APP_URL') || this.configService.get<string>('FRONTEND_URL') || '';
+      this.emailNotificationService.sendNotification({
+        event: 'educator_pending',
+        recipient: existingCv.email,
+        recipientName: existingCv.firstName ?? undefined,
+        payload: {
+          firstName: existingCv.firstName || 'Educator',
+          supportUrl: `${appUrl}/support`,
+        },
+        bypassPreferences: true,
+      }).catch(() => {});
     }
 
     return {

--- a/api/src/settings/settings.controller.ts
+++ b/api/src/settings/settings.controller.ts
@@ -37,6 +37,7 @@ import { UpdateNotificationSettingsDto } from './dto/notification-settings.dto';
 import { TranslationService } from '../translation/translation.service';
 import { FIELDS_BY_ENTITY } from '../translation/translation.config';
 import { normalizeRegionsServed } from '../common/utils/regions.util';
+import { AllowPendingEducator } from '../auth/decorators/allow-pending-educator.decorator';
 
 @ApiTags('settings')
 @Controller('settings')
@@ -342,6 +343,7 @@ export class SettingsController {
 
   @Get('educator')
   @Roles(UserRole.EDUCATOR)
+  @AllowPendingEducator()
   @ApiOperation({ summary: 'Get educator settings' })
   @ApiResponse({ status: 200, description: 'Settings retrieved successfully' })
   async getEducatorSettings(@Request() req) {
@@ -393,6 +395,7 @@ export class SettingsController {
 
   @Patch('educator')
   @Roles(UserRole.EDUCATOR)
+  @AllowPendingEducator()
   @ApiOperation({ summary: 'Update educator settings' })
   @ApiResponse({ status: 200, description: 'Settings updated successfully' })
   async updateEducatorSettings(@Request() req, @Body() settings: UpdateEducatorSettingsDto) {

--- a/api/src/settings/settings.controller.ts
+++ b/api/src/settings/settings.controller.ts
@@ -10,7 +10,7 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { AssetKind } from '@prisma/client';
+import { AssetKind, EducatorApprovalStatus } from '@prisma/client';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { UserRole } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
@@ -595,7 +595,7 @@ export class SettingsController {
     const isFirstSubmission =
       !existingCv?.shortBio?.trim() &&
       settings.shortBio?.trim() &&
-      existingCv?.approvalStatus === 'PENDING_REVIEW';
+      existingCv?.approvalStatus === EducatorApprovalStatus.PENDING_REVIEW;
 
     if (isFirstSubmission && existingCv?.email) {
       const appUrl = this.configService.get<string>('APP_URL') || this.configService.get<string>('FRONTEND_URL') || '';
@@ -608,6 +608,7 @@ export class SettingsController {
           supportUrl: `${appUrl}/support`,
         },
         bypassPreferences: true,
+        allowUnknownRecipient: false,
       }).catch(() => {});
     }
 

--- a/api/src/settings/settings.controller.ts
+++ b/api/src/settings/settings.controller.ts
@@ -127,6 +127,11 @@ export class SettingsController {
     return { profileId, accountId, clerkUserId };
   }
 
+  private async isFeatureEnabled(flagKey: string): Promise<boolean> {
+    const flag = await this.prisma.featureFlag.findUnique({ where: { key: flagKey } });
+    return flag ? flag.isActive : true;
+  }
+
   /**
    * Validates that an asset exists, belongs to the user, and has the correct kind.
    * @param tx Prisma transaction client
@@ -597,18 +602,25 @@ export class SettingsController {
       settings.shortBio?.trim() &&
       existingCv?.approvalStatus === EducatorApprovalStatus.PENDING_REVIEW;
 
-    if (isFirstSubmission && existingCv?.email) {
-      const appUrl = this.configService.get<string>('APP_URL') || this.configService.get<string>('FRONTEND_URL') || '';
-      this.emailNotificationService.sendNotification({
-        event: 'educator_pending',
-        recipient: existingCv.email,
-        recipientName: existingCv.firstName ?? undefined,
-        payload: {
-          firstName: existingCv.firstName || 'Educator',
-          supportUrl: `${appUrl}/support`,
-        },
-        bypassPreferences: true,
-        allowUnknownRecipient: false,
+    // Use settings values (post-update) for name/email, falling back to pre-update snapshot.
+    const recipientEmail = settings.email ?? existingCv?.email;
+    const recipientName = settings.firstName ?? existingCv?.firstName;
+
+    if (isFirstSubmission && recipientEmail) {
+      this.isFeatureEnabled('v2_staffing_emails').then(enabled => {
+        if (!enabled) return;
+        const appUrl = this.configService.get<string>('APP_URL') || this.configService.get<string>('FRONTEND_URL') || '';
+        return this.emailNotificationService.sendNotification({
+          event: 'educator_pending',
+          recipient: recipientEmail,
+          recipientName: recipientName ?? undefined,
+          payload: {
+            firstName: recipientName || 'Educator',
+            supportUrl: appUrl ? `${appUrl}/support` : '',
+          },
+          bypassPreferences: true,
+          allowUnknownRecipient: false,
+        });
       }).catch(() => {});
     }
 

--- a/api/src/settings/settings.module.ts
+++ b/api/src/settings/settings.module.ts
@@ -5,9 +5,10 @@ import { AuthModule } from '../auth/auth.module';
 import { PrincipalModule } from '../principal/principal.module';
 import { TranslationModule } from '../translation/translation.module';
 import { UploadModule } from '../upload/upload.module';
+import { EmailNotificationModule } from '../email-notification/email-notification.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule, PrincipalModule, TranslationModule, UploadModule],
+  imports: [PrismaModule, AuthModule, PrincipalModule, TranslationModule, UploadModule, EmailNotificationModule],
   controllers: [SettingsController],
 })
 export class SettingsModule {}

--- a/frontend/pages/NotificationsPage.tsx
+++ b/frontend/pages/NotificationsPage.tsx
@@ -1,25 +1,32 @@
 
-
 import React from 'react';
-import { useNotifications } from '../contexts/NotificationContext';
+import { useInAppNotifications } from '../contexts/InAppNotificationContext';
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
-import { BellIcon, CheckCircleIcon, InformationCircleIcon, ExclamationTriangleIcon, XCircleIcon, TrashIcon, InboxIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import {
+  BellIcon,
+  CheckCircleIcon,
+  BriefcaseIcon,
+  UserGroupIcon,
+  ArrowPathIcon,
+  InboxIcon,
+  CheckIcon,
+} from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 
+const getNotificationIcon = (type: string) => {
+  if (type.startsWith('REPLACEMENT')) return <ArrowPathIcon className="w-5 h-5 text-swiss-teal" />;
+  if (type.startsWith('JOB') || type.startsWith('APPLICATION')) return <BriefcaseIcon className="w-5 h-5 text-swiss-mint" />;
+  if (type.startsWith('INTERN')) return <UserGroupIcon className="w-5 h-5 text-blue-500" />;
+  return <BellIcon className="w-5 h-5 text-gray-400" />;
+};
+
 const NotificationsPage: React.FC = () => {
   const { t } = useTranslation(['dashboard', 'common']);
-  const { notifications, removeNotification } = useNotifications();
+  const { notifications, isLoading, markRead, markAllRead } = useInAppNotifications();
 
-  const getNotificationIcon = (type: 'success' | 'info' | 'warning' | 'error') => {
-    switch (type) {
-      case 'success': return <CheckCircleIcon className="w-6 h-6 text-green-500" />;
-      case 'info': return <InformationCircleIcon className="w-6 h-6 text-blue-500" />;
-      case 'warning': return <ExclamationTriangleIcon className="w-6 h-6 text-yellow-500" />;
-      case 'error': return <XCircleIcon className="w-6 h-6 text-red-500" />;
-    }
-  };
+  const unreadCount = notifications.filter(n => !n.read).length;
 
   return (
     <div className="space-y-6">
@@ -28,49 +35,58 @@ const NotificationsPage: React.FC = () => {
           <BellIcon className="w-8 h-8 mr-3 text-swiss-mint" />
           {t('notificationsPage.title')}
         </h1>
-        {notifications.length > 0 && (
-          <Button 
-            variant="light" 
-            size="sm" 
-            leftIcon={TrashIcon}
-            onClick={() => notifications.forEach(n => removeNotification(n.id))}
+        {unreadCount > 0 && (
+          <Button
+            variant="light"
+            size="sm"
+            leftIcon={CheckIcon}
+            onClick={markAllRead}
             className="mt-4 sm:mt-0"
-           >
-             {t('notificationsPage.clearAll')}
+          >
+            {t('notificationsPage.markAllRead', 'Mark all as read')}
           </Button>
         )}
       </div>
-      
+
       <Card className="p-4 md:p-6">
-        {notifications.length === 0 ? (
+        {isLoading ? (
+          <div className="text-center py-12 text-gray-400">{t('common:loading', 'Loading…')}</div>
+        ) : notifications.length === 0 ? (
           <div className="text-center py-12">
             <InboxIcon className="w-16 h-16 mx-auto text-gray-300 mb-4" />
             <h2 className="text-xl font-semibold text-swiss-charcoal">{t('notificationsPage.emptyState.title')}</h2>
             <p className="text-gray-500 mt-1">{t('notificationsPage.emptyState.message')}</p>
           </div>
         ) : (
-          <ul className="space-y-3">
+          <ul className="space-y-2">
             {notifications.map(notif => (
-              <li key={notif.id} className="p-4 flex items-start bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
-                <div className="flex-shrink-0 mr-4">
+              <li
+                key={notif.id}
+                className={`p-4 flex items-start rounded-lg transition-colors ${notif.read ? 'bg-white hover:bg-gray-50' : 'bg-blue-50 hover:bg-blue-100'}`}
+              >
+                <div className="flex-shrink-0 mr-3 mt-0.5">
                   {getNotificationIcon(notif.type)}
                 </div>
-                <div className="flex-grow">
-                  <Link to={notif.link || '#'} className={`${notif.link ? 'cursor-pointer hover:underline' : 'cursor-default'}`}>
-                    <p className="font-semibold text-swiss-charcoal">{notif.title}</p>
-                    <p className="text-sm text-gray-600">{notif.message}</p>
-                  </Link>
-                  <p className="text-xs text-gray-400 mt-1">{new Date(notif.timestamp).toLocaleString()}</p>
+                <div className="flex-grow min-w-0">
+                  {notif.link ? (
+                    <Link to={notif.link} className="hover:underline" onClick={() => !notif.read && markRead(notif.id)}>
+                      <p className={`font-semibold text-swiss-charcoal truncate ${!notif.read ? 'font-bold' : ''}`}>{notif.title}</p>
+                    </Link>
+                  ) : (
+                    <p className={`font-semibold text-swiss-charcoal truncate ${!notif.read ? 'font-bold' : ''}`}>{notif.title}</p>
+                  )}
+                  <p className="text-sm text-gray-600 mt-0.5">{notif.body}</p>
+                  <p className="text-xs text-gray-400 mt-1">{new Date(notif.createdAt).toLocaleString()}</p>
                 </div>
-                <Button 
-                  variant="ghost" 
-                  size="sm" 
-                  className="!p-2 text-gray-400 hover:text-swiss-coral"
-                  onClick={() => removeNotification(notif.id)}
-                  aria-label={t('common:buttons.dismiss')}
-                >
-                  <XMarkIcon className="w-5 h-5" />
-                </Button>
+                {!notif.read && (
+                  <button
+                    onClick={() => markRead(notif.id)}
+                    className="flex-shrink-0 ml-3 mt-0.5 p-1 rounded text-swiss-teal hover:text-swiss-mint"
+                    aria-label={t('common:buttons.markRead', 'Mark as read')}
+                  >
+                    <CheckCircleIcon className="w-5 h-5" />
+                  </button>
+                )}
               </li>
             ))}
           </ul>

--- a/frontend/pages/NotificationsPage.tsx
+++ b/frontend/pages/NotificationsPage.tsx
@@ -70,10 +70,10 @@ const NotificationsPage: React.FC = () => {
                 <div className="flex-grow min-w-0">
                   {notif.link ? (
                     <Link to={notif.link} className="hover:underline" onClick={() => !notif.read && markRead(notif.id)}>
-                      <p className={`font-semibold text-swiss-charcoal truncate ${!notif.read ? 'font-bold' : ''}`}>{notif.title}</p>
+                      <p className={`${notif.read ? 'font-semibold' : 'font-bold'} text-swiss-charcoal truncate`}>{notif.title}</p>
                     </Link>
                   ) : (
-                    <p className={`font-semibold text-swiss-charcoal truncate ${!notif.read ? 'font-bold' : ''}`}>{notif.title}</p>
+                    <p className={`${notif.read ? 'font-semibold' : 'font-bold'} text-swiss-charcoal truncate`}>{notif.title}</p>
                   )}
                   <p className="text-sm text-gray-600 mt-0.5">{notif.body}</p>
                   <p className="text-xs text-gray-400 mt-1">{new Date(notif.createdAt).toLocaleString()}</p>


### PR DESCRIPTION
## Summary
Extends the replacement staffing module and educator profile setup with transactional email notifications, plus UI improvements to the in-app notifications page. Educators can now receive emails when proposed for replacement shifts, and foundations receive confirmation emails when matches are accepted/declined. First-time educator profile submissions also trigger an "application received" email.

## Key Changes

**Backend — Email Notifications**
- Added three new email templates to `EmailTemplateService`:
  - `replacement_match_proposed` — sent to educators when proposed for a shift
  - `replacement_match_accepted` — sent to foundation requesters when match is accepted
  - `replacement_match_declined` — sent to foundation requesters when match is declined
- Updated `ReplacementsService` to send emails (fire-and-forget) when:
  - A match is proposed to an educator
  - An educator accepts/declines a match (notifies the requester)
- Updated `SettingsController` to send `educator_pending` email on first profile submission (when `shortBio` transitions from empty to filled and account is still `PENDING_REVIEW`)
- Injected `EmailNotificationService` and `ConfigService` into replacements and settings modules

**Backend — Auth & Access Control**
- Created new `@AllowPendingEducator()` decorator to allow educators with `PENDING_REVIEW` approval status to access profile setup endpoints
- Updated `RolesGuard` to check `ALLOW_PENDING_EDUCATOR_KEY` and permit access for educators still awaiting admin review
- Applied decorator to `GET /settings/educator` and `PATCH /settings/educator` so educators can submit profiles before approval

**Frontend — Notifications UI**
- Refactored `NotificationsPage` to use new `useInAppNotifications()` hook (replacing `useNotifications()`)
- Updated notification icon logic to map by notification type (e.g., `REPLACEMENT_*`, `JOB_*`, `INTERN_*`) instead of severity
- Added unread state styling: unread notifications show with blue background, read notifications with white
- Replaced "Clear all" button with "Mark all as read" button
- Added individual "Mark as read" button (checkmark icon) on unread notifications
- Improved notification list layout with better spacing and truncation for long titles
- Added loading state while notifications are being fetched
- Changed notification property references: `message` → `body`, `timestamp` → `createdAt`

## Implementation Details

- Email sends are wrapped in `.catch(() => {})` to prevent blocking API responses if email service fails
- Educator "application received" email only sends on first submission (checks `!existingCv?.shortBio?.trim()` and `settings.shortBio?.trim()`)
- Email payloads include `APP_URL` or `FRONTEND_URL` for deep links back to the platform
- Notification read/unread state now persists and drives UI styling
- All new email templates follow existing HTML/text dual-format pattern

https://claude.ai/code/session_01DaYVpwHu4NwMJbDnPKFoWz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pending educators can now update their profiles and automatically receive email confirmation of their application status.
  * Replacement match notifications are now delivered via email to relevant users.
  * Enhanced notifications interface with better icons, read status indicators, and ability to mark all notifications as read.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/One-S-Digital/PC-Solutions-Platform/pull/636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->