### PR TITLE
Fix OpenRouter model slugs — verified against openrouter.ai catalog

### DIFF
--- a/api/src/ai/ai-agents.config.ts
+++ b/api/src/ai/ai-agents.config.ts
@@ -25,11 +25,11 @@ export interface AgentConfig {
 // The OpenRouter adapter tries each in order on failure.
 
 const FREE_THEN_VALUE = [
-  'deepseek/deepseek-chat-v4-flash:free',   // DeepSeek V4 Flash — free tier
-  'google/gemma-4-31b-it:free',             // Gemma 4 31B — free tier
-  'deepseek/deepseek-chat-v4-flash',        // DeepSeek V4 Flash — paid ($0.10/$0.20 per 1M)
-  'google/gemini-3-flash',                  // Gemini 3 Flash — paid ($0.50/$3.00 per 1M)
-  'x-ai/grok-4.1-fast',                    // Grok 4.1 Fast — paid ($1.25/$2.50 per 1M)
+  'deepseek/deepseek-v4-flash:free',        // DeepSeek V4 Flash — free tier
+  'google/gemma-3-27b-it:free',             // Gemma 3 27B — largest available free Gemma
+  'deepseek/deepseek-v4-flash',             // DeepSeek V4 Flash — paid ($0.10/$0.20 per 1M)
+  'google/gemini-2.5-flash',               // Gemini 2.5 Flash — stable paid ($0.50/$3.00 per 1M)
+  'x-ai/grok-4-fast',                      // Grok 4 Fast — paid ($1.25/$2.50 per 1M)
 ];
 
 const ORCHESTRATOR_MODELS = FREE_THEN_VALUE;


### PR DESCRIPTION
Corrections:
  deepseek-chat-v4-flash → deepseek-v4-flash (correct slug)
  google/gemma-4-31b-it:free → google/gemma-3-27b-it:free (gemma-4 doesn't exist; 27B is largest free)
  google/gemini-3-flash → google/gemini-2.5-flash (gemini-3 is preview-only; 2.5 is stable)
  x-ai/grok-4.1-fast → x-ai/grok-4-fast (no .1 in the slug)

https://claude.ai/code/session_01VK8t54QejkpqrvGtfxdcfv