### PR TITLE
fix(assistant): correct feature-flag convention and prevent unknown-t…

### DIFF
--- a/api/src/ai/agents/assistant-orchestrator/prompt.v1.ts
+++ b/api/src/ai/agents/assistant-orchestrator/prompt.v1.ts
@@ -40,6 +40,8 @@ Respond with JSON: {"message": "...", "toolCall": null}`;
     ? `TOOLS: Use tools for actions. Never describe an action without using the appropriate tool.
 Available tools: ${input.availableTools}
 
+CRITICAL: Only call tools listed in "Available tools" above. Never call a tool not in that list.
+
 TOOL SELECTION RULES:
 1. Platform question / how-to → use search_help_docs
 2. Find candidates / staffing request → use search_internal_candidates (FOUNDATION only)

--- a/api/src/ai/knowledge/knowledge-embedding.service.ts
+++ b/api/src/ai/knowledge/knowledge-embedding.service.ts
@@ -32,7 +32,7 @@ export class KnowledgeEmbeddingService implements OnModuleInit {
     });
   }
 
-  async searchSemantic(query: string, role: UserRole, limit = 3, activeFlags: Set<string> = new Set()): Promise<KnowledgeArticle[]> {
+  async searchSemantic(query: string, role: UserRole, limit = 3, disabledFlags: Set<string> = new Set()): Promise<KnowledgeArticle[]> {
     if (!this._ready) return [];
 
     const { embedding } = await this.llm.embed(query);
@@ -52,7 +52,7 @@ export class KnowledgeEmbeddingService implements OnModuleInit {
       PLATFORM_ARTICLES.filter(
         (a) =>
           (!a.roles || a.roles.includes(role)) &&
-          (!a.featureFlag || activeFlags.has(a.featureFlag)),
+          (!a.featureFlag || !disabledFlags.has(a.featureFlag)),
       ).map((a) => a.id),
     );
 

--- a/api/src/ai/knowledge/knowledge.service.ts
+++ b/api/src/ai/knowledge/knowledge.service.ts
@@ -9,7 +9,7 @@ export interface KnowledgeSearchResult {
 
 @Injectable()
 export class KnowledgeService {
-  search(query: string, role: UserRole, maxResults = 3, activeFlags: Set<string> = new Set()): KnowledgeArticle[] {
+  search(query: string, role: UserRole, maxResults = 3, disabledFlags: Set<string> = new Set()): KnowledgeArticle[] {
     const terms = query
       .toLowerCase()
       .split(/[\s,?!.]+/)
@@ -20,7 +20,7 @@ export class KnowledgeService {
     const accessible = PLATFORM_ARTICLES.filter(
       (a) =>
         (!a.roles || a.roles.includes(role)) &&
-        (!a.featureFlag || activeFlags.has(a.featureFlag)),
+        (!a.featureFlag || !disabledFlags.has(a.featureFlag)),
     );
 
     const scored: KnowledgeSearchResult[] = accessible.map((article) => {

--- a/api/src/ai/knowledge/role-capabilities.ts
+++ b/api/src/ai/knowledge/role-capabilities.ts
@@ -76,9 +76,9 @@ IMPORTANT: Profile must be approved by an admin before you can access the job bo
 - Platform-wide configuration and oversight across all roles`,
 };
 
-export function getRoleCapabilities(role: UserRole, activeFlags: Set<string>): string {
+export function getRoleCapabilities(role: UserRole, disabledFlags: Set<string>): string {
   const base = ROLE_CAPABILITIES_BASE[role] ?? '';
-  if (role === UserRole.FOUNDATION && activeFlags.has('v2_staffing_ia')) {
+  if (role === UserRole.FOUNDATION && !disabledFlags.has('v2_staffing_ia')) {
     return base + FOUNDATION_STAFFING_LINES;
   }
   return base;

--- a/api/src/ai/knowledge/role-capabilities.ts
+++ b/api/src/ai/knowledge/role-capabilities.ts
@@ -62,24 +62,96 @@ IMPORTANT: Profile must be approved by an admin before you can access the job bo
 - Settings: account, billing, language → /settings
 - Support: submit help tickets → /service-provider/support`,
 
-  [UserRole.ADMIN]: `You are a platform administrator. What you can do:
+  [UserRole.ADMIN]: `You are a platform administrator with access to every feature across all roles. You can use and test the full platform. What you can do:
+
+ADMIN TOOLS:
 - Content Management: upload and manage e-learning, HR procedures, state policies → /admin/content-dashboard
 - System Monitoring: platform health and metrics → /admin/system-monitoring
 - User Management: view and manage all users and roles → /users
 - Discount Management: create and manage discount codes → /admin/discount-terminations
 - Design System: component library → /design-system
-- You also have read access to Foundation, Supplier, Service Provider, and Educator sections for oversight.`,
 
-  [UserRole.SUPER_ADMIN]: `You are a super administrator with full platform access. What you can do:
-- Everything an Admin can do, with elevated permissions
-- Content Management, System Monitoring, User Management, Discount Management
-- Platform-wide configuration and oversight across all roles`,
+FOUNDATION FEATURES (you can access and test these):
+- Foundation Dashboard: KPIs for staff, leads, orders, intern pool → /foundation/dashboard
+- Parent Leads: view and respond to parent childcare enquiries → /foundation/leads
+- Marketplace: order products and book services → /marketplace/products, /marketplace/services
+- Orders & Appointments: track fulfillment and bookings → /foundation/orders-appointments
+- Analytics: revenue, lead conversion, staffing metrics → /foundation/analytics
+- Organisation Profile: update foundation details → /foundation/organisation-profile
+
+EDUCATOR FEATURES (you can access and test these):
+- Educator Dashboard: profile completion summary and job matches → /educator/dashboard
+- Educator Profile: CV, qualifications, skills, certifications, availability → /educator/profile
+- Job Board: search and apply for positions → /educator/job-board
+- My Applications: track application statuses → /educator/applications
+- Profile Approval: approve or reject educator profiles → /users
+
+PARENT FEATURES (you can access and test these):
+- Foundations: browse childcare foundations → /parent/foundations
+- My Enquiries: view and track submitted childcare enquiries → /parent/enquiries
+
+SUPPLIER FEATURES (you can access and test these):
+- Supplier Dashboard → /supplier/dashboard
+- Product Listings: manage product catalog → /supplier/product-listings
+- Orders: view and manage incoming orders → /supplier/orders
+
+SERVICE PROVIDER FEATURES (you can access and test these):
+- Service Provider Dashboard → /service-provider/dashboard
+- Service Listings: manage service catalog → /service-provider/service-listings
+- Requests: view and manage incoming service bookings → /service-provider/requests`,
+
+  [UserRole.SUPER_ADMIN]: `You are a super administrator with full platform access and elevated permissions across every role. You can use and test every feature on the platform. What you can do:
+
+ADMIN TOOLS:
+- Content Management: upload and manage e-learning, HR procedures, state policies → /admin/content-dashboard
+- System Monitoring: platform health and metrics → /admin/system-monitoring
+- User Management: view and manage all users and roles → /users
+- Discount Management: create and manage discount codes → /admin/discount-terminations
+- Design System: component library → /design-system
+- Platform-wide configuration and oversight
+
+FOUNDATION FEATURES (you can access and test these):
+- Foundation Dashboard: KPIs for staff, leads, orders, intern pool → /foundation/dashboard
+- Parent Leads: view and respond to parent childcare enquiries → /foundation/leads
+- Marketplace: order products and book services → /marketplace/products, /marketplace/services
+- Orders & Appointments: track fulfillment and bookings → /foundation/orders-appointments
+- Analytics: revenue, lead conversion, staffing metrics → /foundation/analytics
+- Organisation Profile: update foundation details → /foundation/organisation-profile
+
+EDUCATOR FEATURES (you can access and test these):
+- Educator Dashboard: profile completion summary and job matches → /educator/dashboard
+- Educator Profile: CV, qualifications, skills, certifications, availability → /educator/profile
+- Job Board: search and apply for positions → /educator/job-board
+- My Applications: track application statuses → /educator/applications
+- Profile Approval: approve or reject educator profiles → /users
+
+PARENT FEATURES (you can access and test these):
+- Foundations: browse childcare foundations → /parent/foundations
+- My Enquiries: view and track submitted childcare enquiries → /parent/enquiries
+
+SUPPLIER FEATURES (you can access and test these):
+- Supplier Dashboard → /supplier/dashboard
+- Product Listings: manage product catalog → /supplier/product-listings
+- Orders: view and manage incoming orders → /supplier/orders
+
+SERVICE PROVIDER FEATURES (you can access and test these):
+- Service Provider Dashboard → /service-provider/dashboard
+- Service Listings: manage service catalog → /service-provider/service-listings
+- Requests: view and manage incoming service bookings → /service-provider/requests`,
 };
+
+const ADMIN_STAFFING_LINES = `
+STAFFING & RECRUITMENT FEATURES (v2 — you can access and test these):
+- Recruitment: post jobs, browse and shortlist candidates → /recruitment/job-listings, /recruitment/candidate-pool
+- Staffing Replacements: create replacement requests (matched automatically) → /foundation/replacements
+- Staffing Requests: manage general staffing needs → /foundation/staffing-requests
+- Intern Pool: manage interns → /foundation/intern-pool`;
 
 export function getRoleCapabilities(role: UserRole, disabledFlags: Set<string>): string {
   const base = ROLE_CAPABILITIES_BASE[role] ?? '';
-  if (role === UserRole.FOUNDATION && !disabledFlags.has('v2_staffing_ia')) {
-    return base + FOUNDATION_STAFFING_LINES;
+  const staffingRoles: UserRole[] = [UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN];
+  if (staffingRoles.includes(role) && !disabledFlags.has('v2_staffing_ia')) {
+    return base + (role === UserRole.FOUNDATION ? FOUNDATION_STAFFING_LINES : ADMIN_STAFFING_LINES);
   }
   return base;
 }

--- a/api/src/assistant/orchestrator.service.spec.ts
+++ b/api/src/assistant/orchestrator.service.spec.ts
@@ -73,6 +73,10 @@ function mockPrisma() {
       // No flags are explicitly disabled → all tools/articles available by default
       findMany: jest.fn().mockResolvedValue([]),
     },
+    systemSettings: {
+      // No FEATURE_FLAGS settings disabled by default
+      findMany: jest.fn().mockResolvedValue([]),
+    },
   };
 }
 
@@ -354,6 +358,28 @@ describe('OrchestratorService', () => {
       mockLlmSequence({ message: 'Using tool.', toolCall: { name: 'non_existent_tool', args: {} } });
       await service.run({ conversationId: CONVERSATION_ID, userMessage: 'Do something', principal: FOUNDATION_PRINCIPAL, locale: 'fr', sendEvent });
       expect(sendEvent).toHaveBeenCalledWith('error', expect.objectContaining({ message: expect.stringContaining('non_existent_tool') }));
+    });
+  });
+
+  // ── Feature flags — systemSettings source ────────────────────────────────
+
+  describe('fetchDisabledFlags — systemSettings integration', () => {
+    it('treats v2_staffing_ia=false in systemSettings as disabled, hiding staffing tools from the LLM prompt', async () => {
+      // Simulate the seeded default: v2_staffing_ia stored in system_settings with value 'false'
+      prisma.systemSettings.findMany.mockResolvedValue([
+        { key: 'v2_staffing_ia', value: 'false' },
+      ]);
+
+      // LLM responds without calling any tool
+      mockLlmSequence({ message: 'Staffing info here.', toolCall: null });
+
+      await service.run({ conversationId: CONVERSATION_ID, userMessage: 'find candidates', principal: FOUNDATION_PRINCIPAL, locale: 'fr', sendEvent });
+
+      // The availableTools string passed to the LLM must not list staffing-only tools
+      const firstRunCall = (llm as any).run.mock.calls[0];
+      const availableTools: string = firstRunCall[0].input.availableTools;
+      expect(availableTools).not.toContain('search_internal_candidates');
+      expect(availableTools).not.toContain('draft_job_post');
     });
   });
 

--- a/api/src/assistant/orchestrator.service.spec.ts
+++ b/api/src/assistant/orchestrator.service.spec.ts
@@ -70,9 +70,8 @@ function mockPrisma() {
       findMany: jest.fn().mockResolvedValue([]),
     },
     featureFlag: {
-      findMany: jest.fn().mockResolvedValue([
-        { key: 'v2_staffing_ia' },
-      ]),
+      // No flags are explicitly disabled → all tools/articles available by default
+      findMany: jest.fn().mockResolvedValue([]),
     },
   };
 }

--- a/api/src/assistant/orchestrator.service.ts
+++ b/api/src/assistant/orchestrator.service.ts
@@ -52,14 +52,14 @@ export class OrchestratorService {
       .map((m) => `${m.sender === 'USER' ? 'User' : 'Assistant'}: ${m.content}`)
       .join('\n');
 
-    // Fetch user context and active feature flags in parallel
-    const [ctx, activeFlags] = await Promise.all([
+    // Fetch user context and disabled feature flags in parallel
+    const [ctx, disabledFlags] = await Promise.all([
       this.userContext.build(principal.userId, principal.role, principal.organizationId),
-      this.fetchActiveFlags(),
+      this.fetchDisabledFlags(),
     ]);
 
-    const platformContext = getRoleCapabilities(principal.role, activeFlags);
-    const availableTools = getToolsForRole(principal.role, activeFlags)
+    const platformContext = getRoleCapabilities(principal.role, disabledFlags);
+    const availableTools = getToolsForRole(principal.role, disabledFlags)
       .map((t) => `${t.name}: ${t.description}`)
       .join(', ');
 
@@ -103,7 +103,7 @@ export class OrchestratorService {
       }
 
       const { name: toolName, args } = output.toolCall;
-      const toolDef = getToolsForRole(principal.role, activeFlags).find((t) => t.name === toolName);
+      const toolDef = getToolsForRole(principal.role, disabledFlags).find((t) => t.name === toolName);
       if (!toolDef) {
         sendEvent('error', { message: `Unknown tool: ${toolName}` });
         return;
@@ -160,7 +160,7 @@ export class OrchestratorService {
       let toolError: string | undefined;
 
       try {
-        toolResult = await this.executeTool(toolName, args, principal, locale, activeFlags);
+        toolResult = await this.executeTool(toolName, args, principal, locale, disabledFlags);
         await this.prisma.aIToolCall.update({
           where: { id: toolCallRecord.id },
           data: { status: AIToolCallStatus.EXECUTED, outputJson: toolResult as any, executedAt: new Date() },
@@ -192,8 +192,10 @@ export class OrchestratorService {
     });
   }
 
-  private async fetchActiveFlags(): Promise<Set<string>> {
-    const flags = await this.prisma.featureFlag.findMany({ where: { isActive: true }, select: { key: true } });
+  // Returns the set of flag keys that are explicitly disabled (isActive: false).
+  // Convention: absent flag → enabled (consistent with the rest of this codebase).
+  private async fetchDisabledFlags(): Promise<Set<string>> {
+    const flags = await this.prisma.featureFlag.findMany({ where: { isActive: false }, select: { key: true } });
     return new Set(flags.map((f) => f.key));
   }
 
@@ -202,7 +204,7 @@ export class OrchestratorService {
     args: Record<string, unknown>,
     principal: AssistantPrincipalContext,
     _locale: 'fr' | 'de' | 'en',
-    activeFlags: Set<string> = new Set(),
+    disabledFlags: Set<string> = new Set(),
   ): Promise<unknown> {
     const limit = Math.min(Number(args.limit) || 5, 10);
 
@@ -211,9 +213,9 @@ export class OrchestratorService {
       case 'search_help_docs': {
         const query = (args.query as string) || '';
         // Semantic search first (Phase 4); keyword fallback when embeddings not ready
-        let articles = await this.knowledgeEmbedding.searchSemantic(query, principal.role, 3, activeFlags);
+        let articles = await this.knowledgeEmbedding.searchSemantic(query, principal.role, 3, disabledFlags);
         if (articles.length === 0) {
-          articles = this.knowledge.search(query, principal.role, 3, activeFlags);
+          articles = this.knowledge.search(query, principal.role, 3, disabledFlags);
         }
         return { docs: this.knowledge.formatForPrompt(articles) };
       }

--- a/api/src/assistant/orchestrator.service.ts
+++ b/api/src/assistant/orchestrator.service.ts
@@ -192,11 +192,23 @@ export class OrchestratorService {
     });
   }
 
-  // Returns the set of flag keys that are explicitly disabled (isActive: false).
-  // Convention: absent flag → enabled (consistent with the rest of this codebase).
+  // Returns the set of flag keys that are explicitly disabled.
+  // Checks both sources: featureFlag rows (isActive:false) and systemSettings rows
+  // with category='FEATURE_FLAGS' and value='false' (v2 rollout flags live there).
+  // Convention: absent flag → enabled.
   private async fetchDisabledFlags(): Promise<Set<string>> {
-    const flags = await this.prisma.featureFlag.findMany({ where: { isActive: false }, select: { key: true } });
-    return new Set(flags.map((f) => f.key));
+    const [flagRows, settingRows] = await Promise.all([
+      this.prisma.featureFlag.findMany({ where: { isActive: false }, select: { key: true } }),
+      this.prisma.systemSettings.findMany({ where: { category: 'FEATURE_FLAGS' }, select: { key: true, value: true } }),
+    ]);
+
+    const disabled = new Set<string>(flagRows.map((f) => f.key));
+    for (const row of settingRows) {
+      if (row.value === false || row.value === 'false') {
+        disabled.add(row.key);
+      }
+    }
+    return disabled;
   }
 
   private async executeTool(

--- a/api/src/assistant/tools/tool-registry.ts
+++ b/api/src/assistant/tools/tool-registry.ts
@@ -177,8 +177,8 @@ export const TOOL_REGISTRY: ToolDefinition[] = [
   },
 ];
 
-export function getToolsForRole(role: UserRole, activeFlags: Set<string> = new Set()): ToolDefinition[] {
+export function getToolsForRole(role: UserRole, disabledFlags: Set<string> = new Set()): ToolDefinition[] {
   return TOOL_REGISTRY.filter(
-    (t) => t.allowedRoles.includes(role) && (!t.featureFlag || activeFlags.has(t.featureFlag)),
+    (t) => t.allowedRoles.includes(role) && (!t.featureFlag || !disabledFlags.has(t.featureFlag)),
   );
 }


### PR DESCRIPTION
…ool errors

The previous implementation queried actively-enabled flags, treating an absent flag as disabled. The codebase convention (flag absent → enabled) is the opposite. This caused search_internal_candidates and other staffing tools to be silently removed when v2_staffing_ia was not present in the DB, even though the feature should be on by default.

Changes:
- fetchDisabledFlags() (was fetchActiveFlags()) now queries isActive:false — absent flag is treated as enabled, consistent with the rest of the codebase
- Flip check in getToolsForRole, knowledge.search, searchSemantic, and getRoleCapabilities from "must be in active set" to "must not be in disabled set"
- Add "CRITICAL: Only call tools in Available tools" to the prompt so the LLM cannot call a tool that has been filtered out by a disabled flag

https://claude.ai/code/session_01EMF2mUFpw2xXqH9LqtJVU4