### PR TITLE
Limit OpenRouter model selection to top 3 models

### DIFF
--- a/api/src/ai/providers/openrouter.adapter.ts
+++ b/api/src/ai/providers/openrouter.adapter.ts
@@ -57,7 +57,7 @@ export class OpenRouterAdapter {
     };
 
     if (models.length > 1) {
-      body.models = models;
+      body.models = models.slice(0, 3);
     }
 
     if (jsonMode) {


### PR DESCRIPTION
## Summary
Restricts the OpenRouter adapter to send a maximum of 3 models in the request body, even when more models are available. This change optimizes API requests by capping the model list size.

## Changes
- **`api/src/ai/providers/openrouter.adapter.ts`**: Modified the models array assignment to use `.slice(0, 3)`, limiting the models sent to OpenRouter to the first 3 entries when multiple models are provided.

## Implementation Details
- The change only applies when `models.length > 1`, preserving the existing behavior for single-model requests
- Uses array slicing to non-destructively limit the array to the first 3 elements
- This may improve API response times or reduce token usage when interacting with OpenRouter's API

https://claude.ai/code/session_01HGsy3QAXnseUZtHXjWheE2