### PR TITLE
Add educator approval status filter & transport config diagnostics

### DIFF
--- a/admin/src/components/mailing/MailingFilterPanel.tsx
+++ b/admin/src/components/mailing/MailingFilterPanel.tsx
@@ -58,7 +58,12 @@ const MailingFilterPanel: React.FC<Props> = ({ filters, onChange }) => {
   const toggleRole = (role: string) => {
     const current = filters.roles || []
     const next = current.includes(role) ? current.filter((r) => r !== role) : [...current, role]
-    update({ roles: next.length > 0 ? next : undefined })
+    const patch: Partial<MailingFilters> = { roles: next.length > 0 ? next : undefined }
+    // Clear educator-specific filters when EDUCATOR is no longer in the active role set
+    if (role === 'EDUCATOR' && !next.includes('EDUCATOR')) {
+      patch.educatorApprovalStatuses = undefined
+    }
+    update(patch)
   }
 
   const activeFilterCount = Object.entries(filters).filter(

--- a/admin/src/components/mailing/MailingFilterPanel.tsx
+++ b/admin/src/components/mailing/MailingFilterPanel.tsx
@@ -15,6 +15,12 @@ const SUBSCRIPTION_STATUSES = [
   'ACTIVE', 'TRIAL', 'PAST_DUE', 'EXPIRED', 'CANCELLED', 'PAUSED', 'PENDING', 'GRACE_PERIOD',
 ]
 
+const EDUCATOR_APPROVAL_STATUSES = [
+  { value: 'PENDING_REVIEW', label: 'Pending Review' },
+  { value: 'APPROVED', label: 'Approved' },
+  { value: 'REJECTED', label: 'Rejected' },
+]
+
 const SUBSCRIPTION_TIERS = ['BASIC', 'ESSENTIAL', 'PROFESSIONAL', 'ENTERPRISE']
 
 interface Props {
@@ -159,6 +165,52 @@ const MailingFilterPanel: React.FC<Props> = ({ filters, onChange }) => {
           ))}
         </div>
       </Section>
+
+      {/* Show educator approval filter only when EDUCATOR role is selected, or no role filter is set */}
+      {(!filters.roles?.length || filters.roles.includes('EDUCATOR')) && (
+        <Section title={t('admin:mailing.filters.educatorApproval', 'Educator Approval Status')} defaultOpen={filters.educatorApprovalStatuses !== undefined}>
+          <p className="text-xs text-gray-500 mb-2">
+            {t('admin:mailing.filters.educatorApprovalDesc', 'Filter by profile approval status (applies to Educator accounts only)')}
+          </p>
+          <div className="space-y-1.5">
+            {EDUCATOR_APPROVAL_STATUSES.map((status) => (
+              <label key={status.value} className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={filters.educatorApprovalStatuses?.includes(status.value) || false}
+                  onChange={() => {
+                    const current = filters.educatorApprovalStatuses || []
+                    const next = current.includes(status.value)
+                      ? current.filter((s) => s !== status.value)
+                      : [...current, status.value]
+                    update({ educatorApprovalStatuses: next.length > 0 ? next : undefined })
+                  }}
+                  className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                <span
+                  className={`inline-flex items-center gap-1 ${
+                    status.value === 'APPROVED'
+                      ? 'text-green-700'
+                      : status.value === 'REJECTED'
+                        ? 'text-red-700'
+                        : 'text-amber-700'
+                  }`}
+                >
+                  {status.label}
+                </span>
+              </label>
+            ))}
+          </div>
+          {filters.educatorApprovalStatuses?.length ? (
+            <button
+              onClick={() => update({ educatorApprovalStatuses: undefined })}
+              className="mt-1 text-xs text-gray-400 hover:text-gray-600"
+            >
+              {t('admin:mailing.filters.clearSelection', 'Clear selection')}
+            </button>
+          ) : null}
+        </Section>
+      )}
 
       <Section title="Account Status">
         <div className="space-y-1.5">

--- a/admin/src/pages/MailingList.tsx
+++ b/admin/src/pages/MailingList.tsx
@@ -144,6 +144,27 @@ const MailingListPage: React.FC = () => {
     retry: noRetryOnClientError,
   })
 
