### PR TITLE
Add support for extra email recipients in mailing campaigns

### DIFF
--- a/admin/src/components/mailing/ComposeEmailModal.tsx
+++ b/admin/src/components/mailing/ComposeEmailModal.tsx
@@ -98,8 +98,9 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
           <div className="flex-1 overflow-y-auto p-4 space-y-4">
             {(() => {
               const parsedExtras = parseExtraEmails(extraEmailsRaw)
-              const validExtras = parsedExtras.filter((e) => EMAIL_REGEX.test(e))
-              const invalidExtras = parsedExtras.filter((e) => !EMAIL_REGEX.test(e))
+              const uniqueExtras = [...new Set(parsedExtras)]
+              const validExtras = uniqueExtras.filter((e) => EMAIL_REGEX.test(e))
+              const invalidExtras = uniqueExtras.filter((e) => !EMAIL_REGEX.test(e))
               const totalCount = recipientCount + validExtras.length
               return (
                 <div className="bg-blue-50 border border-blue-200 rounded-md p-3 text-sm text-blue-700">
@@ -261,7 +262,7 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
             </button>
             <button
               onClick={() => {
-                const validExtras = parseExtraEmails(extraEmailsRaw).filter((e) => EMAIL_REGEX.test(e))
+                const validExtras = [...new Set(parseExtraEmails(extraEmailsRaw))].filter((e) => EMAIL_REGEX.test(e))
                 onSend(subject, bodyHtml, validExtras)
               }}
               disabled={!subject.trim() || !bodyHtml.trim() || loading}

--- a/admin/src/components/mailing/ComposeEmailModal.tsx
+++ b/admin/src/components/mailing/ComposeEmailModal.tsx
@@ -12,7 +12,7 @@ import EmailPreview from './EmailPreview'
 interface Props {
   isOpen: boolean
   onClose: () => void
-  onSend: (subject: string, bodyHtml: string) => Promise<void>
+  onSend: (subject: string, bodyHtml: string, extraEmails: string[]) => Promise<void>
   loading: boolean
   recipientCount: number
 }
@@ -21,6 +21,15 @@ const TOKENS = [
   '{{firstName}}', '{{lastName}}', '{{email}}', '{{role}}', '{{orgName}}', '{{canton}}',
   '{{logoUrl}}', '{{iconUrl}}',
 ]
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+function parseExtraEmails(raw: string): string[] {
+  return raw
+    .split(/[\n,;]+/)
+    .map((e) => e.trim().toLowerCase())
+    .filter((e) => e.length > 0)
+}
 
 const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, recipientCount }) => {
   const { t } = useTranslation(['admin'])
@@ -32,6 +41,8 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
   const [saveAsName, setSaveAsName] = useState('')
   const [showSaveAs, setShowSaveAs] = useState(false)
   const [savingTemplate, setSavingTemplate] = useState(false)
+  const [extraEmailsRaw, setExtraEmailsRaw] = useState('')
+  const [showExtraEmails, setShowExtraEmails] = useState(false)
 
   if (!isOpen) return null
 
@@ -85,9 +96,27 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
           </div>
 
           <div className="flex-1 overflow-y-auto p-4 space-y-4">
-            <div className="bg-blue-50 border border-blue-200 rounded-md p-3 text-sm text-blue-700">
-              {t('admin:mailing.compose.recipientInfo', { count: recipientCount.toLocaleString() })}
-            </div>
+            {(() => {
+              const parsedExtras = parseExtraEmails(extraEmailsRaw)
+              const validExtras = parsedExtras.filter((e) => EMAIL_REGEX.test(e))
+              const invalidExtras = parsedExtras.filter((e) => !EMAIL_REGEX.test(e))
+              const totalCount = recipientCount + validExtras.length
+              return (
+                <div className="bg-blue-50 border border-blue-200 rounded-md p-3 text-sm text-blue-700">
+                  {t('admin:mailing.compose.recipientInfo', { count: totalCount.toLocaleString() })}
+                  {validExtras.length > 0 && (
+                    <span className="ml-1 text-blue-600">
+                      ({recipientCount.toLocaleString()} filtered + {validExtras.length} extra)
+                    </span>
+                  )}
+                  {invalidExtras.length > 0 && (
+                    <div className="mt-1 text-red-600 text-xs">
+                      Invalid emails will be skipped: {invalidExtras.join(', ')}
+                    </div>
+                  )}
+                </div>
+              )
+            })()}
 
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -130,6 +159,43 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
                   rows={10}
                   className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm font-mono focus:ring-blue-500 focus:border-blue-500"
                 />
+              )}
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between mb-1">
+                <label className="text-sm font-medium text-gray-700">
+                  {t('admin:mailing.compose.extraEmails', 'Extra recipients')}
+                </label>
+                <button
+                  type="button"
+                  onClick={() => setShowExtraEmails((v) => !v)}
+                  className="text-xs text-blue-600 hover:text-blue-800"
+                >
+                  {showExtraEmails
+                    ? t('admin:mailing.compose.hideExtraEmails', 'Hide')
+                    : t('admin:mailing.compose.addExtraEmails', '+ Add emails not in DB')}
+                </button>
+              </div>
+              {showExtraEmails && (
+                <div className="space-y-1">
+                  <textarea
+                    value={extraEmailsRaw}
+                    onChange={(e) => setExtraEmailsRaw(e.target.value)}
+                    placeholder={t(
+                      'admin:mailing.compose.extraEmailsPlaceholder',
+                      'Enter email addresses separated by commas, semicolons, or new lines',
+                    )}
+                    rows={3}
+                    className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
+                  />
+                  <p className="text-xs text-gray-400">
+                    {t(
+                      'admin:mailing.compose.extraEmailsHint',
+                      'These addresses are sent the email regardless of DB filters. Max 500.',
+                    )}
+                  </p>
+                </div>
               )}
             </div>
 
@@ -194,7 +260,10 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
               {t('admin:mailing.campaign.detail.cancel')}
             </button>
             <button
-              onClick={() => onSend(subject, bodyHtml)}
+              onClick={() => {
+                const validExtras = parseExtraEmails(extraEmailsRaw).filter((e) => EMAIL_REGEX.test(e))
+                onSend(subject, bodyHtml, validExtras)
+              }}
               disabled={!subject.trim() || !bodyHtml.trim() || loading}
               className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
             >

--- a/admin/src/pages/MailingList.tsx
+++ b/admin/src/pages/MailingList.tsx
@@ -251,13 +251,14 @@ const MailingListPage: React.FC = () => {
     }
   }, [apiClient, filters, preview?.count])
 
