### PR TITLE
fix(mailing): resolve production 500 on campaign creation and cron sc…

### DIFF
--- a/api/prisma/migrations/20260520000000_ensure_email_notification_tables/migration.sql
+++ b/api/prisma/migrations/20260520000000_ensure_email_notification_tables/migration.sql
@@ -1,0 +1,49 @@
+-- Idempotent safety migration: ensure email notification tables exist.
+-- These were defined in the init migration using the "public." prefix
+-- which can be skipped on some hosted PostgreSQL providers.
+-- All statements use IF NOT EXISTS so re-running is safe.
+
+CREATE TABLE IF NOT EXISTS "scheduled_emails" (
+    "id" TEXT NOT NULL,
+    "event" TEXT NOT NULL,
+    "recipient" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "scheduledAt" TIMESTAMP(3) NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "scheduled_emails_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE IF NOT EXISTS "email_templates" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "event" TEXT NOT NULL,
+    "subject" TEXT NOT NULL,
+    "htmlContent" TEXT NOT NULL,
+    "textContent" TEXT NOT NULL,
+    "variables" TEXT[],
+    "category" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "email_templates_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "email_templates_event_key" ON "email_templates"("event");
+
+CREATE TABLE IF NOT EXISTS "email_logs" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT,
+    "event" TEXT NOT NULL,
+    "recipient" TEXT NOT NULL,
+    "templateId" TEXT,
+    "messageId" TEXT,
+    "status" TEXT NOT NULL,
+    "payload" JSONB,
+    "error" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "email_logs_pkey" PRIMARY KEY ("id")
+);

--- a/api/src/mailing/mailing.controller.ts
+++ b/api/src/mailing/mailing.controller.ts
@@ -40,7 +40,8 @@ export class MailingController {
 
   /** Extract admin user ID from request context, or throw if missing. */
   private getAdminId(req: any): string {
-    const adminId = req.context?.userId || req.user?.id;
+    // Use the database UUID, not the Clerk ID (req.context.userId is 'user_xxx' format)
+    const adminId = req.context?.appUserId || req.user?.id;
     if (!adminId) {
       throw new BadRequestException('Unable to determine admin user ID from request context');
     }

--- a/api/src/mailing/mailing.service.ts
+++ b/api/src/mailing/mailing.service.ts
@@ -593,16 +593,20 @@ export class MailingService {
       },
     });
 
-    // Audit log
-    await this.prisma.auditLog.create({
-      data: {
-        entity: 'MailingCampaign',
-        entityId: campaign.id,
-        action: 'create',
-        actorId: createdById,
-        metadata: { subject, segmentId, totalEstimated },
-      },
-    });
+    // Audit log — non-critical; must not roll back a successful campaign creation
+    try {
+      await this.prisma.auditLog.create({
+        data: {
+          entity: 'MailingCampaign',
+          entityId: campaign.id,
+          action: 'create',
+          actorId: createdById,
+          metadata: { subject, segmentId, totalEstimated },
+        },
+      });
+    } catch (auditErr: any) {
+      this.logger.warn(`Audit log failed for campaign ${campaign.id}: ${auditErr?.message}`);
+    }
 
     return { campaignId: campaign.id, estimatedCount: totalEstimated, status: campaign.status };
   }


### PR DESCRIPTION
…heduler crash

Campaign creation (POST /admin/mailing/campaigns):
- getAdminId() was returning req.context.userId (Clerk ID: "user_xxx") instead of the database UUID, causing audit_logs FK constraint violation after the campaign row was already written
- Fix: use req.context.appUserId || req.user.id (both are DB UUIDs)
- Wrap auditLog.create() in try/catch so a future audit failure can never roll back a successful campaign

Scheduler cron crash (processScheduledEmails every minute):
- The 'scheduled_emails' table was defined in the init migration using the "public." schema prefix which some hosted PostgreSQL providers skip
- Add idempotent migration 20260520000000_ensure_email_notification_tables with CREATE TABLE IF NOT EXISTS for scheduled_emails, email_templates and email_logs so they are guaranteed to exist on all deployments