### PR TITLE
fix: correct recipients type annotation to include organizations rela…

### DIFF
--- a/api/src/mailing/mailing.service.ts
+++ b/api/src/mailing/mailing.service.ts
@@ -739,7 +739,14 @@ export class MailingService {
       throw new BadRequestException('Campaign has no filter configuration');
     }
 
-    let recipients: Awaited<ReturnType<typeof this.prisma.user.findMany>> = [];
+    let recipients: Array<Prisma.UserGetPayload<{
+      include: {
+        organizations: {
+          take: 1;
+          include: { organization: { select: { name: true; canton: true } } };
+        };
+      };
+    }>> = [];
 
     if (filters) {
       const where = this.buildRecipientWhere(filters);


### PR DESCRIPTION
…tion

The refactor that made the findMany conditional left recipients typed as User[] (no organizations field), causing a TS2339 build error on the recipient.organizations access in the send loop. Use the full Prisma payload type so TypeScript knows the shape of each recipient.

https://claude.ai/code/session_01RVaGib7ZBt3K5SkTaeP4oS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety for internal mailing service operations to improve code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->