### PR TITLE
Add email notifications for new messages in conversations

### DIFF
--- a/api/src/messaging/messaging.module.ts
+++ b/api/src/messaging/messaging.module.ts
@@ -4,9 +4,10 @@ import { AuthModule } from '../auth/auth.module';
 import { MessagingController } from './messaging.controller';
 import { MessagingService } from './messaging.service';
 import { MessagingGateway } from './messaging.gateway';
+import { EmailNotificationModule } from '../email-notification/email-notification.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule],
+  imports: [PrismaModule, AuthModule, EmailNotificationModule],
   controllers: [MessagingController],
   providers: [MessagingService, MessagingGateway],
   exports: [MessagingService, MessagingGateway],

--- a/api/src/messaging/messaging.service.ts
+++ b/api/src/messaging/messaging.service.ts
@@ -5,6 +5,7 @@ import { CreateConversationDto } from './dto/create-conversation.dto';
 import { MessageType } from '@workspace/types';
 import { MessagingGateway } from './messaging.gateway';
 import { UserRole } from '@prisma/client';
+import { EmailNotificationService } from '../email-notification/email-notification.service';
 
 @Injectable()
 export class MessagingService {
@@ -103,6 +104,7 @@ export class MessagingService {
   constructor(
     private prisma: PrismaService,
     @Optional() @Inject(MessagingGateway) private messagingGateway?: MessagingGateway,
+    @Optional() private emailNotificationService?: EmailNotificationService,
   ) {}
 
   /**
@@ -187,9 +189,10 @@ export class MessagingService {
         ];
       
       case UserRole.FOUNDATION:
-        // Foundation can message: FOUNDATION, PRODUCT_SUPPLIER, SERVICE_PROVIDER, ADMIN
+        // Foundation can message: FOUNDATION, EDUCATOR, PRODUCT_SUPPLIER, SERVICE_PROVIDER, ADMIN
         return [
           UserRole.FOUNDATION,
+          UserRole.EDUCATOR,
           UserRole.PRODUCT_SUPPLIER,
           UserRole.SERVICE_PROVIDER,
           UserRole.ADMIN,
@@ -924,7 +927,38 @@ export class MessagingService {
       if (message.conversationId && this.messagingGateway) {
         this.messagingGateway.broadcastNewMessage(message.conversationId, transformedMessage);
       }
-      
+
+      // Send email notifications to other conversation participants
+      if (this.emailNotificationService) {
+        const senderName = message.sender
+          ? `${message.sender.firstName || ''} ${message.sender.lastName || ''}`.trim() || message.sender.email
+          : 'Someone';
+        const messagePreview = finalMessageType === 'TEXT'
+          ? (trimmedContent.length > 200 ? trimmedContent.substring(0, 200) + '...' : trimmedContent)
+          : `[${finalMessageType.toLowerCase()} attachment]`;
+        const frontendUrl = process.env.FRONTEND_URL || process.env.APP_URL || 'https://app.procrechesolutions.com';
+        const messageUrl = `${frontendUrl}/messages/${conversationId}`;
+
+        const otherParticipants = message.conversation?.participants?.filter(
+          p => p.userId !== finalSenderUserId,
+        ) || [];
+
+        for (const participant of otherParticipants) {
+          if (participant.user?.email) {
+            this.emailNotificationService.sendNotification({
+              event: 'new_message',
+              recipient: participant.user.email,
+              payload: {
+                firstName: participant.user.firstName || participant.user.email,
+                senderName,
+                messagePreview,
+                messageUrl,
+              },
+            }).catch(err => this.logger.error(`Failed to send new_message email: ${err.message}`));
+          }
+        }
+      }
+
       return transformedMessage;
     } catch (error) {
       this.logger.error({


### PR DESCRIPTION
## Summary
Integrates email notifications into the messaging service to notify conversation participants when new messages are received. This enhancement improves user engagement by ensuring users are alerted to new messages even when not actively using the platform.

## Key Changes
- **EmailNotificationService integration**: Injected `EmailNotificationService` as an optional dependency in `MessagingService` to enable email notifications without breaking existing functionality
- **Email notification dispatch**: Added logic to send email notifications to all conversation participants (except the sender) when a new message is created
  - Extracts sender name from user profile or falls back to email address
  - Generates message preview (truncated to 200 characters for text messages, or attachment type indicator)
  - Constructs deep link to the conversation using `FRONTEND_URL` or `APP_URL` environment variables
  - Gracefully handles email sending failures with error logging
- **Expanded FOUNDATION role permissions**: Updated `FOUNDATION` user role to include `EDUCATOR` in the list of roles they can message (in addition to existing `FOUNDATION`, `PRODUCT_SUPPLIER`, `SERVICE_PROVIDER`, `ADMIN`)
- **Module dependency**: Added `EmailNotificationModule` to `MessagingModule` imports to make the email service available

## Implementation Details
- Email notifications are sent asynchronously without blocking message creation
- Uses the existing `new_message` event key with payload containing recipient name, sender name, message preview, and conversation URL
- Leverages the seeded email event system already in place (per `CLAUDE.md`)
- Maintains backward compatibility by making `EmailNotificationService` optional via `@Optional()` decorator

https://claude.ai/code/session_01Do71m2vzEPEQvRCRy7caSj