### PR TITLE
Add email template management system for mailing campaigns

### DIFF
--- a/admin/.env.example
+++ b/admin/.env.example
@@ -8,6 +8,9 @@ VITE_NODE_ENV=development
 # Canton policy crawler pages (feature-flagged; disabled by default)
 VITE_CRAWLER_ENABLED=false
 
+# v2 feature flags (set to 'false' to disable; enabled by default)
+VITE_MAILING_TEMPLATES=true
+
 # Sentry Error Tracking & Monitoring (Optional but recommended for production)
 # Get your DSN from https://sentry.io after creating a project
 # VITE_SENTRY_DSN=https://your-sentry-dsn@sentry.io/project-id

--- a/admin/src/components/mailing/ComposeEmailModal.tsx
+++ b/admin/src/components/mailing/ComposeEmailModal.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react'
 import { X, Send, Eye, FileText, Save } from 'lucide-react'
+
+const MAILING_TEMPLATES_ENABLED = import.meta.env.VITE_MAILING_TEMPLATES !== 'false'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
 import { useApiClient, apiService } from '../../services/api'
@@ -62,12 +64,14 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
           <div className="flex items-center justify-between p-4 border-b shrink-0">
             <h3 className="text-lg font-semibold text-gray-900">{t('admin:mailing.compose.title')}</h3>
             <div className="flex items-center gap-2">
-              <button
-                onClick={() => setTemplatePickerOpen(true)}
-                className="flex items-center gap-1.5 text-xs px-2.5 py-1.5 border border-gray-300 rounded-md text-gray-600 hover:bg-gray-50"
-              >
-                <FileText className="w-3.5 h-3.5" /> {t('admin:mailing.compose.loadTemplate')}
-              </button>
+              {MAILING_TEMPLATES_ENABLED && (
+                <button
+                  onClick={() => setTemplatePickerOpen(true)}
+                  className="flex items-center gap-1.5 text-xs px-2.5 py-1.5 border border-gray-300 rounded-md text-gray-600 hover:bg-gray-50"
+                >
+                  <FileText className="w-3.5 h-3.5" /> {t('admin:mailing.compose.loadTemplate')}
+                </button>
+              )}
               <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
                 <X className="w-5 h-5" />
               </button>
@@ -139,7 +143,7 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
               <p className="text-xs text-gray-400 mt-1">{t('admin:mailing.compose.tokenHint')}</p>
             </div>
 
-            {showSaveAs ? (
+            {MAILING_TEMPLATES_ENABLED && (showSaveAs ? (
               <div className="bg-gray-50 border border-gray-200 rounded-md p-3 space-y-2">
                 <label className="text-xs font-medium text-gray-700">
                   {t('admin:mailing.compose.saveAsTemplate')}
@@ -175,7 +179,7 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
               >
                 <Save className="w-3 h-3" /> {t('admin:mailing.compose.saveCurrentAsTemplate')}
               </button>
-            )}
+            ))}
           </div>
 
           <div className="flex justify-end gap-2 p-4 border-t shrink-0">
@@ -194,11 +198,13 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
         </div>
       </div>
 
-      <TemplatePickerModal
-        isOpen={templatePickerOpen}
-        onClose={() => setTemplatePickerOpen(false)}
-        onSelect={handleSelectTemplate}
-      />
+      {MAILING_TEMPLATES_ENABLED && (
+        <TemplatePickerModal
+          isOpen={templatePickerOpen}
+          onClose={() => setTemplatePickerOpen(false)}
+          onSelect={handleSelectTemplate}
+        />
+      )}
     </>
   )
 }

--- a/admin/src/components/mailing/ComposeEmailModal.tsx
+++ b/admin/src/components/mailing/ComposeEmailModal.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react'
 import { X, Send, Eye, FileText, Save } from 'lucide-react'
-import DOMPurify from 'dompurify'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
 import { useApiClient, apiService } from '../../services/api'
 import { MailingTemplate } from '../../types/api'
 import TemplatePickerModal from './TemplatePickerModal'
+import EmailPreview from './EmailPreview'
 
 interface Props {
   isOpen: boolean
@@ -59,7 +59,7 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
     <>
       <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50">
         <div className="w-full max-w-2xl bg-white rounded-lg shadow-xl max-h-[90vh] flex flex-col">
-          <div className="flex items-center justify-between p-4 border-b">
+          <div className="flex items-center justify-between p-4 border-b shrink-0">
             <h3 className="text-lg font-semibold text-gray-900">{t('admin:mailing.compose.title')}</h3>
             <div className="flex items-center gap-2">
               <button
@@ -105,10 +105,13 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
               </div>
 
               {showPreview ? (
-                <div
-                  className="border border-gray-300 rounded-md p-3 min-h-[200px] text-sm bg-white prose prose-sm max-w-none"
-                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(bodyHtml) }}
-                />
+                <div className="border border-gray-200 rounded-md bg-gray-100 overflow-y-auto" style={{ maxHeight: '320px' }}>
+                  <div className="p-2">
+                    <div className="bg-white rounded shadow-sm overflow-hidden">
+                      <EmailPreview html={bodyHtml} />
+                    </div>
+                  </div>
+                </div>
               ) : (
                 <textarea
                   value={bodyHtml}
@@ -160,7 +163,7 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
                     onClick={() => { setShowSaveAs(false); setSaveAsName('') }}
                     className="px-3 py-1.5 text-sm text-gray-500 hover:text-gray-700"
                   >
-                    {t('admin:mailing.segment.delete')}
+                    {t('admin:mailing.campaign.detail.cancel')}
                   </button>
                 </div>
               </div>
@@ -175,7 +178,7 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
             )}
           </div>
 
-          <div className="flex justify-end gap-2 p-4 border-t">
+          <div className="flex justify-end gap-2 p-4 border-t shrink-0">
             <button onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">
               {t('admin:mailing.campaign.detail.cancel')}
             </button>

--- a/admin/src/components/mailing/ComposeEmailModal.tsx
+++ b/admin/src/components/mailing/ComposeEmailModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { X, Send, Eye, FileText, Save } from 'lucide-react'
 import DOMPurify from 'dompurify'
 import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
 import { useApiClient, apiService } from '../../services/api'
 import { MailingTemplate } from '../../types/api'
 import TemplatePickerModal from './TemplatePickerModal'
@@ -20,6 +21,7 @@ const TOKENS = [
 ]
 
 const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, recipientCount }) => {
+  const { t } = useTranslation(['admin'])
   const apiClient = useApiClient()
   const [subject, setSubject] = useState('')
   const [bodyHtml, setBodyHtml] = useState('')
@@ -33,7 +35,7 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
 
   const handleSelectTemplate = (template: MailingTemplate) => {
     if ((subject.trim() || bodyHtml.trim()) &&
-      !window.confirm('Replace current content with this template?')) return
+      !window.confirm(t('admin:mailing.compose.replaceConfirm'))) return
     setSubject(template.subject)
     setBodyHtml(template.bodyHtml ?? '')
   }
@@ -43,11 +45,11 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
     setSavingTemplate(true)
     try {
       await apiService.mailingCreateTemplate(apiClient, { name: saveAsName, subject, bodyHtml })
-      toast.success(`Template "${saveAsName}" saved`)
+      toast.success(t('admin:mailing.compose.templateSaved', { name: saveAsName }))
       setSaveAsName('')
       setShowSaveAs(false)
     } catch (err: any) {
-      toast.error(err?.response?.data?.message || 'Failed to save template')
+      toast.error(err?.response?.data?.message || t('admin:mailing.compose.templateSaveFailed'))
     } finally {
       setSavingTemplate(false)
     }
@@ -58,14 +60,13 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
       <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50">
         <div className="w-full max-w-2xl bg-white rounded-lg shadow-xl max-h-[90vh] flex flex-col">
           <div className="flex items-center justify-between p-4 border-b">
-            <h3 className="text-lg font-semibold text-gray-900">Compose Campaign Email</h3>
+            <h3 className="text-lg font-semibold text-gray-900">{t('admin:mailing.compose.title')}</h3>
             <div className="flex items-center gap-2">
               <button
                 onClick={() => setTemplatePickerOpen(true)}
                 className="flex items-center gap-1.5 text-xs px-2.5 py-1.5 border border-gray-300 rounded-md text-gray-600 hover:bg-gray-50"
-                title="Load from template"
               >
-                <FileText className="w-3.5 h-3.5" /> Load template
+                <FileText className="w-3.5 h-3.5" /> {t('admin:mailing.compose.loadTemplate')}
               </button>
               <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
                 <X className="w-5 h-5" />
@@ -75,30 +76,31 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
 
           <div className="flex-1 overflow-y-auto p-4 space-y-4">
             <div className="bg-blue-50 border border-blue-200 rounded-md p-3 text-sm text-blue-700">
-              This email will be sent to <span className="font-semibold">{recipientCount.toLocaleString()}</span> recipients.
-              An unsubscribe link and company footer will be appended automatically.
+              {t('admin:mailing.compose.recipientInfo', { count: recipientCount.toLocaleString() })}
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Subject *</label>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                {t('admin:mailing.compose.subject')} *
+              </label>
               <input
                 type="text"
                 value={subject}
                 onChange={(e) => setSubject(e.target.value)}
-                placeholder="Email subject line"
+                placeholder={t('admin:mailing.compose.subjectPlaceholder')}
                 className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
               />
             </div>
 
             <div>
               <div className="flex items-center justify-between mb-1">
-                <label className="text-sm font-medium text-gray-700">Body (HTML) *</label>
+                <label className="text-sm font-medium text-gray-700">{t('admin:mailing.compose.body')} *</label>
                 <button
                   onClick={() => setShowPreview(!showPreview)}
                   className="text-xs text-blue-600 hover:text-blue-800 flex items-center gap-1"
                 >
                   <Eye className="w-3 h-3" />
-                  {showPreview ? 'Edit' : 'Preview'}
+                  {showPreview ? t('admin:mailing.compose.edit') : t('admin:mailing.compose.preview')}
                 </button>
               </div>
 
@@ -111,7 +113,7 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
                 <textarea
                   value={bodyHtml}
                   onChange={(e) => setBodyHtml(e.target.value)}
-                  placeholder="<p>Hello {{firstName}},</p><p>Your email content here...</p>"
+                  placeholder={t('admin:mailing.compose.bodyPlaceholder')}
                   rows={10}
                   className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm font-mono focus:ring-blue-500 focus:border-blue-500"
                 />
@@ -119,7 +121,7 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
             </div>
 
             <div>
-              <label className="text-xs text-gray-500 block mb-1">Personalization tokens — click to insert</label>
+              <label className="text-xs text-gray-500 block mb-1">{t('admin:mailing.compose.tokens')}</label>
               <div className="flex flex-wrap gap-1.5">
                 {TOKENS.map((token) => (
                   <button
@@ -131,22 +133,20 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
                   </button>
                 ))}
               </div>
-              <p className="text-xs text-gray-400 mt-1">
-                {'{{logoUrl}}'} and {'{{iconUrl}}'} resolve to the platform logo/favicon URLs — wrap in{' '}
-                <code className="bg-gray-100 px-1 rounded">{'<img src="…" />'}</code>.
-              </p>
+              <p className="text-xs text-gray-400 mt-1">{t('admin:mailing.compose.tokenHint')}</p>
             </div>
 
-            {/* Save as template */}
             {showSaveAs ? (
               <div className="bg-gray-50 border border-gray-200 rounded-md p-3 space-y-2">
-                <label className="text-xs font-medium text-gray-700">Save as template</label>
+                <label className="text-xs font-medium text-gray-700">
+                  {t('admin:mailing.compose.saveAsTemplate')}
+                </label>
                 <div className="flex gap-2">
                   <input
                     type="text"
                     value={saveAsName}
                     onChange={(e) => setSaveAsName(e.target.value)}
-                    placeholder="Template name"
+                    placeholder={t('admin:mailing.compose.templateNamePlaceholder')}
                     className="flex-1 border border-gray-300 rounded-md px-3 py-1.5 text-sm focus:ring-blue-500 focus:border-blue-500"
                   />
                   <button
@@ -154,13 +154,13 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
                     disabled={!saveAsName.trim() || savingTemplate}
                     className="px-3 py-1.5 text-sm bg-gray-700 text-white rounded-md hover:bg-gray-800 disabled:opacity-50"
                   >
-                    {savingTemplate ? 'Saving...' : 'Save'}
+                    {savingTemplate ? t('admin:mailing.template.saving') : t('admin:mailing.template.save')}
                   </button>
                   <button
                     onClick={() => { setShowSaveAs(false); setSaveAsName('') }}
                     className="px-3 py-1.5 text-sm text-gray-500 hover:text-gray-700"
                   >
-                    Cancel
+                    {t('admin:mailing.segment.delete')}
                   </button>
                 </div>
               </div>
@@ -170,14 +170,14 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
                 disabled={!subject.trim() || !bodyHtml.trim()}
                 className="flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-700 disabled:opacity-40"
               >
-                <Save className="w-3 h-3" /> Save current content as template
+                <Save className="w-3 h-3" /> {t('admin:mailing.compose.saveCurrentAsTemplate')}
               </button>
             )}
           </div>
 
           <div className="flex justify-end gap-2 p-4 border-t">
             <button onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">
-              Cancel
+              {t('admin:mailing.campaign.detail.cancel')}
             </button>
             <button
               onClick={() => onSend(subject, bodyHtml)}
@@ -185,7 +185,7 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
               className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
             >
               <Send className="w-4 h-4" />
-              {loading ? 'Creating...' : 'Create Campaign & Send'}
+              {loading ? t('admin:mailing.compose.creating') : t('admin:mailing.compose.send')}
             </button>
           </div>
         </div>

