### PR TITLE
fix(brevo): replace sib-api-v3-sdk usage with correct @getbrevo/brevo…

### DIFF
--- a/api/src/mailing/transports/brevo.transport.ts
+++ b/api/src/mailing/transports/brevo.transport.ts
@@ -1,3 +1,4 @@
+import { BrevoClient } from '@getbrevo/brevo';
 import {
   MailingTransportAdapter,
   MailingSendOptions,
@@ -14,16 +15,16 @@ function parseAddress(raw: string): { name: string; email: string } {
 }
 
 export class BrevoTransport implements MailingTransportAdapter {
-  private apiKey: string | null = null;
+  private client: BrevoClient | null = null;
 
   constructor() {
     if (this.isConfigured()) {
-      this.apiKey = process.env.BREVO_API_KEY!.trim();
+      this.client = new BrevoClient({ apiKey: process.env.BREVO_API_KEY!.trim() });
     }
   }
 
   async sendEmail(options: MailingSendOptions): Promise<MailingSendResult> {
-    if (!this.apiKey) {
+    if (!this.client) {
       return { success: false, error: 'Brevo transport not initialised', provider: 'brevo' };
     }
 
@@ -36,35 +37,28 @@ export class BrevoTransport implements MailingTransportAdapter {
     const replyToEmail = options.replyTo ?? process.env.BREVO_REPLY_TO;
 
     try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const SibApiV3Sdk = require('@getbrevo/brevo');
-      const apiInstance = new SibApiV3Sdk.TransactionalEmailsApi();
-      apiInstance.setApiKey(SibApiV3Sdk.TransactionalEmailsApiApiKeys.apiKey, this.apiKey);
-
-      const sendSmtpEmail = new SibApiV3Sdk.SendSmtpEmail();
-      sendSmtpEmail.sender = { name: sender.name, email: sender.email };
-      sendSmtpEmail.to = [{ email: options.to }];
-      sendSmtpEmail.subject = options.subject;
-      sendSmtpEmail.htmlContent = options.html;
-      sendSmtpEmail.textContent = options.text;
+      const body: Record<string, any> = {
+        sender: { name: sender.name, email: sender.email },
+        to: [{ email: options.to }],
+        subject: options.subject,
+        htmlContent: options.html,
+        textContent: options.text,
+      };
 
       if (replyToEmail) {
-        sendSmtpEmail.replyTo = { email: replyToEmail };
+        body.replyTo = { email: replyToEmail };
       }
       if (options.tags?.length) {
-        sendSmtpEmail.tags = options.tags;
+        body.tags = options.tags;
       }
-
-      // Forward campaign metadata as custom email headers for provider-side correlation
       if (options.metadata && Object.keys(options.metadata).length) {
-        sendSmtpEmail.headers = Object.fromEntries(
+        body.headers = Object.fromEntries(
           Object.entries(options.metadata).map(([k, v]) => [`X-${k}`, v]),
         );
       }
 
-      const response = await apiInstance.sendTransacEmail(sendSmtpEmail);
-      const messageId: string | undefined =
-        response?.body?.messageId ?? response?.messageId ?? undefined;
+      const response = await this.client.transactionalEmails.sendTransacEmail(body);
+      const messageId: string | undefined = (response as any)?.messageId ?? undefined;
 
       return { success: true, messageId, provider: 'brevo' };
     } catch (error: any) {


### PR DESCRIPTION
… BrevoClient API

The @getbrevo/brevo package exports BrevoClient, not SibApiV3Sdk. The old code called SibApiV3Sdk.TransactionalEmailsApi which is not a constructor in this package, causing all campaign sends to fail.

Use BrevoClient({ apiKey }) with client.transactionalEmails.sendTransacEmail() which is the actual SDK surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated email transport implementation to use the official SDK client, improving code maintainability and reliability without affecting user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/One-S-Digital/PC-Solutions-Platform/pull/642?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->