+  // Transport status — loaded once on mount so we can show a config warning
+  const { data: transportStatus } = useQuery({
+    queryKey: ['mailing-transport-status'],
+    queryFn: async () => {
+      const res = await apiService.mailingTransportStatus(apiClient)
+      return res.data as {
+        configured: boolean
+        activeProvider: string | null
+        providers: {
+          mailgun: { configured: boolean; present: Record<string, boolean> }
+          smtp: { configured: boolean; present: Record<string, boolean> }
+          sendgrid: { configured: boolean; present: Record<string, boolean> }
+        }
+        fromEmail: string | null
+        fromName: string | null
+      }
+    },
+    staleTime: 60_000,
+    retry: false,
+  })
+
   // Custom Lists query
   const { data: customListsData, isLoading: customListsLoading } = useQuery({
     queryKey: ['mailing-custom-lists'],
@@ -328,6 +349,47 @@ const MailingListPage: React.FC = () => {
           </div>
         </div>
       </div>
+
+      {/* Transport not configured warning */}
+      {transportStatus && !transportStatus.configured && (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 p-4">
+          <div className="flex items-start gap-3">
+            <Mail className="w-5 h-5 text-amber-600 shrink-0 mt-0.5" />
+            <div className="flex-1">
+              <p className="text-sm font-semibold text-amber-800">Email transport not configured — newsletters cannot be sent</p>
+              <p className="text-xs text-amber-700 mt-1">
+                Set one of the following in your server environment, then redeploy:
+              </p>
+              <ul className="text-xs text-amber-700 mt-1 list-disc list-inside space-y-0.5">
+                {!transportStatus.providers.mailgun.configured && (
+                  <li>
+                    Mailgun: <code className="bg-amber-100 px-1 rounded">MAILGUN_API_KEY</code> +{' '}
+                    <code className="bg-amber-100 px-1 rounded">MAILGUN_DOMAIN</code>
+                    {transportStatus.providers.mailgun.present.MAILGUN_API_KEY && !transportStatus.providers.mailgun.present.MAILGUN_DOMAIN && (
+                      <span className="ml-1 text-amber-600">(API key found — only MAILGUN_DOMAIN is missing)</span>
+                    )}
+                    {!transportStatus.providers.mailgun.present.MAILGUN_API_KEY && transportStatus.providers.mailgun.present.MAILGUN_DOMAIN && (
+                      <span className="ml-1 text-amber-600">(domain found — only MAILGUN_API_KEY is missing)</span>
+                    )}
+                  </li>
+                )}
+                {!transportStatus.providers.smtp.configured && (
+                  <li>
+                    SMTP: <code className="bg-amber-100 px-1 rounded">MAILING_SMTP_HOST</code> +{' '}
+                    <code className="bg-amber-100 px-1 rounded">MAILING_SMTP_USER</code> +{' '}
+                    <code className="bg-amber-100 px-1 rounded">MAILING_SMTP_PASS</code>
+                  </li>
+                )}
+                {!transportStatus.providers.sendgrid.configured && (
+                  <li>
+                    SendGrid: <code className="bg-amber-100 px-1 rounded">SENDGRID_API_KEY</code>
+                  </li>
+                )}
+              </ul>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Tabs */}
       <div className="border-b border-gray-200">

--- a/admin/src/services/api.ts
+++ b/admin/src/services/api.ts
@@ -1128,6 +1128,9 @@ export const apiService = {
   // Mailing List
   // ========================
 
+  mailingTransportStatus: (apiClient: AxiosInstance) =>
+    apiClient.get('/admin/mailing/transport-status'),
+
   mailingPreview: (apiClient: AxiosInstance, data: {
     filters: any;
     page?: number;

--- a/admin/src/types/api.ts
+++ b/admin/src/types/api.ts
@@ -573,6 +573,7 @@ export interface MailingFilters {
   createdTo?: string;
   lastActiveFrom?: string;
   lastActiveTo?: string;
+  educatorApprovalStatuses?: string[];
   search?: string;
 }
 

--- a/api/src/mailing/dto/mailing-filters.dto.ts
+++ b/api/src/mailing/dto/mailing-filters.dto.ts
@@ -1,5 +1,5 @@
 import { IsOptional, IsArray, IsBoolean, IsString, IsEnum, ArrayMaxSize } from 'class-validator';
-import { UserRole, SubscriptionStatus, SubscriptionTier } from '@prisma/client';
+import { UserRole, SubscriptionStatus, SubscriptionTier, EducatorApprovalStatus } from '@prisma/client';
 
 export class MailingFiltersDto {
   @IsOptional()
@@ -81,6 +81,11 @@ export class MailingFiltersDto {
   @IsOptional()
   @IsString()
   lastActiveTo?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsEnum(EducatorApprovalStatus, { each: true })
+  educatorApprovalStatuses?: EducatorApprovalStatus[];
 
   @IsOptional()
   @IsString()

--- a/api/src/mailing/mailing.controller.ts
+++ b/api/src/mailing/mailing.controller.ts
@@ -58,6 +58,12 @@ export class MailingController {
     return { status: 'ok', module: 'mailing', timestamp: new Date().toISOString() };
   }
 
+  @Get('transport-status')
+  @ApiOperation({ summary: 'Check email transport configuration (admin only)' })
+  async transportStatus() {
+    return this.mailingService.getTransportStatus();
+  }
+
   /* ================================================================ */
   /*  PREVIEW                                                          */
   /* ================================================================ */

--- a/api/src/mailing/mailing.service.ts
+++ b/api/src/mailing/mailing.service.ts
@@ -544,12 +544,6 @@ export class MailingService {
     filters?: MailingFiltersDto,
     segmentId?: string,
   ) {
-    if (!this.transport.isConfigured()) {
-      throw new BadRequestException(
-        'No email transport configured. Set MAILING_SMTP_HOST, MAILGUN_API_KEY, or SENDGRID_API_KEY.',
-      );
-    }
-
     let resolvedFilters = filters;
 
     // If segmentId is provided, load its filters
@@ -686,7 +680,9 @@ export class MailingService {
     }
 
     if (!this.transport.isConfigured()) {
-      throw new BadRequestException('No email transport configured');
+      throw new BadRequestException(
+        'No email transport configured. Set MAILGUN_API_KEY + MAILGUN_DOMAIN, MAILING_SMTP_HOST + MAILING_SMTP_USER + MAILING_SMTP_PASS, or SENDGRID_API_KEY in your environment.',
+      );
     }
 
     // Resolve filters from the campaign itself or from the associated segment
@@ -936,6 +932,55 @@ export class MailingService {
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&#39;');
+  }
+
+  /** Returns current transport configuration status for admin diagnostics. */
+  getTransportStatus() {
+    const configured = this.transport.isConfigured();
+    const provider = this.transport.getProviderName();
+
+    const vars = {
+      smtp: {
+        configured: !!(
+          process.env.MAILING_SMTP_HOST &&
+          process.env.MAILING_SMTP_USER &&
+          process.env.MAILING_SMTP_PASS
+        ),
+        vars: ['MAILING_SMTP_HOST', 'MAILING_SMTP_USER', 'MAILING_SMTP_PASS'],
+        present: {
+          MAILING_SMTP_HOST: !!process.env.MAILING_SMTP_HOST,
+          MAILING_SMTP_USER: !!process.env.MAILING_SMTP_USER,
+          MAILING_SMTP_PASS: !!process.env.MAILING_SMTP_PASS,
+        },
+      },
+      mailgun: {
+        configured: !!(process.env.MAILGUN_API_KEY && process.env.MAILGUN_DOMAIN),
+        vars: ['MAILGUN_API_KEY', 'MAILGUN_DOMAIN'],
+        present: {
+          MAILGUN_API_KEY: !!process.env.MAILGUN_API_KEY,
+          MAILGUN_DOMAIN: !!process.env.MAILGUN_DOMAIN,
+        },
+      },
+      sendgrid: {
+        configured: !!process.env.SENDGRID_API_KEY,
+        vars: ['SENDGRID_API_KEY'],
+        present: {
+          SENDGRID_API_KEY: !!process.env.SENDGRID_API_KEY,
+        },
+      },
+    };
+
+    return {
+      configured,
+      activeProvider: configured ? provider : null,
+      providers: vars,
+      fromEmail:
+        process.env.MAILING_FROM_EMAIL ||
+        process.env.MAILING_SMTP_USER ||
+        process.env.FROM_EMAIL ||
+        null,
+      fromName: process.env.MAILING_FROM_NAME || process.env.FROM_NAME || null,
+    };
   }
 
   /** Resolve filters: either from a segment or from the provided filters directly. */

--- a/api/src/mailing/mailing.service.ts
+++ b/api/src/mailing/mailing.service.ts
@@ -114,9 +114,14 @@ export class MailingService {
     }
 
     // C2) Educator approval status ---------------------------------
+    // Scoped to EDUCATOR role only: non-educator users in a mixed audience
+    // are not filtered out because they have no approvalStatus at all.
     if (filters.educatorApprovalStatuses?.length) {
       andConditions.push({
-        approvalStatus: { in: filters.educatorApprovalStatuses },
+        OR: [
+          { role: { not: UserRole.EDUCATOR } },
+          { approvalStatus: { in: filters.educatorApprovalStatuses } },
+        ],
       });
     }
 

--- a/api/src/mailing/mailing.service.ts
+++ b/api/src/mailing/mailing.service.ts
@@ -113,6 +113,13 @@ export class MailingService {
       }
     }
 
+    // C2) Educator approval status ---------------------------------
+    if (filters.educatorApprovalStatuses?.length) {
+      andConditions.push({
+        approvalStatus: { in: filters.educatorApprovalStatuses },
+      });
+    }
+
     // D) Location & language (via Organization) ------------------
     const orgWhere: Prisma.OrganizationWhereInput = {};
     if (filters.cantons?.length) {


### PR DESCRIPTION
## Summary
Adds support for filtering mailing campaigns by educator profile approval status, and introduces a new admin diagnostic endpoint to check email transport configuration status with detailed environment variable reporting.

## Key Changes

**Mailing Service & Filters:**
- Added `educatorApprovalStatuses` filter field to `MailingFiltersDto` with enum validation against `EducatorApprovalStatus` from Prisma
- Implemented filter logic in `MailingService.getRecipients()` to apply educator approval status conditions to query
- Moved transport configuration validation from `sendCampaign()` to `sendCampaignEmails()` to allow preview operations without email setup
- Enhanced error message to list all three supported transport providers (Mailgun, SMTP, SendGrid) with required env vars

**New Diagnostic Endpoint:**
- Added `getTransportStatus()` method to `MailingService` that returns:
  - Overall `configured` status and active provider name
  - Per-provider configuration state (Mailgun, SMTP, SendGrid) with individual env var presence flags
  - Resolved `fromEmail` and `fromName` with fallback chain
- Exposed via new `GET /admin/mailing/transport-status` controller endpoint

**Admin UI:**
- Added educator approval status filter section to `MailingFilterPanel` (conditionally shown when EDUCATOR role is selected or no role filter applied)
- Displays three approval statuses (Pending Review, Approved, Rejected) with color-coded labels
- Added transport configuration warning banner to `MailingListPage` that:
  - Shows when transport is not configured
  - Lists missing provider credentials with specific env var names
  - Highlights partial configurations (e.g., "API key found — only MAILGUN_DOMAIN is missing")
  - Uses amber styling to indicate non-blocking warning state

**API Integration:**
- Added `mailingTransportStatus()` call to `admin/src/services/api.ts`
- Updated `MailingFilters` interface to include `educatorApprovalStatuses` field

## Implementation Details
- Filter is only applied when educator approval statuses are explicitly selected (no default filtering)
- Transport status endpoint is read-only and safe for admin diagnostics — does not expose actual credential values, only presence flags
- Educator approval filter respects role-based visibility: only shown when filtering by EDUCATOR role or when no role filter is active
- Uses existing Prisma `EducatorApprovalStatus` enum for type safety

https://claude.ai/code/session_01RXZC2hiiqAfTAVAZdGxnK3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added educator approval status filtering to the mailing list, allowing selection of multiple statuses via checkboxes with a quick "Clear selection" option.
  * Implemented email transport configuration status checking with inline warnings displaying missing configuration details and relevant environment variables.
  * Enhanced error messaging for email transport configuration issues, providing specific guidance per provider.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/One-S-Digital/PC-Solutions-Platform/pull/638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->