### PR TITLE
Fix educator approval flow: routing, visibility, emails, and admin no…

### DIFF
--- a/api/prisma/migrations/20260519000000_backfill_educator_approval_status/migration.sql
+++ b/api/prisma/migrations/20260519000000_backfill_educator_approval_status/migration.sql
@@ -1,0 +1,8 @@
+-- Backfill: set approvalStatus = 'PENDING_REVIEW' for all EDUCATOR users
+-- where approvalStatus is still NULL (rows created before the approval workflow
+-- was enforced). Previously visible educators disappear from candidate queries
+-- once the APPROVED filter is applied, so this must run before that deployment.
+UPDATE "users"
+SET "approvalStatus" = 'PENDING_REVIEW'
+WHERE "role" = 'EDUCATOR'
+  AND "approvalStatus" IS NULL;

--- a/api/src/compat/compat.controller.ts
+++ b/api/src/compat/compat.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Post, Put, Patch, Delete, Body, Param, Query, UseGuard
 import { Public } from '../auth/decorators/public.decorator';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
-import { Prisma, UserRole, JobStatus, JobContractType, OrganizationType, SubscriptionStatus } from '@prisma/client';
+import { Prisma, UserRole, JobStatus, JobContractType, OrganizationType, SubscriptionStatus, EducatorApprovalStatus } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateCandidateDto } from './dto/create-candidate.dto';
 import { CreateJobListingDto } from '../recruitment/dto/create-job-listing.dto';