--- a/admin/src/components/mailing/ComposeEmailModal.tsx
+++ b/admin/src/components/mailing/ComposeEmailModal.tsx
@@ -43,10 +43,16 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
   }
 
   const handleSaveAsTemplate = async () => {
-    if (!saveAsName.trim() || !subject.trim() || !bodyHtml.trim()) return
+    const trimmedName = saveAsName.trim()
+    const trimmedSubject = subject.trim()
+    if (!trimmedName || !trimmedSubject || !bodyHtml.trim()) return
+    if (trimmedName.length > 200 || trimmedSubject.length > 998) {
+      toast.error(t('admin:mailing.compose.templateSaveFailed'))
+      return
+    }
     setSavingTemplate(true)
     try {
-      await apiService.mailingCreateTemplate(apiClient, { name: saveAsName, subject, bodyHtml })
+      await apiService.mailingCreateTemplate(apiClient, { name: trimmedName, subject: trimmedSubject, bodyHtml })
       toast.success(t('admin:mailing.compose.templateSaved', { name: saveAsName }))
       setSaveAsName('')
       setShowSaveAs(false)
@@ -154,6 +160,7 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
                     value={saveAsName}
                     onChange={(e) => setSaveAsName(e.target.value)}
                     placeholder={t('admin:mailing.compose.templateNamePlaceholder')}
+                    maxLength={200}
                     className="flex-1 border border-gray-300 rounded-md px-3 py-1.5 text-sm focus:ring-blue-500 focus:border-blue-500"
                   />
                   <button

--- a/admin/src/components/mailing/ComposeEmailModal.tsx
+++ b/admin/src/components/mailing/ComposeEmailModal.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from 'react'
-import { X, Send, Eye } from 'lucide-react'
+import { X, Send, Eye, FileText, Save } from 'lucide-react'
 import DOMPurify from 'dompurify'
+import { toast } from 'sonner'
+import { useApiClient, apiService } from '../../services/api'
+import { MailingTemplate } from '../../types/api'
+import TemplatePickerModal from './TemplatePickerModal'
 
 interface Props {
   isOpen: boolean
@@ -10,103 +14,189 @@ interface Props {
   recipientCount: number
 }
 
+const TOKENS = [
+  '{{firstName}}', '{{lastName}}', '{{email}}', '{{role}}', '{{orgName}}', '{{canton}}',
+  '{{logoUrl}}', '{{iconUrl}}',
+]
+
 const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, recipientCount }) => {
+  const apiClient = useApiClient()
   const [subject, setSubject] = useState('')
   const [bodyHtml, setBodyHtml] = useState('')
   const [showPreview, setShowPreview] = useState(false)
+  const [templatePickerOpen, setTemplatePickerOpen] = useState(false)
+  const [saveAsName, setSaveAsName] = useState('')
+  const [showSaveAs, setShowSaveAs] = useState(false)
+  const [savingTemplate, setSavingTemplate] = useState(false)
 
   if (!isOpen) return null
 
-  const tokens = [
-    '{{firstName}}', '{{lastName}}', '{{email}}', '{{role}}', '{{orgName}}', '{{canton}}',
-  ]
+  const handleSelectTemplate = (template: MailingTemplate) => {
+    if ((subject.trim() || bodyHtml.trim()) &&
+      !window.confirm('Replace current content with this template?')) return
+    setSubject(template.subject)
+    setBodyHtml(template.bodyHtml ?? '')
+  }
+
+  const handleSaveAsTemplate = async () => {
+    if (!saveAsName.trim() || !subject.trim() || !bodyHtml.trim()) return
+    setSavingTemplate(true)
+    try {
+      await apiService.mailingCreateTemplate(apiClient, { name: saveAsName, subject, bodyHtml })
+      toast.success(`Template "${saveAsName}" saved`)
+      setSaveAsName('')
+      setShowSaveAs(false)
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message || 'Failed to save template')
+    } finally {
+      setSavingTemplate(false)
+    }
+  }
 
   return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50">
-      <div className="w-full max-w-2xl bg-white rounded-lg shadow-xl max-h-[90vh] flex flex-col">
-        <div className="flex items-center justify-between p-4 border-b">
-          <h3 className="text-lg font-semibold text-gray-900">Compose Campaign Email</h3>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
-            <X className="w-5 h-5" />
-          </button>
-        </div>
-
-        <div className="flex-1 overflow-y-auto p-4 space-y-4">
-          <div className="bg-blue-50 border border-blue-200 rounded-md p-3 text-sm text-blue-700">
-            This email will be sent to <span className="font-semibold">{recipientCount.toLocaleString()}</span> recipients.
-            An unsubscribe link and company footer will be appended automatically.
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Subject *</label>
-            <input
-              type="text"
-              value={subject}
-              onChange={(e) => setSubject(e.target.value)}
-              placeholder="Email subject line"
-              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
-            />
-          </div>
-
-          <div>
-            <div className="flex items-center justify-between mb-1">
-              <label className="text-sm font-medium text-gray-700">Body (HTML) *</label>
+    <>
+      <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50">
+        <div className="w-full max-w-2xl bg-white rounded-lg shadow-xl max-h-[90vh] flex flex-col">
+          <div className="flex items-center justify-between p-4 border-b">
+            <h3 className="text-lg font-semibold text-gray-900">Compose Campaign Email</h3>
+            <div className="flex items-center gap-2">
               <button
-                onClick={() => setShowPreview(!showPreview)}
-                className="text-xs text-blue-600 hover:text-blue-800 flex items-center gap-1"
+                onClick={() => setTemplatePickerOpen(true)}
+                className="flex items-center gap-1.5 text-xs px-2.5 py-1.5 border border-gray-300 rounded-md text-gray-600 hover:bg-gray-50"
+                title="Load from template"
               >
-                <Eye className="w-3 h-3" />
-                {showPreview ? 'Edit' : 'Preview'}
+                <FileText className="w-3.5 h-3.5" /> Load template
+              </button>
+              <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+                <X className="w-5 h-5" />
               </button>
             </div>
+          </div>
 
-            {showPreview ? (
-              <div
-                className="border border-gray-300 rounded-md p-3 min-h-[200px] text-sm bg-white prose prose-sm max-w-none"
-                dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(bodyHtml) }}
+          <div className="flex-1 overflow-y-auto p-4 space-y-4">
+            <div className="bg-blue-50 border border-blue-200 rounded-md p-3 text-sm text-blue-700">
+              This email will be sent to <span className="font-semibold">{recipientCount.toLocaleString()}</span> recipients.
+              An unsubscribe link and company footer will be appended automatically.
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Subject *</label>
+              <input
+                type="text"
+                value={subject}
+                onChange={(e) => setSubject(e.target.value)}
+                placeholder="Email subject line"
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
               />
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between mb-1">
+                <label className="text-sm font-medium text-gray-700">Body (HTML) *</label>
+                <button
+                  onClick={() => setShowPreview(!showPreview)}
+                  className="text-xs text-blue-600 hover:text-blue-800 flex items-center gap-1"
+                >
+                  <Eye className="w-3 h-3" />
+                  {showPreview ? 'Edit' : 'Preview'}
+                </button>
+              </div>
+
+              {showPreview ? (
+                <div
+                  className="border border-gray-300 rounded-md p-3 min-h-[200px] text-sm bg-white prose prose-sm max-w-none"
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(bodyHtml) }}
+                />
+              ) : (
+                <textarea
+                  value={bodyHtml}
+                  onChange={(e) => setBodyHtml(e.target.value)}
+                  placeholder="<p>Hello {{firstName}},</p><p>Your email content here...</p>"
+                  rows={10}
+                  className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm font-mono focus:ring-blue-500 focus:border-blue-500"
+                />
+              )}
+            </div>
+
+            <div>
+              <label className="text-xs text-gray-500 block mb-1">Personalization tokens — click to insert</label>
+              <div className="flex flex-wrap gap-1.5">
+                {TOKENS.map((token) => (
+                  <button
+                    key={token}
+                    onClick={() => setBodyHtml((prev) => prev + token)}
+                    className="text-xs px-2 py-0.5 bg-gray-100 text-gray-600 rounded border border-gray-200 hover:bg-gray-200 font-mono"
+                  >
+                    {token}
+                  </button>
+                ))}
+              </div>
+              <p className="text-xs text-gray-400 mt-1">
+                {'{{logoUrl}}'} and {'{{iconUrl}}'} resolve to the platform logo/favicon URLs — wrap in{' '}
+                <code className="bg-gray-100 px-1 rounded">{'<img src="…" />'}</code>.
+              </p>
+            </div>
+
+            {/* Save as template */}
+            {showSaveAs ? (
+              <div className="bg-gray-50 border border-gray-200 rounded-md p-3 space-y-2">
+                <label className="text-xs font-medium text-gray-700">Save as template</label>
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={saveAsName}
+                    onChange={(e) => setSaveAsName(e.target.value)}
+                    placeholder="Template name"
+                    className="flex-1 border border-gray-300 rounded-md px-3 py-1.5 text-sm focus:ring-blue-500 focus:border-blue-500"
+                  />
+                  <button
+                    onClick={handleSaveAsTemplate}
+                    disabled={!saveAsName.trim() || savingTemplate}
+                    className="px-3 py-1.5 text-sm bg-gray-700 text-white rounded-md hover:bg-gray-800 disabled:opacity-50"
+                  >
+                    {savingTemplate ? 'Saving...' : 'Save'}
+                  </button>
+                  <button
+                    onClick={() => { setShowSaveAs(false); setSaveAsName('') }}
+                    className="px-3 py-1.5 text-sm text-gray-500 hover:text-gray-700"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
             ) : (
-              <textarea
-                value={bodyHtml}
-                onChange={(e) => setBodyHtml(e.target.value)}
-                placeholder="<p>Hello {{firstName}},</p><p>Your email content here...</p>"
-                rows={10}
-                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm font-mono focus:ring-blue-500 focus:border-blue-500"
-              />
+              <button
+                onClick={() => setShowSaveAs(true)}
+                disabled={!subject.trim() || !bodyHtml.trim()}
+                className="flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-700 disabled:opacity-40"
+              >
+                <Save className="w-3 h-3" /> Save current content as template
+              </button>
             )}
           </div>
 
-          <div>
-            <label className="text-xs text-gray-500 block mb-1">Available personalization tokens</label>
-            <div className="flex flex-wrap gap-1.5">
-              {tokens.map((token) => (
-                <button
-                  key={token}
-                  onClick={() => setBodyHtml((prev) => prev + token)}
-                  className="text-xs px-2 py-0.5 bg-gray-100 text-gray-600 rounded border border-gray-200 hover:bg-gray-200 font-mono"
-                >
-                  {token}
-                </button>
-              ))}
-            </div>
+          <div className="flex justify-end gap-2 p-4 border-t">
+            <button onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">
+              Cancel
+            </button>
+            <button
+              onClick={() => onSend(subject, bodyHtml)}
+              disabled={!subject.trim() || !bodyHtml.trim() || loading}
+              className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
+            >
+              <Send className="w-4 h-4" />
+              {loading ? 'Creating...' : 'Create Campaign & Send'}
+            </button>
           </div>
         </div>
-
-        <div className="flex justify-end gap-2 p-4 border-t">
-          <button onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">
-            Cancel
-          </button>
-          <button
-            onClick={() => onSend(subject, bodyHtml)}
-            disabled={!subject.trim() || !bodyHtml.trim() || loading}
-            className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
-          >
-            <Send className="w-4 h-4" />
-            {loading ? 'Creating...' : 'Create Campaign & Send'}
-          </button>
-        </div>
       </div>
-    </div>
+
+      <TemplatePickerModal
+        isOpen={templatePickerOpen}
+        onClose={() => setTemplatePickerOpen(false)}
+        onSelect={handleSelectTemplate}
+      />
+    </>
   )
 }
 

--- a/admin/src/components/mailing/EmailPreview.tsx
+++ b/admin/src/components/mailing/EmailPreview.tsx
@@ -1,0 +1,98 @@
+import React, { useRef } from 'react'
+import DOMPurify from 'dompurify'
+import { useQuery } from '@tanstack/react-query'
+import { useApiClient, apiService } from '../../services/api'
+
+// Sample values shown in preview for per-recipient tokens
+const SAMPLE_TOKENS: Record<string, string> = {
+  firstName: 'Jane',
+  lastName: 'Doe',
+  email: 'jane.doe@example.com',
+  role: 'FOUNDATION',
+  orgName: 'Example Foundation',
+  canton: 'VD',
+  unsubscribeUrl: '#',
+}
+
+function resolveTokens(html: string, vars: Record<string, string>): string {
+  let result = html
+  for (const [key, value] of Object.entries(vars)) {
+    result = result.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value)
+  }
+  return result
+}
+
+interface Props {
+  html: string
+  className?: string
+}
+
+const EmailPreview: React.FC<Props> = ({ html, className = '' }) => {
+  const apiClient = useApiClient()
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+
+  // Fetch platform branding so {{logoUrl}} / {{iconUrl}} resolve to real URLs in preview
+  const { data: settings } = useQuery({
+    queryKey: ['platform-branding-preview'],
+    queryFn: async () => {
+      const res = await apiService.getFrontendSettings(apiClient)
+      return res.data?.data
+    },
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  })
+
+  const logoUrl = settings?.logoAsset?.publicUrl || ''
+  const iconUrl = settings?.faviconAsset?.publicUrl || ''
+
+  const tokens: Record<string, string> = {
+    ...SAMPLE_TOKENS,
+    logoUrl,
+    iconUrl,
+  }
+
+  const resolved = resolveTokens(DOMPurify.sanitize(html), tokens)
+
+  // Wrap in a full HTML document so email styles render properly and images
+  // respect max-width so nothing overflows the preview pane.
+  const srcDoc = [
+    '<!DOCTYPE html><html><head>',
+    '<meta charset="utf-8">',
+    '<meta name="viewport" content="width=device-width,initial-scale=1">',
+    '<style>',
+    '*{box-sizing:border-box;}',
+    'html,body{margin:0;padding:0;width:100%;}',
+    'body{padding:12px;font-family:Arial,sans-serif;font-size:14px;color:#111;word-break:break-word;overflow-x:hidden;}',
+    'img{max-width:100%!important;height:auto!important;display:block;}',
+    'table{max-width:100%!important;width:100%!important;}',
+    'td,th{word-break:break-word;}',
+    'a{color:#3b82f6;}',
+    '</style>',
+    '</head><body>',
+    resolved,
+    '</body></html>',
+  ].join('')
+
+  const handleLoad = () => {
+    if (!iframeRef.current) return
+    const doc = iframeRef.current.contentDocument
+    if (doc?.documentElement) {
+      // Auto-size height to content so no double scroll bar
+      iframeRef.current.style.height = `${doc.documentElement.scrollHeight}px`
+    }
+  }
+
+  return (
+    <iframe
+      ref={iframeRef}
+      srcDoc={srcDoc}
+      className={`w-full border-0 block ${className}`}
+      style={{ minHeight: '180px' }}
+      sandbox="allow-same-origin"
+      onLoad={handleLoad}
+      title="Email preview"
+    />
+  )
+}
+
+export default EmailPreview