-  const handleCreateCampaign = useCallback(async (subject: string, bodyHtml: string) => {
+  const handleCreateCampaign = useCallback(async (subject: string, bodyHtml: string, extraEmails: string[]) => {
     setActionLoading(true)
     try {
       const res = await apiService.mailingCreateCampaign(apiClient, {
         subject,
         bodyHtml,
         filters,
+        ...(extraEmails.length > 0 ? { extraEmails } : {}),
       })
       const campaignId = res.data?.campaignId
       toast.success('Campaign created')
@@ -288,7 +289,7 @@ const MailingListPage: React.FC = () => {
     setActiveTab('build')
   }, [])
 
-  const handleCreateListCampaign = useCallback(async (subject: string, bodyHtml: string) => {
+  const handleCreateListCampaign = useCallback(async (subject: string, bodyHtml: string, extraEmails: string[]) => {
     if (!activeList) return
     setActionLoading(true)
     try {
@@ -296,6 +297,7 @@ const MailingListPage: React.FC = () => {
         subject,
         bodyHtml,
         customListId: activeList.id,
+        ...(extraEmails.length > 0 ? { extraEmails } : {}),
       })
       const campaignId = res.data?.campaignId
       toast.success('Campaign created')

--- a/admin/src/services/api.ts
+++ b/admin/src/services/api.ts
@@ -1179,6 +1179,7 @@ export const apiService = {
     filters?: any;
     segmentId?: string;
     customListId?: string;
+    extraEmails?: string[];
   }) => apiClient.post('/admin/mailing/campaigns', data),
 
   mailingListCampaigns: (apiClient: AxiosInstance, params?: { page?: number; pageSize?: number }) =>

--- a/api/prisma/migrations/20260530000000_add_extra_emails_to_campaign/migration.sql
+++ b/api/prisma/migrations/20260530000000_add_extra_emails_to_campaign/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "mailing_campaigns" ADD COLUMN "extra_emails_json" JSONB,
+ADD COLUMN "extra_emails_sent" BOOLEAN NOT NULL DEFAULT false;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -2618,8 +2618,10 @@ model MailingCampaign {
   bodyText       String?               @db.Text @map("body_text")
 
   // Recipient source (one must be set)
-  segmentId      String?               @map("segment_id")
-  filtersJson    Json?                 @map("filters_json")
+  segmentId        String?             @map("segment_id")
+  filtersJson      Json?               @map("filters_json")
+  extraEmailsJson  Json?               @map("extra_emails_json")
+  extraEmailsSent  Boolean             @default(false) @map("extra_emails_sent")
 
   // Status & progress
   status         MailingCampaignStatus @default(DRAFT)

--- a/api/src/mailing/dto/campaign.dto.ts
+++ b/api/src/mailing/dto/campaign.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, ValidateNested, IsInt, Min, Max } from 'class-validator';
+import { IsString, IsOptional, ValidateNested, IsInt, Min, Max, IsArray, IsEmail, ArrayMaxSize } from 'class-validator';
 import { Type } from 'class-transformer';
 import { MailingFiltersDto } from './mailing-filters.dto';
 
@@ -25,6 +25,12 @@ export class CreateCampaignDto {
   @IsOptional()
   @IsString()
   customListId?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(500)
+  @IsEmail({}, { each: true })
+  extraEmails?: string[];
 }
 
 export class SendBatchDto {

--- a/api/src/mailing/mailing.controller.ts
+++ b/api/src/mailing/mailing.controller.ts
@@ -249,10 +249,13 @@ export class MailingController {
     // If targeting a custom list, resolve the member user IDs and inject them into filters
     if (body.customListId) {
       const memberIds = await this.mailingService.getAllCustomListMemberIds(body.customListId);
-      if (memberIds.length === 0) {
+      // Allow campaign even if list is empty, as long as extraEmails are provided
+      if (memberIds.length === 0 && (!body.extraEmails || body.extraEmails.length === 0)) {
         throw new BadRequestException('Custom list has no members');
       }
-      filters = { ...filters, userIds: memberIds };
+      if (memberIds.length > 0) {
+        filters = { ...filters, userIds: memberIds };
+      }
     }
 
     return this.mailingService.createCampaign(
@@ -262,6 +265,7 @@ export class MailingController {
       adminId,
       filters,
       body.customListId ? undefined : body.segmentId,
+      body.extraEmails,
     );
   }
 

--- a/api/src/mailing/mailing.service.ts
+++ b/api/src/mailing/mailing.service.ts
@@ -567,6 +567,7 @@ export class MailingService {
     createdById: string,
     filters?: MailingFiltersDto,
     segmentId?: string,
+    extraEmails?: string[],
   ) {
     let resolvedFilters = filters;
 
@@ -576,12 +577,22 @@ export class MailingService {
       resolvedFilters = segment.filtersJson as unknown as MailingFiltersDto;
     }
 
-    if (!resolvedFilters) {
-      throw new BadRequestException('Either filters or segmentId is required');
+    // Deduplicate and normalise extra emails
+    const normalizedExtras = extraEmails
+      ? [...new Set(extraEmails.map((e) => e.trim().toLowerCase()).filter(Boolean))]
+      : [];
+
+    if (!resolvedFilters && normalizedExtras.length === 0) {
+      throw new BadRequestException('Either filters/segmentId or extraEmails is required');
     }
 
-    const where = this.buildRecipientWhere(resolvedFilters);
-    const totalEstimated = await this.prisma.user.count({ where });
+    let dbCount = 0;
+    if (resolvedFilters) {
+      const where = this.buildRecipientWhere(resolvedFilters);
+      dbCount = await this.prisma.user.count({ where });
+    }
+
+    const totalEstimated = dbCount + normalizedExtras.length;
 
     if (totalEstimated === 0) {
       throw new BadRequestException('No recipients match the given filters');
@@ -605,7 +616,8 @@ export class MailingService {
         bodyHtml: sanitisedHtml,
         bodyText: plainText,
         segmentId: segmentId || null,
-        filtersJson: resolvedFilters as any,
+        filtersJson: resolvedFilters ? (resolvedFilters as any) : null,
+        extraEmailsJson: normalizedExtras.length > 0 ? normalizedExtras : null,
         totalEstimated,
         createdById,
         status: MailingCampaignStatus.DRAFT,
@@ -620,7 +632,7 @@ export class MailingService {
           entityId: campaign.id,
           action: 'create',
           actorId: createdById,
-          metadata: { subject, segmentId, totalEstimated },
+          metadata: { subject, segmentId, totalEstimated, extraEmailCount: normalizedExtras.length },
         },
       });
     } catch (auditErr: any) {
@@ -859,8 +871,80 @@ export class MailingService {
       }
     }
 
-    // Update campaign progress
-    const done = recipients.length < batchSize;
+    // Process extra (out-of-DB) emails once the DB recipient batch is exhausted
+    const dbDone = recipients.length < batchSize;
+    const extraEmails = (campaign.extraEmailsJson as string[] | null) || [];
+
+    if (dbDone && !campaign.extraEmailsSent && extraEmails.length > 0) {
+      for (const extraEmail of extraEmails) {
+        const unsubToken = crypto
+          .createHmac('sha256', UNSUBSCRIBE_SECRET)
+          .update(`${extraEmail}:${campaignId}`)
+          .digest('hex');
+        const unsubscribeUrl = `${unsubscribeBaseUrl}/unsubscribe?token=${unsubToken}`;
+
+        const personalised = this.personalise(campaign.bodyHtml, {
+          firstName: '',
+          lastName: '',
+          email: extraEmail,
+          role: '',
+          orgName: '',
+          canton: '',
+          logoUrl: platformLogoUrl,
+          iconUrl: platformIconUrl,
+          unsubscribeUrl,
+        });
+        const personalisedText = this.personalise(campaign.bodyText || '', {
+          firstName: '',
+          lastName: '',
+          email: extraEmail,
+          role: '',
+          orgName: '',
+          canton: '',
+          logoUrl: platformLogoUrl,
+          iconUrl: platformIconUrl,
+          unsubscribeUrl,
+        });
+        const htmlWithFooter = this.appendFooter(personalised, unsubscribeUrl);
+
+        const result = await this.transport.sendEmail({
+          to: extraEmail,
+          subject: campaign.subject,
+          html: htmlWithFooter,
+          text: personalisedText,
+          tags: ['campaign', campaignId],
+          metadata: { campaignId, extraEmail },
+        });
+
+        try {
+          await this.prisma.emailLog.create({
+            data: {
+              event: `campaign:${campaignId}`,
+              recipient: extraEmail,
+              status: result.success ? 'sent' : 'failed',
+              messageId: result.messageId || null,
+              error: result.error || null,
+              payload: { campaignId, provider: result.provider, isExtraEmail: true },
+            },
+          });
+        } catch {
+          // Don't fail the batch if logging fails
+        }
+
+        if (result.success) {
+          sentThisBatch++;
+        } else {
+          failedThisBatch++;
+        }
+
+        if (INTER_EMAIL_DELAY_MS > 0) {
+          await sleep(INTER_EMAIL_DELAY_MS);
+        }
+      }
+    }
+
+    // Campaign is fully done when: DB batch exhausted AND extra emails sent (or none to send)
+    const done = dbDone;
     const newSentCount = campaign.sentCount + sentThisBatch;
     const newFailedCount = campaign.failedCount + failedThisBatch;
 
@@ -870,6 +954,7 @@ export class MailingService {
         sentCount: newSentCount,
         failedCount: newFailedCount,
         cursor: lastUserId,
+        ...(dbDone && extraEmails.length > 0 ? { extraEmailsSent: true } : {}),
         ...(done
           ? {
               status: MailingCampaignStatus.SENT,

--- a/api/src/mailing/mailing.service.ts
+++ b/api/src/mailing/mailing.service.ts
@@ -731,30 +731,38 @@ export class MailingService {
       const segment = await this.prisma.mailingSegment.findUnique({ where: { id: campaign.segmentId } });
       filters = segment?.filtersJson as unknown as MailingFiltersDto | null;
     }
-    if (!filters) {
+
+    const extraEmails = (campaign.extraEmailsJson as string[] | null) || [];
+
+    // Allow extra-email-only campaigns (filtersJson is null)
+    if (!filters && extraEmails.length === 0) {
       throw new BadRequestException('Campaign has no filter configuration');
     }
 
-    const where = this.buildRecipientWhere(filters);
+    let recipients: Awaited<ReturnType<typeof this.prisma.user.findMany>> = [];
 
-    // Build cursor-based query — fetch next batch of users after the cursor
-    const cursorClause: Prisma.UserWhereInput = campaign.cursor
-      ? { id: { gt: campaign.cursor } }
-      : {};
+    if (filters) {
+      const where = this.buildRecipientWhere(filters);
 
-    const recipients = await this.prisma.user.findMany({
-      where: { AND: [where, cursorClause] },
-      orderBy: { id: 'asc' },
-      take: batchSize,
-      include: {
-        organizations: {
-          take: 1,
-          include: {
-            organization: { select: { name: true, canton: true } },
+      // Build cursor-based query — fetch next batch of users after the cursor
+      const cursorClause: Prisma.UserWhereInput = campaign.cursor
+        ? { id: { gt: campaign.cursor } }
+        : {};
+
+      recipients = await this.prisma.user.findMany({
+        where: { AND: [where, cursorClause] },
+        orderBy: { id: 'asc' },
+        take: batchSize,
+        include: {
+          organizations: {
+            take: 1,
+            include: {
+              organization: { select: { name: true, canton: true } },
+            },
           },
         },
-      },
-    });
+      });
+    }
 
     // SEC: optimistic concurrency — prevent duplicate batch sends from parallel requests
     // Only one request should transition DRAFT -> SENDING; others will see SENDING and proceed safely
@@ -872,15 +880,13 @@ export class MailingService {
     }
 
     // Process extra (out-of-DB) emails once the DB recipient batch is exhausted
-    const dbDone = recipients.length < batchSize;
-    const extraEmails = (campaign.extraEmailsJson as string[] | null) || [];
+    const dbDone = !filters || recipients.length < batchSize;
 
     if (dbDone && !campaign.extraEmailsSent && extraEmails.length > 0) {
       for (const extraEmail of extraEmails) {
-        const unsubToken = crypto
-          .createHmac('sha256', UNSUBSCRIBE_SECRET)
-          .update(`${extraEmail}:${campaignId}`)
-          .digest('hex');
+        // Reuse signUnsubscribeToken with the email address as the identifier so the token
+        // is in the same base64url(payload).hmac format that verifyUnsubscribeToken expects.
+        const unsubToken = this.signUnsubscribeToken(extraEmail, campaignId);
         const unsubscribeUrl = `${unsubscribeBaseUrl}/unsubscribe?token=${unsubToken}`;
 
         const personalised = this.personalise(campaign.bodyHtml, {


### PR DESCRIPTION
## Summary
Extends the mailing campaign system to allow sending emails to recipients outside the database (e.g., external contacts, one-off addresses) in addition to filtered/segmented users. Extra emails are deduplicated, normalized, and sent after the main database recipient batch completes.

## Key Changes

**Backend (API)**
- Added `extraEmails?: string[]` parameter to `CreateCampaignDto` with validation (max 500, valid email format)
- Extended `createCampaign()` to accept and normalize extra emails (deduplicate, trim, lowercase)
- Updated validation logic: campaigns now require either filters/segmentId OR extraEmails (not just filters)
- Modified `sendBatch()` to process extra emails once the database recipient batch is exhausted
- Added `extraEmailsSent` flag to track completion of extra email sending
- Updated Prisma schema: added `extraEmailsJson` and `extraEmailsSent` columns to `MailingCampaign`
- Extra emails are logged to `EmailLog` with `isExtraEmail: true` metadata for tracking
- Updated audit metadata to include `extraEmailCount`

**Frontend (Admin)**
- Added collapsible "Extra recipients" section in `ComposeEmailModal`
- Implemented email parsing (supports comma, semicolon, or newline separators)
- Added real-time validation with visual feedback (invalid emails highlighted in red)
- Updated recipient count display to show breakdown: "X filtered + Y extra"
- Pass validated extra emails to campaign creation API

**Database**
- Added migration to create `extra_emails_json` (JSONB) and `extra_emails_sent` (Boolean) columns

## Implementation Details

- Extra emails are normalized (trimmed, lowercased) and deduplicated using a `Set` before storage
- Invalid email addresses are filtered out on the frontend before submission
- Extra emails are sent with empty personalization fields (firstName, lastName, role, orgName, canton) but include unsubscribe tokens
- Campaign completion logic: marked as `SENT` when both DB batch is exhausted AND extra emails are processed
- Respects `INTER_EMAIL_DELAY_MS` between extra email sends to avoid rate limiting
- Email logging includes `isExtraEmail: true` flag for analytics/debugging

https://claude.ai/code/session_01RVaGib7ZBt3K5SkTaeP4oS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email campaigns now support sending to additional recipient addresses beyond the main segment filters
  * Added email validation controls with real-time feedback on valid and invalid addresses
  * Maximum of 500 extra recipient addresses per campaign
  * Invalid emails are automatically identified and skipped during send operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/One-S-Digital/PC-Solutions-Platform/pull/653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->