### PR TITLE
Expand admin/super-admin capabilities and add Voyage AI retry logic

### DIFF
--- a/api/src/ai/knowledge/role-capabilities.ts
+++ b/api/src/ai/knowledge/role-capabilities.ts
@@ -62,24 +62,96 @@ IMPORTANT: Profile must be approved by an admin before you can access the job bo
 - Settings: account, billing, language → /settings
 - Support: submit help tickets → /service-provider/support`,
 
-  [UserRole.ADMIN]: `You are a platform administrator. What you can do:
+  [UserRole.ADMIN]: `You are a platform administrator with access to every feature across all roles. You can use and test the full platform. What you can do:
+
+ADMIN TOOLS:
 - Content Management: upload and manage e-learning, HR procedures, state policies → /admin/content-dashboard
 - System Monitoring: platform health and metrics → /admin/system-monitoring
 - User Management: view and manage all users and roles → /users
 - Discount Management: create and manage discount codes → /admin/discount-terminations
 - Design System: component library → /design-system
-- You also have read access to Foundation, Supplier, Service Provider, and Educator sections for oversight.`,
 
-  [UserRole.SUPER_ADMIN]: `You are a super administrator with full platform access. What you can do:
-- Everything an Admin can do, with elevated permissions
-- Content Management, System Monitoring, User Management, Discount Management
-- Platform-wide configuration and oversight across all roles`,
+FOUNDATION FEATURES (you can access and test these):
+- Foundation Dashboard: KPIs for staff, leads, orders, intern pool → /foundation/dashboard
+- Parent Leads: view and respond to parent childcare enquiries → /foundation/leads
+- Marketplace: order products and book services → /marketplace/products, /marketplace/services
+- Orders & Appointments: track fulfillment and bookings → /foundation/orders-appointments
+- Analytics: revenue, lead conversion, staffing metrics → /foundation/analytics
+- Organisation Profile: update foundation details → /foundation/organisation-profile
+
+EDUCATOR FEATURES (you can access and test these):
+- Educator Dashboard: profile completion summary and job matches → /educator/dashboard
+- Educator Profile: CV, qualifications, skills, certifications, availability → /educator/profile
+- Job Board: search and apply for positions → /educator/job-board
+- My Applications: track application statuses → /educator/applications
+- Profile Approval: approve or reject educator profiles → /users
+
+PARENT FEATURES (you can access and test these):
+- Foundations: browse childcare foundations → /parent/foundations
+- My Enquiries: view and track submitted childcare enquiries → /parent/enquiries
+
+SUPPLIER FEATURES (you can access and test these):
+- Supplier Dashboard → /supplier/dashboard
+- Product Listings: manage product catalog → /supplier/product-listings
+- Orders: view and manage incoming orders → /supplier/orders
+
+SERVICE PROVIDER FEATURES (you can access and test these):
+- Service Provider Dashboard → /service-provider/dashboard
+- Service Listings: manage service catalog → /service-provider/service-listings
+- Requests: view and manage incoming service bookings → /service-provider/requests`,
+
+  [UserRole.SUPER_ADMIN]: `You are a super administrator with full platform access and elevated permissions across every role. You can use and test every feature on the platform. What you can do:
+
+ADMIN TOOLS:
+- Content Management: upload and manage e-learning, HR procedures, state policies → /admin/content-dashboard
+- System Monitoring: platform health and metrics → /admin/system-monitoring
+- User Management: view and manage all users and roles → /users
+- Discount Management: create and manage discount codes → /admin/discount-terminations
+- Design System: component library → /design-system
+- Platform-wide configuration and oversight
+
+FOUNDATION FEATURES (you can access and test these):
+- Foundation Dashboard: KPIs for staff, leads, orders, intern pool → /foundation/dashboard
+- Parent Leads: view and respond to parent childcare enquiries → /foundation/leads
+- Marketplace: order products and book services → /marketplace/products, /marketplace/services
+- Orders & Appointments: track fulfillment and bookings → /foundation/orders-appointments
+- Analytics: revenue, lead conversion, staffing metrics → /foundation/analytics
+- Organisation Profile: update foundation details → /foundation/organisation-profile
+
+EDUCATOR FEATURES (you can access and test these):
+- Educator Dashboard: profile completion summary and job matches → /educator/dashboard
+- Educator Profile: CV, qualifications, skills, certifications, availability → /educator/profile
+- Job Board: search and apply for positions → /educator/job-board
+- My Applications: track application statuses → /educator/applications
+- Profile Approval: approve or reject educator profiles → /users
+
+PARENT FEATURES (you can access and test these):
+- Foundations: browse childcare foundations → /parent/foundations
+- My Enquiries: view and track submitted childcare enquiries → /parent/enquiries
+
+SUPPLIER FEATURES (you can access and test these):
+- Supplier Dashboard → /supplier/dashboard
+- Product Listings: manage product catalog → /supplier/product-listings
+- Orders: view and manage incoming orders → /supplier/orders
+
+SERVICE PROVIDER FEATURES (you can access and test these):
+- Service Provider Dashboard → /service-provider/dashboard
+- Service Listings: manage service catalog → /service-provider/service-listings
+- Requests: view and manage incoming service bookings → /service-provider/requests`,
 };
+
+const ADMIN_STAFFING_LINES = `
+STAFFING & RECRUITMENT FEATURES (v2 — you can access and test these):
+- Recruitment: post jobs, browse and shortlist candidates → /recruitment/job-listings, /recruitment/candidate-pool
+- Staffing Replacements: create replacement requests (matched automatically) → /foundation/replacements
+- Staffing Requests: manage general staffing needs → /foundation/staffing-requests
+- Intern Pool: manage interns → /foundation/intern-pool`;
 
 export function getRoleCapabilities(role: UserRole, activeFlags: Set<string>): string {
   const base = ROLE_CAPABILITIES_BASE[role] ?? '';
-  if (role === UserRole.FOUNDATION && activeFlags.has('v2_staffing_ia')) {
-    return base + FOUNDATION_STAFFING_LINES;
+  const staffingRoles: UserRole[] = [UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN];
+  if (staffingRoles.includes(role) && activeFlags.has('v2_staffing_ia')) {
+    return base + (role === UserRole.FOUNDATION ? FOUNDATION_STAFFING_LINES : ADMIN_STAFFING_LINES);
   }
   return base;
 }

--- a/api/src/ai/providers/voyage.adapter.ts
+++ b/api/src/ai/providers/voyage.adapter.ts
@@ -7,6 +7,25 @@ export interface EmbeddingResult {
   totalTokens: number;
 }
 
+/**
+ * Parses a Retry-After header value which may be either delta-seconds ("30")
+ * or an HTTP-date ("Wed, 28 May 2026 09:00:00 GMT"). Returns the wait in ms,
+ * falling back to `defaultMs` if the value is absent or unparseable.
+ */
+function parseRetryAfter(header: string | null, defaultMs: number): number {
+  if (!header) return defaultMs;
+  // Delta-seconds: a string containing only digits (possibly with leading spaces)
+  const seconds = parseInt(header, 10);
+  if (!isNaN(seconds) && seconds >= 0) return seconds * 1000;
+  // HTTP-date
+  const date = new Date(header);
+  if (!isNaN(date.getTime())) {
+    const wait = date.getTime() - Date.now();
+    return wait > 0 ? wait : defaultMs;
+  }
+  return defaultMs;
+}
+
 @Injectable()
 export class VoyageAdapter {
   private readonly logger = new Logger(VoyageAdapter.name);
@@ -56,7 +75,7 @@ export class VoyageAdapter {
 
       if (response.status === 429 && attempt < maxAttempts) {
         const retryAfter = response.headers.get('Retry-After');
-        const waitMs = retryAfter ? parseInt(retryAfter, 10) * 1000 : delayMs;
+        const waitMs = parseRetryAfter(retryAfter, delayMs);
         this.logger.warn(`Voyage AI rate-limited — retrying in ${waitMs}ms (attempt ${attempt}/${maxAttempts})`);
         await new Promise((resolve) => setTimeout(resolve, waitMs));
         delayMs *= 2;

--- a/api/src/ai/providers/voyage.adapter.ts
+++ b/api/src/ai/providers/voyage.adapter.ts
@@ -32,24 +32,40 @@ export class VoyageAdapter {
       return { embedding: new Array(512).fill(0), model: useModel, totalTokens: 0 };
     }
 
-    const response = await fetch(`${this.baseUrl}/embeddings`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.apiKey}`,
-      },
-      body: JSON.stringify({ input: [text], model: useModel }),
-    });
+    const maxAttempts = 4;
+    let delayMs = 2_000;
 