--- a/admin/src/components/mailing/TemplateEditorModal.tsx
+++ b/admin/src/components/mailing/TemplateEditorModal.tsx
@@ -12,7 +12,7 @@ const TOKENS = [
 interface Props {
   isOpen: boolean
   onClose: () => void
-  onSave: (data: { name: string; description?: string; subject: string; bodyHtml: string }) => Promise<void>
+  onSave: (data: { name: string; description?: string | null; subject: string; bodyHtml: string }) => Promise<void>
   loading: boolean
   initial?: Partial<MailingTemplate>
   title?: string
@@ -61,6 +61,7 @@ const TemplateEditorModal: React.FC<Props> = ({ isOpen, onClose, onSave, loading
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder={t('admin:mailing.template.namePlaceholder')}
+                maxLength={200}
                 className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
               />
             </div>
@@ -73,6 +74,7 @@ const TemplateEditorModal: React.FC<Props> = ({ isOpen, onClose, onSave, loading
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder={t('admin:mailing.template.descriptionPlaceholder')}
+                maxLength={1000}
                 className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
               />
             </div>
@@ -87,6 +89,7 @@ const TemplateEditorModal: React.FC<Props> = ({ isOpen, onClose, onSave, loading
               value={subject}
               onChange={(e) => setSubject(e.target.value)}
               placeholder={t('admin:mailing.template.subjectPlaceholder')}
+              maxLength={998}
               className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
             />
           </div>
@@ -148,7 +151,7 @@ const TemplateEditorModal: React.FC<Props> = ({ isOpen, onClose, onSave, loading
             {t('admin:mailing.campaign.detail.cancel')}
           </button>
           <button
-            onClick={() => onSave({ name, description: description || undefined, subject, bodyHtml })}
+            onClick={() => onSave({ name, description: description.trim() || null, subject, bodyHtml })}
             disabled={!name.trim() || !subject.trim() || !bodyHtml.trim() || loading}
             className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
           >

--- a/admin/src/components/mailing/TemplateEditorModal.tsx
+++ b/admin/src/components/mailing/TemplateEditorModal.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react'
 import { X, Eye, Save } from 'lucide-react'
-import DOMPurify from 'dompurify'
 import { useTranslation } from 'react-i18next'
 import { MailingTemplate } from '../../types/api'
+import EmailPreview from './EmailPreview'
 
 const TOKENS = [
   '{{firstName}}', '{{lastName}}', '{{email}}', '{{role}}', '{{orgName}}', '{{canton}}',
@@ -43,7 +43,7 @@ const TemplateEditorModal: React.FC<Props> = ({ isOpen, onClose, onSave, loading
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-[60]">
       <div className="w-full max-w-2xl bg-white rounded-lg shadow-xl max-h-[90vh] flex flex-col">
-        <div className="flex items-center justify-between p-4 border-b">
+        <div className="flex items-center justify-between p-4 border-b shrink-0">
           <h3 className="text-lg font-semibold text-gray-900">{modalTitle}</h3>
           <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
             <X className="w-5 h-5" />
@@ -104,11 +104,15 @@ const TemplateEditorModal: React.FC<Props> = ({ isOpen, onClose, onSave, loading
                 {showPreview ? t('admin:mailing.compose.edit') : t('admin:mailing.compose.preview')}
               </button>
             </div>
+
             {showPreview ? (
-              <div
-                className="border border-gray-300 rounded-md p-3 min-h-[200px] text-sm bg-white prose prose-sm max-w-none"
-                dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(bodyHtml) }}
-              />
+              <div className="border border-gray-200 rounded-md bg-gray-100 overflow-y-auto" style={{ maxHeight: '320px' }}>
+                <div className="p-2">
+                  <div className="bg-white rounded shadow-sm overflow-hidden">
+                    <EmailPreview html={bodyHtml} />
+                  </div>
+                </div>
+              </div>
             ) : (
               <textarea
                 value={bodyHtml}
@@ -139,7 +143,7 @@ const TemplateEditorModal: React.FC<Props> = ({ isOpen, onClose, onSave, loading
           </div>
         </div>
 
-        <div className="flex justify-end gap-2 p-4 border-t">
+        <div className="flex justify-end gap-2 p-4 border-t shrink-0">
           <button onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">
             {t('admin:mailing.campaign.detail.cancel')}
           </button>

--- a/admin/src/components/mailing/TemplateEditorModal.tsx
+++ b/admin/src/components/mailing/TemplateEditorModal.tsx
@@ -1,0 +1,161 @@
+import React, { useState, useEffect } from 'react'
+import { X, Eye, Save } from 'lucide-react'
+import DOMPurify from 'dompurify'
+import { MailingTemplate } from '../../types/api'
+
+const TOKENS = [
+  { token: '{{firstName}}', label: 'First name' },
+  { token: '{{lastName}}', label: 'Last name' },
+  { token: '{{email}}', label: 'Email' },
+  { token: '{{role}}', label: 'Role' },
+  { token: '{{orgName}}', label: 'Org name' },
+  { token: '{{canton}}', label: 'Canton' },
+  { token: '{{logoUrl}}', label: 'Logo URL' },
+  { token: '{{iconUrl}}', label: 'Icon URL' },
+]
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  onSave: (data: { name: string; description?: string; subject: string; bodyHtml: string }) => Promise<void>
+  loading: boolean
+  initial?: Partial<MailingTemplate>
+  title?: string
+}
+
+const TemplateEditorModal: React.FC<Props> = ({ isOpen, onClose, onSave, loading, initial, title = 'New Template' }) => {
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [subject, setSubject] = useState('')
+  const [bodyHtml, setBodyHtml] = useState('')
+  const [showPreview, setShowPreview] = useState(false)
+
+  useEffect(() => {
+    if (isOpen) {
+      setName(initial?.name ?? '')
+      setDescription(initial?.description ?? '')
+      setSubject(initial?.subject ?? '')
+      setBodyHtml(initial?.bodyHtml ?? '')
+      setShowPreview(false)
+    }
+  }, [isOpen, initial])
+
+  if (!isOpen) return null
+
+  const insertToken = (token: string) => setBodyHtml((prev) => prev + token)
+
+  const handleSave = async () => {
+    await onSave({ name, description: description || undefined, subject, bodyHtml })
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-[60]">
+      <div className="w-full max-w-2xl bg-white rounded-lg shadow-xl max-h-[90vh] flex flex-col">
+        <div className="flex items-center justify-between p-4 border-b">
+          <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Template name *</label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Monthly newsletter"
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+              <input
+                type="text"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Optional description"
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Default subject *</label>
+            <input
+              type="text"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              placeholder="Email subject line"
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <label className="text-sm font-medium text-gray-700">Body (HTML) *</label>
+              <button
+                onClick={() => setShowPreview(!showPreview)}
+                className="text-xs text-blue-600 hover:text-blue-800 flex items-center gap-1"
+              >
+                <Eye className="w-3 h-3" />
+                {showPreview ? 'Edit' : 'Preview'}
+              </button>
+            </div>
+            {showPreview ? (
+              <div
+                className="border border-gray-300 rounded-md p-3 min-h-[200px] text-sm bg-white prose prose-sm max-w-none"
+                dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(bodyHtml) }}
+              />
+            ) : (
+              <textarea
+                value={bodyHtml}
+                onChange={(e) => setBodyHtml(e.target.value)}
+                placeholder="<p>Hello {{firstName}},</p><p>Your content here...</p>"
+                rows={10}
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm font-mono focus:ring-blue-500 focus:border-blue-500"
+              />
+            )}
+          </div>
+
+          <div>
+            <label className="text-xs text-gray-500 block mb-1">Personalization tokens — click to insert</label>
+            <div className="flex flex-wrap gap-1.5">
+              {TOKENS.map(({ token, label }) => (
+                <button
+                  key={token}
+                  onClick={() => insertToken(token)}
+                  title={label}
+                  className="text-xs px-2 py-0.5 bg-gray-100 text-gray-600 rounded border border-gray-200 hover:bg-gray-200 font-mono"
+                >
+                  {token}
+                </button>
+              ))}
+            </div>
+            <p className="text-xs text-gray-400 mt-1">
+              Use <code className="bg-gray-100 px-1 rounded">{'<img src="{{logoUrl}}" />'}</code> to embed the platform logo.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2 p-4 border-t">
+          <button onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!name.trim() || !subject.trim() || !bodyHtml.trim() || loading}
+            className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
+          >
+            <Save className="w-4 h-4" />
+            {loading ? 'Saving...' : 'Save Template'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default TemplateEditorModal

--- a/admin/src/components/mailing/TemplateEditorModal.tsx
+++ b/admin/src/components/mailing/TemplateEditorModal.tsx
@@ -1,17 +1,12 @@
 import React, { useState, useEffect } from 'react'
 import { X, Eye, Save } from 'lucide-react'
 import DOMPurify from 'dompurify'
+import { useTranslation } from 'react-i18next'
 import { MailingTemplate } from '../../types/api'
 
 const TOKENS = [
-  { token: '{{firstName}}', label: 'First name' },
-  { token: '{{lastName}}', label: 'Last name' },
-  { token: '{{email}}', label: 'Email' },
-  { token: '{{role}}', label: 'Role' },
-  { token: '{{orgName}}', label: 'Org name' },
-  { token: '{{canton}}', label: 'Canton' },
-  { token: '{{logoUrl}}', label: 'Logo URL' },
-  { token: '{{iconUrl}}', label: 'Icon URL' },
+  '{{firstName}}', '{{lastName}}', '{{email}}', '{{role}}', '{{orgName}}', '{{canton}}',
+  '{{logoUrl}}', '{{iconUrl}}',
 ]
 
 interface Props {
@@ -23,7 +18,8 @@ interface Props {
   title?: string
 }
 
-const TemplateEditorModal: React.FC<Props> = ({ isOpen, onClose, onSave, loading, initial, title = 'New Template' }) => {
+const TemplateEditorModal: React.FC<Props> = ({ isOpen, onClose, onSave, loading, initial, title }) => {
+  const { t } = useTranslation(['admin'])
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
   const [subject, setSubject] = useState('')
@@ -42,17 +38,13 @@ const TemplateEditorModal: React.FC<Props> = ({ isOpen, onClose, onSave, loading
 
   if (!isOpen) return null
 
-  const insertToken = (token: string) => setBodyHtml((prev) => prev + token)
-
-  const handleSave = async () => {
-    await onSave({ name, description: description || undefined, subject, bodyHtml })
-  }
+  const modalTitle = title ?? t('admin:mailing.template.newTemplate')
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-[60]">
       <div className="w-full max-w-2xl bg-white rounded-lg shadow-xl max-h-[90vh] flex flex-col">
         <div className="flex items-center justify-between p-4 border-b">
-          <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+          <h3 className="text-lg font-semibold text-gray-900">{modalTitle}</h3>
           <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
             <X className="w-5 h-5" />
           </button>
@@ -61,47 +53,55 @@ const TemplateEditorModal: React.FC<Props> = ({ isOpen, onClose, onSave, loading
         <div className="flex-1 overflow-y-auto p-4 space-y-4">
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Template name *</label>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                {t('admin:mailing.template.nameLabel')} *
+              </label>
               <input
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                placeholder="e.g. Monthly newsletter"
+                placeholder={t('admin:mailing.template.namePlaceholder')}
                 className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                {t('admin:mailing.template.descriptionLabel')}
+              </label>
               <input
                 type="text"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
-                placeholder="Optional description"
+                placeholder={t('admin:mailing.template.descriptionPlaceholder')}
                 className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
               />
             </div>
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Default subject *</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              {t('admin:mailing.template.subjectLabel')} *
+            </label>
             <input
               type="text"
               value={subject}
               onChange={(e) => setSubject(e.target.value)}
-              placeholder="Email subject line"
+              placeholder={t('admin:mailing.template.subjectPlaceholder')}
               className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
             />
           </div>
 
           <div>
             <div className="flex items-center justify-between mb-1">
-              <label className="text-sm font-medium text-gray-700">Body (HTML) *</label>
+              <label className="text-sm font-medium text-gray-700">
+                {t('admin:mailing.template.bodyLabel')} *
+              </label>
               <button
                 onClick={() => setShowPreview(!showPreview)}
                 className="text-xs text-blue-600 hover:text-blue-800 flex items-center gap-1"
               >
                 <Eye className="w-3 h-3" />
-                {showPreview ? 'Edit' : 'Preview'}
+                {showPreview ? t('admin:mailing.compose.edit') : t('admin:mailing.compose.preview')}
               </button>
             </div>
             {showPreview ? (
@@ -113,7 +113,7 @@ const TemplateEditorModal: React.FC<Props> = ({ isOpen, onClose, onSave, loading
               <textarea
                 value={bodyHtml}
                 onChange={(e) => setBodyHtml(e.target.value)}
-                placeholder="<p>Hello {{firstName}},</p><p>Your content here...</p>"
+                placeholder={t('admin:mailing.compose.bodyPlaceholder')}
                 rows={10}
                 className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm font-mono focus:ring-blue-500 focus:border-blue-500"
               />
@@ -121,36 +121,35 @@ const TemplateEditorModal: React.FC<Props> = ({ isOpen, onClose, onSave, loading
           </div>
 
           <div>
-            <label className="text-xs text-gray-500 block mb-1">Personalization tokens — click to insert</label>
+            <label className="text-xs text-gray-500 block mb-1">
+              {t('admin:mailing.template.tokenLabel')}
+            </label>
             <div className="flex flex-wrap gap-1.5">
-              {TOKENS.map(({ token, label }) => (
+              {TOKENS.map((token) => (
                 <button
                   key={token}
-                  onClick={() => insertToken(token)}
-                  title={label}
+                  onClick={() => setBodyHtml((prev) => prev + token)}
                   className="text-xs px-2 py-0.5 bg-gray-100 text-gray-600 rounded border border-gray-200 hover:bg-gray-200 font-mono"
                 >
                   {token}
                 </button>
               ))}
             </div>
-            <p className="text-xs text-gray-400 mt-1">
-              Use <code className="bg-gray-100 px-1 rounded">{'<img src="{{logoUrl}}" />'}</code> to embed the platform logo.
-            </p>
+            <p className="text-xs text-gray-400 mt-1">{t('admin:mailing.template.logoHint')}</p>
           </div>
         </div>
 
         <div className="flex justify-end gap-2 p-4 border-t">
           <button onClick={onClose} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">
-            Cancel
+            {t('admin:mailing.campaign.detail.cancel')}
           </button>
           <button
-            onClick={handleSave}
+            onClick={() => onSave({ name, description: description || undefined, subject, bodyHtml })}
             disabled={!name.trim() || !subject.trim() || !bodyHtml.trim() || loading}
             className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
           >
             <Save className="w-4 h-4" />
-            {loading ? 'Saving...' : 'Save Template'}
+            {loading ? t('admin:mailing.template.saving') : t('admin:mailing.template.save')}
           </button>
         </div>
       </div>

--- a/admin/src/components/mailing/TemplatePickerModal.tsx
+++ b/admin/src/components/mailing/TemplatePickerModal.tsx
@@ -34,7 +34,7 @@ const TemplatePickerModal: React.FC<Props> = ({ isOpen, onClose, onSelect }) => 
       const res = await apiService.mailingGetTemplate(apiClient, previewId!)
       return res.data as MailingTemplate
     },
-    enabled: !!previewId,
+    enabled: isOpen && !!previewId,
   })
 
   if (!isOpen) return null

--- a/admin/src/components/mailing/TemplatePickerModal.tsx
+++ b/admin/src/components/mailing/TemplatePickerModal.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react'
-import { X, Search, FileText, Eye } from 'lucide-react'
+import { X, Search, FileText } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
-import DOMPurify from 'dompurify'
 import { useApiClient, apiService } from '../../services/api'
 import { MailingTemplate } from '../../types/api'
 import LoadingSpinner from '../ui/LoadingSpinner'
+import EmailPreview from './EmailPreview'
 
 interface Props {
   isOpen: boolean
@@ -39,25 +39,27 @@ const TemplatePickerModal: React.FC<Props> = ({ isOpen, onClose, onSelect }) => 
 
   if (!isOpen) return null
 
-  const filtered = (data?.templates ?? []).filter((t: MailingTemplate) =>
-    t.name.toLowerCase().includes(search.toLowerCase()) ||
-    t.subject.toLowerCase().includes(search.toLowerCase()),
+  const filtered = (data?.templates ?? []).filter((tpl: MailingTemplate) =>
+    tpl.name.toLowerCase().includes(search.toLowerCase()) ||
+    tpl.subject.toLowerCase().includes(search.toLowerCase()),
   )
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-[60]">
-      <div className="w-full max-w-3xl bg-white rounded-lg shadow-xl max-h-[85vh] flex flex-col">
-        <div className="flex items-center justify-between p-4 border-b">
+      <div className="w-full max-w-4xl bg-white rounded-lg shadow-xl flex flex-col" style={{ height: 'min(85vh, 700px)' }}>
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b shrink-0">
           <h3 className="text-lg font-semibold text-gray-900">{t('admin:mailing.template.picker.title')}</h3>
           <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
             <X className="w-5 h-5" />
           </button>
         </div>
 
-        <div className="flex flex-1 overflow-hidden">
-          {/* Template list */}
-          <div className="w-72 shrink-0 border-r flex flex-col">
-            <div className="p-3 border-b">
+        {/* Body — fixed height, two columns */}
+        <div className="flex flex-1 overflow-hidden min-h-0">
+          {/* Left: template list */}
+          <div className="w-64 shrink-0 border-r flex flex-col">
+            <div className="p-3 border-b shrink-0">
               <div className="relative">
                 <Search className="w-4 h-4 absolute left-2.5 top-2.5 text-gray-400" />
                 <input
@@ -73,7 +75,7 @@ const TemplatePickerModal: React.FC<Props> = ({ isOpen, onClose, onSelect }) => 
               {isLoading ? (
                 <div className="flex justify-center py-8"><LoadingSpinner /></div>
               ) : filtered.length === 0 ? (
-                <div className="text-center py-12 text-gray-400">
+                <div className="text-center py-12 text-gray-400 px-4">
                   <FileText className="w-8 h-8 mx-auto mb-2 text-gray-300" />
                   <p className="text-sm">
                     {search
@@ -83,45 +85,50 @@ const TemplatePickerModal: React.FC<Props> = ({ isOpen, onClose, onSelect }) => 
                 </div>
               ) : (
                 filtered.map((tpl: MailingTemplate) => (
-                  <div
+                  <button
                     key={tpl.id}
-                    className={`p-3 cursor-pointer border-b border-gray-100 hover:bg-gray-50 transition-colors ${previewId === tpl.id ? 'bg-blue-50 border-l-2 border-l-blue-500' : ''}`}
                     onClick={() => setPreviewId(tpl.id)}
+                    className={`w-full text-left p-3 border-b border-gray-100 hover:bg-gray-50 transition-colors ${
+                      previewId === tpl.id ? 'bg-blue-50 border-l-2 border-l-blue-500' : ''
+                    }`}
                   >
                     <div className="text-sm font-medium text-gray-900 truncate">{tpl.name}</div>
                     <div className="text-xs text-gray-500 truncate mt-0.5">{tpl.subject}</div>
                     <div className="text-xs text-gray-400 mt-1">
                       {new Date(tpl.updatedAt).toLocaleDateString()}
                     </div>
-                  </div>
+                  </button>
                 ))
               )}
             </div>
           </div>
 
-          {/* Preview panel */}
-          <div className="flex-1 flex flex-col overflow-hidden">
+          {/* Right: preview */}
+          <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
             {previewTemplate ? (
               <>
-                <div className="p-4 border-b bg-gray-50">
-                  <div className="text-sm font-medium text-gray-700 mb-1">
+                {/* Subject bar */}
+                <div className="p-3 border-b bg-gray-50 shrink-0">
+                  <span className="text-xs font-medium text-gray-500 uppercase tracking-wide mr-2">
                     {t('admin:mailing.template.picker.subjectLabel')}
-                  </div>
-                  <div className="text-sm text-gray-900">{previewTemplate.subject}</div>
+                  </span>
+                  <span className="text-sm text-gray-900">{previewTemplate.subject}</span>
                   {previewTemplate.description && (
-                    <div className="text-xs text-gray-500 mt-1">{previewTemplate.description}</div>
+                    <p className="text-xs text-gray-400 mt-1">{previewTemplate.description}</p>
                   )}
                 </div>
-                <div className="flex-1 overflow-y-auto p-4">
-                  <div className="flex items-center gap-1 text-xs text-gray-400 mb-2">
-                    <Eye className="w-3 h-3" /> {t('admin:mailing.template.picker.preview')}
+
+                {/* Scrollable preview area */}
+                <div className="flex-1 overflow-y-auto bg-gray-100">
+                  <div className="p-3">
+                    <div className="bg-white rounded shadow-sm overflow-hidden">
+                      <EmailPreview html={previewTemplate.bodyHtml || ''} />
+                    </div>
                   </div>
-                  <div
-                    className="prose prose-sm max-w-none border border-gray-200 rounded-md p-3 bg-white text-sm"
-                    dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(previewTemplate.bodyHtml || '') }}
-                  />
                 </div>
-                <div className="p-4 border-t flex justify-end">
+
+                {/* Footer action */}
+                <div className="p-3 border-t shrink-0 flex justify-end bg-white">
                   <button
                     onClick={() => { onSelect(previewTemplate); onClose() }}
                     className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700"

--- a/admin/src/components/mailing/TemplatePickerModal.tsx
+++ b/admin/src/components/mailing/TemplatePickerModal.tsx
@@ -19,7 +19,7 @@ const TemplatePickerModal: React.FC<Props> = ({ isOpen, onClose, onSelect }) => 
   const [search, setSearch] = useState('')
   const [previewId, setPreviewId] = useState<string | null>(null)
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, error: listError } = useQuery({
     queryKey: ['mailing-templates-picker'],
     queryFn: async () => {
       const res = await apiService.mailingListTemplates(apiClient, { pageSize: 100 })
@@ -28,7 +28,7 @@ const TemplatePickerModal: React.FC<Props> = ({ isOpen, onClose, onSelect }) => 
     enabled: isOpen,
   })
 
-  const { data: previewTemplate } = useQuery({
+  const { data: previewTemplate, error: previewError } = useQuery({
     queryKey: ['mailing-template-detail', previewId],
     queryFn: async () => {
       const res = await apiService.mailingGetTemplate(apiClient, previewId!)
@@ -74,6 +74,10 @@ const TemplatePickerModal: React.FC<Props> = ({ isOpen, onClose, onSelect }) => 
             <div className="flex-1 overflow-y-auto">
               {isLoading ? (
                 <div className="flex justify-center py-8"><LoadingSpinner /></div>
+              ) : listError ? (
+                <div className="text-center py-12 text-red-500 px-4 text-sm">
+                  {t('admin:mailing.template.picker.loadError')}
+                </div>
               ) : filtered.length === 0 ? (
                 <div className="text-center py-12 text-gray-400 px-4">
                   <FileText className="w-8 h-8 mx-auto mb-2 text-gray-300" />
@@ -105,7 +109,11 @@ const TemplatePickerModal: React.FC<Props> = ({ isOpen, onClose, onSelect }) => 
 
           {/* Right: preview */}
           <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
-            {previewTemplate ? (
+            {previewError ? (
+              <div className="flex-1 flex items-center justify-center text-red-500 text-sm px-4">
+                {t('admin:mailing.template.picker.previewError')}
+              </div>
+            ) : previewTemplate ? (
               <>
                 {/* Subject bar */}
                 <div className="p-3 border-b bg-gray-50 shrink-0">

--- a/admin/src/components/mailing/TemplatePickerModal.tsx
+++ b/admin/src/components/mailing/TemplatePickerModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { X, Search, FileText, Eye } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
 import DOMPurify from 'dompurify'
 import { useApiClient, apiService } from '../../services/api'
 import { MailingTemplate } from '../../types/api'
@@ -13,6 +14,7 @@ interface Props {
 }
 
 const TemplatePickerModal: React.FC<Props> = ({ isOpen, onClose, onSelect }) => {
+  const { t } = useTranslation(['admin'])
   const apiClient = useApiClient()
   const [search, setSearch] = useState('')
   const [previewId, setPreviewId] = useState<string | null>(null)
@@ -46,7 +48,7 @@ const TemplatePickerModal: React.FC<Props> = ({ isOpen, onClose, onSelect }) => 
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-[60]">
       <div className="w-full max-w-3xl bg-white rounded-lg shadow-xl max-h-[85vh] flex flex-col">
         <div className="flex items-center justify-between p-4 border-b">
-          <h3 className="text-lg font-semibold text-gray-900">Choose a Template</h3>
+          <h3 className="text-lg font-semibold text-gray-900">{t('admin:mailing.template.picker.title')}</h3>
           <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
             <X className="w-5 h-5" />
           </button>
@@ -62,7 +64,7 @@ const TemplatePickerModal: React.FC<Props> = ({ isOpen, onClose, onSelect }) => 
                   type="text"
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
-                  placeholder="Search templates..."
+                  placeholder={t('admin:mailing.template.picker.searchPlaceholder')}
                   className="w-full pl-8 pr-3 py-2 text-sm border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
                 />
               </div>
@@ -73,19 +75,23 @@ const TemplatePickerModal: React.FC<Props> = ({ isOpen, onClose, onSelect }) => 
               ) : filtered.length === 0 ? (
                 <div className="text-center py-12 text-gray-400">
                   <FileText className="w-8 h-8 mx-auto mb-2 text-gray-300" />
-                  <p className="text-sm">{search ? 'No matching templates' : 'No templates yet'}</p>
+                  <p className="text-sm">
+                    {search
+                      ? t('admin:mailing.template.picker.noMatch')
+                      : t('admin:mailing.template.picker.noTemplates')}
+                  </p>
                 </div>
               ) : (
-                filtered.map((t: MailingTemplate) => (
+                filtered.map((tpl: MailingTemplate) => (
                   <div
-                    key={t.id}
-                    className={`p-3 cursor-pointer border-b border-gray-100 hover:bg-gray-50 transition-colors ${previewId === t.id ? 'bg-blue-50 border-l-2 border-l-blue-500' : ''}`}
-                    onClick={() => setPreviewId(t.id)}
+                    key={tpl.id}
+                    className={`p-3 cursor-pointer border-b border-gray-100 hover:bg-gray-50 transition-colors ${previewId === tpl.id ? 'bg-blue-50 border-l-2 border-l-blue-500' : ''}`}
+                    onClick={() => setPreviewId(tpl.id)}
                   >
-                    <div className="text-sm font-medium text-gray-900 truncate">{t.name}</div>
-                    <div className="text-xs text-gray-500 truncate mt-0.5">{t.subject}</div>
+                    <div className="text-sm font-medium text-gray-900 truncate">{tpl.name}</div>
+                    <div className="text-xs text-gray-500 truncate mt-0.5">{tpl.subject}</div>
                     <div className="text-xs text-gray-400 mt-1">
-                      {new Date(t.updatedAt).toLocaleDateString()}
+                      {new Date(tpl.updatedAt).toLocaleDateString()}
                     </div>
                   </div>
                 ))
@@ -98,7 +104,9 @@ const TemplatePickerModal: React.FC<Props> = ({ isOpen, onClose, onSelect }) => 
             {previewTemplate ? (
               <>
                 <div className="p-4 border-b bg-gray-50">
-                  <div className="text-sm font-medium text-gray-700 mb-1">Subject</div>
+                  <div className="text-sm font-medium text-gray-700 mb-1">
+                    {t('admin:mailing.template.picker.subjectLabel')}
+                  </div>
                   <div className="text-sm text-gray-900">{previewTemplate.subject}</div>
                   {previewTemplate.description && (
                     <div className="text-xs text-gray-500 mt-1">{previewTemplate.description}</div>
@@ -106,7 +114,7 @@ const TemplatePickerModal: React.FC<Props> = ({ isOpen, onClose, onSelect }) => 
                 </div>
                 <div className="flex-1 overflow-y-auto p-4">
                   <div className="flex items-center gap-1 text-xs text-gray-400 mb-2">
-                    <Eye className="w-3 h-3" /> Preview
+                    <Eye className="w-3 h-3" /> {t('admin:mailing.template.picker.preview')}
                   </div>
                   <div
                     className="prose prose-sm max-w-none border border-gray-200 rounded-md p-3 bg-white text-sm"
@@ -118,7 +126,7 @@ const TemplatePickerModal: React.FC<Props> = ({ isOpen, onClose, onSelect }) => 
                     onClick={() => { onSelect(previewTemplate); onClose() }}
                     className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700"
                   >
-                    Use this template
+                    {t('admin:mailing.template.picker.useTemplate')}
                   </button>
                 </div>
               </>
@@ -126,7 +134,7 @@ const TemplatePickerModal: React.FC<Props> = ({ isOpen, onClose, onSelect }) => 
               <div className="flex-1 flex items-center justify-center text-gray-400">
                 <div className="text-center">
                   <FileText className="w-10 h-10 mx-auto mb-2 text-gray-300" />
-                  <p className="text-sm">Select a template to preview</p>
+                  <p className="text-sm">{t('admin:mailing.template.picker.selectHint')}</p>
                 </div>
               </div>
             )}

--- a/admin/src/components/mailing/TemplatePickerModal.tsx
+++ b/admin/src/components/mailing/TemplatePickerModal.tsx
@@ -1,0 +1,140 @@
+import React, { useState } from 'react'
+import { X, Search, FileText, Eye } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+import DOMPurify from 'dompurify'
+import { useApiClient, apiService } from '../../services/api'
+import { MailingTemplate } from '../../types/api'
+import LoadingSpinner from '../ui/LoadingSpinner'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  onSelect: (template: MailingTemplate) => void
+}
+
+const TemplatePickerModal: React.FC<Props> = ({ isOpen, onClose, onSelect }) => {
+  const apiClient = useApiClient()
+  const [search, setSearch] = useState('')
+  const [previewId, setPreviewId] = useState<string | null>(null)
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['mailing-templates-picker'],
+    queryFn: async () => {
+      const res = await apiService.mailingListTemplates(apiClient, { pageSize: 100 })
+      return res.data
+    },
+    enabled: isOpen,
+  })
+
+  const { data: previewTemplate } = useQuery({
+    queryKey: ['mailing-template-detail', previewId],
+    queryFn: async () => {
+      const res = await apiService.mailingGetTemplate(apiClient, previewId!)
+      return res.data as MailingTemplate
+    },
+    enabled: !!previewId,
+  })
+
+  if (!isOpen) return null
+
+  const filtered = (data?.templates ?? []).filter((t: MailingTemplate) =>
+    t.name.toLowerCase().includes(search.toLowerCase()) ||
+    t.subject.toLowerCase().includes(search.toLowerCase()),
+  )
+
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-[60]">
+      <div className="w-full max-w-3xl bg-white rounded-lg shadow-xl max-h-[85vh] flex flex-col">
+        <div className="flex items-center justify-between p-4 border-b">
+          <h3 className="text-lg font-semibold text-gray-900">Choose a Template</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="flex flex-1 overflow-hidden">
+          {/* Template list */}
+          <div className="w-72 shrink-0 border-r flex flex-col">
+            <div className="p-3 border-b">
+              <div className="relative">
+                <Search className="w-4 h-4 absolute left-2.5 top-2.5 text-gray-400" />
+                <input
+                  type="text"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search templates..."
+                  className="w-full pl-8 pr-3 py-2 text-sm border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
+                />
+              </div>
+            </div>
+            <div className="flex-1 overflow-y-auto">
+              {isLoading ? (
+                <div className="flex justify-center py-8"><LoadingSpinner /></div>
+              ) : filtered.length === 0 ? (
+                <div className="text-center py-12 text-gray-400">
+                  <FileText className="w-8 h-8 mx-auto mb-2 text-gray-300" />
+                  <p className="text-sm">{search ? 'No matching templates' : 'No templates yet'}</p>
+                </div>
+              ) : (
+                filtered.map((t: MailingTemplate) => (
+                  <div
+                    key={t.id}
+                    className={`p-3 cursor-pointer border-b border-gray-100 hover:bg-gray-50 transition-colors ${previewId === t.id ? 'bg-blue-50 border-l-2 border-l-blue-500' : ''}`}
+                    onClick={() => setPreviewId(t.id)}
+                  >
+                    <div className="text-sm font-medium text-gray-900 truncate">{t.name}</div>
+                    <div className="text-xs text-gray-500 truncate mt-0.5">{t.subject}</div>
+                    <div className="text-xs text-gray-400 mt-1">
+                      {new Date(t.updatedAt).toLocaleDateString()}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+
+          {/* Preview panel */}
+          <div className="flex-1 flex flex-col overflow-hidden">
+            {previewTemplate ? (
+              <>
+                <div className="p-4 border-b bg-gray-50">
+                  <div className="text-sm font-medium text-gray-700 mb-1">Subject</div>
+                  <div className="text-sm text-gray-900">{previewTemplate.subject}</div>
+                  {previewTemplate.description && (
+                    <div className="text-xs text-gray-500 mt-1">{previewTemplate.description}</div>
+                  )}
+                </div>
+                <div className="flex-1 overflow-y-auto p-4">
+                  <div className="flex items-center gap-1 text-xs text-gray-400 mb-2">
+                    <Eye className="w-3 h-3" /> Preview
+                  </div>
+                  <div
+                    className="prose prose-sm max-w-none border border-gray-200 rounded-md p-3 bg-white text-sm"
+                    dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(previewTemplate.bodyHtml || '') }}
+                  />
+                </div>
+                <div className="p-4 border-t flex justify-end">
+                  <button
+                    onClick={() => { onSelect(previewTemplate); onClose() }}
+                    className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700"
+                  >
+                    Use this template
+                  </button>
+                </div>
+              </>
+            ) : (
+              <div className="flex-1 flex items-center justify-center text-gray-400">
+                <div className="text-center">
+                  <FileText className="w-10 h-10 mx-auto mb-2 text-gray-300" />
+                  <p className="text-sm">Select a template to preview</p>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default TemplatePickerModal

--- a/admin/src/pages/MailingList.tsx
+++ b/admin/src/pages/MailingList.tsx
@@ -2,13 +2,13 @@ import React, { useState, useEffect, useCallback } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
-  Mail, Plus, Download, Send, Save, Trash2, RefreshCw, Users, BarChart3, List, UserPlus, Pencil, Check, X,
+  Mail, Plus, Download, Send, Save, Trash2, RefreshCw, Users, BarChart3, List, UserPlus, Pencil, Check, X, FileText,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
 
 import { useApiClient, apiService } from '../services/api'
-import { MailingFilters, MailingPreviewResponse, MailingSegment, MailingCustomList } from '../types/api'
+import { MailingFilters, MailingPreviewResponse, MailingSegment, MailingCustomList, MailingTemplate } from '../types/api'
 import { useDebouncedValue } from '../hooks/useDebouncedValue'
 import Card from '../components/design-system/Card'
 import LoadingSpinner from '../components/ui/LoadingSpinner'
@@ -20,14 +20,16 @@ import ComposeEmailModal from '../components/mailing/ComposeEmailModal'
 import SendProgressOverlay from '../components/mailing/SendProgressOverlay'
 import AddToListModal from '../components/mailing/AddToListModal'
 import CustomListMembersModal from '../components/mailing/CustomListMembersModal'
+import TemplateEditorModal from '../components/mailing/TemplateEditorModal'
 
-type Tab = 'build' | 'segments' | 'campaigns' | 'lists'
+type Tab = 'build' | 'segments' | 'campaigns' | 'lists' | 'templates'
 
 const TAB_KEYS: { key: Tab; labelKey: string; icon: React.ElementType }[] = [
   { key: 'build', labelKey: 'admin:mailing.tabs.build', icon: Users },
   { key: 'lists', labelKey: 'admin:mailing.tabs.lists', icon: List },
   { key: 'segments', labelKey: 'admin:mailing.tabs.segments', icon: Save },
   { key: 'campaigns', labelKey: 'admin:mailing.tabs.campaigns', icon: BarChart3 },
+  { key: 'templates', labelKey: 'admin:mailing.tabs.templates', icon: FileText },
 ]
 
 const statusBadge = (status: string) => {
@@ -84,6 +86,11 @@ const MailingListPage: React.FC = () => {
   const [listExportModalOpen, setListExportModalOpen] = useState(false)
   const [editingListId, setEditingListId] = useState<string | null>(null)
   const [editingListName, setEditingListName] = useState('')
+
+  // Template state
+  const [templateEditorOpen, setTemplateEditorOpen] = useState(false)
+  const [editingTemplate, setEditingTemplate] = useState<MailingTemplate | null>(null)
+  const [templateActionLoading, setTemplateActionLoading] = useState(false)
 
   const toggleSelectUser = useCallback((id: string) => {
     setSelectedUserIds((prev) => {
@@ -173,6 +180,17 @@ const MailingListPage: React.FC = () => {
       return res.data
     },
     enabled: activeTab === 'lists' || addToListModalOpen,
+    retry: noRetryOnClientError,
+  })
+
+  // Templates query
+  const { data: templatesData, isLoading: templatesLoading } = useQuery({
+    queryKey: ['mailing-templates'],
+    queryFn: async () => {
+      const res = await apiService.mailingListTemplates(apiClient, { pageSize: 100 })
+      return res.data
+    },
+    enabled: activeTab === 'templates',
     retry: noRetryOnClientError,
   })
 
@@ -773,6 +791,81 @@ const MailingListPage: React.FC = () => {
         </Card>
       )}
 
+      {/* TEMPLATES tab */}
+      {activeTab === 'templates' && (
+        <Card className="overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+            <h3 className="text-sm font-semibold text-gray-700">
+              Email Templates{templatesData?.total ? ` (${templatesData.total})` : ''}
+            </h3>
+            <button
+              onClick={() => { setEditingTemplate(null); setTemplateEditorOpen(true) }}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700"
+            >
+              <Plus className="w-4 h-4" /> New Template
+            </button>
+          </div>
+          {templatesLoading ? (
+            <div className="flex justify-center py-16"><LoadingSpinner /></div>
+          ) : !templatesData?.templates?.length ? (
+            <div className="text-center py-16 text-gray-400">
+              <FileText className="w-10 h-10 mx-auto mb-3 text-gray-300" />
+              <p>No templates yet</p>
+              <p className="text-sm mt-1 text-gray-400">Create reusable HTML templates to speed up campaign creation</p>
+            </div>
+          ) : (
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Subject</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Last Updated</th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {templatesData.templates.map((tpl: MailingTemplate) => (
+                  <tr key={tpl.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3">
+                      <div className="text-sm font-medium text-gray-900">{tpl.name}</div>
+                      {tpl.description && <div className="text-xs text-gray-500 truncate max-w-xs">{tpl.description}</div>}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-600 truncate max-w-xs">{tpl.subject}</td>
+                    <td className="px-4 py-3 text-sm text-gray-500">{new Date(tpl.updatedAt).toLocaleDateString()}</td>
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex items-center justify-end gap-1">
+                        <button
+                          onClick={() => { setEditingTemplate(tpl); setTemplateEditorOpen(true) }}
+                          className="text-xs px-2 py-1 text-blue-600 hover:bg-blue-50 rounded"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          onClick={async () => {
+                            if (!window.confirm(`Delete template "${tpl.name}"?`)) return
+                            try {
+                              await apiService.mailingDeleteTemplate(apiClient, tpl.id)
+                              queryClient.invalidateQueries({ queryKey: ['mailing-templates'] })
+                              toast.success('Template deleted')
+                            } catch (err: any) {
+                              toast.error(err?.response?.data?.message || 'Failed to delete template')
+                            }
+                          }}
+                          className="p-1 text-gray-400 hover:text-red-600"
+                          title="Delete"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </Card>
+      )}
+
       {/* Modals */}
       <AddToListModal
         isOpen={addToListModalOpen}
@@ -842,6 +935,34 @@ const MailingListPage: React.FC = () => {
         onExport={handleExportList}
         loading={actionLoading}
         count={activeList?._count?.members ?? 0}
+      />
+
+      {/* Template editor */}
+      <TemplateEditorModal
+        isOpen={templateEditorOpen}
+        onClose={() => { setTemplateEditorOpen(false); setEditingTemplate(null) }}
+        title={editingTemplate ? 'Edit Template' : 'New Template'}
+        initial={editingTemplate ?? undefined}
+        loading={templateActionLoading}
+        onSave={async (data) => {
+          setTemplateActionLoading(true)
+          try {
+            if (editingTemplate) {
+              await apiService.mailingUpdateTemplate(apiClient, editingTemplate.id, data)
+              toast.success('Template updated')
+            } else {
+              await apiService.mailingCreateTemplate(apiClient, data)
+              toast.success('Template created')
+            }
+            queryClient.invalidateQueries({ queryKey: ['mailing-templates'] })
+            setTemplateEditorOpen(false)
+            setEditingTemplate(null)
+          } catch (err: any) {
+            toast.error(err?.response?.data?.message || 'Failed to save template')
+          } finally {
+            setTemplateActionLoading(false)
+          }
+        }}
       />
     </div>
   )

--- a/admin/src/pages/MailingList.tsx
+++ b/admin/src/pages/MailingList.tsx
@@ -796,13 +796,14 @@ const MailingListPage: React.FC = () => {
         <Card className="overflow-hidden">
           <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
             <h3 className="text-sm font-semibold text-gray-700">
-              Email Templates{templatesData?.total ? ` (${templatesData.total})` : ''}
+              {t('admin:mailing.template.title')}
+              {templatesData?.total ? ` (${templatesData.total})` : ''}
             </h3>
             <button
               onClick={() => { setEditingTemplate(null); setTemplateEditorOpen(true) }}
               className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700"
             >
-              <Plus className="w-4 h-4" /> New Template
+              <Plus className="w-4 h-4" /> {t('admin:mailing.template.newTemplate')}
             </button>
           </div>
           {templatesLoading ? (
@@ -810,17 +811,17 @@ const MailingListPage: React.FC = () => {
           ) : !templatesData?.templates?.length ? (
             <div className="text-center py-16 text-gray-400">
               <FileText className="w-10 h-10 mx-auto mb-3 text-gray-300" />
-              <p>No templates yet</p>
-              <p className="text-sm mt-1 text-gray-400">Create reusable HTML templates to speed up campaign creation</p>
+              <p>{t('admin:mailing.template.noTemplates')}</p>
+              <p className="text-sm mt-1 text-gray-400">{t('admin:mailing.template.noTemplatesHint')}</p>
             </div>
           ) : (
             <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50">
                 <tr>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Subject</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Last Updated</th>
-                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">{t('admin:mailing.template.columns.name')}</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">{t('admin:mailing.template.columns.subject')}</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">{t('admin:mailing.template.columns.lastUpdated')}</th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">{t('admin:mailing.template.columns.actions')}</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100">
@@ -838,21 +839,21 @@ const MailingListPage: React.FC = () => {
                           onClick={() => { setEditingTemplate(tpl); setTemplateEditorOpen(true) }}
                           className="text-xs px-2 py-1 text-blue-600 hover:bg-blue-50 rounded"
                         >
-                          Edit
+                          {t('admin:mailing.template.edit')}
                         </button>
                         <button
                           onClick={async () => {
-                            if (!window.confirm(`Delete template "${tpl.name}"?`)) return
+                            if (!window.confirm(t('admin:mailing.template.deleteConfirm', { name: tpl.name }))) return
                             try {
                               await apiService.mailingDeleteTemplate(apiClient, tpl.id)
                               queryClient.invalidateQueries({ queryKey: ['mailing-templates'] })
-                              toast.success('Template deleted')
+                              toast.success(t('admin:mailing.template.deleted'))
                             } catch (err: any) {
-                              toast.error(err?.response?.data?.message || 'Failed to delete template')
+                              toast.error(err?.response?.data?.message || t('admin:mailing.template.deleteFailed'))
                             }
                           }}
                           className="p-1 text-gray-400 hover:text-red-600"
-                          title="Delete"
+                          title={t('admin:mailing.template.delete')}
                         >
                           <Trash2 className="w-3.5 h-3.5" />
                         </button>
@@ -941,7 +942,7 @@ const MailingListPage: React.FC = () => {
       <TemplateEditorModal
         isOpen={templateEditorOpen}
         onClose={() => { setTemplateEditorOpen(false); setEditingTemplate(null) }}
-        title={editingTemplate ? 'Edit Template' : 'New Template'}
+        title={editingTemplate ? t('admin:mailing.template.editTemplate') : t('admin:mailing.template.newTemplate')}
         initial={editingTemplate ?? undefined}
         loading={templateActionLoading}
         onSave={async (data) => {
@@ -949,16 +950,16 @@ const MailingListPage: React.FC = () => {
           try {
             if (editingTemplate) {
               await apiService.mailingUpdateTemplate(apiClient, editingTemplate.id, data)
-              toast.success('Template updated')
+              toast.success(t('admin:mailing.template.updated'))
             } else {
               await apiService.mailingCreateTemplate(apiClient, data)
-              toast.success('Template created')
+              toast.success(t('admin:mailing.template.created'))
             }
             queryClient.invalidateQueries({ queryKey: ['mailing-templates'] })
             setTemplateEditorOpen(false)
             setEditingTemplate(null)
           } catch (err: any) {
-            toast.error(err?.response?.data?.message || 'Failed to save template')
+            toast.error(err?.response?.data?.message || t('admin:mailing.template.saveFailed'))
           } finally {
             setTemplateActionLoading(false)
           }

--- a/admin/src/pages/MailingList.tsx
+++ b/admin/src/pages/MailingList.tsx
@@ -66,7 +66,9 @@ const MailingListPage: React.FC = () => {
   const apiClient = useApiClient()
   const queryClient = useQueryClient()
 
-  const activeTab = (searchParams.get('tab') as Tab) || 'build'
+  const allowedTabs = TAB_KEYS.map((t) => t.key)
+  const rawTab = searchParams.get('tab') as Tab | null
+  const activeTab: Tab = rawTab && allowedTabs.includes(rawTab) ? rawTab : 'build'
   const setActiveTab = (tab: Tab) => setSearchParams({ tab })
 
   // ---- Build a List state ----
@@ -807,7 +809,8 @@ const MailingListPage: React.FC = () => {
             </h3>
             <button
               onClick={() => { setEditingTemplate(null); setTemplateEditorOpen(true) }}
-              className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700"
+              disabled={templateFetchLoading}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
             >
               <Plus className="w-4 h-4" /> {t('admin:mailing.template.newTemplate')}
             </button>

--- a/admin/src/pages/MailingList.tsx
+++ b/admin/src/pages/MailingList.tsx
@@ -22,15 +22,20 @@ import AddToListModal from '../components/mailing/AddToListModal'
 import CustomListMembersModal from '../components/mailing/CustomListMembersModal'
 import TemplateEditorModal from '../components/mailing/TemplateEditorModal'
 
+const MAILING_TEMPLATES_ENABLED = import.meta.env.VITE_MAILING_TEMPLATES !== 'false'
+
 type Tab = 'build' | 'segments' | 'campaigns' | 'lists' | 'templates'
 
-const TAB_KEYS: { key: Tab; labelKey: string; icon: React.ElementType }[] = [
+const BASE_TABS: { key: Tab; labelKey: string; icon: React.ElementType }[] = [
   { key: 'build', labelKey: 'admin:mailing.tabs.build', icon: Users },
   { key: 'lists', labelKey: 'admin:mailing.tabs.lists', icon: List },
   { key: 'segments', labelKey: 'admin:mailing.tabs.segments', icon: Save },
   { key: 'campaigns', labelKey: 'admin:mailing.tabs.campaigns', icon: BarChart3 },
-  { key: 'templates', labelKey: 'admin:mailing.tabs.templates', icon: FileText },
 ]
+
+const TAB_KEYS = MAILING_TEMPLATES_ENABLED
+  ? [...BASE_TABS, { key: 'templates' as Tab, labelKey: 'admin:mailing.tabs.templates', icon: FileText }]
+  : BASE_TABS
 
 const statusBadge = (status: string) => {
   const map: Record<string, string> = {
@@ -91,6 +96,7 @@ const MailingListPage: React.FC = () => {
   const [templateEditorOpen, setTemplateEditorOpen] = useState(false)
   const [editingTemplate, setEditingTemplate] = useState<MailingTemplate | null>(null)
   const [templateActionLoading, setTemplateActionLoading] = useState(false)
+  const [templateFetchLoading, setTemplateFetchLoading] = useState(false)
 
   const toggleSelectUser = useCallback((id: string) => {
     setSelectedUserIds((prev) => {
@@ -183,14 +189,14 @@ const MailingListPage: React.FC = () => {
     retry: noRetryOnClientError,
   })
 
-  // Templates query
+  // Templates query (only when the v2 flag is on)
   const { data: templatesData, isLoading: templatesLoading } = useQuery({
     queryKey: ['mailing-templates'],
     queryFn: async () => {
       const res = await apiService.mailingListTemplates(apiClient, { pageSize: 100 })
       return res.data
     },
-    enabled: activeTab === 'templates',
+    enabled: MAILING_TEMPLATES_ENABLED && activeTab === 'templates',
     retry: noRetryOnClientError,
   })
 
@@ -792,7 +798,7 @@ const MailingListPage: React.FC = () => {
       )}
 
       {/* TEMPLATES tab */}
-      {activeTab === 'templates' && (
+      {MAILING_TEMPLATES_ENABLED && activeTab === 'templates' && (
         <Card className="overflow-hidden">
           <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
             <h3 className="text-sm font-semibold text-gray-700">
@@ -836,8 +842,20 @@ const MailingListPage: React.FC = () => {
                     <td className="px-4 py-3 text-right">
                       <div className="flex items-center justify-end gap-1">
                         <button
-                          onClick={() => { setEditingTemplate(tpl); setTemplateEditorOpen(true) }}
-                          className="text-xs px-2 py-1 text-blue-600 hover:bg-blue-50 rounded"
+                          onClick={async () => {
+                            setTemplateFetchLoading(true)
+                            try {
+                              const res = await apiService.mailingGetTemplate(apiClient, tpl.id)
+                              setEditingTemplate(res.data as MailingTemplate)
+                              setTemplateEditorOpen(true)
+                            } catch (err: any) {
+                              toast.error(err?.response?.data?.message || t('admin:mailing.template.loadFailed'))
+                            } finally {
+                              setTemplateFetchLoading(false)
+                            }
+                          }}
+                          disabled={templateFetchLoading}
+                          className="text-xs px-2 py-1 text-blue-600 hover:bg-blue-50 rounded disabled:opacity-50"
                         >
                           {t('admin:mailing.template.edit')}
                         </button>
@@ -938,8 +956,8 @@ const MailingListPage: React.FC = () => {
         count={activeList?._count?.members ?? 0}
       />
 
-      {/* Template editor */}
-      <TemplateEditorModal
+      {/* Template editor — only rendered when template flag is enabled */}
+      {MAILING_TEMPLATES_ENABLED && <TemplateEditorModal
         isOpen={templateEditorOpen}
         onClose={() => { setTemplateEditorOpen(false); setEditingTemplate(null) }}
         title={editingTemplate ? t('admin:mailing.template.editTemplate') : t('admin:mailing.template.newTemplate')}
@@ -964,7 +982,7 @@ const MailingListPage: React.FC = () => {
             setTemplateActionLoading(false)
           }
         }}
-      />
+      />}
     </div>
   )
 }

--- a/admin/src/services/api.ts
+++ b/admin/src/services/api.ts
@@ -1218,6 +1218,32 @@ export const apiService = {
   mailingGetCustomListMembers: (apiClient: AxiosInstance, listId: string, params?: { page?: number; pageSize?: number }) =>
     apiClient.get(`/admin/mailing/custom-lists/${listId}/members`, { params }),
 
+  // Email Templates
+  mailingCreateTemplate: (apiClient: AxiosInstance, data: {
+    name: string;
+    description?: string;
+    subject: string;
+    bodyHtml: string;
+    bodyText?: string;
+  }) => apiClient.post('/admin/mailing/templates', data),
+
+  mailingListTemplates: (apiClient: AxiosInstance, params?: { page?: number; pageSize?: number }) =>
+    apiClient.get('/admin/mailing/templates', { params }),
+
+  mailingGetTemplate: (apiClient: AxiosInstance, id: string) =>
+    apiClient.get(`/admin/mailing/templates/${id}`),
+
+  mailingUpdateTemplate: (apiClient: AxiosInstance, id: string, data: {
+    name?: string;
+    description?: string;
+    subject?: string;
+    bodyHtml?: string;
+    bodyText?: string;
+  }) => apiClient.put(`/admin/mailing/templates/${id}`, data),
+
+  mailingDeleteTemplate: (apiClient: AxiosInstance, id: string) =>
+    apiClient.delete(`/admin/mailing/templates/${id}`),
+
   // Replacement Staffing (Phase 3)
   getReplacementRequests: (apiClient: AxiosInstance, params?: { status?: string; foundationId?: string }) =>
     apiClient.get('/replacements/requests', { params }),

--- a/admin/src/services/api.ts
+++ b/admin/src/services/api.ts
@@ -1221,7 +1221,7 @@ export const apiService = {
   // Email Templates
   mailingCreateTemplate: (apiClient: AxiosInstance, data: {
     name: string;
-    description?: string;
+    description?: string | null;
     subject: string;
     bodyHtml: string;
     bodyText?: string;
@@ -1235,7 +1235,7 @@ export const apiService = {
 
   mailingUpdateTemplate: (apiClient: AxiosInstance, id: string, data: {
     name?: string;
-    description?: string;
+    description?: string | null;
     subject?: string;
     bodyHtml?: string;
     bodyText?: string;

--- a/admin/src/types/api.ts
+++ b/admin/src/types/api.ts
@@ -695,6 +695,26 @@ export interface MailingCustomListMember {
 }
 
 
+export interface MailingTemplate {
+  id: string;
+  name: string;
+  description: string | null;
+  subject: string;
+  bodyHtml?: string;
+  bodyText?: string | null;
+  createdById: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MailingTemplateListResponse {
+  templates: MailingTemplate[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
 export interface ApiResponse<T> {
   success: boolean;
   message: string;

--- a/api/prisma/migrations/20260520010000_add_mailing_templates/migration.sql
+++ b/api/prisma/migrations/20260520010000_add_mailing_templates/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "mailing_templates" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "subject" TEXT NOT NULL,
+    "body_html" TEXT NOT NULL,
+    "body_text" TEXT,
+    "created_by_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "mailing_templates_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "mailing_templates_created_by_id_idx" ON "mailing_templates"("created_by_id");

--- a/api/prisma/migrations/20260520020000_mailing_templates_fk/migration.sql
+++ b/api/prisma/migrations/20260520020000_mailing_templates_fk/migration.sql
@@ -1,0 +1,2 @@
+-- AddForeignKey
+ALTER TABLE "mailing_templates" ADD CONSTRAINT "mailing_templates_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -2676,6 +2676,22 @@ model MailingCustomListMember {
   @@map("mailing_custom_list_members")
 }
 
+model MailingTemplate {
+  id          String   @id @default(uuid())
+  name        String
+  description String?  @db.Text
+  subject     String
+  bodyHtml    String   @db.Text @map("body_html")
+  bodyText    String?  @db.Text @map("body_text")
+  createdById String   @map("created_by_id")
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@index([createdById])
+  @@map("mailing_templates")
+}
+
 // ─── Replacement Staffing (Phase 3) ───────────────────────────────────────────
 
 enum UrgencyLevel {

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -321,6 +321,7 @@ model User {
 
   // Mailing custom list memberships
   mailingCustomListMemberships MailingCustomListMember[]
+  mailingTemplates             MailingTemplate[]          @relation("MailingTemplateCreator")
 
   // Replacement staffing relations
   replacementRequests  ReplacementRequest[]  @relation("UserReplacementRequests")
@@ -2684,6 +2685,7 @@ model MailingTemplate {
   bodyHtml    String   @db.Text @map("body_html")
   bodyText    String?  @db.Text @map("body_text")
   createdById String   @map("created_by_id")
+  createdBy   User     @relation("MailingTemplateCreator", fields: [createdById], references: [id])
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")

--- a/api/src/mailing/dto/template.dto.ts
+++ b/api/src/mailing/dto/template.dto.ts
@@ -1,0 +1,48 @@
+import { IsString, IsOptional, MaxLength } from 'class-validator';
+
+export class CreateTemplateDto {
+  @IsString()
+  @MaxLength(200)
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  description?: string;
+
+  @IsString()
+  @MaxLength(998)
+  subject: string;
+
+  @IsString()
+  bodyHtml: string;
+
+  @IsOptional()
+  @IsString()
+  bodyText?: string;
+}
+
+export class UpdateTemplateDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(998)
+  subject?: string;
+
+  @IsOptional()
+  @IsString()
+  bodyHtml?: string;
+
+  @IsOptional()
+  @IsString()
+  bodyText?: string;
+}

--- a/api/src/mailing/mailing.controller.ts
+++ b/api/src/mailing/mailing.controller.ts
@@ -26,6 +26,7 @@ import { CreateSegmentDto, UpdateSegmentDto } from './dto/segment.dto';
 import { CreateCampaignDto, SendBatchDto } from './dto/campaign.dto';
 import { ExportRequestDto } from './dto/export.dto';
 import { CreateCustomListDto, UpdateCustomListDto, ManageCustomListMembersDto } from './dto/custom-list.dto';
+import { CreateTemplateDto, UpdateTemplateDto } from './dto/template.dto';
 import { MailingFiltersDto } from './dto/mailing-filters.dto';
 
 @ApiTags('admin/mailing')
@@ -362,5 +363,47 @@ export class MailingController {
       page ? parseInt(page, 10) : 1,
       pageSize ? parseInt(pageSize, 10) : 20,
     );
+  }
+
+  /* ================================================================ */
+  /*  EMAIL TEMPLATES                                                  */
+  /* ================================================================ */
+
+  @Post('templates')
+  @ApiOperation({ summary: 'Create an email template' })
+  async createTemplate(@Body() body: CreateTemplateDto, @Request() req: any) {
+    const adminId = this.getAdminId(req);
+    return this.mailingService.createTemplate(body, adminId);
+  }
+
+  @Get('templates')
+  @ApiOperation({ summary: 'List email templates' })
+  async listTemplates(
+    @Query('page') page?: string,
+    @Query('pageSize') pageSize?: string,
+  ) {
+    return this.mailingService.listTemplates(
+      page ? parseInt(page, 10) : 1,
+      pageSize ? parseInt(pageSize, 10) : 50,
+    );
+  }
+
+  @Get('templates/:id')
+  @ApiOperation({ summary: 'Get email template detail' })
+  async getTemplate(@Param('id') id: string) {
+    return this.mailingService.getTemplate(id);
+  }
+
+  @Put('templates/:id')
+  @ApiOperation({ summary: 'Update an email template' })
+  async updateTemplate(@Param('id') id: string, @Body() body: UpdateTemplateDto) {
+    return this.mailingService.updateTemplate(id, body);
+  }
+
+  @Delete('templates/:id')
+  @ApiOperation({ summary: 'Delete an email template' })
+  async deleteTemplate(@Param('id') id: string) {
+    await this.mailingService.deleteTemplate(id);
+    return { success: true, message: 'Template deleted' };
   }
 }

--- a/api/src/mailing/mailing.service.ts
+++ b/api/src/mailing/mailing.service.ts
@@ -1197,13 +1197,13 @@ export class MailingService {
   ) {
     await this.getTemplate(id);
     const updateData: any = { ...data };
-    if (data.bodyHtml) {
+    if (data.bodyHtml !== undefined) {
       updateData.bodyHtml = this.sanitiseHtml(data.bodyHtml);
-      if (!data.bodyText) {
+      if (data.bodyText === undefined) {
         updateData.bodyText = updateData.bodyHtml.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
       }
     }
-    if (data.subject) updateData.subject = data.subject.slice(0, 998);
+    if (data.subject !== undefined) updateData.subject = data.subject.slice(0, 998);
     return this.prisma.mailingTemplate.update({ where: { id }, data: updateData });
   }
 

--- a/api/src/mailing/mailing.service.ts
+++ b/api/src/mailing/mailing.service.ts
@@ -752,8 +752,13 @@ export class MailingService {
     const platformSettings = await this.prisma.frontendSettings.findFirst({
       include: { logoAsset: true, faviconAsset: true },
     });
+    // SEC: use uploaded asset publicUrl (absolute R2 URL) when available; fall back to
+    // well-known paths relative to FRONTEND_URL so image tokens never resolve to empty src.
+    const frontendUrl = (process.env.FRONTEND_URL || process.env.APP_URL || '').replace(/\/$/, '');
     const platformLogoUrl = platformSettings?.logoAsset?.publicUrl || '';
-    const platformIconUrl = platformSettings?.faviconAsset?.publicUrl || '';
+    const platformIconUrl =
+      platformSettings?.faviconAsset?.publicUrl ||
+      (frontendUrl ? `${frontendUrl}/favicon.ico` : '');
 
     for (const recipient of recipients) {
       lastUserId = recipient.id;

--- a/api/src/mailing/mailing.service.ts
+++ b/api/src/mailing/mailing.service.ts
@@ -748,6 +748,13 @@ export class MailingService {
 
     const unsubscribeBaseUrl = process.env.APP_URL || 'https://procrechesolutions.com';
 
+    // Fetch platform branding once for logo/icon tokens (same for all recipients)
+    const platformSettings = await this.prisma.frontendSettings.findFirst({
+      include: { logoAsset: true, faviconAsset: true },
+    });
+    const platformLogoUrl = platformSettings?.logoAsset?.publicUrl || '';
+    const platformIconUrl = platformSettings?.faviconAsset?.publicUrl || '';
+
     for (const recipient of recipients) {
       lastUserId = recipient.id;
 
@@ -769,6 +776,8 @@ export class MailingService {
         role: recipient.role,
         orgName: org?.name || '',
         canton: org?.canton || '',
+        logoUrl: platformLogoUrl,
+        iconUrl: platformIconUrl,
         unsubscribeUrl,
       });
 
@@ -779,6 +788,8 @@ export class MailingService {
         role: recipient.role,
         orgName: org?.name || '',
         canton: org?.canton || '',
+        logoUrl: platformLogoUrl,
+        iconUrl: platformIconUrl,
         unsubscribeUrl,
       });
 
@@ -1120,5 +1131,79 @@ export class MailingService {
       pageSize: clampedPageSize,
       totalPages: Math.ceil(total / clampedPageSize),
     };
+  }
+
+  /* ================================================================ */
+  /*  EMAIL TEMPLATES                                                  */
+  /* ================================================================ */
+
+  async createTemplate(
+    data: { name: string; description?: string; subject: string; bodyHtml: string; bodyText?: string },
+    createdById: string,
+  ) {
+    const sanitisedHtml = this.sanitiseHtml(data.bodyHtml);
+    const plainText = data.bodyText || sanitisedHtml.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+    return this.prisma.mailingTemplate.create({
+      data: {
+        name: data.name,
+        description: data.description,
+        subject: data.subject.slice(0, 998),
+        bodyHtml: sanitisedHtml,
+        bodyText: plainText,
+        createdById,
+      },
+    });
+  }
+
+  async listTemplates(page = 1, pageSize = 50) {
+    const clampedPageSize = Math.min(Math.max(1, pageSize), MAX_PAGE_SIZE);
+    const clampedPage = Math.max(1, page);
+    const skip = (clampedPage - 1) * clampedPageSize;
+    const [templates, total] = await Promise.all([
+      this.prisma.mailingTemplate.findMany({
+        skip,
+        take: clampedPageSize,
+        orderBy: { updatedAt: 'desc' },
+        select: {
+          id: true, name: true, description: true, subject: true,
+          createdById: true, createdAt: true, updatedAt: true,
+        },
+      }),
+      this.prisma.mailingTemplate.count(),
+    ]);
+    return {
+      templates,
+      total,
+      page: clampedPage,
+      pageSize: clampedPageSize,
+      totalPages: Math.ceil(total / clampedPageSize),
+    };
+  }
+
+  async getTemplate(id: string) {
+    const template = await this.prisma.mailingTemplate.findUnique({ where: { id } });
+    if (!template) throw new NotFoundException('Template not found');
+    return template;
+  }
+
+  async updateTemplate(
+    id: string,
+    data: { name?: string; description?: string; subject?: string; bodyHtml?: string; bodyText?: string },
+  ) {
+    await this.getTemplate(id);
+    const updateData: any = { ...data };
+    if (data.bodyHtml) {
+      updateData.bodyHtml = this.sanitiseHtml(data.bodyHtml);
+      if (!data.bodyText) {
+        updateData.bodyText = updateData.bodyHtml.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+      }
+    }
+    if (data.subject) updateData.subject = data.subject.slice(0, 998);
+    return this.prisma.mailingTemplate.update({ where: { id }, data: updateData });
+  }
+
+  async deleteTemplate(id: string) {
+    await this.getTemplate(id);
+    return this.prisma.mailingTemplate.delete({ where: { id } });
   }
 }

--- a/packages/translations/locales/de/admin.json
+++ b/packages/translations/locales/de/admin.json
@@ -2288,7 +2288,8 @@
       "build": "Liste erstellen",
       "lists": "Benutzerdefinierte Listen",
       "segments": "Segmente",
-      "campaigns": "Kampagnen"
+      "campaigns": "Kampagnen",
+      "templates": "Vorlagen"
     },
     "filters": {
       "title": "Filter",
@@ -2440,9 +2441,59 @@
       "bodyPlaceholder": "<p>Hallo {{firstName}},</p><p>Ihr Inhalt hier...</p>",
       "preview": "Vorschau",
       "edit": "Bearbeiten",
-      "tokens": "Verfügbare Personalisierungs-Token",
+      "tokens": "Personalisierungs-Token — zum Einfügen klicken",
+      "tokenHint": "{{logoUrl}} und {{iconUrl}} werden zu Logo-/Favicon-URLs der Plattform — in <img src=\"…\" /> einbetten.",
       "creating": "Erstelle...",
-      "send": "Kampagne erstellen und senden"
+      "send": "Kampagne erstellen und senden",
+      "loadTemplate": "Vorlage laden",
+      "saveCurrentAsTemplate": "Aktuellen Inhalt als Vorlage speichern",
+      "saveAsTemplate": "Als Vorlage speichern",
+      "templateNamePlaceholder": "Vorlagenname",
+      "templateSaved": "Vorlage \"{{name}}\" gespeichert",
+      "templateSaveFailed": "Vorlage konnte nicht gespeichert werden",
+      "replaceConfirm": "Aktuellen Inhalt durch diese Vorlage ersetzen?"
+    },
+    "template": {
+      "title": "E-Mail-Vorlagen",
+      "newTemplate": "Neue Vorlage",
+      "editTemplate": "Vorlage bearbeiten",
+      "noTemplates": "Noch keine Vorlagen",
+      "noTemplatesHint": "Erstellen Sie wiederverwendbare HTML-Vorlagen für schnellere Kampagnenerstellung",
+      "nameLabel": "Vorlagenname",
+      "namePlaceholder": "z.B. Monatlicher Newsletter",
+      "descriptionLabel": "Beschreibung",
+      "descriptionPlaceholder": "Optionale Beschreibung",
+      "subjectLabel": "Standardbetreff",
+      "subjectPlaceholder": "E-Mail-Betreffzeile",
+      "bodyLabel": "Inhalt (HTML)",
+      "tokenLabel": "Personalisierungs-Token — zum Einfügen klicken",
+      "logoHint": "Verwenden Sie <img src=\"{{logoUrl}}\" /> um das Plattformlogo einzubetten.",
+      "saving": "Speichern...",
+      "save": "Vorlage speichern",
+      "updated": "Vorlage aktualisiert",
+      "created": "Vorlage erstellt",
+      "deleted": "Vorlage gelöscht",
+      "saveFailed": "Vorlage konnte nicht gespeichert werden",
+      "deleteFailed": "Vorlage konnte nicht gelöscht werden",
+      "deleteConfirm": "Vorlage \"{{name}}\" löschen?",
+      "columns": {
+        "name": "Name",
+        "subject": "Betreff",
+        "lastUpdated": "Letzte Aktualisierung",
+        "actions": "Aktionen"
+      },
+      "picker": {
+        "title": "Vorlage auswählen",
+        "searchPlaceholder": "Vorlagen suchen...",
+        "noMatch": "Keine passenden Vorlagen",
+        "noTemplates": "Noch keine Vorlagen",
+        "subjectLabel": "Betreff",
+        "preview": "Vorschau",
+        "selectHint": "Vorlage auswählen, um eine Vorschau anzuzeigen",
+        "useTemplate": "Diese Vorlage verwenden"
+      },
+      "edit": "Bearbeiten",
+      "delete": "Löschen"
     },
     "campaign": {
       "noCampaigns": "Keine Kampagnen",

--- a/packages/translations/locales/de/admin.json
+++ b/packages/translations/locales/de/admin.json
@@ -2490,8 +2490,11 @@
         "subjectLabel": "Betreff",
         "preview": "Vorschau",
         "selectHint": "Vorlage auswählen, um eine Vorschau anzuzeigen",
-        "useTemplate": "Diese Vorlage verwenden"
+        "useTemplate": "Diese Vorlage verwenden",
+        "loadError": "Vorlagen konnten nicht geladen werden. Bitte erneut versuchen.",
+        "previewError": "Vorlagenvorschau konnte nicht geladen werden."
       },
+      "loadFailed": "Vorlage konnte nicht geladen werden",
       "edit": "Bearbeiten",
       "delete": "Löschen"
     },

--- a/packages/translations/locales/en/admin.json
+++ b/packages/translations/locales/en/admin.json
@@ -2490,8 +2490,11 @@
         "subjectLabel": "Subject",
         "preview": "Preview",
         "selectHint": "Select a template to preview",
-        "useTemplate": "Use this template"
+        "useTemplate": "Use this template",
+        "loadError": "Failed to load templates. Please try again.",
+        "previewError": "Failed to load template preview."
       },
+      "loadFailed": "Failed to load template",
       "edit": "Edit",
       "delete": "Delete"
     },

--- a/packages/translations/locales/en/admin.json
+++ b/packages/translations/locales/en/admin.json
@@ -2283,7 +2283,8 @@
       "build": "Build a List",
       "lists": "Custom Lists",
       "segments": "Segments",
-      "campaigns": "Campaigns"
+      "campaigns": "Campaigns",
+      "templates": "Templates"
     },
     "filters": {
       "title": "Filters",
@@ -2440,9 +2441,59 @@
       "bodyPlaceholder": "<p>Hello {{firstName}},</p><p>Your email content here...</p>",
       "preview": "Preview",
       "edit": "Edit",
-      "tokens": "Available personalization tokens",
+      "tokens": "Personalization tokens — click to insert",
+      "tokenHint": "{{logoUrl}} and {{iconUrl}} resolve to the platform logo/favicon URLs — wrap in <img src=\"…\" />.",
       "creating": "Creating...",
-      "send": "Create Campaign & Send"
+      "send": "Create Campaign & Send",
+      "loadTemplate": "Load template",
+      "saveCurrentAsTemplate": "Save current content as template",
+      "saveAsTemplate": "Save as template",
+      "templateNamePlaceholder": "Template name",
+      "templateSaved": "Template \"{{name}}\" saved",
+      "templateSaveFailed": "Failed to save template",
+      "replaceConfirm": "Replace current content with this template?"
+    },
+    "template": {
+      "title": "Email Templates",
+      "newTemplate": "New Template",
+      "editTemplate": "Edit Template",
+      "noTemplates": "No templates yet",
+      "noTemplatesHint": "Create reusable HTML templates to speed up campaign creation",
+      "nameLabel": "Template name",
+      "namePlaceholder": "e.g. Monthly newsletter",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Optional description",
+      "subjectLabel": "Default subject",
+      "subjectPlaceholder": "Email subject line",
+      "bodyLabel": "Body (HTML)",
+      "tokenLabel": "Personalization tokens — click to insert",
+      "logoHint": "Use <img src=\"{{logoUrl}}\" /> to embed the platform logo.",
+      "saving": "Saving...",
+      "save": "Save Template",
+      "updated": "Template updated",
+      "created": "Template created",
+      "deleted": "Template deleted",
+      "saveFailed": "Failed to save template",
+      "deleteFailed": "Failed to delete template",
+      "deleteConfirm": "Delete template \"{{name}}\"?",
+      "columns": {
+        "name": "Name",
+        "subject": "Subject",
+        "lastUpdated": "Last Updated",
+        "actions": "Actions"
+      },
+      "picker": {
+        "title": "Choose a Template",
+        "searchPlaceholder": "Search templates...",
+        "noMatch": "No matching templates",
+        "noTemplates": "No templates yet",
+        "subjectLabel": "Subject",
+        "preview": "Preview",
+        "selectHint": "Select a template to preview",
+        "useTemplate": "Use this template"
+      },
+      "edit": "Edit",
+      "delete": "Delete"
     },
     "campaign": {
       "noCampaigns": "No campaigns yet",

--- a/packages/translations/locales/fr/admin.json
+++ b/packages/translations/locales/fr/admin.json
@@ -2313,7 +2313,8 @@
       "build": "Créer une liste",
       "lists": "Listes personnalisées",
       "segments": "Segments",
-      "campaigns": "Campagnes"
+      "campaigns": "Campagnes",
+      "templates": "Modèles"
     },
     "filters": {
       "title": "Filtres",
@@ -2465,9 +2466,59 @@
       "bodyPlaceholder": "<p>Bonjour {{firstName}},</p><p>Votre contenu ici...</p>",
       "preview": "Aperçu",
       "edit": "Modifier",
-      "tokens": "Jetons de personnalisation disponibles",
+      "tokens": "Jetons de personnalisation — cliquer pour insérer",
+      "tokenHint": "{{logoUrl}} et {{iconUrl}} correspondent aux URLs du logo/favicon — à utiliser dans <img src=\"…\" />.",
       "creating": "Création...",
-      "send": "Créer la campagne et envoyer"
+      "send": "Créer la campagne et envoyer",
+      "loadTemplate": "Charger un modèle",
+      "saveCurrentAsTemplate": "Enregistrer le contenu actuel comme modèle",
+      "saveAsTemplate": "Enregistrer comme modèle",
+      "templateNamePlaceholder": "Nom du modèle",
+      "templateSaved": "Modèle \"{{name}}\" enregistré",
+      "templateSaveFailed": "Impossible d'enregistrer le modèle",
+      "replaceConfirm": "Remplacer le contenu actuel par ce modèle ?"
+    },
+    "template": {
+      "title": "Modèles d'email",
+      "newTemplate": "Nouveau modèle",
+      "editTemplate": "Modifier le modèle",
+      "noTemplates": "Aucun modèle",
+      "noTemplatesHint": "Créez des modèles HTML réutilisables pour accélérer la création de campagnes",
+      "nameLabel": "Nom du modèle",
+      "namePlaceholder": "ex. Newsletter mensuelle",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Description optionnelle",
+      "subjectLabel": "Objet par défaut",
+      "subjectPlaceholder": "Ligne d'objet de l'email",
+      "bodyLabel": "Corps (HTML)",
+      "tokenLabel": "Jetons de personnalisation — cliquer pour insérer",
+      "logoHint": "Utilisez <img src=\"{{logoUrl}}\" /> pour intégrer le logo de la plateforme.",
+      "saving": "Enregistrement...",
+      "save": "Enregistrer le modèle",
+      "updated": "Modèle mis à jour",
+      "created": "Modèle créé",
+      "deleted": "Modèle supprimé",
+      "saveFailed": "Impossible d'enregistrer le modèle",
+      "deleteFailed": "Impossible de supprimer le modèle",
+      "deleteConfirm": "Supprimer le modèle \"{{name}}\" ?",
+      "columns": {
+        "name": "Nom",
+        "subject": "Objet",
+        "lastUpdated": "Dernière mise à jour",
+        "actions": "Actions"
+      },
+      "picker": {
+        "title": "Choisir un modèle",
+        "searchPlaceholder": "Rechercher des modèles...",
+        "noMatch": "Aucun modèle correspondant",
+        "noTemplates": "Aucun modèle",
+        "subjectLabel": "Objet",
+        "preview": "Aperçu",
+        "selectHint": "Sélectionnez un modèle pour le prévisualiser",
+        "useTemplate": "Utiliser ce modèle"
+      },
+      "edit": "Modifier",
+      "delete": "Supprimer"
     },
     "campaign": {
       "noCampaigns": "Aucune campagne",

--- a/packages/translations/locales/fr/admin.json
+++ b/packages/translations/locales/fr/admin.json
@@ -2515,8 +2515,11 @@
         "subjectLabel": "Objet",
         "preview": "Aperçu",
         "selectHint": "Sélectionnez un modèle pour le prévisualiser",
-        "useTemplate": "Utiliser ce modèle"
+        "useTemplate": "Utiliser ce modèle",
+        "loadError": "Échec du chargement des modèles. Veuillez réessayer.",
+        "previewError": "Échec du chargement de l'aperçu du modèle."
       },
+      "loadFailed": "Échec du chargement du modèle",
       "edit": "Modifier",
       "delete": "Supprimer"
     },


### PR DESCRIPTION
## Summary

Adds a complete email template management system to the mailing module, allowing admins to create, save, reuse, and manage HTML email templates with personalization tokens. Templates can be created from scratch or saved from composed campaigns, and loaded into the compose modal for quick campaign creation.

## Key Changes

**Backend (API)**
- Added `MailingTemplate` Prisma model with fields: `name`, `description`, `subject`, `bodyHtml`, `bodyText`, `createdById`, timestamps
- Implemented template CRUD service methods: `createTemplate()`, `listTemplates()`, `getTemplate()`, `updateTemplate()`, `deleteTemplate()`
- Added controller endpoints: `POST /templates`, `GET /templates`, `GET /templates/:id`, `PUT /templates/:id`, `DELETE /templates/:id`
- Created `CreateTemplateDto` and `UpdateTemplateDto` validation classes
- Enhanced email token replacement to include `{{logoUrl}}` and `{{iconUrl}}` (fetched once per campaign from platform branding settings)
- Added database migration for `mailing_templates` table with index on `created_by_id`

**Frontend (Admin)**
- Created `TemplatePickerModal` component: searchable template browser with preview panel
- Created `TemplateEditorModal` component: full-featured template editor with preview, token insertion, and save functionality
- Enhanced `ComposeEmailModal`:
  - Added "Load template" button to open template picker
  - Added "Save current content as template" feature with inline save form
  - Expanded token list to include `{{logoUrl}}` and `{{iconUrl}}`
  - Improved token documentation with usage examples
- Added new "Templates" tab to `MailingList` page with full CRUD UI (create, edit, delete, list)
- Added API service methods for all template endpoints
- Added `MailingTemplate` and `MailingTemplateListResponse` TypeScript interfaces

## Implementation Details

- Templates are sanitized on save using the existing `sanitiseHtml()` method
- Plain text version auto-generated from HTML if not provided
- Platform logo/icon URLs fetched once per campaign send (not per recipient) for efficiency
- Template picker uses React Query for data fetching with search/filter on client side
- All template operations include proper error handling with toast notifications
- Template names and descriptions support up to 200 and 1000 characters respectively
- Subject lines clamped to 998 characters (consistent with campaign subjects)

https://claude.ai/code/session_019xvdxR4aZp2jTD54RCAsKb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email template management in admin: create, edit, delete, and apply saved templates when composing emails
  * Template picker modal and “Save as template” action in the compose flow
  * Expanded personalization tokens including logo and icon URLs; improved email preview rendering

* **Localization**
  * Added translation strings for templates, picker, saving/loading, and token help text

* **Configuration**
  * Template features can be toggled via an admin feature flag example entry

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/One-S-Digital/PC-Solutions-Platform/pull/643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->