@@ -446,7 +446,7 @@ export class CompatController {
         where: {
           role: UserRole.EDUCATOR,
           isActive: { not: false },
-          ...(!showAll ? { candidatePoolVisible: true } : {}),
+          ...(!showAll ? { candidatePoolVisible: true, approvalStatus: EducatorApprovalStatus.APPROVED } : {}),
         },
         orderBy: { createdAt: 'desc' },
         take: 100,

--- a/api/src/principal/principal.service.ts
+++ b/api/src/principal/principal.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
-import { Prisma, UserRole } from '@prisma/client';
+import { Prisma, UserRole, EducatorApprovalStatus } from '@prisma/client';
 
 type UserPayload<TInclude extends Prisma.UserInclude | undefined> = Prisma.UserGetPayload<
   TInclude extends Prisma.UserInclude ? { include: TInclude } : {}
@@ -63,7 +63,7 @@ export class PrincipalService {
       emailForCreate = existingUser?.email ?? null;
     }
 
-    const user = await this.prisma.user.upsert({
+    let user = await this.prisma.user.upsert({
       where: { clerkId },
       update: {
         email: appUser.email ?? undefined,
@@ -71,12 +71,22 @@ export class PrincipalService {
       },
       create: {
         clerkId,
-        email: emailForCreate, // Use existing User email if AppUser email is null
+        email: emailForCreate,
         role: appUser.role,
         isActive: true,
+        ...(appUser.role === UserRole.EDUCATOR ? { approvalStatus: EducatorApprovalStatus.PENDING_REVIEW } : {}),
       },
       ...(include ? { include } : {}),
     } as Prisma.UserUpsertArgs);
+
+    // Backfill: educators created before this fix may have null approvalStatus
+    if (appUser.role === UserRole.EDUCATOR && !(user as any).approvalStatus) {
+      user = await this.prisma.user.update({
+        where: { clerkId },
+        data: { approvalStatus: EducatorApprovalStatus.PENDING_REVIEW },
+        ...(include ? { include } : {}),
+      } as Prisma.UserUpdateArgs);
+    }
 
     const duration = Date.now() - startTime;
 

--- a/api/src/recruitment/recruitment.service.ts
+++ b/api/src/recruitment/recruitment.service.ts
@@ -6,7 +6,7 @@ import { UpdateJobListingDto } from './dto/update-job-listing.dto';
 import { CreateJobApplicationDto } from './dto/create-job-application.dto';
 import { UpdateJobApplicationDto } from './dto/create-job-application.dto';
 import { JobContractType, JobStatus } from '@workspace/types';
-import { JobEmploymentType, Prisma } from '@prisma/client';
+import { JobEmploymentType, Prisma, EducatorApprovalStatus } from '@prisma/client';
 import { TranslationService } from '../translation/translation.service';
 import { FIELDS_BY_ENTITY } from '../translation/translation.config';
 import { EmailNotificationService } from '../email-notification/email-notification.service';
@@ -669,10 +669,8 @@ export class RecruitmentService {
       where: {
         ...where,
         role: 'EDUCATOR',
-        // Exclude suspended / inactive educators from the candidate pool.
-        // Use { not: false } so legacy rows with null isActive are treated
-        // as active, consistent with the rest of the codebase.
         isActive: { not: false },
+        approvalStatus: EducatorApprovalStatus.APPROVED,
       },
       include: {
         avatarAsset: true,
@@ -742,6 +740,7 @@ export class RecruitmentService {
         role: 'EDUCATOR',
         isActive: { not: false },
         candidatePoolVisible: true,
+        approvalStatus: EducatorApprovalStatus.APPROVED,
       },
       include: {
         workExperienceItems: { orderBy: { sortOrder: 'asc' } },
@@ -850,7 +849,7 @@ export class RecruitmentService {
       : [];
     if (!ids.length) return [];
     return this.prisma.user.findMany({
-      where: { id: { in: ids }, role: 'EDUCATOR' },
+      where: { id: { in: ids }, role: 'EDUCATOR', approvalStatus: EducatorApprovalStatus.APPROVED },
       include: { avatarAsset: true },
       orderBy: { createdAt: 'desc' },
     });

--- a/api/src/replacements/replacements.service.ts
+++ b/api/src/replacements/replacements.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../prisma/prisma.service';
-import { NotificationType, ReplacementMatchStatus, ReplacementRequestStatus, UrgencyLevel, UserRole } from '@prisma/client';
+import { EducatorApprovalStatus, NotificationType, ReplacementMatchStatus, ReplacementRequestStatus, UrgencyLevel, UserRole } from '@prisma/client';
 import { CreateReplacementRequestDto } from './dto/create-replacement-request.dto';
 import { UpdateReplacementRequestDto } from './dto/update-replacement-request.dto';
 import { RespondMatchDto } from './dto/respond-match.dto';
@@ -366,6 +366,7 @@ export class ReplacementsService {
         availableForReplacement: true,
         candidatePoolVisible: true,
         isActive: true,
+        approvalStatus: EducatorApprovalStatus.APPROVED,
         ...(filters?.region ? { region: filters.region } : {}),
         ...roleFilter,
       },

--- a/api/src/settings/settings.controller.ts
+++ b/api/src/settings/settings.controller.ts
@@ -612,28 +612,35 @@ export class SettingsController {
 
     if (isFirstSubmission && recipientEmail) {
       const appUrl = this.configService.get<string>('APP_URL') || this.configService.get<string>('FRONTEND_URL') || '';
-      this.emailNotificationService.sendNotification({
-        event: 'educator_pending',
-        recipient: recipientEmail,
-        recipientName: recipientName ?? undefined,
-        payload: {
-          firstName: recipientName || 'Educator',
-          supportUrl: appUrl ? `${appUrl}/support` : '',
-        },
-        bypassPreferences: true,
-        allowUnknownRecipient: false,
+
+      // educator_pending email — gated by v2_staffing_emails (defaults enabled when flag absent)
+      this.isFeatureEnabled('v2_staffing_emails').then(async (enabled) => {
+        if (!enabled) return;
+        await this.emailNotificationService.sendNotification({
+          event: 'educator_pending',
+          recipient: recipientEmail,
+          recipientName: recipientName ?? undefined,
+          payload: {
+            firstName: recipientName || 'Educator',
+            supportUrl: appUrl ? `${appUrl}/support` : '',
+          },
+          bypassPreferences: true,
+          allowUnknownRecipient: false,
+        });
       }).catch((err: any) => {
         this.logger.warn(`Educator pending email failed: ${(err as Error)?.message || err}`);
       });
 
-      // Notify all admin users that a new educator application was received (Step 11)
-      this.prisma.user.findMany({
-        where: {
-          role: { in: [PrismaUserRole.ADMIN, PrismaUserRole.SUPER_ADMIN] },
-          isActive: { not: false },
-        },
-        select: { id: true },
-      }).then(async (admins) => {
+      // Admin in-app notifications — gated by v2_in_app_notifications
+      this.isFeatureEnabled('v2_in_app_notifications').then(async (enabled) => {
+        if (!enabled) return;
+        const admins = await this.prisma.user.findMany({
+          where: {
+            role: { in: [PrismaUserRole.ADMIN, PrismaUserRole.SUPER_ADMIN] },
+            isActive: { not: false },
+          },
+          select: { id: true },
+        });
         const educatorName = [recipientName, existingCv?.firstName].find(Boolean) || 'An educator';
         const adminLink = appUrl ? `${appUrl}/admin/content-dashboard` : '/admin/content-dashboard';
         for (const admin of admins) {

--- a/api/src/settings/settings.controller.ts
+++ b/api/src/settings/settings.controller.ts
@@ -9,8 +9,9 @@ import {
   BadRequestException,
   UseGuards,
   UseInterceptors,
+  Logger,
 } from '@nestjs/common';
-import { AssetKind, EducatorApprovalStatus } from '@prisma/client';
+import { AssetKind, EducatorApprovalStatus, NotificationType, UserRole as PrismaUserRole } from '@prisma/client';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { UserRole } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
@@ -47,6 +48,8 @@ import { ConfigService } from '@nestjs/config';
 @UseInterceptors(EnsureProfileInterceptor)
 @ApiBearerAuth()
 export class SettingsController {
+  private readonly logger = new Logger(SettingsController.name);
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly principal: PrincipalService,
@@ -594,34 +597,59 @@ export class SettingsController {
     }
 
     // Send "application received" email the first time an educator submits their profile.
-    // Condition: previously had no shortBio (blank profile) and is now submitting one,
-    // and their account is still PENDING_REVIEW (not yet reviewed by admin).
+    // Fires when: profile was blank (no shortBio) and is now being filled in,
+    // AND the educator has not yet been approved or rejected.
     // This covers the email/password signup path; OAuth educators get it via completeProfile.
     const isFirstSubmission =
       !existingCv?.shortBio?.trim() &&
       settings.shortBio?.trim() &&
-      existingCv?.approvalStatus === EducatorApprovalStatus.PENDING_REVIEW;
+      existingCv?.approvalStatus !== EducatorApprovalStatus.APPROVED &&
+      existingCv?.approvalStatus !== EducatorApprovalStatus.REJECTED;
 
     // Use settings values (post-update) for name/email, falling back to pre-update snapshot.
     const recipientEmail = settings.email ?? existingCv?.email;
     const recipientName = settings.firstName ?? existingCv?.firstName;
 
     if (isFirstSubmission && recipientEmail) {
-      this.isFeatureEnabled('v2_staffing_emails').then(enabled => {
-        if (!enabled) return;
-        const appUrl = this.configService.get<string>('APP_URL') || this.configService.get<string>('FRONTEND_URL') || '';
-        return this.emailNotificationService.sendNotification({
-          event: 'educator_pending',
-          recipient: recipientEmail,
-          recipientName: recipientName ?? undefined,
-          payload: {
-            firstName: recipientName || 'Educator',
-            supportUrl: appUrl ? `${appUrl}/support` : '',
-          },
-          bypassPreferences: true,
-          allowUnknownRecipient: false,
-        });
-      }).catch(() => {});
+      const appUrl = this.configService.get<string>('APP_URL') || this.configService.get<string>('FRONTEND_URL') || '';
+      this.emailNotificationService.sendNotification({
+        event: 'educator_pending',
+        recipient: recipientEmail,
+        recipientName: recipientName ?? undefined,
+        payload: {
+          firstName: recipientName || 'Educator',
+          supportUrl: appUrl ? `${appUrl}/support` : '',
+        },
+        bypassPreferences: true,
+        allowUnknownRecipient: false,
+      }).catch((err: any) => {
+        this.logger.warn(`Educator pending email failed: ${(err as Error)?.message || err}`);
+      });
+
+      // Notify all admin users that a new educator application was received (Step 11)
+      this.prisma.user.findMany({
+        where: {
+          role: { in: [PrismaUserRole.ADMIN, PrismaUserRole.SUPER_ADMIN] },
+          isActive: { not: false },
+        },
+        select: { id: true },
+      }).then(async (admins) => {
+        const educatorName = [recipientName, existingCv?.firstName].find(Boolean) || 'An educator';
+        const adminLink = appUrl ? `${appUrl}/admin/content-dashboard` : '/admin/content-dashboard';
+        for (const admin of admins) {
+          await this.prisma.notification.create({
+            data: {
+              userId: admin.id,
+              type: NotificationType.GENERAL,
+              title: 'New Educator Application',
+              body: `${educatorName} has submitted their profile and is awaiting approval.`,
+              link: adminLink,
+            },
+          }).catch(() => {});
+        }
+      }).catch((err: any) => {
+        this.logger.warn(`Admin notification for educator signup failed: ${(err as Error)?.message || err}`);
+      });
     }
 
     return {

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -711,12 +711,37 @@ export class UsersService {
           recipientName: firstName || undefined,
           payload: {
             firstName: firstName || 'Educator',
-            supportUrl: `${appUrl}/support`,
+            supportUrl: appUrl ? `${appUrl}/support` : '',
           },
           bypassPreferences: true,
           allowUnknownRecipient: false,
         }).catch((err: any) => {
           this.logger.warn(`Educator pending email failed: ${err?.message || err}`);
+        });
+
+        // Notify all admin users that a new educator profile was submitted
+        const adminLink = appUrl ? `${appUrl}/admin/content-dashboard` : '/admin/content-dashboard';
+        this.prisma.user.findMany({
+          where: {
+            role: { in: [UserRole.ADMIN, UserRole.SUPER_ADMIN] },
+            isActive: { not: false },
+          },
+          select: { id: true },
+        }).then(async (admins) => {
+          const educatorName = firstName || email || 'An educator';
+          for (const admin of admins) {
+            await this.prisma.notification.create({
+              data: {
+                userId: admin.id,
+                type: 'GENERAL' as any,
+                title: 'New Educator Application',
+                body: `${educatorName} has submitted their profile and is awaiting approval.`,
+                link: adminLink,
+              },
+            }).catch(() => {});
+          }
+        }).catch((err: any) => {
+          this.logger.warn(`Admin notification for educator signup failed: ${err?.message || err}`);
         });
       }
     }

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -705,29 +705,36 @@ export class UsersService {
       // user row is visible to EmailNotificationService.findUnique({ email }).
       if (dto.role === UserRole.EDUCATOR) {
         const appUrl = this.configService.get<string>('APP_URL') || this.configService.get<string>('FRONTEND_URL') || '';
-        this.emailNotificationService.sendNotification({
-          event: 'educator_pending',
-          recipient: email,
-          recipientName: firstName || undefined,
-          payload: {
-            firstName: firstName || 'Educator',
-            supportUrl: appUrl ? `${appUrl}/support` : '',
-          },
-          bypassPreferences: true,
-          allowUnknownRecipient: false,
+
+        // educator_pending email — gated by v2_staffing_emails (defaults enabled when flag absent)
+        this.prisma.featureFlag.findUnique({ where: { key: 'v2_staffing_emails' } }).then(async (flag) => {
+          if (flag && !flag.isActive) return;
+          await this.emailNotificationService.sendNotification({
+            event: 'educator_pending',
+            recipient: email,
+            recipientName: firstName || undefined,
+            payload: {
+              firstName: firstName || 'Educator',
+              supportUrl: appUrl ? `${appUrl}/support` : '',
+            },
+            bypassPreferences: true,
+            allowUnknownRecipient: false,
+          });
         }).catch((err: any) => {
           this.logger.warn(`Educator pending email failed: ${err?.message || err}`);
         });
 
-        // Notify all admin users that a new educator profile was submitted
+        // Admin in-app notifications — gated by v2_in_app_notifications
         const adminLink = appUrl ? `${appUrl}/admin/content-dashboard` : '/admin/content-dashboard';
-        this.prisma.user.findMany({
-          where: {
-            role: { in: [UserRole.ADMIN, UserRole.SUPER_ADMIN] },
-            isActive: { not: false },
-          },
-          select: { id: true },
-        }).then(async (admins) => {
+        this.prisma.featureFlag.findUnique({ where: { key: 'v2_in_app_notifications' } }).then(async (flag) => {
+          if (flag && !flag.isActive) return;
+          const admins = await this.prisma.user.findMany({
+            where: {
+              role: { in: [UserRole.ADMIN, UserRole.SUPER_ADMIN] },
+              isActive: { not: false },
+            },
+            select: { id: true },
+          });
           const educatorName = firstName || email || 'An educator';
           for (const admin of admins) {
             await this.prisma.notification.create({

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -159,7 +159,7 @@ const SubscriptionGatedRoute: React.FC<{
 
 const RoleBasedDashboardRedirect: React.FC = () => {
   const { currentUser } = useAppContext();
-  if (!currentUser) return <Navigate to="/login" replace />; // Default to login for non-logged-in
+  if (!currentUser) return <Navigate to="/login" replace />;
 
   switch (currentUser.role) {
     case UserRole.PRODUCT_SUPPLIER:
@@ -168,15 +168,19 @@ const RoleBasedDashboardRedirect: React.FC = () => {
       return <Navigate to="/service-provider/dashboard" replace />;
     case UserRole.FOUNDATION:
       return <Navigate to="/foundation/dashboard" replace />;
-    case UserRole.EDUCATOR:
+    case UserRole.EDUCATOR: {
+      const approvalStatus = (currentUser as any).approvalStatus;
+      if (approvalStatus === 'REJECTED') return <Navigate to="/educator/rejected" replace />;
+      if (approvalStatus !== 'APPROVED') return <Navigate to="/educator/pending-approval" replace />;
       return <Navigate to="/educator/dashboard" replace />;
+    }
     case UserRole.PARENT:
-      return <Navigate to="/parent/dashboard" replace />; // Updated Parent redirect
+      return <Navigate to="/parent/dashboard" replace />;
     case UserRole.ADMIN:
     case UserRole.SUPER_ADMIN:
       return <Navigate to="/admin/content-dashboard" replace />;
     default:
-      return <Navigate to="/login" replace />; // Fallback to login
+      return <Navigate to="/login" replace />;
   }
 };
 
@@ -557,7 +561,13 @@ const ProtectedLayout: React.FC = () => {
           <ProtectedRoute roles={[UserRole.FOUNDATION]}><FoundationSupportPage /></ProtectedRoute>
         } />
 
-        {/* Educator Routes — EducatorApprovalGate overlays gated content until approved */}
+        {/* Educator Routes */}
+        <Route path="/educator/pending-approval" element={
+          <ProtectedRoute roles={[UserRole.EDUCATOR]}><EducatorPendingApprovalPage /></ProtectedRoute>
+        } />
+        <Route path="/educator/rejected" element={
+          <ProtectedRoute roles={[UserRole.EDUCATOR]}><EducatorRejectedPage /></ProtectedRoute>
+        } />
         <Route path="/educator/dashboard" element={
           <ProtectedRoute roles={[UserRole.EDUCATOR]}>
             <EducatorApprovalGate><EducatorDashboardPage /></EducatorApprovalGate>

--- a/frontend/components/educator/EducatorApprovalGate.tsx
+++ b/frontend/components/educator/EducatorApprovalGate.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
-import { ClockIcon, XCircleIcon, EnvelopeIcon } from '@heroicons/react/24/outline';
-import { useClerk } from '@clerk/clerk-react';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAppContext } from '../../contexts/AppContext';
 import { EducatorApprovalStatus } from '../../types';
 
+// Routes the educator can always access regardless of approval status
 const ALWAYS_ALLOWED = [
   '/educator/profile',
   '/educator/support',
+  '/educator/pending-approval',
+  '/educator/rejected',
   '/settings',
   '/profile',
   '/support',
@@ -16,90 +17,27 @@ const ALWAYS_ALLOWED = [
 
 const EducatorApprovalGate: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { currentUser } = useAppContext();
-  const { signOut } = useClerk();
   const location = useLocation();
 
-  const status = currentUser?.approvalStatus;
+  const status = (currentUser as any)?.approvalStatus as EducatorApprovalStatus | null | undefined;
 
   const isAllowed = ALWAYS_ALLOWED.some(
     (route) => location.pathname === route || location.pathname.startsWith(route + '/'),
   );
 
-  if (!status || status === EducatorApprovalStatus.APPROVED || isAllowed) {
+  if (isAllowed) {
     return <>{children}</>;
   }
 
-  const isPending = status === EducatorApprovalStatus.PENDING_REVIEW;
+  if (status === EducatorApprovalStatus.REJECTED) {
+    return <Navigate to="/educator/rejected" replace />;
+  }
 
-  return (
-    <div className="relative">
-      {/* Blurred background — dashboard still renders but is inaccessible */}
-      <div className="pointer-events-none select-none blur-sm opacity-40" aria-hidden="true">
-        {children}
-      </div>
+  if (status !== EducatorApprovalStatus.APPROVED) {
+    return <Navigate to="/educator/pending-approval" replace />;
+  }
 
-      {/* Overlay */}
-      <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/30">
-        <div className="max-w-lg w-full bg-white rounded-2xl shadow-xl p-8 text-center">
-          <div className="flex justify-center mb-6">
-            <div className={`w-20 h-20 rounded-full flex items-center justify-center ${isPending ? 'bg-amber-100' : 'bg-red-100'}`}>
-              {isPending
-                ? <ClockIcon className="w-10 h-10 text-amber-500" />
-                : <XCircleIcon className="w-10 h-10 text-red-500" />}
-            </div>
-          </div>
-
-          {isPending ? (
-            <>
-              <h1 className="text-2xl font-bold text-gray-900 mb-3">Application Under Review</h1>
-              <p className="text-gray-600 mb-6">
-                Your application has been submitted and is currently being reviewed by our team.
-                You will be notified by email once your application has been approved.
-              </p>
-              <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-8 text-left space-y-2">
-                <p className="text-sm font-medium text-amber-800">What happens next?</p>
-                <ul className="text-sm text-amber-700 space-y-1 list-disc list-inside">
-                  <li>Our team reviews your submitted profile</li>
-                  <li>You receive an approval or feedback email</li>
-                  <li>Once approved, you get full access to the platform</li>
-                </ul>
-              </div>
-            </>
-          ) : (
-            <>
-              <h1 className="text-2xl font-bold text-gray-900 mb-3">Application Not Approved</h1>
-              <p className="text-gray-600 mb-6">
-                Unfortunately, your educator application was not approved at this time.
-                Please review the reason below and contact our support team if you have questions.
-              </p>
-              {currentUser?.approvalNotes && (
-                <div className="bg-red-50 border border-red-200 rounded-xl p-4 mb-6 text-left">
-                  <p className="text-sm font-medium text-red-800 mb-1">Reason provided by our team:</p>
-                  <p className="text-sm text-red-700">{currentUser.approvalNotes}</p>
-                </div>
-              )}
-            </>
-          )}
-
-          <div className="border-t border-gray-100 pt-6 flex flex-col sm:flex-row gap-3 justify-center">
-            <a
-              href="mailto:support@procreche.ch"
-              className="inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors"
-            >
-              <EnvelopeIcon className="w-4 h-4" />
-              Contact Support
-            </a>
-            <button
-              onClick={() => signOut().catch((err) => console.error('Sign out failed:', err))}
-              className="px-5 py-2.5 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors"
-            >
-              Sign Out
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+  return <>{children}</>;
 };
 
 export default EducatorApprovalGate;


### PR DESCRIPTION
…tifications

- principal.service: set approvalStatus=PENDING_REVIEW on new EDUCATOR rows; backfill existing educators with null approvalStatus
- App.tsx: redirect PENDING_REVIEW educators to /educator/pending-approval, REJECTED to /educator/rejected; restore dedicated approval pages
- EducatorApprovalGate: replace modal overlay with redirect guard so educators land on the correct dedicated page instead of a blurred modal
- settings.controller: remove v2_staffing_emails gate from educator_pending email; loosen isFirstSubmission condition to cover null approvalStatus; notify all admin users in-app when educator submits profile for the first time
- users.service: mirror admin in-app notification for OAuth educator signup path
- recruitment.service, compat.controller, replacements.service: filter unapproved educators (approvalStatus != APPROVED) from all platform-facing candidate/educator queries to prevent premature visibility

https://claude.ai/code/session_01DaYVpwHu4NwMJbDnPKFoWz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented educator approval workflow; educators default to pending status upon registration
  * Only approved educators appear in recruitment searches and candidate pools
  * Administrators receive notifications when educators submit applications
  * Educators are routed to status-specific pages based on approval status (pending approval, rejected, or approved)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/One-S-Digital/PC-Solutions-Platform/pull/637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->