-    if (!response.ok) {
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const response = await fetch(`${this.baseUrl}/embeddings`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify({ input: [text], model: useModel }),
+      });
+
+      if (response.ok) {
+        const data = (await response.json()) as any;
+        return {
+          embedding: data.data[0].embedding,
+          model: useModel,
+          totalTokens: data.usage?.total_tokens || 0,
+        };
+      }
+
+      if (response.status === 429 && attempt < maxAttempts) {
+        const retryAfter = response.headers.get('Retry-After');
+        const waitMs = retryAfter ? parseInt(retryAfter, 10) * 1000 : delayMs;
+        this.logger.warn(`Voyage AI rate-limited — retrying in ${waitMs}ms (attempt ${attempt}/${maxAttempts})`);
+        await new Promise((resolve) => setTimeout(resolve, waitMs));
+        delayMs *= 2;
+        continue;
+      }
+
       throw new Error(`Voyage AI error: ${response.status} ${response.statusText}`);
     }
 
-    const data = (await response.json()) as any;
-    return {
-      embedding: data.data[0].embedding,
-      model: useModel,
-      totalTokens: data.usage?.total_tokens || 0,
-    };
+    throw new Error('Voyage AI error: max retries exceeded');
   }
 }

--- a/api/src/assistant/orchestrator.service.ts
+++ b/api/src/assistant/orchestrator.service.ts
@@ -242,8 +242,14 @@ export class OrchestratorService {
 
       // ── Foundation ────────────────────────────────────────────────────────
       case 'get_my_leads': {
-        if (!principal.organizationId) return { leads: [], total: 0, error: 'No organization context' };
-        const where: any = { foundationId: principal.organizationId };
+        const isAdminRole = principal.role === UserRole.ADMIN || principal.role === UserRole.SUPER_ADMIN;
+        // Admins without an org get a platform-wide view of recent leads
+        const where: any = (!principal.organizationId && isAdminRole)
+          ? {}
+          : principal.organizationId
+            ? { foundationId: principal.organizationId }
+            : null;
+        if (!where) return { leads: [], total: 0, error: 'No organization context' };
         if (args.status) where.status = args.status;
         const leads = await this.prisma.parentLead.findMany({
           where,
@@ -258,17 +264,20 @@ export class OrchestratorService {
             createdAt: true,
           },
         });
-        return { leads, total: leads.length };
+        return { leads, total: leads.length, scope: !principal.organizationId ? 'platform-wide' : 'organization' };
       }
 
       case 'get_my_orders': {
-        if (!principal.organizationId) return { orders: [], total: 0, error: 'No organization context' };
-        // Foundations query by their own organizationId (buyer).
-        // Product suppliers query orders that contain their products (seller view).
-        const where: any =
-          principal.role === UserRole.PRODUCT_SUPPLIER
-            ? { items: { some: { product: { supplierId: principal.organizationId } } } }
-            : { organizationId: principal.organizationId };
+        const isAdminRole = principal.role === UserRole.ADMIN || principal.role === UserRole.SUPER_ADMIN;
+        const where: any = {};
+        if (principal.role === UserRole.PRODUCT_SUPPLIER && principal.organizationId) {
+          where.items = { some: { product: { supplierId: principal.organizationId } } };
+        } else if (principal.organizationId) {
+          where.organizationId = principal.organizationId;
+        } else if (!isAdminRole) {
+          return { orders: [], total: 0, error: 'No organization context' };
+        }
+        // Admins with no org: no where filter → platform-wide
         if (args.status) where.status = args.status;
         const orders = await this.prisma.order.findMany({
           where,
@@ -281,7 +290,7 @@ export class OrchestratorService {
             createdAt: true,
           },
         });
-        return { orders, total: orders.length };
+        return { orders, total: orders.length, scope: !principal.organizationId ? 'platform-wide' : 'organization' };
       }
 
       case 'search_internal_candidates': {
@@ -349,8 +358,9 @@ export class OrchestratorService {
 
       // ── Supplier ───────────────────────────────────────────────────────────
       case 'get_my_listings': {
-        if (!principal.organizationId) return { listings: [], total: 0, error: 'No organization context' };
-        if (principal.role === UserRole.PRODUCT_SUPPLIER || principal.role === UserRole.ADMIN || principal.role === UserRole.SUPER_ADMIN) {
+        const isAdminRole = principal.role === UserRole.ADMIN || principal.role === UserRole.SUPER_ADMIN;
+        if (principal.role === UserRole.PRODUCT_SUPPLIER) {
+          if (!principal.organizationId) return { listings: [], total: 0, error: 'No organization context' };
           const products = await this.prisma.product.findMany({
             where: { supplierId: principal.organizationId },
             take: limit,
@@ -359,6 +369,7 @@ export class OrchestratorService {
           return { listings: products, type: 'products', total: products.length };
         }
         if (principal.role === UserRole.SERVICE_PROVIDER) {
+          if (!principal.organizationId) return { listings: [], total: 0, error: 'No organization context' };
           const sp = await this.prisma.serviceProvider.findFirst({
             where: { organizationId: principal.organizationId },
             select: { id: true },
@@ -371,11 +382,47 @@ export class OrchestratorService {
           });
           return { listings: services, type: 'services', total: services.length };
         }
+        if (isAdminRole) {
+          // Platform-wide view: most recent active products and services
+          const [products, services] = await Promise.all([
+            this.prisma.product.findMany({
+              take: Math.ceil(limit / 2),
+              orderBy: { createdAt: 'desc' },
+              select: { id: true, title: true, price: true, status: true, isActive: true },
+            }),
+            this.prisma.service.findMany({
+              take: Math.floor(limit / 2),
+              orderBy: { createdAt: 'desc' },
+              select: { id: true, title: true, price: true, isActive: true, category: true },
+            }),
+          ]);
+          return { listings: [...products, ...services], type: 'all', total: products.length + services.length, scope: 'platform-wide' };
+        }
         return { listings: [], total: 0 };
       }
 
       // ── Service Provider ───────────────────────────────────────────────────
       case 'get_my_service_requests': {
+        const isAdminRole = principal.role === UserRole.ADMIN || principal.role === UserRole.SUPER_ADMIN;
+        if (isAdminRole && !principal.organizationId) {
+          // Platform-wide view of all recent service requests
+          const where: any = {};
+          if (args.status) where.status = args.status;
+          const requests = await this.prisma.serviceRequest.findMany({
+            where,
+            orderBy: { createdAt: 'desc' },
+            take: limit,
+            select: {
+              id: true,
+              status: true,
+              description: true,
+              scheduledAt: true,
+              requestedAt: true,
+              service: { select: { title: true } },
+            },
+          });
+          return { requests, total: requests.length, scope: 'platform-wide' };
+        }
         if (!principal.organizationId) return { requests: [], total: 0, error: 'No organization context' };
         const sp = await this.prisma.serviceProvider.findFirst({
           where: { organizationId: principal.organizationId },

--- a/api/src/sync/reconcile.service.ts
+++ b/api/src/sync/reconcile.service.ts
@@ -32,6 +32,7 @@ export class ReconcileService {
       const users = await this.prisma.appUser.findMany({
         take: batchSize,
         skip: processed,
+        where: { clerkId: { not: { startsWith: 'system-' } } },
         orderBy: { createdAt: 'asc' },
       });
       


### PR DESCRIPTION
## Summary

This PR expands the role capabilities for `ADMIN` and `SUPER_ADMIN` users to include full platform-wide access for testing and oversight, updates the orchestrator service to support admin platform-wide data views, and adds exponential backoff retry logic to the Voyage AI embedding adapter.

## Key Changes

### Role Capabilities & Documentation
- **Admin role**: Now explicitly documented as having access to every feature across all roles (Foundation, Educator, Parent, Supplier, Service Provider) for testing purposes
- **Super Admin role**: Clarified with full platform access and elevated permissions; mirrors Admin's feature access with additional "platform-wide configuration and oversight"
- **Staffing features**: Added `ADMIN_STAFFING_LINES` constant to include v2 staffing/recruitment features for both `ADMIN` and `SUPER_ADMIN` when `v2_staffing_ia` flag is active
- Updated `getRoleCapabilities()` to apply staffing lines to Admin and Super Admin roles (not just Foundation)

### Orchestrator Service — Platform-Wide Admin Views
- **`get_my_leads`**: Admins without an `organizationId` now receive a platform-wide view of all recent parent leads (empty `where` filter) instead of an error
- **`get_my_orders`**: Admins without an `organizationId` now see all platform orders; refactored query logic to handle Admin/Super Admin as a distinct case
- **`get_my_listings`**: Admins without an `organizationId` now see a platform-wide view of recent products and services (split 50/50 by limit)
- **`get_my_service_requests`**: Admins without an `organizationId` now see all recent service requests platform-wide
- All affected endpoints now return a `scope` field (`'platform-wide'` or `'organization'`) to indicate the data context

### Voyage AI Adapter — Retry Logic
- Added exponential backoff retry mechanism (up to 4 attempts) for embedding requests
- Detects HTTP 429 (rate limit) responses and respects `Retry-After` header if present
- Falls back to exponential delay (2s → 4s → 8s → 16s) if no header provided
- Logs retry attempts with delay duration for observability
- Throws error only after max retries exceeded

### Reconcile Service
- Added filter to exclude system users (`clerkId` starting with `'system-'`) from user reconciliation batch processing

## Implementation Details

- Admin/Super Admin role descriptions now include full feature lists with route references for clarity
- Platform-wide views use empty `where` filters or no organization-specific constraints to fetch all records
- Voyage AI retries use `setTimeout` for delay; suitable for non-critical background operations
- Scope metadata helps frontend distinguish between organization-scoped and platform-wide data contexts

https://claude.ai/code/session_01As5stMAAKduZbPDPQ8X1Hu