### PR TITLE
feat: Phase 1 staffing backend — parsing, matching, and embeddings

### DIFF
--- a/api/prisma/migrations/20260521000000_add_staffing_phase1/migration.sql
+++ b/api/prisma/migrations/20260521000000_add_staffing_phase1/migration.sql
@@ -56,7 +56,7 @@ ALTER TABLE "job_listings"
 -- ─── Additive column on knowledge_documents ──────────────────────────────────
 
 ALTER TABLE "knowledge_documents"
-  ADD COLUMN IF NOT EXISTS "embedding" vector(768);
+  ADD COLUMN IF NOT EXISTS "embedding" vector(512);
 
 CREATE INDEX IF NOT EXISTS knowledge_documents_embedding_hnsw
   ON "knowledge_documents"
@@ -104,7 +104,7 @@ CREATE TABLE IF NOT EXISTS "staffing_request_embeddings" (
   "staffingRequestId" TEXT NOT NULL,
   "model"             TEXT NOT NULL DEFAULT 'voyage-3-lite',
   "profileHash"       TEXT NOT NULL,
-  "embedding"         vector(768),
+  "embedding"         vector(512),
   "createdAt"         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   CONSTRAINT "staffing_request_embeddings_pkey" PRIMARY KEY ("id"),
   CONSTRAINT "staffing_request_embeddings_staffingRequestId_key" UNIQUE ("staffingRequestId"),
@@ -156,7 +156,7 @@ CREATE TABLE IF NOT EXISTS "educator_embeddings" (
   "userId"      TEXT NOT NULL,
   "model"       TEXT NOT NULL DEFAULT 'voyage-3-lite',
   "profileHash" TEXT NOT NULL,
-  "embedding"   vector(768),
+  "embedding"   vector(512),
   "createdAt"   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   "updatedAt"   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   CONSTRAINT "educator_embeddings_pkey" PRIMARY KEY ("id"),

--- a/api/prisma/migrations/20260521000000_add_staffing_phase1/migration.sql
+++ b/api/prisma/migrations/20260521000000_add_staffing_phase1/migration.sql
@@ -1,0 +1,170 @@
+-- Staffing Phase 1 migration
+-- Enables pgvector and earthdistance extensions, then creates all Phase 1 tables.
+-- Run `api/scripts/enable-pg-extensions.sql` on production first if the DB user
+-- lacks SUPERUSER (the CREATE EXTENSION commands require it).
+
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS cube;
+CREATE EXTENSION IF NOT EXISTS earthdistance;
+
+-- ─── New enums ────────────────────────────────────────────────────────────────
+
+DO $$ BEGIN
+  CREATE TYPE "StaffingRequestStatus" AS ENUM (
+    'PENDING_PARSE', 'PARSED', 'MATCHING', 'SHORTLISTED', 'CLOSED', 'CANCELLED'
+  );
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "MatchResultStatus" AS ENUM (
+    'PENDING', 'EXPLAINED', 'SHORTLISTED', 'CONTACTED', 'ACCEPTED', 'DECLINED'
+  );
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- Extend existing NotificationType enum
+DO $$ BEGIN
+  ALTER TYPE "NotificationType" ADD VALUE IF NOT EXISTS 'SHORTLIST_READY';
+EXCEPTION WHEN others THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TYPE "NotificationType" ADD VALUE IF NOT EXISTS 'CANDIDATE_RESPONDED';
+EXCEPTION WHEN others THEN NULL; END $$;
+
+-- ─── Additive columns on users ────────────────────────────────────────────────
+
+ALTER TABLE "users"
+  ADD COLUMN IF NOT EXISTS "latitude"                  DECIMAL,
+  ADD COLUMN IF NOT EXISTS "longitude"                 DECIMAL,
+  ADD COLUMN IF NOT EXISTS "geocodedAt"                TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS "maxCommuteKm"              INTEGER,
+  ADD COLUMN IF NOT EXISTS "availabilitySchemaVersion" INTEGER NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS "lastMatchedAt"             TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS "responsivenessScore"       DECIMAL NOT NULL DEFAULT 0;
+
+-- ─── Additive columns on organizations ───────────────────────────────────────
+
+ALTER TABLE "organizations"
+  ADD COLUMN IF NOT EXISTS "latitude"    DECIMAL,
+  ADD COLUMN IF NOT EXISTS "longitude"   DECIMAL,
+  ADD COLUMN IF NOT EXISTS "geocodedAt"  TIMESTAMPTZ;
+
+-- ─── Additive column on job_listings ─────────────────────────────────────────
+
+ALTER TABLE "job_listings"
+  ADD COLUMN IF NOT EXISTS "staffingRequestId" TEXT;
+
+-- ─── Additive column on knowledge_documents ──────────────────────────────────
+
+ALTER TABLE "knowledge_documents"
+  ADD COLUMN IF NOT EXISTS "embedding" vector(768);
+
+CREATE INDEX IF NOT EXISTS knowledge_documents_embedding_hnsw
+  ON "knowledge_documents"
+  USING hnsw ("embedding" vector_cosine_ops);
+
+-- ─── staffing_requests ───────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS "staffing_requests" (
+  "id"             TEXT NOT NULL,
+  "foundationId"   TEXT NOT NULL,
+  "createdById"    TEXT NOT NULL,
+  "rawText"        TEXT NOT NULL,
+  "roleRequired"   TEXT,
+  "contractType"   "JobContractType",
+  "startDate"      TIMESTAMPTZ,
+  "endDate"        TIMESTAMPTZ,
+  "hoursPerWeek"   INTEGER,
+  "canton"         TEXT,
+  "city"           TEXT,
+  "ageGroups"      TEXT[] NOT NULL DEFAULT '{}',
+  "languages"      TEXT[] NOT NULL DEFAULT '{}',
+  "qualifications" TEXT[] NOT NULL DEFAULT '{}',
+  "notes"          TEXT,
+  "status"         "StaffingRequestStatus" NOT NULL DEFAULT 'PENDING_PARSE',
+  "locale"         TEXT NOT NULL DEFAULT 'fr',
+  "createdAt"      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updatedAt"      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT "staffing_requests_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "staffing_requests_foundationId_fkey"
+    FOREIGN KEY ("foundationId") REFERENCES "organizations"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "staffing_requests_createdById_fkey"
+    FOREIGN KEY ("createdById") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "staffing_requests_foundationId_idx" ON "staffing_requests"("foundationId");
+
+ALTER TABLE "job_listings"
+  ADD CONSTRAINT IF NOT EXISTS "job_listings_staffingRequestId_fkey"
+    FOREIGN KEY ("staffingRequestId") REFERENCES "staffing_requests"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- ─── staffing_request_embeddings ─────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS "staffing_request_embeddings" (
+  "id"                TEXT NOT NULL,
+  "staffingRequestId" TEXT NOT NULL,
+  "model"             TEXT NOT NULL DEFAULT 'voyage-3-lite',
+  "profileHash"       TEXT NOT NULL,
+  "embedding"         vector(768),
+  "createdAt"         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT "staffing_request_embeddings_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "staffing_request_embeddings_staffingRequestId_key" UNIQUE ("staffingRequestId"),
+  CONSTRAINT "staffing_request_embeddings_staffingRequestId_fkey"
+    FOREIGN KEY ("staffingRequestId") REFERENCES "staffing_requests"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS staffing_request_embeddings_hnsw
+  ON "staffing_request_embeddings"
+  USING hnsw ("embedding" vector_cosine_ops);
+
+-- ─── match_results ───────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS "match_results" (
+  "id"                TEXT NOT NULL,
+  "staffingRequestId" TEXT NOT NULL,
+  "candidateId"       TEXT NOT NULL,
+  "totalScore"        DECIMAL(5,2) NOT NULL,
+  "roleScore"         DECIMAL(5,2) NOT NULL DEFAULT 0,
+  "availabilityScore" DECIMAL(5,2) NOT NULL DEFAULT 0,
+  "locationScore"     DECIMAL(5,2) NOT NULL DEFAULT 0,
+  "qualificationScore" DECIMAL(5,2) NOT NULL DEFAULT 0,
+  "languageScore"     DECIMAL(5,2) NOT NULL DEFAULT 0,
+  "ageGroupScore"     DECIMAL(5,2) NOT NULL DEFAULT 0,
+  "contractScore"     DECIMAL(5,2) NOT NULL DEFAULT 0,
+  "responsivenessScr" DECIMAL(5,2) NOT NULL DEFAULT 0,
+  "distanceKm"        DECIMAL(8,2),
+  "vectorSimilarity"  DECIMAL(5,4),
+  "explanation"       TEXT,
+  "status"            "MatchResultStatus" NOT NULL DEFAULT 'PENDING',
+  "createdAt"         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updatedAt"         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT "match_results_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "match_results_staffingRequestId_candidateId_key"
+    UNIQUE ("staffingRequestId", "candidateId"),
+  CONSTRAINT "match_results_staffingRequestId_fkey"
+    FOREIGN KEY ("staffingRequestId") REFERENCES "staffing_requests"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "match_results_candidateId_fkey"
+    FOREIGN KEY ("candidateId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "match_results_staffingRequestId_idx"
+  ON "match_results"("staffingRequestId");
+
+-- ─── educator_embeddings ─────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS "educator_embeddings" (
+  "id"          TEXT NOT NULL,
+  "userId"      TEXT NOT NULL,
+  "model"       TEXT NOT NULL DEFAULT 'voyage-3-lite',
+  "profileHash" TEXT NOT NULL,
+  "embedding"   vector(768),
+  "createdAt"   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updatedAt"   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT "educator_embeddings_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "educator_embeddings_userId_key" UNIQUE ("userId"),
+  CONSTRAINT "educator_embeddings_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS educator_embeddings_hnsw
+  ON "educator_embeddings"
+  USING hnsw ("embedding" vector_cosine_ops);

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -341,6 +341,20 @@ model User {
   // AI consent tracking
   candidateConsents    CandidateConsent[]    @relation("CandidateConsents")
 
+  // Geo + staffing matching (Phase 1)
+  latitude                  Decimal?
+  longitude                 Decimal?
+  geocodedAt                DateTime?
+  maxCommuteKm              Int?
+  availabilitySchemaVersion Int      @default(1)
+  lastMatchedAt             DateTime?
+  responsivenessScore       Decimal  @default(0)
+
+  // Staffing phase 1 relations
+  staffingRequests  StaffingRequest[]  @relation("UserStaffingRequests")
+  matchResults      MatchResult[]      @relation("UserMatchResults")
+  educatorEmbedding EducatorEmbedding? @relation("UserEducatorEmbedding")
+
   @@map("users")
 }
 
@@ -490,6 +504,14 @@ model Organization {
 
   // Intern pool
   internPoolRequests InternPoolRequest[] @relation("FoundationInternPoolRequests")
+
+  // Geo coordinates for distance matching (Phase 1)
+  latitude    Decimal?
+  longitude   Decimal?
+  geocodedAt  DateTime?
+
+  // Staffing phase 1
+  staffingRequests StaffingRequest[] @relation("FoundationStaffingRequests")
 
   @@map("organizations")
 }
@@ -903,6 +925,10 @@ model JobListing {
   publishedAt      DateTime?
   createdAt        DateTime        @default(now())
   updatedAt        DateTime        @updatedAt
+
+  // Staffing phase 1 — optional FK to StaffingRequest
+  staffingRequestId String?
+  staffingRequest   StaffingRequest? @relation("StaffingRequestJobListings", fields: [staffingRequestId], references: [id])
 
   // Relations
   foundation   Organization     @relation(fields: [foundationId], references: [id])
@@ -2767,7 +2793,27 @@ enum NotificationType {
   INTERN_APPLICATION_ACCEPTED
   INTERN_APPLICATION_DECLINED
   INTERN_APPLICATION_CONFIRMED
+  SHORTLIST_READY
+  CANDIDATE_RESPONDED
   GENERAL
+}
+
+enum StaffingRequestStatus {
+  PENDING_PARSE
+  PARSED
+  MATCHING
+  SHORTLISTED
+  CLOSED
+  CANCELLED
+}
+
+enum MatchResultStatus {
+  PENDING
+  EXPLAINED
+  SHORTLISTED
+  CONTACTED
+  ACCEPTED
+  DECLINED
 }
 
 model Notification {
@@ -2943,10 +2989,106 @@ model KnowledgeDocument {
   audience    String?
   version     Int      @default(1)
   title       String
-  content     String   @db.Text
+  content     String                      @db.Text
+  embedding   Unsupported("vector(768)")?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
   @@index([source, locale])
   @@map("knowledge_documents")
+}
+
+// ─── Staffing Phase 1 ────────────────────────────────────────────────────────
+
+model StaffingRequest {
+  id           String  @id @default(uuid())
+  foundationId String
+  createdById  String
+  rawText      String  @db.Text
+
+  // Parsed structured fields (populated after staffing-request-parser runs)
+  roleRequired   String?
+  contractType   JobContractType?
+  startDate      DateTime?
+  endDate        DateTime?
+  hoursPerWeek   Int?
+  canton         String?
+  city           String?
+  ageGroups      String[] @default([])
+  languages      String[] @default([])
+  qualifications String[] @default([])
+  notes          String?  @db.Text
+
+  status StaffingRequestStatus @default(PENDING_PARSE)
+  locale String               @default("fr")
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  foundation  Organization             @relation("FoundationStaffingRequests", fields: [foundationId], references: [id])
+  createdBy   User                     @relation("UserStaffingRequests", fields: [createdById], references: [id])
+  embedding   StaffingRequestEmbedding?
+  matches     MatchResult[]
+  jobListings JobListing[]             @relation("StaffingRequestJobListings")
+
+  @@index([foundationId])
+  @@map("staffing_requests")
+}
+
+model StaffingRequestEmbedding {
+  id                String   @id @default(uuid())
+  staffingRequestId String   @unique
+  model             String   @default("voyage-3-lite")
+  profileHash       String
+  embedding         Unsupported("vector(768)")?
+  createdAt         DateTime @default(now())
+
+  staffingRequest StaffingRequest @relation(fields: [staffingRequestId], references: [id], onDelete: Cascade)
+
+  @@map("staffing_request_embeddings")
+}
+
+model MatchResult {
+  id                String  @id @default(uuid())
+  staffingRequestId String
+  candidateId       String
+
+  totalScore         Decimal @db.Decimal(5, 2)
+  roleScore          Decimal @default(0) @db.Decimal(5, 2)
+  availabilityScore  Decimal @default(0) @db.Decimal(5, 2)
+  locationScore      Decimal @default(0) @db.Decimal(5, 2)
+  qualificationScore Decimal @default(0) @db.Decimal(5, 2)
+  languageScore      Decimal @default(0) @db.Decimal(5, 2)
+  ageGroupScore      Decimal @default(0) @db.Decimal(5, 2)
+  contractScore      Decimal @default(0) @db.Decimal(5, 2)
+  responsivenessScr  Decimal @default(0) @db.Decimal(5, 2)
+  distanceKm         Decimal? @db.Decimal(8, 2)
+  vectorSimilarity   Decimal? @db.Decimal(5, 4)
+
+  explanation String?          @db.Text
+  status      MatchResultStatus @default(PENDING)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  staffingRequest StaffingRequest @relation(fields: [staffingRequestId], references: [id], onDelete: Cascade)
+  candidate       User            @relation("UserMatchResults", fields: [candidateId], references: [id])
+
+  @@unique([staffingRequestId, candidateId])
+  @@index([staffingRequestId])
+  @@map("match_results")
+}
+
+model EducatorEmbedding {
+  id          String   @id @default(uuid())
+  userId      String   @unique
+  model       String   @default("voyage-3-lite")
+  profileHash String
+  embedding   Unsupported("vector(768)")?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  user User @relation("UserEducatorEmbedding", fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("educator_embeddings")
 }

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -2990,7 +2990,7 @@ model KnowledgeDocument {
   version     Int      @default(1)
   title       String
   content     String                      @db.Text
-  embedding   Unsupported("vector(768)")?
+  embedding   Unsupported("vector(512)")?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
@@ -3040,7 +3040,7 @@ model StaffingRequestEmbedding {
   staffingRequestId String   @unique
   model             String   @default("voyage-3-lite")
   profileHash       String
-  embedding         Unsupported("vector(768)")?
+  embedding         Unsupported("vector(512)")?
   createdAt         DateTime @default(now())
 
   staffingRequest StaffingRequest @relation(fields: [staffingRequestId], references: [id], onDelete: Cascade)
@@ -3084,7 +3084,7 @@ model EducatorEmbedding {
   userId      String   @unique
   model       String   @default("voyage-3-lite")
   profileHash String
-  embedding   Unsupported("vector(768)")?
+  embedding   Unsupported("vector(512)")?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -992,6 +992,20 @@ async function seedAiFoundationFlag() {
       conditions: {},
     },
   });
+
+  await prisma.featureFlag.upsert({
+    where: { key: 'ai_staffing_matching' },
+    update: {},
+    create: {
+      name: 'AI Staffing Matching',
+      description: 'Phase 1 — Internal matching MVP: staffing-request-parser + hybrid matcher',
+      key: 'ai_staffing_matching',
+      isActive: false,
+      rolloutPercentage: 0,
+      targetSegments: [],
+      conditions: {},
+    },
+  });
 }
 
 function getMonthlyPrice(planCode: string): number {

--- a/api/scripts/enable-pg-extensions.sql
+++ b/api/scripts/enable-pg-extensions.sql
@@ -1,0 +1,10 @@
+-- Run this script once on each environment as a superuser BEFORE running Prisma migrations.
+-- Required for the staffing Phase 1 migration (20260521000000_add_staffing_phase1).
+--
+-- On Supabase: Dashboard → SQL Editor, paste and run.
+-- On RDS: use a superuser connection or request the extension from your DBA.
+-- On local Postgres: psql -U postgres -d <db> -f this_file.sql
+
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS cube;
+CREATE EXTENSION IF NOT EXISTS earthdistance;

--- a/api/src/ai/agents/echo-validate/fixtures/golden.json
+++ b/api/src/ai/agents/echo-validate/fixtures/golden.json
@@ -1,0 +1,8 @@
+{
+  "input": {
+    "message": "hello world"
+  },
+  "expected": {
+    "echo": "hello world"
+  }
+}

--- a/api/src/ai/agents/match-explanation/fixtures/golden-fr.json
+++ b/api/src/ai/agents/match-explanation/fixtures/golden-fr.json
@@ -1,0 +1,20 @@
+{
+  "input": {
+    "roleScore": 100,
+    "availabilityScore": 80,
+    "locationScore": 90,
+    "distanceKm": 3.2,
+    "qualificationScore": 100,
+    "languageScore": 100,
+    "ageGroupScore": 100,
+    "contractScore": 80,
+    "responsivenessScore": 75,
+    "totalScore": 91,
+    "requestSummary": "EDE educator, replacement, 30h/week, Geneva, infants/toddlers, French",
+    "candidateSummary": "Certified EDE, 5 years experience with infants, based in Carouge (3km from Geneva), French native",
+    "locale": "fr"
+  },
+  "expected": {
+    "explanation": "Candidate est une éducatrice EDE certifiée avec 5 ans d'expérience auprès des nourrissons, parfaitement alignée avec les besoins du poste. Basée à Carouge, à seulement 3 km, elle est disponible aux horaires demandés et répond avec fiabilité. Sa maîtrise du français et son expérience en crèche en font une candidate de premier choix."
+  }
+}

--- a/api/src/ai/agents/match-explanation/index.ts
+++ b/api/src/ai/agents/match-explanation/index.ts
@@ -1,0 +1,2 @@
+export { MatchExplanationSchema } from './schema';
+export type { MatchExplanationOutput } from './schema';

--- a/api/src/ai/agents/match-explanation/prompt.v1.ts
+++ b/api/src/ai/agents/match-explanation/prompt.v1.ts
@@ -1,0 +1,26 @@
+export default function prompt(
+  input: Record<string, unknown>,
+  locale: string,
+): string {
+  const lang =
+    locale === 'de' ? 'German' : locale === 'en' ? 'English' : 'French';
+
+  return `You are a staffing coordinator assistant. Write a concise (≤80 words) explanation in ${lang}
+of why a candidate matches a staffing request, based on the score breakdown below.
+Be specific, professional, and avoid repeating raw numbers.
+Respond ONLY with a JSON object: {"explanation": "<text>"}
+
+Score breakdown (0–100 per dimension):
+- Role match:         ${input.roleScore}
+- Availability:       ${input.availabilityScore}
+- Location:           ${input.locationScore}  (distance: ${input.distanceKm ?? 'unknown'} km)
+- Qualifications:     ${input.qualificationScore}
+- Languages:          ${input.languageScore}
+- Age groups:         ${input.ageGroupScore}
+- Contract type:      ${input.contractScore}
+- Responsiveness:     ${input.responsivenessScore}
+- Total:              ${input.totalScore}
+
+Request summary: ${input.requestSummary}
+Candidate summary: ${input.candidateSummary}`;
+}

--- a/api/src/ai/agents/match-explanation/schema.ts
+++ b/api/src/ai/agents/match-explanation/schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const MatchExplanationSchema = z.object({
+  explanation: z
+    .string()
+    .max(400)
+    .describe('80-word prose summary of why this candidate matches the request'),
+});
+
+export type MatchExplanationOutput = z.infer<typeof MatchExplanationSchema>;

--- a/api/src/ai/agents/staffing-request-parser/fixtures/golden-fr.json
+++ b/api/src/ai/agents/staffing-request-parser/fixtures/golden-fr.json
@@ -1,0 +1,19 @@
+{
+  "input": {
+    "rawText": "Bonjour, nous cherchons une éducatrice diplômée EDE pour un remplacement de 3 semaines dès le 2 juin, 30h/semaine, dans notre crèche à Genève (GE). Les enfants ont entre 3 mois et 2 ans. Merci.",
+    "locale": "fr"
+  },
+  "expected": {
+    "roleRequired": "Educator",
+    "contractType": "REPLACEMENT",
+    "startDate": "2026-06-02",
+    "endDate": null,
+    "hoursPerWeek": 30,
+    "canton": "GE",
+    "city": "Genève",
+    "ageGroups": ["INFANT", "TODDLER"],
+    "languages": ["fr"],
+    "qualifications": ["EDE"],
+    "notes": "Duration: 3 weeks from start date"
+  }
+}

--- a/api/src/ai/agents/staffing-request-parser/index.ts
+++ b/api/src/ai/agents/staffing-request-parser/index.ts
@@ -1,0 +1,2 @@
+export { StaffingRequestParserSchema } from './schema';
+export type { StaffingRequestParserOutput } from './schema';

--- a/api/src/ai/agents/staffing-request-parser/prompt.v1.ts
+++ b/api/src/ai/agents/staffing-request-parser/prompt.v1.ts
@@ -1,0 +1,33 @@
+export default function prompt(
+  input: Record<string, unknown>,
+  locale: string,
+): string {
+  const lang =
+    locale === 'de' ? 'German' : locale === 'en' ? 'English' : 'French';
+
+  return `You are a staffing coordinator assistant for Swiss childcare foundations.
+Extract structured staffing requirements from the free-text request below.
+The request is written in ${lang}. Respond ONLY with a valid JSON object — no markdown, no explanation.
+
+Required JSON shape:
+{
+  "roleRequired": string,           // Primary role, e.g. "Educator" / "Assistant" / "Auxiliaire"
+  "contractType": "FULL_TIME"|"PART_TIME"|"TEMPORARY"|"INTERNSHIP"|"REPLACEMENT"|null,
+  "startDate": "YYYY-MM-DD"|null,
+  "endDate": "YYYY-MM-DD"|null,
+  "hoursPerWeek": integer|null,
+  "canton": string|null,            // Swiss canton abbreviation, e.g. "GE"
+  "city": string|null,
+  "ageGroups": ("INFANT"|"TODDLER"|"PRESCHOOL"|"SCHOOL_AGE")[],
+  "languages": string[],            // ISO 639-1 codes, e.g. ["fr","de"]
+  "qualifications": string[],       // e.g. ["EDE","ASSC","CFC"]
+  "notes": string|null              // anything not captured above
+}
+
+Use null for fields not mentioned. Do not invent information.
+
+Free-text request:
+---
+${input.rawText as string}
+---`;
+}

--- a/api/src/ai/agents/staffing-request-parser/schema.ts
+++ b/api/src/ai/agents/staffing-request-parser/schema.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const StaffingRequestParserSchema = z.object({
+  roleRequired: z.string().describe('Primary role needed, e.g. "Educator", "Assistant"'),
+  contractType: z
+    .enum(['FULL_TIME', 'PART_TIME', 'TEMPORARY', 'INTERNSHIP', 'REPLACEMENT'])
+    .nullable()
+    .optional(),
+  startDate: z.string().nullable().optional().describe('ISO date string or null'),
+  endDate: z.string().nullable().optional().describe('ISO date string or null'),
+  hoursPerWeek: z.number().int().min(1).max(45).nullable().optional(),
+  canton: z.string().nullable().optional().describe('Swiss canton abbreviation, e.g. "GE", "VD"'),
+  city: z.string().nullable().optional(),
+  ageGroups: z
+    .array(z.enum(['INFANT', 'TODDLER', 'PRESCHOOL', 'SCHOOL_AGE']))
+    .default([]),
+  languages: z.array(z.string()).default([]).describe('ISO 639-1 language codes, e.g. ["fr","de"]'),
+  qualifications: z
+    .array(z.string())
+    .default([])
+    .describe('Required diplomas or certifications, e.g. ["EDE", "ASSC"]'),
+  notes: z.string().nullable().optional().describe('Any extra context not captured in structured fields'),
+});
+
+export type StaffingRequestParserOutput = z.infer<typeof StaffingRequestParserSchema>;

--- a/api/src/ai/ai-agents.config.ts
+++ b/api/src/ai/ai-agents.config.ts
@@ -1,6 +1,9 @@
 import { UserRole } from '@prisma/client';
 
-export type AgentName = 'echo-validate';
+export type AgentName =
+  | 'echo-validate'
+  | 'staffing-request-parser'
+  | 'match-explanation';
 
 export type ScopeRule = 'self' | 'organization' | 'admin-only' | 'any';
 
@@ -23,6 +26,25 @@ export const AI_AGENTS: Record<AgentName, AgentConfig> = {
     maxOutputTokens: 200,
     allowedRoles: [UserRole.SUPER_ADMIN, UserRole.ADMIN],
     scopeRule: 'admin-only',
-    cacheTtlSeconds: undefined,
+  },
+
+  'staffing-request-parser': {
+    name: 'staffing-request-parser',
+    models: ['google/gemini-2.5-flash', 'deepseek/deepseek-chat'],
+    maxOutputTokens: 120,
+    allowedRoles: [UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN],
+    scopeRule: 'organization',
+    requiredInputFields: ['rawText'],
+    dailyTokenBudget: 50000,
+  },
+
+  'match-explanation': {
+    name: 'match-explanation',
+    models: ['google/gemini-2.5-flash', 'deepseek/deepseek-chat'],
+    maxOutputTokens: 100,
+    allowedRoles: [UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN],
+    scopeRule: 'organization',
+    cacheTtlSeconds: 3600,
+    dailyTokenBudget: 100000,
   },
 };

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -64,6 +64,7 @@ import { MaintenanceModule } from './maintenance/maintenance.module';
 import { CategoriesModule } from './categories/categories.module';
 import { MailingModule } from './mailing/mailing.module';
 import { AiModule } from './ai/ai.module';
+import { StaffingModule } from './staffing/staffing.module';
 
 import {
   AUTH_REQUESTS_LIMIT,
@@ -158,6 +159,7 @@ import {
     CrawlerModule,
     MailingModule,
     AiModule,
+    StaffingModule,
   ],
   controllers: [AppController],
   providers: [

--- a/api/src/staffing/dto/create-staffing-request.dto.ts
+++ b/api/src/staffing/dto/create-staffing-request.dto.ts
@@ -1,0 +1,13 @@
+import { IsString, IsNotEmpty, MinLength, MaxLength, IsOptional, IsIn } from 'class-validator';
+
+export class CreateStaffingRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(10)
+  @MaxLength(2000)
+  rawText: string;
+
+  @IsOptional()
+  @IsIn(['fr', 'de', 'en'])
+  locale?: 'fr' | 'de' | 'en';
+}

--- a/api/src/staffing/hybrid-matcher.service.ts
+++ b/api/src/staffing/hybrid-matcher.service.ts
@@ -1,0 +1,245 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { Prisma } from '@prisma/client';
+
+interface ScoreWeights {
+  role: number;
+  availability: number;
+  location: number;
+  qualification: number;
+  language: number;
+  ageGroup: number;
+  contract: number;
+  responsiveness: number;
+}
+
+const WEIGHTS: ScoreWeights = {
+  role: 20,
+  availability: 20,
+  location: 15,
+  qualification: 15,
+  language: 10,
+  ageGroup: 10,
+  contract: 5,
+  responsiveness: 5,
+};
+
+const CONTRACT_MAP: Record<string, string[]> = {
+  REPLACEMENT: ['TEMPORARY', 'REPLACEMENT'],
+  TEMPORARY: ['TEMPORARY', 'REPLACEMENT'],
+  PART_TIME: ['PART_TIME'],
+  FULL_TIME: ['FULL_TIME'],
+  INTERNSHIP: ['INTERNSHIP'],
+};
+
+@Injectable()
+export class HybridMatcherService {
+  private readonly logger = new Logger(HybridMatcherService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async match(staffingRequestId: string): Promise<number> {
+    const request = await this.prisma.staffingRequest.findUniqueOrThrow({
+      where: { id: staffingRequestId },
+      include: { foundation: { select: { latitude: true, longitude: true, regionsServed: true } } },
+    });
+
+    // ── Hard filters ─────────────────────────────────────────────────────────
+    const whereClause: Prisma.UserWhereInput = {
+      role: 'EDUCATOR',
+      candidatePoolVisible: true,
+      approvalStatus: 'APPROVED',
+      isActive: true,
+      ...(request.canton
+        ? {
+            OR: [
+              { region: { contains: request.canton, mode: 'insensitive' } },
+              { cities: { has: request.canton } },
+            ],
+          }
+        : {}),
+      ...(request.languages.length > 0
+        ? { skills: { hasSome: request.languages } }
+        : {}),
+    };
+
+    const candidates = await this.prisma.user.findMany({
+      where: whereClause,
+      select: {
+        id: true,
+        jobRoles: true,
+        jobRole: true,
+        availability: true,
+        availabilitySettings: true,
+        region: true,
+        cities: true,
+        skills: true,
+        certifications: true,
+        latitude: true,
+        longitude: true,
+        maxCommuteKm: true,
+        responsivenessScore: true,
+        availableForReplacement: true,
+      },
+      take: 200,
+    });
+
+    this.logger.log(`Scoring ${candidates.length} candidates for request ${staffingRequestId}`);
+
+    const orgLat = request.foundation?.latitude ? Number(request.foundation.latitude) : null;
+    const orgLon = request.foundation?.longitude ? Number(request.foundation.longitude) : null;
+
+    // Fetch existing match results to upsert
+    const existing = await this.prisma.matchResult.findMany({
+      where: { staffingRequestId },
+      select: { id: true, candidateId: true },
+    });
+    const existingMap = new Map(existing.map((m) => [m.candidateId, m.id]));
+
+    let upserted = 0;
+
+    for (const c of candidates) {
+      const scores = this.scoreCandidate(request, c, orgLat, orgLon);
+      const total = Object.entries(scores).reduce((sum, [key, val]) => {
+        const weight = WEIGHTS[key as keyof ScoreWeights] ?? 0;
+        return sum + (val / 100) * weight;
+      }, 0);
+
+      const data = {
+        staffingRequestId,
+        candidateId: c.id,
+        totalScore: new Prisma.Decimal(total.toFixed(2)),
+        roleScore: new Prisma.Decimal(scores.role.toFixed(2)),
+        availabilityScore: new Prisma.Decimal(scores.availability.toFixed(2)),
+        locationScore: new Prisma.Decimal(scores.location.toFixed(2)),
+        qualificationScore: new Prisma.Decimal(scores.qualification.toFixed(2)),
+        languageScore: new Prisma.Decimal(scores.language.toFixed(2)),
+        ageGroupScore: new Prisma.Decimal(scores.ageGroup.toFixed(2)),
+        contractScore: new Prisma.Decimal(scores.contract.toFixed(2)),
+        responsivenessScr: new Prisma.Decimal(scores.responsiveness.toFixed(2)),
+        ...(scores.distanceKm !== null
+          ? { distanceKm: new Prisma.Decimal(scores.distanceKm.toFixed(2)) }
+          : {}),
+      };
+
+      const existingId = existingMap.get(c.id);
+      if (existingId) {
+        await this.prisma.matchResult.update({ where: { id: existingId }, data });
+      } else {
+        await this.prisma.matchResult.create({ data });
+      }
+      upserted++;
+    }
+
+    await this.prisma.staffingRequest.update({
+      where: { id: staffingRequestId },
+      data: { status: 'SHORTLISTED', updatedAt: new Date() },
+    });
+
+    return upserted;
+  }
+
+  private scoreCandidate(
+    request: {
+      roleRequired: string | null;
+      contractType: string | null;
+      languages: string[];
+      qualifications: string[];
+      ageGroups: string[];
+      canton: string | null;
+    },
+    candidate: {
+      jobRoles: string[];
+      jobRole: string | null;
+      availability: string | null;
+      availabilitySettings: unknown;
+      skills: string[];
+      certifications: string[];
+      latitude: unknown;
+      longitude: unknown;
+      maxCommuteKm: number | null;
+      responsivenessScore: unknown;
+      availableForReplacement: boolean;
+    },
+    orgLat: number | null,
+    orgLon: number | null,
+  ): ScoreWeights & { distanceKm: number | null } {
+    const roles = [
+      ...(candidate.jobRoles ?? []),
+      ...(candidate.jobRole ? [candidate.jobRole] : []),
+    ].map((r) => r.toLowerCase());
+
+    const role = request.roleRequired
+      ? roles.some((r) => r.includes(request.roleRequired!.toLowerCase())) ? 100 : 0
+      : 50;
+
+    // Availability — simplified: if availabilitySettings exists treat as structured (80+); legacy text = 50
+    const availability = candidate.availabilitySettings ? 80 : candidate.availability ? 50 : 0;
+
+    // Location / distance
+    let location = 50;
+    let distanceKm: number | null = null;
+    const cLat = candidate.latitude ? Number(candidate.latitude) : null;
+    const cLon = candidate.longitude ? Number(candidate.longitude) : null;
+    if (orgLat !== null && orgLon !== null && cLat !== null && cLon !== null) {
+      distanceKm = this.haversineKm(orgLat, orgLon, cLat, cLon);
+      const maxKm = candidate.maxCommuteKm ?? 30;
+      location = distanceKm <= maxKm ? 100 : distanceKm <= maxKm * 2 ? 50 : 0;
+    }
+
+    // Qualifications
+    const certs = [...(candidate.certifications ?? []), ...(candidate.skills ?? [])].map((s) =>
+      s.toLowerCase(),
+    );
+    const qualification =
+      request.qualifications.length === 0
+        ? 50
+        : (() => {
+            const matched = request.qualifications.filter((q) =>
+              certs.some((c) => c.includes(q.toLowerCase())),
+            ).length;
+            return Math.round((matched / request.qualifications.length) * 100);
+          })();
+
+    // Languages
+    const language =
+      request.languages.length === 0
+        ? 50
+        : (() => {
+            const matched = request.languages.filter((l) =>
+              candidate.skills.some((s) => s.toLowerCase() === l.toLowerCase()),
+            ).length;
+            return Math.round((matched / request.languages.length) * 100);
+          })();
+
+    // Age groups — stored in skills/certifications as tags in some setups; default 50 if no data
+    const ageGroup = request.ageGroups.length === 0 ? 50 : 50;
+
+    // Contract
+    const allowed = request.contractType ? (CONTRACT_MAP[request.contractType] ?? []) : [];
+    const contract =
+      allowed.length === 0
+        ? 50
+        : request.contractType === 'REPLACEMENT' && candidate.availableForReplacement
+        ? 100
+        : 30;
+
+    const responsiveness = candidate.responsivenessScore
+      ? Math.min(100, Number(candidate.responsivenessScore) * 100)
+      : 50;
+
+    return { role, availability, location, qualification, language, ageGroup, contract, responsiveness, distanceKm };
+  }
+
+  private haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+    const R = 6371;
+    const dLat = ((lat2 - lat1) * Math.PI) / 180;
+    const dLon = ((lon2 - lon1) * Math.PI) / 180;
+    const a =
+      Math.sin(dLat / 2) ** 2 +
+      Math.cos((lat1 * Math.PI) / 180) *
+        Math.cos((lat2 * Math.PI) / 180) *
+        Math.sin(dLon / 2) ** 2;
+    return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  }
+}

--- a/api/src/staffing/queues/staffing-queues.module.ts
+++ b/api/src/staffing/queues/staffing-queues.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bull';
 import { sharedRedisOptions, REDIS_ENABLED } from '../../common/redis.config';
 
+export const STAFFING_PARSE_REQUEST_QUEUE = 'staffing.parse-request';
 export const STAFFING_MATCH_QUEUE = 'staffing.match';
 export const STAFFING_EXPLAIN_QUEUE = 'staffing.explain';
 export const STAFFING_EMBED_PROFILE_QUEUE = 'staffing.embed-profile';
@@ -19,6 +20,7 @@ const defaultJobOptions = {
     ...(REDIS_ENABLED
       ? [
           BullModule.registerQueue(
+            { name: STAFFING_PARSE_REQUEST_QUEUE, redis: sharedRedisOptions, defaultJobOptions },
             { name: STAFFING_MATCH_QUEUE, redis: sharedRedisOptions, defaultJobOptions },
             { name: STAFFING_EXPLAIN_QUEUE, redis: sharedRedisOptions, defaultJobOptions },
             { name: STAFFING_EMBED_PROFILE_QUEUE, redis: sharedRedisOptions, defaultJobOptions },

--- a/api/src/staffing/queues/staffing-queues.module.ts
+++ b/api/src/staffing/queues/staffing-queues.module.ts
@@ -1,0 +1,32 @@
+import { Module } from '@nestjs/common';
+import { BullModule } from '@nestjs/bull';
+import { sharedRedisOptions, REDIS_ENABLED } from '../../common/redis.config';
+
+export const STAFFING_MATCH_QUEUE = 'staffing.match';
+export const STAFFING_EXPLAIN_QUEUE = 'staffing.explain';
+export const STAFFING_EMBED_PROFILE_QUEUE = 'staffing.embed-profile';
+export const STAFFING_EMBED_REQUEST_QUEUE = 'staffing.embed-request';
+
+const defaultJobOptions = {
+  attempts: 3,
+  backoff: { type: 'exponential', delay: 2000 },
+  removeOnComplete: true,
+  removeOnFail: false,
+};
+
+@Module({
+  imports: [
+    ...(REDIS_ENABLED
+      ? [
+          BullModule.registerQueue(
+            { name: STAFFING_MATCH_QUEUE, redis: sharedRedisOptions, defaultJobOptions },
+            { name: STAFFING_EXPLAIN_QUEUE, redis: sharedRedisOptions, defaultJobOptions },
+            { name: STAFFING_EMBED_PROFILE_QUEUE, redis: sharedRedisOptions, defaultJobOptions },
+            { name: STAFFING_EMBED_REQUEST_QUEUE, redis: sharedRedisOptions, defaultJobOptions },
+          ),
+        ]
+      : []),
+  ],
+  exports: [BullModule],
+})
+export class StaffingQueuesModule {}

--- a/api/src/staffing/staffing.controller.ts
+++ b/api/src/staffing/staffing.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Param,
+  Body,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { StaffingService } from './staffing.service';
+import { CreateStaffingRequestDto } from './dto/create-staffing-request.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { UserRole } from '@prisma/client';
+
+@Controller('staffing')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class StaffingController {
+  constructor(private readonly staffingService: StaffingService) {}
+
+  @Post('requests')
+  @Roles(UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  createRequest(
+    @Body() dto: CreateStaffingRequestDto,
+    @Request() req: { user: { userId: string; role: UserRole; organizationId?: string } },
+  ) {
+    return this.staffingService.createRequest(dto, req.user);
+  }
+
+  @Get('requests/:id')
+  @Roles(UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  getRequest(
+    @Param('id') id: string,
+    @Request() req: { user: { userId: string; role: UserRole; organizationId?: string } },
+  ) {
+    return this.staffingService.getRequest(id, req.user);
+  }
+
+  @Get('requests/:id/matches')
+  @Roles(UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  getMatches(
+    @Param('id') id: string,
+    @Request() req: { user: { userId: string; role: UserRole; organizationId?: string } },
+  ) {
+    return this.staffingService.getMatches(id, req.user);
+  }
+}

--- a/api/src/staffing/staffing.module.ts
+++ b/api/src/staffing/staffing.module.ts
@@ -6,6 +6,7 @@ import { StaffingController } from './staffing.controller';
 import { StaffingService } from './staffing.service';
 import { HybridMatcherService } from './hybrid-matcher.service';
 import { StaffingQueuesModule } from './queues/staffing-queues.module';
+import { StaffingParseProcessor } from './workers/staffing-parse.processor';
 import { StaffingMatchProcessor } from './workers/staffing-match.processor';
 import { StaffingExplainProcessor } from './workers/staffing-explain.processor';
 import { StaffingEmbedProfileProcessor, StaffingEmbedRequestProcessor } from './workers/staffing-embed.processor';
@@ -19,6 +20,7 @@ import { REDIS_ENABLED } from '../common/redis.config';
     HybridMatcherService,
     ...(REDIS_ENABLED
       ? [
+          StaffingParseProcessor,
           StaffingMatchProcessor,
           StaffingExplainProcessor,
           StaffingEmbedProfileProcessor,

--- a/api/src/staffing/staffing.module.ts
+++ b/api/src/staffing/staffing.module.ts
@@ -1,0 +1,31 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { AuthModule } from '../auth/auth.module';
+import { AiModule } from '../ai/ai.module';
+import { StaffingController } from './staffing.controller';
+import { StaffingService } from './staffing.service';
+import { HybridMatcherService } from './hybrid-matcher.service';
+import { StaffingQueuesModule } from './queues/staffing-queues.module';
+import { StaffingMatchProcessor } from './workers/staffing-match.processor';
+import { StaffingExplainProcessor } from './workers/staffing-explain.processor';
+import { StaffingEmbedProfileProcessor, StaffingEmbedRequestProcessor } from './workers/staffing-embed.processor';
+import { REDIS_ENABLED } from '../common/redis.config';
+
+@Module({
+  imports: [PrismaModule, AuthModule, AiModule, StaffingQueuesModule],
+  controllers: [StaffingController],
+  providers: [
+    StaffingService,
+    HybridMatcherService,
+    ...(REDIS_ENABLED
+      ? [
+          StaffingMatchProcessor,
+          StaffingExplainProcessor,
+          StaffingEmbedProfileProcessor,
+          StaffingEmbedRequestProcessor,
+        ]
+      : []),
+  ],
+  exports: [StaffingService],
+})
+export class StaffingModule {}

--- a/api/src/staffing/staffing.service.ts
+++ b/api/src/staffing/staffing.service.ts
@@ -1,0 +1,216 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bull';
+import { Queue } from 'bull';
+import { PrismaService } from '../prisma/prisma.service';
+import { LlmClient } from '../ai/llm-client';
+import { StaffingRequestParserSchema } from '../ai/agents/staffing-request-parser/schema';
+import { HybridMatcherService } from './hybrid-matcher.service';
+import { CreateStaffingRequestDto } from './dto/create-staffing-request.dto';
+import { UserRole } from '@prisma/client';
+import { REDIS_ENABLED } from '../../common/redis.config';
+import {
+  STAFFING_MATCH_QUEUE,
+  STAFFING_EXPLAIN_QUEUE,
+  STAFFING_EMBED_PROFILE_QUEUE,
+  STAFFING_EMBED_REQUEST_QUEUE,
+} from './queues/staffing-queues.module';
+
+export interface StaffingPrincipal {
+  userId: string;
+  role: UserRole;
+  organizationId?: string;
+}
+
+// Characters above this threshold are sent to the async queue; shorter ones get
+// a synchronous preview response so the UI feels snappy.
+const SYNC_THRESHOLD_CHARS = 800;
+
+@Injectable()
+export class StaffingService {
+  private readonly logger = new Logger(StaffingService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly llm: LlmClient,
+    private readonly matcher: HybridMatcherService,
+    @InjectQueue(STAFFING_MATCH_QUEUE)
+    private readonly matchQueue: Queue,
+    @InjectQueue(STAFFING_EXPLAIN_QUEUE)
+    private readonly explainQueue: Queue,
+    @InjectQueue(STAFFING_EMBED_REQUEST_QUEUE)
+    private readonly embedRequestQueue: Queue,
+    @InjectQueue(STAFFING_EMBED_PROFILE_QUEUE)
+    private readonly embedProfileQueue: Queue,
+  ) {}
+
+  async createRequest(
+    dto: CreateStaffingRequestDto,
+    principal: StaffingPrincipal,
+  ) {
+    if (!principal.organizationId) {
+      throw new ForbiddenException('No organisation linked to this account');
+    }
+
+    const locale = dto.locale ?? 'fr';
+    const isShort = dto.rawText.length <= SYNC_THRESHOLD_CHARS;
+
+    // ── Create the raw record immediately ───────────────────────────────────
+    const request = await this.prisma.staffingRequest.create({
+      data: {
+        foundationId: principal.organizationId,
+        createdById: principal.userId,
+        rawText: dto.rawText,
+        locale,
+        status: 'PENDING_PARSE',
+      },
+    });
+
+    if (isShort) {
+      // ── Synchronous parse preview ────────────────────────────────────────
+      try {
+        const { output } = await this.llm.run({
+          agent: 'staffing-request-parser',
+          input: { rawText: dto.rawText },
+          schema: StaffingRequestParserSchema,
+          locale,
+          principal,
+          entityRef: request.id,
+        });
+
+        await this.prisma.staffingRequest.update({
+          where: { id: request.id },
+          data: {
+            ...this.parsedOutputToData(output),
+            status: 'PARSED',
+          },
+        });
+
+        // Kick off async matching in background
+        await this.enqueueMatchJobs(request.id);
+
+        return this.prisma.staffingRequest.findUniqueOrThrow({
+          where: { id: request.id },
+        });
+      } catch (err) {
+        this.logger.error(`Sync parse failed for request ${request.id}`, err);
+        // Return the raw record; background queue will retry parsing
+        await this.enqueueMatchJobs(request.id);
+        return request;
+      }
+    }
+
+    // ── Long input — fully async ─────────────────────────────────────────────
+    await this.enqueueMatchJobs(request.id);
+    return request;
+  }
+
+  async getRequest(id: string, principal: StaffingPrincipal) {
+    const req = await this.prisma.staffingRequest.findUnique({
+      where: { id },
+      include: { foundation: { select: { id: true, name: true } } },
+    });
+    if (!req) throw new NotFoundException('Staffing request not found');
+    this.assertAccess(req.foundationId, principal);
+    return req;
+  }
+
+  async getMatches(requestId: string, principal: StaffingPrincipal) {
+    const req = await this.prisma.staffingRequest.findUnique({
+      where: { id: requestId },
+      select: { foundationId: true },
+    });
+    if (!req) throw new NotFoundException('Staffing request not found');
+    this.assertAccess(req.foundationId, principal);
+
+    return this.prisma.matchResult.findMany({
+      where: { staffingRequestId: requestId },
+      orderBy: { totalScore: 'desc' },
+      take: 50,
+      include: {
+        candidate: {
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            jobRole: true,
+            jobRoles: true,
+            region: true,
+            cities: true,
+            certifications: true,
+            skills: true,
+            shortBio: true,
+            avatarAsset: { select: { url: true } },
+          },
+        },
+      },
+    });
+  }
+
+  // Called by the match queue processor
+  async runMatching(requestId: string) {
+    const count = await this.matcher.match(requestId);
+    this.logger.log(`Matched ${count} candidates for request ${requestId}`);
+
+    // Enqueue explanations for the top 5
+    const top = await this.prisma.matchResult.findMany({
+      where: { staffingRequestId: requestId },
+      orderBy: { totalScore: 'desc' },
+      take: 5,
+      select: { id: true },
+    });
+
+    if (REDIS_ENABLED) {
+      for (const m of top) {
+        await this.explainQueue.add({ matchResultId: m.id });
+      }
+    }
+
+    return count;
+  }
+
+  private async enqueueMatchJobs(requestId: string) {
+    if (!REDIS_ENABLED) {
+      // Fallback: run synchronously in dev when Redis is absent
+      await this.matcher.match(requestId).catch((err) =>
+        this.logger.error('Sync fallback match failed', err),
+      );
+      return;
+    }
+    await this.matchQueue.add({ staffingRequestId: requestId });
+    await this.embedRequestQueue.add({ staffingRequestId: requestId });
+  }
+
+  private parsedOutputToData(
+    output: Awaited<ReturnType<typeof StaffingRequestParserSchema.parseAsync>>,
+  ) {
+    return {
+      roleRequired: output.roleRequired ?? null,
+      contractType: output.contractType ?? null,
+      startDate: output.startDate ? new Date(output.startDate) : null,
+      endDate: output.endDate ? new Date(output.endDate) : null,
+      hoursPerWeek: output.hoursPerWeek ?? null,
+      canton: output.canton ?? null,
+      city: output.city ?? null,
+      ageGroups: output.ageGroups ?? [],
+      languages: output.languages ?? [],
+      qualifications: output.qualifications ?? [],
+      notes: output.notes ?? null,
+    };
+  }
+
+  private assertAccess(foundationId: string, principal: StaffingPrincipal) {
+    if (
+      principal.role === UserRole.ADMIN ||
+      principal.role === UserRole.SUPER_ADMIN
+    )
+      return;
+    if (principal.organizationId !== foundationId) {
+      throw new ForbiddenException('Access denied');
+    }
+  }
+}

--- a/api/src/staffing/staffing.service.ts
+++ b/api/src/staffing/staffing.service.ts
@@ -3,17 +3,22 @@ import {
   Logger,
   NotFoundException,
   ForbiddenException,
+  Optional,
 } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bull';
 import { PrismaService } from '../prisma/prisma.service';
 import { LlmClient } from '../ai/llm-client';
-import { StaffingRequestParserSchema } from '../ai/agents/staffing-request-parser/schema';
+import {
+  StaffingRequestParserSchema,
+  StaffingRequestParserOutput,
+} from '../ai/agents/staffing-request-parser/schema';
 import { HybridMatcherService } from './hybrid-matcher.service';
 import { CreateStaffingRequestDto } from './dto/create-staffing-request.dto';
 import { UserRole } from '@prisma/client';
-import { REDIS_ENABLED } from '../../common/redis.config';
+import { REDIS_ENABLED } from '../common/redis.config';
 import {
+  STAFFING_PARSE_REQUEST_QUEUE,
   STAFFING_MATCH_QUEUE,
   STAFFING_EXPLAIN_QUEUE,
   STAFFING_EMBED_PROFILE_QUEUE,
@@ -38,14 +43,16 @@ export class StaffingService {
     private readonly prisma: PrismaService,
     private readonly llm: LlmClient,
     private readonly matcher: HybridMatcherService,
-    @InjectQueue(STAFFING_MATCH_QUEUE)
-    private readonly matchQueue: Queue,
-    @InjectQueue(STAFFING_EXPLAIN_QUEUE)
-    private readonly explainQueue: Queue,
-    @InjectQueue(STAFFING_EMBED_REQUEST_QUEUE)
-    private readonly embedRequestQueue: Queue,
-    @InjectQueue(STAFFING_EMBED_PROFILE_QUEUE)
-    private readonly embedProfileQueue: Queue,
+    @Optional() @InjectQueue(STAFFING_PARSE_REQUEST_QUEUE)
+    private readonly parseQueue: Queue | null = null,
+    @Optional() @InjectQueue(STAFFING_MATCH_QUEUE)
+    private readonly matchQueue: Queue | null = null,
+    @Optional() @InjectQueue(STAFFING_EXPLAIN_QUEUE)
+    private readonly explainQueue: Queue | null = null,
+    @Optional() @InjectQueue(STAFFING_EMBED_REQUEST_QUEUE)
+    private readonly embedRequestQueue: Queue | null = null,
+    @Optional() @InjectQueue(STAFFING_EMBED_PROFILE_QUEUE)
+    private readonly embedProfileQueue: Queue | null = null,
   ) {}
 
   async createRequest(
@@ -59,7 +66,6 @@ export class StaffingService {
     const locale = dto.locale ?? 'fr';
     const isShort = dto.rawText.length <= SYNC_THRESHOLD_CHARS;
 
-    // ── Create the raw record immediately ───────────────────────────────────
     const request = await this.prisma.staffingRequest.create({
       data: {
         foundationId: principal.organizationId,
@@ -71,41 +77,23 @@ export class StaffingService {
     });
 
     if (isShort) {
-      // ── Synchronous parse preview ────────────────────────────────────────
+      // Sync parse preview for snappy UI
       try {
-        const { output } = await this.llm.run({
-          agent: 'staffing-request-parser',
-          input: { rawText: dto.rawText },
-          schema: StaffingRequestParserSchema,
-          locale,
-          principal,
-          entityRef: request.id,
-        });
-
-        await this.prisma.staffingRequest.update({
-          where: { id: request.id },
-          data: {
-            ...this.parsedOutputToData(output),
-            status: 'PARSED',
-          },
-        });
-
-        // Kick off async matching in background
-        await this.enqueueMatchJobs(request.id);
-
+        await this.parseRequest(request.id, principal);
+        await this.enqueueMatchAndEmbed(request.id);
         return this.prisma.staffingRequest.findUniqueOrThrow({
           where: { id: request.id },
         });
       } catch (err) {
         this.logger.error(`Sync parse failed for request ${request.id}`, err);
-        // Return the raw record; background queue will retry parsing
-        await this.enqueueMatchJobs(request.id);
+        // Fall back to async parse path so we don't lose the request
+        await this.enqueueParse(request.id);
         return request;
       }
     }
 
-    // ── Long input — fully async ─────────────────────────────────────────────
-    await this.enqueueMatchJobs(request.id);
+    // Long input — fully async: parse first, then match
+    await this.enqueueParse(request.id);
     return request;
   }
 
@@ -151,12 +139,51 @@ export class StaffingService {
     });
   }
 
-  // Called by the match queue processor
+  // Called by parse-request processor or sync path.
+  // Runs the LLM parser and writes structured fields back to the StaffingRequest.
+  async parseRequest(requestId: string, principal?: StaffingPrincipal) {
+    const req = await this.prisma.staffingRequest.findUniqueOrThrow({
+      where: { id: requestId },
+    });
+
+    const resolvedPrincipal: StaffingPrincipal = principal ?? {
+      userId: req.createdById,
+      role: UserRole.FOUNDATION,
+      organizationId: req.foundationId,
+    };
+
+    const { output } = await this.llm.run({
+      agent: 'staffing-request-parser',
+      input: { rawText: req.rawText },
+      schema: StaffingRequestParserSchema,
+      locale: (req.locale as 'fr' | 'de' | 'en') ?? 'fr',
+      principal: resolvedPrincipal,
+      entityRef: req.id,
+    });
+
+    await this.prisma.staffingRequest.update({
+      where: { id: req.id },
+      data: { ...this.parsedOutputToData(output), status: 'PARSED' },
+    });
+  }
+
+  // Called by the match-queue processor. Defensive: if status is still
+  // PENDING_PARSE (e.g. parse failed and was retried, but caller bypassed it),
+  // run the parser before matching.
   async runMatching(requestId: string) {
+    const req = await this.prisma.staffingRequest.findUniqueOrThrow({
+      where: { id: requestId },
+      select: { id: true, status: true, createdById: true, foundationId: true },
+    });
+
+    if (req.status === 'PENDING_PARSE') {
+      this.logger.warn(`Request ${requestId} reached match worker unparsed — parsing inline`);
+      await this.parseRequest(requestId);
+    }
+
     const count = await this.matcher.match(requestId);
     this.logger.log(`Matched ${count} candidates for request ${requestId}`);
 
-    // Enqueue explanations for the top 5
     const top = await this.prisma.matchResult.findMany({
       where: { staffingRequestId: requestId },
       orderBy: { totalScore: 'desc' },
@@ -164,7 +191,7 @@ export class StaffingService {
       select: { id: true },
     });
 
-    if (REDIS_ENABLED) {
+    if (this.explainQueue) {
       for (const m of top) {
         await this.explainQueue.add({ matchResultId: m.id });
       }
@@ -173,21 +200,36 @@ export class StaffingService {
     return count;
   }
 
-  private async enqueueMatchJobs(requestId: string) {
-    if (!REDIS_ENABLED) {
-      // Fallback: run synchronously in dev when Redis is absent
+  // Called by the parse-request processor after a successful parse.
+  async enqueueMatchAndEmbed(requestId: string) {
+    if (!REDIS_ENABLED || !this.matchQueue) {
+      // No Redis → run match synchronously so the dev flow still works
       await this.matcher.match(requestId).catch((err) =>
         this.logger.error('Sync fallback match failed', err),
       );
       return;
     }
     await this.matchQueue.add({ staffingRequestId: requestId });
-    await this.embedRequestQueue.add({ staffingRequestId: requestId });
+    if (this.embedRequestQueue) {
+      await this.embedRequestQueue.add({ staffingRequestId: requestId });
+    }
   }
 
-  private parsedOutputToData(
-    output: Awaited<ReturnType<typeof StaffingRequestParserSchema.parseAsync>>,
-  ) {
+  private async enqueueParse(requestId: string) {
+    if (!REDIS_ENABLED || !this.parseQueue) {
+      // Dev fallback: parse + match inline
+      try {
+        await this.parseRequest(requestId);
+        await this.matcher.match(requestId);
+      } catch (err) {
+        this.logger.error(`Sync fallback parse/match failed for ${requestId}`, err);
+      }
+      return;
+    }
+    await this.parseQueue.add({ staffingRequestId: requestId });
+  }
+
+  private parsedOutputToData(output: StaffingRequestParserOutput) {
     return {
       roleRequired: output.roleRequired ?? null,
       contractType: output.contractType ?? null,

--- a/api/src/staffing/workers/staffing-embed.processor.ts
+++ b/api/src/staffing/workers/staffing-embed.processor.ts
@@ -67,9 +67,7 @@ export class StaffingEmbedProfileProcessor {
     if (existing?.profileHash === hash) return; // unchanged
 
     try {
-      const vector = await this.llm.embed(text);
-      // Store as raw JSON array — Prisma cannot write vector type directly;
-      // we use a raw query instead.
+      const { embedding } = await this.llm.embed(text);
       await this.prisma.$executeRawUnsafe(
         `INSERT INTO educator_embeddings ("id","userId","model","profileHash","embedding","updatedAt")
          VALUES (gen_random_uuid(), $1, 'voyage-3-lite', $2, $3::vector, NOW())
@@ -79,7 +77,7 @@ export class StaffingEmbedProfileProcessor {
                "updatedAt"   = NOW()`,
         userId,
         hash,
-        JSON.stringify(vector),
+        JSON.stringify(embedding),
       );
     } catch (err) {
       this.logger.error(`Profile embed failed for user ${userId}`, err);
@@ -119,7 +117,7 @@ export class StaffingEmbedRequestProcessor {
     const hash = createHash('sha256').update(text).digest('hex');
 
     try {
-      const vector = await this.llm.embed(text);
+      const { embedding } = await this.llm.embed(text);
       await this.prisma.$executeRawUnsafe(
         `INSERT INTO staffing_request_embeddings ("id","staffingRequestId","model","profileHash","embedding","createdAt")
          VALUES (gen_random_uuid(), $1, 'voyage-3-lite', $2, $3::vector, NOW())
@@ -128,7 +126,7 @@ export class StaffingEmbedRequestProcessor {
                "embedding"   = EXCLUDED."embedding"`,
         staffingRequestId,
         hash,
-        JSON.stringify(vector),
+        JSON.stringify(embedding),
       );
     } catch (err) {
       this.logger.error(`Request embed failed for ${staffingRequestId}`, err);

--- a/api/src/staffing/workers/staffing-embed.processor.ts
+++ b/api/src/staffing/workers/staffing-embed.processor.ts
@@ -1,0 +1,138 @@
+import { Processor, Process } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bull';
+import { PrismaService } from '../../prisma/prisma.service';
+import { LlmClient } from '../../ai/llm-client';
+import { createHash } from 'crypto';
+import {
+  STAFFING_EMBED_PROFILE_QUEUE,
+  STAFFING_EMBED_REQUEST_QUEUE,
+} from '../queues/staffing-queues.module';
+
+function profileText(user: {
+  jobRole: string | null;
+  jobRoles: string[];
+  skills: string[];
+  certifications: string[];
+  region: string | null;
+  shortBio: string | null;
+}): string {
+  return [
+    user.jobRole,
+    ...user.jobRoles,
+    ...user.skills,
+    ...user.certifications,
+    user.region,
+    user.shortBio,
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+@Processor(STAFFING_EMBED_PROFILE_QUEUE)
+export class StaffingEmbedProfileProcessor {
+  private readonly logger = new Logger(StaffingEmbedProfileProcessor.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly llm: LlmClient,
+  ) {}
+
+  @Process()
+  async handle(job: Job<{ userId: string }>) {
+    const { userId } = job.data;
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        jobRole: true,
+        jobRoles: true,
+        skills: true,
+        certifications: true,
+        region: true,
+        shortBio: true,
+      },
+    });
+    if (!user) return;
+
+    const text = profileText(user);
+    if (!text.trim()) return;
+
+    const hash = createHash('sha256').update(text).digest('hex');
+
+    const existing = await this.prisma.educatorEmbedding.findUnique({
+      where: { userId },
+      select: { profileHash: true },
+    });
+    if (existing?.profileHash === hash) return; // unchanged
+
+    try {
+      const vector = await this.llm.embed(text);
+      // Store as raw JSON array — Prisma cannot write vector type directly;
+      // we use a raw query instead.
+      await this.prisma.$executeRawUnsafe(
+        `INSERT INTO educator_embeddings ("id","userId","model","profileHash","embedding","updatedAt")
+         VALUES (gen_random_uuid(), $1, 'voyage-3-lite', $2, $3::vector, NOW())
+         ON CONFLICT ("userId") DO UPDATE
+           SET "profileHash" = EXCLUDED."profileHash",
+               "embedding"   = EXCLUDED."embedding",
+               "updatedAt"   = NOW()`,
+        userId,
+        hash,
+        JSON.stringify(vector),
+      );
+    } catch (err) {
+      this.logger.error(`Profile embed failed for user ${userId}`, err);
+      throw err;
+    }
+  }
+}
+
+@Processor(STAFFING_EMBED_REQUEST_QUEUE)
+export class StaffingEmbedRequestProcessor {
+  private readonly logger = new Logger(StaffingEmbedRequestProcessor.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly llm: LlmClient,
+  ) {}
+
+  @Process()
+  async handle(job: Job<{ staffingRequestId: string }>) {
+    const { staffingRequestId } = job.data;
+    const req = await this.prisma.staffingRequest.findUnique({
+      where: { id: staffingRequestId },
+      select: { rawText: true, roleRequired: true, canton: true, languages: true, qualifications: true },
+    });
+    if (!req) return;
+
+    const text = [
+      req.rawText,
+      req.roleRequired,
+      req.canton,
+      ...(req.languages ?? []),
+      ...(req.qualifications ?? []),
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    const hash = createHash('sha256').update(text).digest('hex');
+
+    try {
+      const vector = await this.llm.embed(text);
+      await this.prisma.$executeRawUnsafe(
+        `INSERT INTO staffing_request_embeddings ("id","staffingRequestId","model","profileHash","embedding","createdAt")
+         VALUES (gen_random_uuid(), $1, 'voyage-3-lite', $2, $3::vector, NOW())
+         ON CONFLICT ("staffingRequestId") DO UPDATE
+           SET "profileHash" = EXCLUDED."profileHash",
+               "embedding"   = EXCLUDED."embedding"`,
+        staffingRequestId,
+        hash,
+        JSON.stringify(vector),
+      );
+    } catch (err) {
+      this.logger.error(`Request embed failed for ${staffingRequestId}`, err);
+      throw err;
+    }
+  }
+}

--- a/api/src/staffing/workers/staffing-explain.processor.ts
+++ b/api/src/staffing/workers/staffing-explain.processor.ts
@@ -1,0 +1,109 @@
+import { Processor, Process } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bull';
+import { PrismaService } from '../../prisma/prisma.service';
+import { LlmClient } from '../../ai/llm-client';
+import { MatchExplanationSchema } from '../../ai/agents/match-explanation/schema';
+import { STAFFING_EXPLAIN_QUEUE } from '../queues/staffing-queues.module';
+import { UserRole } from '@prisma/client';
+
+@Processor(STAFFING_EXPLAIN_QUEUE)
+export class StaffingExplainProcessor {
+  private readonly logger = new Logger(StaffingExplainProcessor.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly llm: LlmClient,
+  ) {}
+
+  @Process()
+  async handle(job: Job<{ matchResultId: string }>) {
+    const { matchResultId } = job.data;
+
+    const match = await this.prisma.matchResult.findUnique({
+      where: { id: matchResultId },
+      include: {
+        staffingRequest: {
+          select: {
+            locale: true,
+            roleRequired: true,
+            canton: true,
+            city: true,
+            languages: true,
+            createdById: true,
+            foundationId: true,
+          },
+        },
+        candidate: {
+          select: {
+            firstName: true,
+            lastName: true,
+            jobRole: true,
+            certifications: true,
+            region: true,
+          },
+        },
+      },
+    });
+
+    if (!match) {
+      this.logger.warn(`MatchResult ${matchResultId} not found`);
+      return;
+    }
+
+    const req = match.staffingRequest;
+    const cand = match.candidate;
+
+    const requestSummary = [
+      req.roleRequired,
+      req.canton ?? req.city,
+      req.languages.join('/'),
+    ]
+      .filter(Boolean)
+      .join(', ');
+
+    const candidateSummary = [
+      `${cand.firstName ?? ''} ${cand.lastName ?? ''}`.trim(),
+      cand.jobRole,
+      cand.region,
+      cand.certifications.slice(0, 3).join(', '),
+    ]
+      .filter(Boolean)
+      .join(', ');
+
+    try {
+      const { output } = await this.llm.run({
+        agent: 'match-explanation',
+        input: {
+          roleScore: Number(match.roleScore),
+          availabilityScore: Number(match.availabilityScore),
+          locationScore: Number(match.locationScore),
+          distanceKm: match.distanceKm ? Number(match.distanceKm) : null,
+          qualificationScore: Number(match.qualificationScore),
+          languageScore: Number(match.languageScore),
+          ageGroupScore: Number(match.ageGroupScore),
+          contractScore: Number(match.contractScore),
+          responsivenessScore: Number(match.responsivenessScr),
+          totalScore: Number(match.totalScore),
+          requestSummary,
+          candidateSummary,
+        },
+        schema: MatchExplanationSchema,
+        locale: (req.locale as 'fr' | 'de' | 'en') ?? 'fr',
+        principal: {
+          userId: req.createdById,
+          role: UserRole.FOUNDATION,
+          organizationId: req.foundationId,
+        },
+        entityRef: matchResultId,
+      });
+
+      await this.prisma.matchResult.update({
+        where: { id: matchResultId },
+        data: { explanation: output.explanation, status: 'EXPLAINED' },
+      });
+    } catch (err) {
+      this.logger.error(`Explanation failed for match ${matchResultId}`, err);
+    }
+  }
+}

--- a/api/src/staffing/workers/staffing-match.processor.ts
+++ b/api/src/staffing/workers/staffing-match.processor.ts
@@ -1,0 +1,18 @@
+import { Processor, Process } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bull';
+import { STAFFING_MATCH_QUEUE } from '../queues/staffing-queues.module';
+import { StaffingService } from '../staffing.service';
+
+@Processor(STAFFING_MATCH_QUEUE)
+export class StaffingMatchProcessor {
+  private readonly logger = new Logger(StaffingMatchProcessor.name);
+
+  constructor(private readonly staffingService: StaffingService) {}
+
+  @Process()
+  async handle(job: Job<{ staffingRequestId: string }>) {
+    this.logger.log(`Processing match job for request ${job.data.staffingRequestId}`);
+    await this.staffingService.runMatching(job.data.staffingRequestId);
+  }
+}

--- a/api/src/staffing/workers/staffing-parse.processor.ts
+++ b/api/src/staffing/workers/staffing-parse.processor.ts
@@ -1,0 +1,20 @@
+import { Processor, Process } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bull';
+import { STAFFING_PARSE_REQUEST_QUEUE } from '../queues/staffing-queues.module';
+import { StaffingService } from '../staffing.service';
+
+@Processor(STAFFING_PARSE_REQUEST_QUEUE)
+export class StaffingParseProcessor {
+  private readonly logger = new Logger(StaffingParseProcessor.name);
+
+  constructor(private readonly staffingService: StaffingService) {}
+
+  @Process()
+  async handle(job: Job<{ staffingRequestId: string }>) {
+    const { staffingRequestId } = job.data;
+    this.logger.log(`Parsing staffing request ${staffingRequestId}`);
+    await this.staffingService.parseRequest(staffingRequestId);
+    await this.staffingService.enqueueMatchAndEmbed(staffingRequestId);
+  }
+}

--- a/docs/AI_ASSISTANT_MASTER_PLAN.md
+++ b/docs/AI_ASSISTANT_MASTER_PLAN.md
@@ -1,0 +1,672 @@
+# ProCrèche AI Assistant — Master Plan
+
+**Status:** Active planning document — supersedes `AI_LAYER1_HANDOVER.md` for strategic direction
+**Last updated:** 2026-05-21
+**Owner:** AI integration workstream
+
+---
+
+## 0. TL;DR
+
+We are not building a chatbot. We are building the **ProCrèche Virtual Assistant** — a role-aware natural-language command layer that orchestrates every platform workflow (staffing, HR docs, parent leads, suppliers, e-learning, WhatsApp) through a single conversational surface backed by structured tool calls and pre-filled modals.
+
+**Architectural rule:** _The assistant understands and prepares. The platform validates and executes._
+
+```
+Shared AI Foundation  (✅ Layer 1 — done)
+        ↓
+AI Virtual Assistant / Orchestrator   ← THE NEW CORE
+        ↓
+Connected modals + specialist modules
+        ↓
+Staffing (Phase 1 done) · External Routing · HR Docs · Parent Leads
+Suppliers · E-learning · WhatsApp (later)
+```
+
+---
+
+## 1. Current state — what exists today
+
+### 1.1 Layer 1: Shared AI Foundation ✅
+Branch `claude/analyze-ai-layer-1-8rj9s` (PR #647) — fully shipped.
+
+| Component | Path | Status |
+|---|---|---|
+| LLM gateway | `api/src/ai/llm-client.ts` | ✅ |
+| OpenRouter adapter | `api/src/ai/providers/openrouter.adapter.ts` | ✅ |
+| Voyage adapter (embeddings) | `api/src/ai/providers/voyage.adapter.ts` | ✅ |
+| Circuit breaker | `api/src/ai/circuit-breaker.service.ts` | ✅ |
+| Audit log + AiAgentRun | `api/src/ai/audit-log.service.ts` | ✅ |
+| Budget service | `api/src/ai/budget.service.ts` | ✅ |
+| Safety / consent | `api/src/ai/safety.service.ts` | ✅ |
+| Result cache (Postgres) | `api/src/ai/result-cache.service.ts` | ✅ |
+| Agent registry | `api/src/ai/ai-agents.config.ts` | ✅ |
+| BullMQ queues (ai.exec, ai.embed, ai.geocode) | `api/src/ai/queues/ai-exec.queue.ts` | ✅ (geocode processor not built) |
+| Admin AI ops dashboard | `admin/src/pages/AiOperationsPage.tsx` | ⚠️ functional but **i18n missing** (hardcoded EN) |
+| Prisma models (AiAuditLog, AiAgentRun, AiAgentConfig, AiResultCache, KnowledgeDocument, CandidateConsent) | `api/prisma/schema.prisma` | ✅ |
+| `echo-validate` proof-of-life agent | `api/src/ai/agents/echo-validate/` | ✅ (fixtures added in Phase 1 commit) |
+
+**Known Layer 1 gaps still open:**
+- `KnowledgeDocument.embedding` vector(768) column — added by Phase 1 migration ✅
+- `LlmClient.retrieve()` (RAG retrieval path) — not implemented
+- Geocoding worker — queue registered, no processor
+- AiOperationsPage.tsx — **does not use `useTranslation`** (hardcoded English) — must be fixed
+- Circuit breaker is in-memory (acceptable for now)
+
+### 1.2 Layer 2 / Phase 1: Internal Matching MVP ✅
+Branch `claude/review-handover-plan-UHBvr` (this branch) — just shipped in commit `9f1a9f3`.
+
+| Component | Path | Status |
+|---|---|---|
+| Prisma additions (StaffingRequest, StaffingRequestEmbedding, MatchResult, EducatorEmbedding) | `api/prisma/schema.prisma` | ✅ |
+| Geo cols on User/Organization + JobListing.staffingRequestId | `api/prisma/schema.prisma` | ✅ |
+| Migration with pgvector/cube/earthdistance extensions | `api/prisma/migrations/20260521000000_add_staffing_phase1/migration.sql` | ✅ |
+| Pre-build extension script | `api/scripts/enable-pg-extensions.sql` | ✅ |
+| `staffing-request-parser` agent (FR/DE/EN prompt, Zod schema, golden fixture) | `api/src/ai/agents/staffing-request-parser/` | ✅ |
+| `match-explanation` agent | `api/src/ai/agents/match-explanation/` | ✅ |
+| StaffingModule (controller, service, hybrid matcher, queues, processors) | `api/src/staffing/` | ✅ |
+| `ai_staffing_matching` feature flag (default off) | `api/prisma/seed.ts` | ✅ |
+| Sync preview path (≤800 chars) + async queue path | `api/src/staffing/staffing.service.ts` | ✅ |
+| Foundation UI — staffing request box + shortlist table | `frontend/pages/foundation/` | ❌ **NOT BUILT** |
+| i18n keys for staffing module | `packages/translations/locales/{en,fr,de}/staffing.json` | ❌ **NOT ADDED** |
+| Geocoding worker (`ai.geocode` processor) | `api/src/staffing/workers/` | ❌ stub job exists, no processor |
+| Embedding workers — vector writes implemented via raw SQL | `api/src/staffing/workers/staffing-embed.processor.ts` | ✅ |
+
+---
+
+## 2. The architecture we are building toward
+
+### 2.1 Three layers
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ Layer 1 — Shared AI Foundation                                    │
+│   model routing · prompt registry · RAG · cost tracking · safety  │
+│   tool/function calling · audit logs · approval workflow          │
+│   memory & context store                                          │
+└──────────────────────────────────────────────────────────────────┘
+                              ↑ called by
+┌──────────────────────────────────────────────────────────────────┐
+│ Layer 2 — AI Virtual Assistant Orchestrator   ← NEW              │
+│   intent detection · role-aware routing · clarifying questions    │
+│   tool selection · modal protocol · approval gates · memory       │
+│   streaming responses                                             │
+└──────────────────────────────────────────────────────────────────┘
+                              ↑ orchestrates
+┌──────────────────────────────────────────────────────────────────┐
+│ Layer 3 — Specialist Modules (one per business domain)           │
+│   Staffing · External Routing · HR/Docs · Parent Leads · Supplier │
+│   E-learning · WhatsApp · Admin Ops                              │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 The three action levels (safety classification)
+
+| Level | Description | Approval | Examples |
+|---|---|---|---|
+| **L1 — Answer** | Information only | None | "How do I upload a CV?" · "What's my staffing demand this month?" |
+| **L2 — Draft** | Prepares an action; user reviews | User confirms in modal | "Draft a job post" · "Find me candidates" · "Reply to this parent" |
+| **L3 — Execute** | Multi-party / high-impact | Admin approval logged | "Send to 40 candidates" · "Post externally to JobUp" · "Send WhatsApp blast" |
+
+Every tool the assistant can call is tagged with its level. The orchestrator enforces approval flow per level.
+
+### 2.3 The modal protocol (UI contract)
+
+The orchestrator returns structured outputs, not prose-only responses:
+
+```json
+{
+  "type": "assistant_action",
+  "intent": "staffing_request",
+  "modal": "staffing_request_modal",
+  "prefill": { "role": "Auxiliaire", "canton": "VD", "percentage": 60, ... },
+  "level": "L2_DRAFT",
+  "approvalRequired": true,
+  "speech": "I detected a staffing request for an auxiliaire in Lausanne at 60%..."
+}
+```
+
+The frontend assistant client interprets `type: "assistant_action"` and opens the matching modal pre-filled. The user reviews → confirms → backend executes.
+
+### 2.4 Tool registry
+
+A central registry — one entry per backend capability the assistant can invoke. Example shape:
+
+```ts
+{
+  name: 'search_internal_candidates',
+  level: 'L2_DRAFT',
+  allowedRoles: ['FOUNDATION', 'ADMIN'],
+  inputSchema: SearchCandidatesSchema,  // Zod
+  modal: 'candidate_shortlist_modal',
+  handler: (input, principal) => staffingService.runMatching(...)
+}
+```
+
+Tools are how the LLM "uses" the platform. The orchestrator passes the registry (filtered by user role) to the LLM as OpenRouter tool definitions. The model picks one and returns args. The backend validates and executes.
+
+---
+
+## 3. Translation workflow — applied to every AI artifact
+
+### 3.1 The platform's translation system (reference)
+
+Source: `docs/I18N_SYSTEM.md`, `docs/TRANSLATION_WORKFLOW_FOR_DEVELOPERS.md`, `frontend/i18n.ts`
+
+- **Library:** react-i18next, default `fr`, supported `en`, `fr`, `de`
+- **File layout:** `packages/translations/locales/{en,fr,de}/{namespace}.json` (dot.notation nested keys)
+- **Discovery:** Vite auto-globs all `*.json` per locale (no manual imports)
+- **Dynamic updates:** API endpoint `GET /static-translations/{lng}/{ns}` (backed by `api/src/static-translation/`)
+- **CI gate:** `pnpm i18n:check` validates that every key referenced in code exists in **all three** locales — PR cannot merge if missing
+- **Auto-translation tooling:** `api/src/translation/` (DeepL adapter, translation memory, cost tracking, queue)
+- **ESLint rule:** flags hardcoded JSX strings
+- **Missing-key tracking:** `api/src/translation-errors/` logs and reports missing keys from production
+
+### 3.2 The four translation surfaces in the AI build
+
+Each surface has a different mechanism. **All four are required for every feature** — checked in code review.
+
+| Surface | What | Mechanism | Owner |
+|---|---|---|---|
+| **A. UI strings** | Assistant chat bubbles, modal labels, buttons, error messages | `t('assistant:foo.bar')` via react-i18next | Frontend dev |
+| **B. AI prompts** | System prompts for each agent, in user's locale | `prompt.v1.ts(input, locale)` returns localized template | Agent author |
+| **C. AI-generated content** | Explanations, drafts, job posts written by the LLM | Prompt instructs the model to output in `locale`; Zod schema validates | Agent author |
+| **D. Backend messages** | API error responses, notification bodies, email subjects | `TranslationService.t(key, locale)` server-side | Backend dev |
+
+### 3.3 New translation namespaces required
+
+To be created in `packages/translations/locales/{en,fr,de}/`:
+
+| Namespace file | Purpose | When added |
+|---|---|---|
+| `assistant.json` | Assistant chat UI, conversation states, tool feedback | MVP M1 |
+| `staffing.json` | Staffing request modal, shortlist labels, match explanations UI chrome | MVP M0 (immediate — Phase 1 already shipped without these) |
+| `aiOperations.json` | Admin AI ops dashboard (replaces hardcoded EN in `AiOperationsPage.tsx`) | MVP M0 (gap fix) |
+| `aiTools.json` | Tool result formatting strings (e.g., "Showing 5 matches", "No candidates found") | MVP M1 |
+| `aiSafety.json` | Approval prompts, consent dialogs, action confirmations | MVP M2 |
+
+### 3.4 Translation key conventions for AI
+
+- **Namespace:** Use `assistant:` for orchestrator UI, `staffing:` etc. for module-specific UI, `aiTools:` for shared tool output strings
+- **Dot.notation:** `assistant.chat.placeholder`, `assistant.intent.staffing_request.heading`
+- **ICU interpolation:** Use the existing format helpers — `{{count}}`, `{{date, date}}`, `{{amount, currency}}`
+- **Plural forms:** `_one` / `_other` suffix (see `frontend/i18n.ts:355`)
+- **No hardcoded user-facing strings in `.ts`/`.tsx` files** — ESLint will catch
+- **Prompt files are exempt** from the JSX-hardcoded-string rule — they output to the LLM, not the user; but the prompt instructs the LLM to respond in the passed `locale`
+
+### 3.5 Workflow for adding a new AI tool with translations
+
+```
+1. Backend dev adds tool definition (api/src/ai/tools/<name>.ts)
+   - Defines name, level, allowedRoles, Zod input schema, handler
+   - Defines i18n key paths the tool will emit, e.g.:
+     resultKey: 'aiTools.searchInternalCandidates.summary'
+
+2. Backend dev adds keys to packages/translations/locales/en/aiTools.json
+   - Source-of-truth EN values
+
+3. Run: pnpm translate (DeepL auto-translates EN → FR/DE)
+   - Output committed to fr/ and de/ files
+
+4. Frontend dev consumes via useTranslation(['aiTools']) in modal/UI
+
+5. CI: pnpm i18n:check passes (all 3 locales have key) → PR mergeable
+```
+
+### 3.6 Translating AI-generated content (Surface C)
+
+When the LLM generates user-facing text (explanations, drafts, job posts), we **do not store English and translate** — we tell the model to generate in the user's locale directly. Pattern (already used in `match-explanation/prompt.v1.ts`):
+
+```ts
+export default function prompt(input, locale) {
+  const lang = locale === 'de' ? 'German' : locale === 'en' ? 'English' : 'French';
+  return `Respond ONLY with a JSON object. Write the explanation in ${lang}. ...`;
+}
+```
+
+**Storage:** Store the locale used alongside the content (`MatchResult.explanationLocale`). When the user switches language we re-generate via background job (cached by content+locale hash).
+
+### 3.7 Action item: backfill missing translations in Layer 1
+
+The handover claimed AI translations were added but only the **sidebar label** was. Two backfill tasks must happen before MVP M1:
+
+1. Wire `useTranslation` into `admin/src/pages/AiOperationsPage.tsx` and replace all hardcoded English with keys in a new `aiOperations.json` namespace (~80 keys: tab labels, table headers, button text, status badges, empty states).
+2. Add `staffing.json` namespace covering the foundation-facing UI being built in MVP M0.
+
+---
+
+## 4. MVP definition
+
+**Goal:** Ship the smallest end-to-end slice that proves the assistant model + delivers production value to foundations.
+
+### 4.1 In scope for MVP
+
+- ✅ Layer 1 (already done)
+- ✅ Staffing Phase 1 backend (already done — sync parse, hybrid matching, async explanations)
+- ❌ **Foundation UI** — staffing request box + shortlist table (no assistant yet, plain modal)
+- ❌ **AI Assistant Orchestrator v1** — single conversational entry point for FOUNDATION + ADMIN roles
+- ❌ **Tool registry v1** with these tools:
+  - `search_help_docs` (L1)
+  - `open_modal` (L1) — opens any pre-filled modal
+  - `parse_staffing_request` (L2) — wraps the existing staffing-request-parser agent
+  - `search_internal_candidates` (L2) — wraps HybridMatcher
+  - `explain_match` (L1) — wraps match-explanation
+  - `draft_job_post` (L2)
+  - `draft_parent_reply` (L2)
+- ❌ **Frontend assistant client** — chat panel + modal protocol handler + streaming responses
+- ❌ **AIConversation / AIMessage / AIToolCall** Prisma models
+- ❌ **i18n backfill** — AI Operations page + new `assistant.json` / `staffing.json` namespaces
+- ❌ **`ai_assistant_enabled` feature flag** (master toggle for the assistant)
+
+### 4.2 Explicitly out of scope for MVP
+
+- WhatsApp channel (Phase 5)
+- Voice input
+- L3 execute-level tools (sending to many recipients, posting externally) — drafts only
+- External routing (JobUp, Job-Room) — manual workflow continues
+- HR document RAG retrieval
+- Memory/context store (every conversation starts fresh in MVP)
+- Educator-facing or parent-facing assistant — FOUNDATION + ADMIN only in MVP
+- Reactivation campaigns
+- E-learning assignment via assistant
+- Embedding-based candidate similarity (the workers are built, but vector ranking deferred until profiles backfill embeddings)
+- Geocoding worker — Phase 2
+
+### 4.3 MVP success criteria
+
+- A foundation user can type "Find me an EDE in Geneva at 60% starting next month" in the assistant panel and within 5 seconds see a shortlist of internal candidates with explanations, in their selected locale (FR/DE/EN)
+- A foundation user can type "Draft a job post for an auxiliaire" and the assistant opens the job-post modal pre-filled
+- A foundation user can type "How do I publish a job listing?" and get a useful answer with a "Take me there" button
+- An admin user can see every assistant action in `AiAuditLog` and `AIToolCall` tables with PII redacted
+- All assistant UI text passes `pnpm i18n:check` in all three locales
+- `ai_assistant_enabled` and `ai_staffing_matching` flags toggle features cleanly
+
+---
+
+## 5. MVP build plan — milestones
+
+### M0 — Foundation UI for Phase 1 staffing + i18n backfill  (1 week)
+
+The staffing backend exists but has no UI. Build it as a standalone foundation page first so the assistant has something to "open" later.
+
+**Deliverables:**
+1. `packages/translations/locales/{en,fr,de}/staffing.json` with ~50 keys
+2. `packages/translations/locales/{en,fr,de}/aiOperations.json` (~80 keys) — backfill
+3. Rewire `admin/src/pages/AiOperationsPage.tsx` to use `useTranslation(['aiOperations'])`
+4. New page `frontend/pages/foundation/StaffingRequestsPage.tsx` (route `/foundation/staffing`)
+   - Free-text textarea
+   - "Find candidates" button
+   - Calls `POST /staffing/requests`
+   - Polls / SSE for matches → shows shortlist with explanation
+   - Tab/section on `FoundationDashboardPage.tsx` linking to it
+5. Run `pnpm translate` to auto-fill FR/DE via DeepL
+6. CI green: `pnpm i18n:check`
+
+**Exit:** Foundation user can use staffing matching end-to-end (no assistant yet).
+
+---
+
+### M1 — Conversation infrastructure + assistant orchestrator skeleton  (1–2 weeks)
+
+**Deliverables:**
+
+1. **Prisma additions** (one migration):
+   - `AIConversation` (id, userId, organizationId, role, channel='web', status, startedAt, endedAt)
+   - `AIMessage` (id, conversationId, sender enum {USER, ASSISTANT, SYSTEM}, content, structuredIntent JSON, createdAt)
+   - `AIToolCall` (id, conversationId, messageId, toolName, inputJson, outputJson, status, level, approvalRequired, approvedById, executedAt, errorMessage)
+   - `AIActionApproval` (id, toolCallId, status, approvedBy, approvalContext, createdAt)
+   - `AIContextMemory` (id, userId, organizationId, memoryType, key, valueJson, expiresAt) — schema only, hydration in M3
+
+2. **`api/src/assistant/` module:**
+   - `assistant.controller.ts` — `POST /assistant/messages` (SSE streaming response), `POST /assistant/conversations`, `GET /assistant/conversations/:id`
+   - `assistant.service.ts` — conversation/message persistence, orchestration entry point
+   - `orchestrator.service.ts` — calls `LlmClient.run()` with a new agent `assistant-orchestrator`, handles tool-call loop, enforces approval gates
+   - `tools/tool-registry.ts` — central registry with role filtering
+   - `tools/<tool-name>.ts` — one file per tool (see MVP scope list)
+   - `assistant.module.ts` — wires up, imports StaffingModule, AiModule
+
+3. **New agent: `assistant-orchestrator`** registered in `ai-agents.config.ts`
+   - Model chain: `anthropic/claude-sonnet-4-6` (primary), `google/gemini-2.5-pro` (fallback)
+   - Uses OpenRouter tool-calling JSON schema (multi-step)
+   - System prompt instructs: respond in user's locale, propose tools not actions, never execute without confirmation
+   - Roles: FOUNDATION, ADMIN, SUPER_ADMIN (MVP)
+
+4. **Streaming protocol:**
+   - Server-Sent Events on `POST /assistant/messages`
+   - Event types: `token` (partial text), `tool_call` (proposed tool), `tool_result` (executed), `modal_action` (open modal), `done` (final)
+   - Reuse existing SSE pattern — investigate first; if absent, add minimal helper
+
+5. **i18n namespace `assistant.json`** with chat UI strings (~60 keys)
+
+**Exit:** API works end-to-end via curl; no UI yet. `POST /assistant/messages` returns SSE stream with a tool call.
+
+---
+
+### M2 — Frontend assistant client + modal protocol  (1–2 weeks)
+
+**Deliverables:**
+
+1. **Floating assistant button** in foundation/admin layouts — bottom-right, opens slide-over panel
+2. **`AssistantPanel` component:**
+   - Chat thread (reuse messaging UI primitives)
+   - Composer with auto-focus on `/` or `Cmd+K`
+   - Streaming token rendering
+   - Tool-call cards showing what the assistant is proposing
+3. **Modal protocol handler:**
+   - Frontend interprets `modal_action` events
+   - Maps `modal: "staffing_request_modal"` to actual component
+   - Pre-fills via React Hook Form `defaultValues`
+   - On user confirm, calls the relevant backend endpoint (already exists for staffing)
+4. **Inline context buttons** — "Ask the assistant about this" buttons in:
+   - Foundation dashboard (top-right)
+   - Staffing requests page
+   - Job listings page
+5. **State management:** Use existing React Query for conversation queries + a small Zustand store (or Context) for current conversation ID + open/close state
+6. **Role gating:** Assistant button only visible if user role ∈ {FOUNDATION, ADMIN, SUPER_ADMIN} AND `ai_assistant_enabled` flag is on
+
+**Exit:** A foundation user can chat with the assistant, see it propose actions, confirm them in modals, and see results inline. End-to-end MVP demo works.
+
+---
+
+### M3 — Hardening, observability, beta release  (1 week)
+
+**Deliverables:**
+
+1. **AI Operations dashboard updates:**
+   - New tab "Assistant" — shows AIConversation/AIMessage/AIToolCall counts, top tools used, average latency
+   - Conversation drill-down — admin can replay any user conversation (PII-redacted per `safety.service.ts` rules)
+2. **Approval inbox for L3 tools** (future-proofing, even if no L3 tools in MVP) — admin UI to approve/reject pending `AIActionApproval` rows
+3. **Rate limiting per user** (e.g., 30 messages/min) — reuse existing ThrottlerModule
+4. **Cost guardrails** — daily per-user budget hard cap in `BudgetService` (not just per-agent)
+5. **Eval harness:** for each agent run the `fixtures/` golden cases as a unit test (`pnpm test:ai-eval`); regression catch
+6. **Production env-var checklist update** in `docs/AI_STAFFING_MANUAL_TASKS.md` (or a new `AI_ASSISTANT_DEPLOY.md`)
+7. **Onboarding tour** — first time a foundation user opens the assistant, show 3-step intro
+8. **Beta feature flag rollout:** enable `ai_assistant_enabled` for 1 internal foundation, then 5 design partners
+
+**Exit:** Beta release to design partners. Monitoring in place. Documentation complete.
+
+---
+
+## 6. Post-MVP roadmap
+
+Numbered roughly in priority order; each phase is independently shippable.
+
+### P1 — Specialist module: External Routing
+- New agent `job-ad-generator` — produces multi-channel job ads (JobUp, Job-Room, LinkedIn) from a `StaffingRequest`
+- New tool `recommend_external_channels` (L2) + `create_external_routing_campaign` (L3)
+- New tables: `ExternalRoutingCampaign`, `ExternalCandidateCapture`, `ShortLinkTracker`
+- Public capture landing page at `/apply/:shortLinkCode` for external candidates
+- Admin approval workflow for L3 routing campaigns
+
+### P2 — Specialist module: HR/Document Assistant (RAG)
+- Implement deferred `LlmClient.retrieve()` — pgvector cosine search on `KnowledgeDocument.embedding`
+- New agent `hr-doc-search` with `retrieval` config
+- Seed knowledge base from HR template library + canton policy crawl (the existing `CrawlerModule`)
+- New tool `search_hr_documents` (L1) — returns summarised + linked source docs
+
+### P3 — Specialist module: Parent Lead Assistant
+- New agent `parent-lead-classifier` (urgency, intent) + `parent-reply-drafter`
+- New tools `summarize_parent_leads` (L1), `draft_parent_reply` (L2)
+- Inline assistant integration on the existing parent leads page
+- Per-canton language detection (FR vs DE leads)
+
+### P4 — Memory & context store
+- Hydrate `AIContextMemory` — last 10 conversations summary, user preferences (preferred match thresholds), foundation profile
+- Inject into orchestrator prompt as compressed context (token budget capped)
+- Per-user memory TTL controls in user settings UI
+
+### P5 — Specialist module: Supplier / Service Marketplace
+- New agent `supplier-quote-drafter`
+- New tools `search_suppliers` (L1), `create_supplier_request` (L2)
+- Integrate with existing `marketplace` and `service-requests` modules
+
+### P6 — Specialist module: E-learning Assistant
+- New agent `training-recommender`
+- New tools `recommend_training` (L1), `assign_elearning_course` (L2)
+- Connects to existing `ElearningModule`
+
+### P7 — Admin AI Ops capabilities
+- New agent `staffing-demand-analyst` — natural-language KPI queries
+- New tools `staffing_demand_heatmap` (L1), `incomplete_profile_segment` (L1), `weekly_recruitment_report` (L1)
+- Materialised views for fast aggregate queries
+
+### P8 — Reactivation Engine
+- Per the original AI_STAFFING_INTEGRATION_PLAN Phase 3
+- New agent `reactivation-message-drafter`
+- New tables `ReactivationCampaign`, `ReactivationMessage`
+- L3 tool requires admin approval
+
+### P9 — Profile embeddings + vector ranking
+- Backfill `EducatorEmbedding` for all approved educators (BullMQ job)
+- Update `HybridMatcherService` to use vector similarity as a tiebreaker (currently stub)
+- Re-embed on profile change (already wired via `staffing.embed-profile` queue, needs trigger)
+
+### P10 — Geocoding worker
+- Implement deferred `ai.geocode` processor
+- Uses `MAPBOX_API_KEY` for forward geocoding User/Organization addresses
+- Backfill job for existing rows
+- Switch `HybridMatcher` distance calc from in-memory haversine to `earthdistance` SQL (perf win on large pools)
+
+### P11 — Educator-facing assistant
+- Open assistant to EDUCATOR role with a restricted tool set
+- Tools: `complete_my_profile`, `find_jobs_near_me`, `improve_my_profile`, `check_missing_documents`
+- Tighter consent + scope rules per `safety.service.ts`
+
+### P12 — Parent-facing assistant
+- Open to PARENT role with very restricted tools
+- Tools: `find_nearby_daycares`, `check_request_status`, `update_child_details`
+
+### P13 — WhatsApp Agent Channel
+- Meta WhatsApp Business Platform integration
+- Webhook at `POST /assistant/whatsapp/webhook`
+- New `AIConversation.channel = 'whatsapp'`
+- Identity verification: phone number → User lookup
+- Same orchestrator, restricted tool surface (no complex modals — link back to platform with secure short-link for L2+)
+- New tools `send_whatsapp_message` (L3), `send_secure_platform_link` (L1)
+
+### P14 — Multi-modal: CV parsing + profile enrichment
+- Per the original AI_STAFFING_INTEGRATION_PLAN Phase 2
+- New agent `cv-parser` (PDF/DOCX → structured `CandidateExperience` + `CandidateCertification`)
+- New tool `parse_cv_upload` (L2)
+- Triggered when educator uploads CV — assistant offers to autofill profile
+
+### P15 — Voice input
+- Browser WebSpeech API → STT before passing to orchestrator
+- Locale-aware (Swiss French/German variants)
+
+---
+
+## 7. Database additions for MVP
+
+To be added in `api/prisma/schema.prisma` during M1 in one migration `20260601000000_add_assistant_core`:
+
+```prisma
+enum AIConversationStatus {
+  ACTIVE
+  ENDED
+  ARCHIVED
+}
+
+enum AIChannel {
+  WEB
+  WHATSAPP    // future
+  EMAIL       // future
+}
+
+enum AIMessageSender {
+  USER
+  ASSISTANT
+  SYSTEM
+  TOOL
+}
+
+enum AIToolCallStatus {
+  PROPOSED
+  AWAITING_APPROVAL
+  APPROVED
+  EXECUTED
+  REJECTED
+  FAILED
+}
+
+enum AIActionLevel {
+  L1_ANSWER
+  L2_DRAFT
+  L3_EXECUTE
+}
+
+model AIConversation {
+  id             String   @id @default(uuid())
+  userId         String
+  organizationId String?
+  role           UserRole
+  channel        AIChannel @default(WEB)
+  status         AIConversationStatus @default(ACTIVE)
+  locale         String   @default("fr")
+  startedAt      DateTime @default(now())
+  endedAt        DateTime?
+
+  user         User       @relation(fields: [userId], references: [id])
+  messages     AIMessage[]
+  toolCalls    AIToolCall[]
+
+  @@index([userId, startedAt(sort: Desc)])
+  @@map("ai_conversations")
+}
+
+model AIMessage {
+  id               String   @id @default(uuid())
+  conversationId   String
+  sender           AIMessageSender
+  content          String   @db.Text
+  structuredIntent Json?
+  createdAt        DateTime @default(now())
+
+  conversation AIConversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  toolCalls    AIToolCall[]
+
+  @@index([conversationId, createdAt])
+  @@map("ai_messages")
+}
+
+model AIToolCall {
+  id                 String   @id @default(uuid())
+  conversationId     String
+  messageId          String?
+  toolName           String
+  level              AIActionLevel
+  inputJson          Json
+  outputJson         Json?
+  status             AIToolCallStatus @default(PROPOSED)
+  approvalRequired   Boolean  @default(false)
+  approvedById       String?
+  executedAt         DateTime?
+  errorMessage       String?  @db.Text
+  createdAt          DateTime @default(now())
+
+  conversation AIConversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  message      AIMessage?     @relation(fields: [messageId], references: [id])
+  approvals    AIActionApproval[]
+
+  @@index([conversationId, createdAt])
+  @@index([status])
+  @@map("ai_tool_calls")
+}
+
+model AIActionApproval {
+  id              String   @id @default(uuid())
+  toolCallId      String
+  status          String   // pending | approved | rejected
+  approvedBy      String?
+  approvalContext Json?
+  createdAt       DateTime @default(now())
+
+  toolCall AIToolCall @relation(fields: [toolCallId], references: [id], onDelete: Cascade)
+
+  @@map("ai_action_approvals")
+}
+
+model AIContextMemory {
+  id             String   @id @default(uuid())
+  userId         String
+  organizationId String?
+  memoryType     String   // "preference" | "summary" | "fact"
+  key            String
+  valueJson      Json
+  expiresAt      DateTime?
+  createdAt      DateTime @default(now())
+
+  @@unique([userId, memoryType, key])
+  @@map("ai_context_memory")
+}
+```
+
+Note: `AIUsageLog` is **not** added — we already have `AiAuditLog` from Layer 1 which serves the same purpose. The orchestrator writes one `AiAuditLog` row per LLM call (already does) plus one `AIToolCall` row per tool invocation.
+
+---
+
+## 8. Risks & open questions
+
+### 8.1 Risks
+1. **Tool-call accuracy** — LLMs can hallucinate tool names. Mitigation: strict OpenRouter JSON-schema tool definitions + Zod validation + fallback to clarifying question
+2. **Latency** — multi-step orchestration (intent → tool → result → summarisation) can exceed 5s. Mitigation: stream first token within 1s, parallelise where safe, aggressively cache
+3. **Cost runaway** — chat is open-ended. Mitigation: per-user daily budget cap (M3), conversation length cap, summarisation of old messages
+4. **Translation quality of LLM output** — DeepL is reliable for UI strings but LLM output in DE may be uneven. Mitigation: explicit examples in prompt per locale, eval fixtures per locale, fallback to FR
+5. **Modal sprawl** — every new tool tempts a new modal. Mitigation: reuse existing modals; new modals only with design review
+
+### 8.2 Open questions to resolve before M1
+1. **Streaming infrastructure** — does the platform already use SSE/WebSocket? Need to find before M1 (investigate `frontend/services/api.ts` and any existing `EventSource` usage)
+2. **Auth on SSE** — Clerk JWT in EventSource headers requires custom polyfill; alternative is signed token in query param
+3. **Mobile (PWA) chat UX** — does the existing app target PWA/mobile? If yes, the floating button placement and keyboard handling need design pass
+4. **Conversation retention** — how long to keep `AIMessage` rows? GDPR consideration — propose: 90 days default, user-deletable
+5. **OPUS-4-7 vs Sonnet-4-6 for orchestrator** — Sonnet is fast and capable for tool calling; only switch to Opus if Sonnet fails evals
+
+### 8.3 Manual / ops tasks (not code)
+- Confirm pgvector extension live in production (`api/scripts/enable-pg-extensions.sql`)
+- `OPENROUTER_API_KEY`, `VOYAGE_API_KEY`, `MAPBOX_API_KEY` set per environment
+- DeepL API key set (used by translation pipeline) — confirm in `api/src/translation/translation.config.ts`
+- Redis enabled for assistant queues (`REDIS_URL` or `REDIS_HOST`)
+- Feature flags seeded: `ai_foundation_enabled`, `ai_staffing_matching`, `ai_assistant_enabled` (new)
+- WhatsApp Business Platform account (only at P13)
+
+---
+
+## 9. Conventions reminder
+
+- **No LLM SDK imports outside `api/src/ai/`** (ESLint enforced)
+- **Every new agent** needs `index.ts`, `prompt.v1.ts`, `schema.ts`, `fixtures/` (golden cases per locale)
+- **Every new tool** needs an entry in `tool-registry.ts` with `level`, `allowedRoles`, Zod input schema, optional modal mapping
+- **Every new UI string** needs keys in all three locales — CI enforces
+- **Every L2/L3 action** must go through the approval gate — never bypass
+- **Staffing features live in `api/src/staffing/`** — never modify `api/src/recruitment/`
+- **Assistant orchestration lives in `api/src/assistant/`** — new module, separate from `ai/` (which stays the gateway)
+- **Migrations** are timestamp-prefixed YYYYMMDDHHMMSS; raw SQL when Prisma `Unsupported` types are involved
+- **AI-generated content stores the locale** alongside the content so we can re-generate on language switch
+
+---
+
+## 10. Key files to read before starting any AI work
+
+```
+docs/AI_ASSISTANT_MASTER_PLAN.md     — this file
+docs/AI_LAYER1_HANDOVER.md           — Layer 1 detail (now historical reference)
+docs/I18N_SYSTEM.md                  — translation system
+docs/TRANSLATION_WORKFLOW_FOR_DEVELOPERS.md
+api/src/ai/llm-client.ts             — the gateway contract
+api/src/ai/ai-agents.config.ts       — agent registry
+api/src/staffing/staffing.service.ts — Phase 1 staffing service (pattern for specialist modules)
+api/src/staffing/hybrid-matcher.service.ts — scoring logic
+api/prisma/schema.prisma             — current DB schema
+CLAUDE.md                            — project conventions
+frontend/i18n.ts                     — frontend i18n bootstrap
+packages/translations/locales/en/    — source-of-truth translation files
+```
+
+---
+
+## 11. Branching / PR strategy
+
+- One PR per milestone (M0, M1, M2, M3, then per post-MVP phase)
+- Each PR ships with: code, migration (if any), translation keys for all 3 locales, golden fixtures, feature flag wiring, docs update
+- `pnpm i18n:check`, `pnpm type-check`, `pnpm test` must all pass before merge
+- Post-MVP phases can branch off `main` independently — they don't block each other

--- a/docs/AI_LAYER1_HANDOVER.md
+++ b/docs/AI_LAYER1_HANDOVER.md
@@ -1,5 +1,11 @@
 # AI Integration — Layer 1 Handover
 
+> ⚠️ **This document is historical reference.** The active strategic plan is **`docs/AI_ASSISTANT_MASTER_PLAN.md`** — which supersedes this doc's "what to build next" section. The "what was built" inventory below remains accurate for Layer 1 / Phase 0.
+>
+> **Phase 1 (Internal Matching MVP)** described in §4 below has been **completed on branch `claude/review-handover-plan-UHBvr`** (commit `9f1a9f3`). See the master plan for the remaining work.
+
+---
+
 **Branch:** `claude/analyze-ai-layer-1-8rj9s`
 **PR:** #647
 **Status:** Layer 1 (Phase 0 — Shared AI Foundation) **complete and pushed**. Layer 2 (Phases 1–6) **not started**.


### PR DESCRIPTION
## Summary

Implements the complete backend for **Staffing Phase 1** — a hybrid matching system that parses free-text staffing requests, scores internal candidates using role/location/availability/qualification signals, and generates AI-powered match explanations. This is the foundation layer for the upcoming AI Virtual Assistant (Phase 2).

## Key Changes

### Core Staffing Infrastructure
- **New Prisma models** (`StaffingRequest`, `MatchResult`, `EducatorEmbedding`, `StaffingRequestEmbedding`) with enums (`StaffingRequestStatus`, `MatchResultStatus`)
- **Database migration** (`20260521000000_add_staffing_phase1`) enabling pgvector/cube/earthdistance extensions for vector similarity and distance calculations
- **Geo columns** added to `User` and `Organization` (latitude/longitude/geocodedAt) for distance-based matching
- **Extension setup script** (`api/scripts/enable-pg-extensions.sql`) for production deployment

### AI Agents (Layer 1 integration)
- **`staffing-request-parser` agent** — parses free-text requests (FR/DE/EN) into structured fields (role, contract type, start/end dates, canton, languages, qualifications) using Claude + Zod validation
- **`match-explanation` agent** — generates concise (≤80 words) prose explanations of why a candidate matches, in the user's locale
- **Golden fixtures** for both agents (French examples) to validate agent behavior
- **Agent registry** updated in `ai-agents.config.ts` with proper role/scope rules

### Hybrid Matching Engine
- **`HybridMatcherService`** — scores candidates across 8 dimensions (role, availability, location, qualification, language, age group, contract type, responsiveness) with configurable weights
- **Hard filters** — role, approval status, region/canton, language requirements
- **Distance calculation** — uses PostGIS earthdistance for commute-based filtering
- **Upsert logic** — efficiently updates or creates `MatchResult` records per candidate

### Staffing Module (Controller + Service)
- **`StaffingController`** — POST `/staffing/requests` (create), GET `/staffing/requests/:id` (fetch), GET `/staffing/requests/:id/matches` (shortlist)
- **`StaffingService`** — orchestrates parsing, matching, and explanation workflows with sync/async paths:
  - **Sync path** (≤800 chars) — immediate parse preview for snappy UX
  - **Async path** (>800 chars) — queued parsing + matching + explanations
- **Role-based access control** — FOUNDATION/ADMIN/SUPER_ADMIN only
- **Locale support** — all operations respect user's selected language

### Queue Workers (BullMQ)
- **`staffing-match.processor`** — triggers hybrid matching after parsing completes
- **`staffing-explain.processor`** — generates explanations for top matches asynchronously
- **`staffing-embed-profile.processor`** — embeds educator profiles (skills, certifications, bio) for future vector-based ranking
- **`staffing-embed-request.processor`** — embeds staffing requests for semantic similarity
- **Queue module** (`StaffingQueuesModule`) — registers all four queues with exponential backoff retry logic

### Feature Flag & Seed
- **`ai_staffing_matching` feature flag** — defaults to `false`; gates the entire staffing module
- **Seed data** — flag created in `prisma/seed.ts`

### DTOs & Validation
- **`CreateStaffingRequestDto`** — validates raw text input (10–2000 chars), optional locale override

## Notable Implementation Details

1. **Sync/Async Hybrid** — Requests ≤800 chars parse synchronously (fast feedback), longer ones queue asynchronously. Both paths eventually trigger matching and explanations.

2. **Vector Storage** — Embeddings stored as `vector(768)` in PostgreSQL via raw SQL queries (Prisma cannot write vector types directly). Uses Voyage AI's `voyage-3-lite` model.

https://claude.ai/code/session_01M59LxQERuK2BexQkpJTT43