### PR TITLE
Fix assistant JSON truncation: raise maxOutputTokens and enforce clea…

### DIFF
--- a/api/src/ai/agents/assistant-orchestrator/prompt.v1.ts
+++ b/api/src/ai/agents/assistant-orchestrator/prompt.v1.ts
@@ -79,7 +79,7 @@ ${input.conversationHistory}
 
 USER MESSAGE: ${input.userMessage}
 
-Be concise, accurate, and helpful. Always respond in ${lang}.
+Be concise. Always respond in ${lang}. Your ENTIRE response must be a single valid JSON object — no preamble, no trailing text.
 
 Respond with JSON: {"message": "...", "toolCall": {"name": "...", "args": {...}} | null}`;
 }

--- a/api/src/ai/ai-agents.config.ts
+++ b/api/src/ai/ai-agents.config.ts
@@ -52,7 +52,7 @@ export const AI_AGENTS: Record<AgentName, AgentConfig> = {
   'assistant-orchestrator': {
     name: 'assistant-orchestrator',
     models: ['anthropic/claude-sonnet-4-6', 'google/gemini-2.5-pro'],
-    maxOutputTokens: 1000,
+    maxOutputTokens: 2000,
     allowedRoles: [UserRole.FOUNDATION, UserRole.ADMIN, UserRole.SUPER_ADMIN],
     scopeRule: 'organization',
     dailyTokenBudget: 500000,


### PR DESCRIPTION
…n JSON output

The orchestrator was hitting the 1000-token output cap mid-JSON when handling admin multi-step prompts with the extended tool list. Raised to 2000 tokens. Also added an explicit prompt instruction that the entire response must be a single valid JSON object with no preamble, reducing wasted tokens on prose.

https://claude.ai/code/session_01VK8t54QejkpqrvGtfxdcfv