### PR TITLE
Remove MailingTemplate creator relationship from User model

### DIFF
--- a/api/prisma/migrations/20260601000000_drop_mailing_template_fk/migration.sql
+++ b/api/prisma/migrations/20260601000000_drop_mailing_template_fk/migration.sql
@@ -1,0 +1,2 @@
+-- DropForeignKey
+ALTER TABLE "mailing_templates" DROP CONSTRAINT IF EXISTS "mailing_templates_created_by_id_fkey";

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -321,7 +321,6 @@ model User {
 
   // Mailing custom list memberships
   mailingCustomListMemberships MailingCustomListMember[]
-  mailingTemplates             MailingTemplate[]          @relation("MailingTemplateCreator")
 
   // Replacement staffing relations
   replacementRequests  ReplacementRequest[]  @relation("UserReplacementRequests")
@@ -2687,7 +2686,6 @@ model MailingTemplate {
   bodyHtml    String   @db.Text @map("body_html")
   bodyText    String?  @db.Text @map("body_text")
   createdById String   @map("created_by_id")
-  createdBy   User     @relation("MailingTemplateCreator", fields: [createdById], references: [id])
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")


### PR DESCRIPTION
## Summary
Removes the bidirectional relationship between `User` and `MailingTemplate` models, specifically the `createdBy` foreign key relation. This decouples the User model from tracking which user created a mailing template.

## Changes
- **Migration:** Added `20260601000000_drop_mailing_template_fk` to drop the `mailing_templates_created_by_id_fkey` foreign key constraint
- **Schema:** 
  - Removed `mailingTemplates MailingTemplate[] @relation("MailingTemplateCreator")` from `User` model
  - Removed `createdBy User @relation("MailingTemplateCreator", ...)` from `MailingTemplate` model
  - Retained `createdById String` field in `MailingTemplate` for audit purposes (no longer enforced as FK)

## Notes
The `createdById` column remains in the database for historical tracking, but is no longer enforced as a foreign key constraint. This allows for more flexible data management if user records are deleted or if audit trails need to be preserved independently.

https://claude.ai/code/session_01334oFuL5WCdepFrLPo3n4N

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated database schema and data relationships to optimize system architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->