### PR TITLE
Allow admins to create platform-wide staffing requests

### DIFF
--- a/api/prisma/migrations/20260603000000_make_staffing_request_foundation_nullable/migration.sql
+++ b/api/prisma/migrations/20260603000000_make_staffing_request_foundation_nullable/migration.sql
@@ -1,0 +1,2 @@
+-- Allow admin-created staffing requests to exist without a foundation organisation
+ALTER TABLE "staffing_requests" ALTER COLUMN "foundationId" DROP NOT NULL;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -3023,7 +3023,7 @@ model KnowledgeDocument {
 
 model StaffingRequest {
   id           String  @id @default(uuid())
-  foundationId String
+  foundationId String?
   createdById  String
   rawText      String  @db.Text
 
@@ -3046,7 +3046,7 @@ model StaffingRequest {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  foundation  Organization             @relation("FoundationStaffingRequests", fields: [foundationId], references: [id])
+  foundation  Organization?            @relation("FoundationStaffingRequests", fields: [foundationId], references: [id])
   createdBy   User                     @relation("UserStaffingRequests", fields: [createdById], references: [id])
   embedding   StaffingRequestEmbedding?
   matches     MatchResult[]

--- a/api/src/ai/agents/assistant-orchestrator/prompt.v1.ts
+++ b/api/src/ai/agents/assistant-orchestrator/prompt.v1.ts
@@ -44,8 +44,8 @@ CRITICAL: Only call tools listed in "Available tools" above. Never call a tool n
 
 TOOL SELECTION RULES:
 1. Platform question / how-to → use search_help_docs
-2. Find candidates / staffing request → use search_internal_candidates (FOUNDATION, ADMIN, SUPER_ADMIN). Admins may pass foundationId to scope to a specific org, or omit it for a platform-wide search.
-3. Draft job post → use draft_job_post (FOUNDATION, ADMIN, SUPER_ADMIN)
+2. Find candidates / staffing request → use search_internal_candidates (FOUNDATION, ADMIN, SUPER_ADMIN). Admins may pass foundationId to scope to a specific org, or omit for a platform-wide search.
+3. Draft job post → use draft_job_post (FOUNDATION, ADMIN, SUPER_ADMIN). Admins may pass foundationId to post on behalf of a specific org.
 4. Draft parent reply → use draft_parent_reply (FOUNDATION only)
 5. Open a form/modal → use open_modal
 6. View my profile data → use get_my_profile
@@ -57,7 +57,9 @@ TOOL SELECTION RULES:
 12. View my service requests (SERVICE_PROVIDER) → use get_my_service_requests
 13. Navigate to a page → use navigate_to
 14. L2 tools: explain what you will do before running
-15. If no tool fits → answer directly with toolCall: null`
+15. If no tool fits → answer directly with toolCall: null
+
+ADMIN RULE — FOUNDATION LOOKUP: When an ADMIN or SUPER_ADMIN mentions a foundation or organisation by name (e.g. "for Kinderwelt", "post a job for Les Bout'choux") and no foundationId is in context, you MUST call find_foundation first to resolve the name to an ID. Then use that ID in the subsequent tool call. Never guess or invent a foundationId.`
     : '';
 
   const priorToolResults = input.toolResult

--- a/api/src/ai/agents/assistant-orchestrator/prompt.v1.ts
+++ b/api/src/ai/agents/assistant-orchestrator/prompt.v1.ts
@@ -44,7 +44,7 @@ CRITICAL: Only call tools listed in "Available tools" above. Never call a tool n
 
 TOOL SELECTION RULES:
 1. Platform question / how-to → use search_help_docs
-2. Find candidates / staffing request → use search_internal_candidates (FOUNDATION, ADMIN, SUPER_ADMIN)
+2. Find candidates / staffing request → use search_internal_candidates (FOUNDATION, ADMIN, SUPER_ADMIN). Admins may pass foundationId to scope to a specific org, or omit it for a platform-wide search.
 3. Draft job post → use draft_job_post (FOUNDATION, ADMIN, SUPER_ADMIN)
 4. Draft parent reply → use draft_parent_reply (FOUNDATION only)
 5. Open a form/modal → use open_modal

--- a/api/src/ai/agents/assistant-orchestrator/prompt.v1.ts
+++ b/api/src/ai/agents/assistant-orchestrator/prompt.v1.ts
@@ -44,8 +44,8 @@ CRITICAL: Only call tools listed in "Available tools" above. Never call a tool n
 
 TOOL SELECTION RULES:
 1. Platform question / how-to → use search_help_docs
-2. Find candidates / staffing request → use search_internal_candidates (FOUNDATION only)
-3. Draft job post → use draft_job_post (FOUNDATION only)
+2. Find candidates / staffing request → use search_internal_candidates (FOUNDATION, ADMIN, SUPER_ADMIN)
+3. Draft job post → use draft_job_post (FOUNDATION, ADMIN, SUPER_ADMIN)
 4. Draft parent reply → use draft_parent_reply (FOUNDATION only)
 5. Open a form/modal → use open_modal
 6. View my profile data → use get_my_profile

--- a/api/src/assistant/orchestrator.service.ts
+++ b/api/src/assistant/orchestrator.service.ts
@@ -309,10 +309,10 @@ export class OrchestratorService {
 
       case 'search_internal_candidates': {
         const req = await this.staffing.createRequest(
-          { rawText: args.rawText as string },
+          { rawText: args.rawText as string, foundationId: (args.foundationId as string | undefined) },
           { userId: principal.userId, role: principal.role, organizationId: principal.organizationId },
         );
-        return { staffingRequestId: req.id, status: req.status };
+        return { staffingRequestId: req.id, status: req.status, scope: req.foundationId ? 'foundation' : 'platform-wide' };
       }
 
       case 'explain_match': {

--- a/api/src/assistant/orchestrator.service.ts
+++ b/api/src/assistant/orchestrator.service.ts
@@ -254,6 +254,21 @@ export class OrchestratorService {
       case 'open_modal':
         return { modal: args.modal, prefill: args.prefill };
 
+      // ── Admin-only ────────────────────────────────────────────────────────
+      case 'find_foundation': {
+        const query = ((args.query as string) || '').trim();
+        const foundations = await this.prisma.organization.findMany({
+          where: {
+            type: 'FOUNDATION',
+            name: { contains: query, mode: 'insensitive' },
+          },
+          select: { id: true, name: true, city: true, canton: true },
+          orderBy: { name: 'asc' },
+          take: 5,
+        });
+        return { foundations, total: foundations.length };
+      }
+
       // ── Foundation ────────────────────────────────────────────────────────
       case 'get_my_leads': {
         const isAdminRole = principal.role === UserRole.ADMIN || principal.role === UserRole.SUPER_ADMIN;
@@ -326,7 +341,13 @@ export class OrchestratorService {
       case 'draft_job_post':
         return {
           modal: 'job_post_modal',
-          prefill: { role: args.role, canton: args.canton, workPercentage: args.percentage, notes: args.notes },
+          prefill: {
+            role: args.role,
+            canton: args.canton,
+            workPercentage: args.percentage,
+            notes: args.notes,
+            ...(args.foundationId ? { foundationId: args.foundationId } : {}),
+          },
         };
 
       case 'draft_parent_reply':

--- a/api/src/assistant/tools/tool-registry.ts
+++ b/api/src/assistant/tools/tool-registry.ts
@@ -24,6 +24,8 @@ const ALL_ROLES: UserRole[] = [
 
 const FOUNDATION_ADMIN: UserRole[] = [UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN];
 
+const ADMIN_ONLY: UserRole[] = [UserRole.ADMIN, UserRole.SUPER_ADMIN];
+
 export const TOOL_REGISTRY: ToolDefinition[] = [
   // ── Universal tools (all roles) ────────────────────────────────────────────
   {
@@ -60,6 +62,17 @@ export const TOOL_REGISTRY: ToolDefinition[] = [
     inputSchema: {
       modal: { type: 'string', description: 'Modal identifier, e.g. staffing_request_modal, job_post_modal' },
       prefill: { type: 'object', description: 'Key-value pairs to pre-fill in the modal' },
+    },
+  },
+
+  // ── Admin-only tools ───────────────────────────────────────────────────────
+  {
+    name: 'find_foundation',
+    description: 'Look up foundation organisations by name. Use this before acting on behalf of a foundation when only a name was provided — returns the foundationId needed by other tools.',
+    level: 'L1_ANSWER',
+    allowedRoles: ADMIN_ONLY,
+    inputSchema: {
+      query: { type: 'string', description: 'Organisation name or partial name to search for (e.g. "Kinderwelt", "Les Bout\'choux")' },
     },
   },
 
@@ -118,6 +131,7 @@ export const TOOL_REGISTRY: ToolDefinition[] = [
       canton: { type: 'string', description: 'Swiss canton (e.g. VD, GE)' },
       percentage: { type: 'number', description: 'Work percentage (e.g. 80)' },
       notes: { type: 'string', description: 'Additional notes for the posting' },
+      foundationId: { type: 'string', description: 'Optional: UUID of the foundation to post on behalf of (admin only). Resolve with find_foundation first if only a name is known.' },
     },
   },
   {

--- a/api/src/assistant/tools/tool-registry.ts
+++ b/api/src/assistant/tools/tool-registry.ts
@@ -91,7 +91,10 @@ export const TOOL_REGISTRY: ToolDefinition[] = [
     allowedRoles: FOUNDATION_ADMIN,
     featureFlag: 'v2_staffing_ia',
     modal: 'candidate_shortlist_modal',
-    inputSchema: { rawText: { type: 'string', description: 'Free-text staffing request describing role, canton, dates, qualifications' } },
+    inputSchema: {
+      rawText: { type: 'string', description: 'Free-text staffing request describing role, canton, dates, qualifications' },
+      foundationId: { type: 'string', description: 'Optional: UUID of a specific foundation org to scope the search. Omit for a platform-wide search (admin only).' },
+    },
   },
   {
     name: 'explain_match',

--- a/api/src/staffing/dto/create-staffing-request.dto.ts
+++ b/api/src/staffing/dto/create-staffing-request.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, MinLength, MaxLength, IsOptional, IsIn } from 'class-validator';
+import { IsString, IsNotEmpty, IsUUID, MinLength, MaxLength, IsOptional, IsIn } from 'class-validator';
 
 export class CreateStaffingRequestDto {
   @IsString()
@@ -10,4 +10,9 @@ export class CreateStaffingRequestDto {
   @IsOptional()
   @IsIn(['fr', 'de', 'en'])
   locale?: 'fr' | 'de' | 'en';
+
+  /** Admin/Super-admin only: scope the request to a specific foundation org. */
+  @IsOptional()
+  @IsUUID()
+  foundationId?: string;
 }

--- a/api/src/staffing/staffing.service.ts
+++ b/api/src/staffing/staffing.service.ts
@@ -65,12 +65,16 @@ export class StaffingService {
       throw new ForbiddenException('No organisation linked to this account');
     }
 
+    // Admins may pass an explicit foundationId to act on behalf of a specific org,
+    // or leave it null for a platform-wide search.
+    const resolvedFoundationId = dto.foundationId ?? principal.organizationId ?? null;
+
     const locale = dto.locale ?? 'fr';
     const isShort = dto.rawText.length <= SYNC_THRESHOLD_CHARS;
 
     const request = await this.prisma.staffingRequest.create({
       data: {
-        foundationId: principal.organizationId ?? null,
+        foundationId: resolvedFoundationId,
         createdById: principal.userId,
         rawText: dto.rawText,
         locale,

--- a/api/src/staffing/staffing.service.ts
+++ b/api/src/staffing/staffing.service.ts
@@ -59,7 +59,9 @@ export class StaffingService {
     dto: CreateStaffingRequestDto,
     principal: StaffingPrincipal,
   ) {
-    if (!principal.organizationId) {
+    const isAdmin =
+      principal.role === UserRole.ADMIN || principal.role === UserRole.SUPER_ADMIN;
+    if (!principal.organizationId && !isAdmin) {
       throw new ForbiddenException('No organisation linked to this account');
     }
 
@@ -68,7 +70,7 @@ export class StaffingService {
 
     const request = await this.prisma.staffingRequest.create({
       data: {
-        foundationId: principal.organizationId,
+        foundationId: principal.organizationId ?? null,
         createdById: principal.userId,
         rawText: dto.rawText,
         locale,
@@ -149,7 +151,7 @@ export class StaffingService {
     const resolvedPrincipal: StaffingPrincipal = principal ?? {
       userId: req.createdById,
       role: UserRole.FOUNDATION,
-      organizationId: req.foundationId,
+      organizationId: req.foundationId ?? undefined,
     };
 
     const { output } = await this.llm.run({
@@ -245,7 +247,7 @@ export class StaffingService {
     };
   }
 
-  private assertAccess(foundationId: string, principal: StaffingPrincipal) {
+  private assertAccess(foundationId: string | null, principal: StaffingPrincipal) {
     if (
       principal.role === UserRole.ADMIN ||
       principal.role === UserRole.SUPER_ADMIN

--- a/api/src/staffing/staffing.service.ts
+++ b/api/src/staffing/staffing.service.ts
@@ -65,9 +65,11 @@ export class StaffingService {
       throw new ForbiddenException('No organisation linked to this account');
     }
 
-    // Admins may pass an explicit foundationId to act on behalf of a specific org,
-    // or leave it null for a platform-wide search.
-    const resolvedFoundationId = dto.foundationId ?? principal.organizationId ?? null;
+    // Only admins may override the organisation via the DTO; foundation users are
+    // always scoped to their own org regardless of what the body contains.
+    const resolvedFoundationId = isAdmin
+      ? (dto.foundationId ?? principal.organizationId ?? null)
+      : principal.organizationId ?? null;
 
     const locale = dto.locale ?? 'fr';
     const isShort = dto.rawText.length <= SYNC_THRESHOLD_CHARS;

--- a/api/src/staffing/workers/staffing-explain.processor.ts
+++ b/api/src/staffing/workers/staffing-explain.processor.ts
@@ -93,7 +93,7 @@ export class StaffingExplainProcessor {
         principal: {
           userId: req.createdById,
           role: UserRole.FOUNDATION,
-          organizationId: req.foundationId,
+          organizationId: req.foundationId ?? undefined,
         },
         entityRef: matchResultId,
       });


### PR DESCRIPTION
## Summary

Extends the staffing request workflow to allow ADMIN and SUPER_ADMIN users to create staffing requests on behalf of any foundation organisation, or platform-wide without a specific foundation. This enables admins to manage recruitment across the entire platform and act on behalf of foundations when needed.

## Key Changes

- **New admin-only tool `find_foundation`**: Allows admins to look up foundation organisations by name and resolve them to IDs before acting on their behalf
- **Extended `search_internal_candidates` tool**: Now accepts optional `foundationId` parameter; admins can scope searches to a specific foundation or leave it null for platform-wide search
- **Extended `draft_job_post` tool**: Now accepts optional `foundationId` parameter to post on behalf of a specific foundation (admin only)
- **Made `StaffingRequest.foundationId` nullable**: Allows creation of staffing requests without a linked foundation (for platform-wide admin searches)
- **Updated `CreateStaffingRequestDto`**: Added optional `foundationId` field with UUID validation
- **Updated orchestrator logic**: 
  - Admins can now create staffing requests without requiring `principal.organizationId`
  - Resolves `foundationId` from explicit parameter, principal org, or null (for platform-wide)
  - Returns `scope` field indicating whether search is `'foundation'` or `'platform-wide'`
- **Updated tool registry**: Added `ADMIN_ONLY` role constant; documented new parameters and admin-only behavior
- **Updated assistant prompt**: Added `ADMIN RULE — FOUNDATION LOOKUP` requiring admins to call `find_foundation` first when acting on behalf of a foundation by name
- **Database migration**: Drops NOT NULL constraint on `StaffingRequest.foundationId`

## Implementation Details

- Access control: `assertAccess()` now allows admins to access requests with `foundationId: null`
- Backward compatible: Foundation users continue to work as before (foundationId auto-resolved from principal)
- Tool selection rules in prompt clarify that admins may pass `foundationId` to scope actions, or omit for platform-wide behavior
- Validation ensures admins must resolve foundation names via `find_foundation` before using the ID in subsequent calls

https://claude.ai/code/session_01VK8t54QejkpqrvGtfxdcfv