### PR TITLE
AI Assistant V2 Phases 2–4: L3 write tools, admin completeness, streaming status

### DIFF
--- a/api/src/ai/agents/assistant-orchestrator/prompt.v1.ts
+++ b/api/src/ai/agents/assistant-orchestrator/prompt.v1.ts
@@ -61,10 +61,24 @@ TOOL SELECTION RULES:
 SEARCH RULES:
 - Find candidates, fast and structured (role/canton/skills) → use search_candidates
 - Find candidates from a natural-language request (dates, hours, qualifications), AI-ranked with scores → use search_candidates_ai
+- View ranked matches for an existing staffing request ID → use view_match_results
 - Find marketplace products → use search_products
 - Find marketplace services → use search_services
 - Find available jobs (EDUCATOR) → use search_jobs
 - Find childcare foundations (PARENT) → use search_foundations
+- Find a platform user by name/email (ADMIN) → use find_user
+- Platform-wide operational counts (ADMIN) → use get_platform_stats
+
+WRITE-ACTION RULES (all L3 — confirm before executing):
+- Publish a job listing → post_job (FOUNDATION/ADMIN)
+- Shortlist a candidate → shortlist_candidate (FOUNDATION/ADMIN)
+- Move an application through the pipeline → update_application_status (FOUNDATION/ADMIN)
+- Open a staff replacement request → create_replacement_request (FOUNDATION/ADMIN)
+- Respond to a parent lead → respond_to_lead (FOUNDATION/ADMIN)
+- Place a product order → place_order; request a service → request_service; ask a supplier for a quote → send_supplier_inquiry (FOUNDATION/ADMIN)
+- Apply to a job (EDUCATOR) → apply_to_job
+- Submit a childcare enquiry (PARENT) → submit_enquiry
+- Message another user directly (any role) → send_message. If only a name is known and you are an admin, resolve the recipient with find_user first.
 
 NO-RESULTS RULE:
 - When any search returns total: 0, present each item in its suggestions[] as a

--- a/api/src/assistant/assistant-v2.e2e.spec.ts
+++ b/api/src/assistant/assistant-v2.e2e.spec.ts
@@ -303,18 +303,20 @@ describe('AI Assistant V2 — e2e integration', () => {
       expect(sendEvent).toHaveBeenCalledWith('tool_result', expect.objectContaining({ toolName: 'view_match_results' }));
     });
 
-    it('calls getRequest and getMatches with the provided requestId', async () => {
+    it('calls getMatches with the resolved request id and principal context', async () => {
       staffingMock.getMatches.mockResolvedValue([]);
-      staffingMock.getRequest.mockResolvedValue({ roleRequired: 'EDE', canton: 'GE' });
       // Handler accepts 'staffingRequestId' or 'requestId' aliases
       mockLlmOnce({ message: 'Fetching.', toolCall: { name: 'view_match_results', args: { staffingRequestId: 'sr-42', requestId: 'sr-42' } } });
       mockLlmOnce({ message: 'No matches yet.', toolCall: null });
 
       await service.run({ conversationId: CONVERSATION_ID, userMessage: 'matches for sr-42', principal: FOUNDATION_PRINCIPAL, locale: 'en', sendEvent });
 
-      // The handler should have resolved the request ID and called both methods
+      // The handler resolves the request ID and calls getMatches with it plus a
+      // principal context object (for org-scoping inside the service).
       const getMatchesCalls = staffingMock.getMatches.mock.calls;
-      expect(getMatchesCalls.some((c: unknown[]) => c[0] === 'sr-42')).toBe(true);
+      const call = getMatchesCalls.find((c: unknown[]) => c[0] === 'sr-42');
+      expect(call).toBeDefined();
+      expect(call![1]).toEqual(expect.objectContaining({ userId: FOUNDATION_PRINCIPAL.userId }));
     });
   });
 
@@ -665,22 +667,101 @@ describe('AI Assistant V2 — e2e integration', () => {
   });
 
   // ─────────────────────────────────────────────────────────────────────────────
+  // Cross-tenant write protection (resolveOnBehalfOrgId hardening)
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('Cross-tenant write protection', () => {
+    // A foundation user (org-1) must not be able to act on another org by passing
+    // its foundationId/organizationId in the tool args.
+    async function confirmAsForeignOrg(toolName: string, inputJson: Record<string, unknown>) {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-1' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-xt', conversationId: CONVERSATION_ID, toolName, status: 'AWAITING_APPROVAL', inputJson,
+      });
+      await makeService(prisma);
+      return service.confirmToolCall('tc-xt', FOUNDATION_PRINCIPAL, 'en');
+    }
+
+    it('rejects post_job targeting another foundation', async () => {
+      const result = await confirmAsForeignOrg('post_job', { role: 'EDE', location: 'Genève', foundationId: 'org-OTHER' });
+      expect(result.error).toBeDefined();
+      expect(recruitmentMock.createJobListing).not.toHaveBeenCalled();
+    });
+
+    it('rejects shortlist_candidate targeting another foundation', async () => {
+      const result = await confirmAsForeignOrg('shortlist_candidate', { candidateId: 'cand-1', foundationId: 'org-OTHER' });
+      expect(result.error).toBeDefined();
+      expect(recruitmentMock.saveCandidate).not.toHaveBeenCalled();
+    });
+
+    it('rejects respond_to_lead on behalf of another foundation', async () => {
+      const result = await confirmAsForeignOrg('respond_to_lead', { leadId: 'lead-1', message: 'hi', foundationId: 'org-OTHER' });
+      expect(result.error).toBeDefined();
+      expect(leadsMock.respondToLead).not.toHaveBeenCalled();
+    });
+
+    it('rejects place_order billed to another organization', async () => {
+      const result = await confirmAsForeignOrg('place_order', { productId: 'prod-1', quantity: 1, organizationId: 'org-OTHER' });
+      expect(result.error).toBeDefined();
+      expect(marketplaceMock.createOrder).not.toHaveBeenCalled();
+    });
+
+    it('allows the caller to pass their OWN org id explicitly (no false positive)', async () => {
+      const result = await confirmAsForeignOrg('post_job', { role: 'EDE', location: 'Genève', foundationId: FOUNDATION_PRINCIPAL.organizationId });
+      expect(result.error).toBeUndefined();
+      expect(recruitmentMock.createJobListing).toHaveBeenCalled();
+    });
+
+    it('admin handler rejects find_user from a non-admin principal (defense in depth)', async () => {
+      const handler = new AdminHandler(usersMock as any, prisma as any);
+      await expect(handler.execute('find_user', { search: 'bob' }, FOUNDATION_PRINCIPAL as any))
+        .rejects.toThrow();
+      expect(usersMock.findAll).not.toHaveBeenCalled();
+    });
+
+    it('admin handler allows get_platform_stats for an admin principal', async () => {
+      const handler = new AdminHandler(usersMock as any, prisma as any);
+      const result = await handler.execute('get_platform_stats', {}, ADMIN_PRINCIPAL as any);
+      expect(result.scope).toBe('platform-wide');
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
   // Per-role welcome chips — frontend constant validation
   // ─────────────────────────────────────────────────────────────────────────────
 
   describe('Per-role welcome suggestions', () => {
-    // These are checked by importing the data directly from the compiled source.
-    it('AssistantPanel exports suggestions for all 7 roles', async () => {
+    // Validates the SUGGESTIONS_BY_ROLE mapping itself (scoped to that object
+    // literal), not just that role names appear somewhere in the file — so a
+    // comment or type union can't satisfy the check.
+    it('SUGGESTIONS_BY_ROLE populates an entry for every role', async () => {
       const fs = await import('fs');
       const path = await import('path');
       const panelSrc = fs.readFileSync(
         path.join(__dirname, '../../..', 'frontend/components/assistant/AssistantPanel.tsx'),
         'utf8',
       );
-      const roles = ['FOUNDATION', 'EDUCATOR', 'PARENT', 'PRODUCT_SUPPLIER', 'SERVICE_PROVIDER', 'ADMIN', 'SUPER_ADMIN'];
-      for (const role of roles) {
-        expect(panelSrc).toContain(role);
+
+      // Extract just the SUGGESTIONS_BY_ROLE object literal.
+      const start = panelSrc.indexOf('const SUGGESTIONS_BY_ROLE');
+      expect(start).toBeGreaterThanOrEqual(0);
+      const literal = panelSrc.slice(start, panelSrc.indexOf('\n};', start));
+
+      // Each of the 5 non-admin roles must key into the map with a welcome.* entry.
+      const roleToPrefix: Record<string, string> = {
+        FOUNDATION: 'welcome.foundation.',
+        EDUCATOR: 'welcome.educator.',
+        PARENT: 'welcome.parent.',
+        PRODUCT_SUPPLIER: 'welcome.supplier.',
+        SERVICE_PROVIDER: 'welcome.serviceProvider.',
+        ADMIN: 'welcome.admin.',
+      };
+      for (const [role, prefix] of Object.entries(roleToPrefix)) {
+        expect(literal).toContain(`[UserRole.${role}]`);
+        expect(literal).toContain(prefix);
       }
+      // SUPER_ADMIN reuses the ADMIN list — assert that aliasing line explicitly.
+      expect(panelSrc).toContain('SUGGESTIONS_BY_ROLE[UserRole.SUPER_ADMIN] = SUGGESTIONS_BY_ROLE[UserRole.ADMIN]');
     });
 
     it('translation files contain welcome keys for every role (en)', async () => {
@@ -701,7 +782,7 @@ describe('AI Assistant V2 — e2e integration', () => {
       }
     });
 
-    it('translation files have parity across en/fr/de (96 keys each)', async () => {
+    it('translation files have parity across en/fr/de', async () => {
       const fs = await import('fs');
       const path = await import('path');
       const countKeys = (obj: unknown): number => {
@@ -712,8 +793,27 @@ describe('AI Assistant V2 — e2e integration', () => {
       const counts = ['en', 'fr', 'de'].map((l) =>
         countKeys(JSON.parse(fs.readFileSync(path.join(base, l, 'assistant.json'), 'utf8'))),
       );
-      expect(counts[0]).toBe(96);
+      // Parity matters more than the absolute count; assert all three match.
+      expect(counts[0]).toBeGreaterThan(0);
       expect(counts.every((c) => c === counts[0])).toBe(true);
+    });
+
+    it('every result-card tool has a localized toolStatus label in all locales', async () => {
+      const fs = await import('fs');
+      const path = await import('path');
+      const base = path.join(__dirname, '../../..', 'packages/translations/locales');
+      const toolNames = [
+        'search_candidates', 'search_candidates_ai', 'search_products', 'search_services',
+        'search_jobs', 'search_foundations', 'find_foundation', 'view_match_results',
+      ];
+      for (const loc of ['en', 'fr', 'de']) {
+        const json = JSON.parse(fs.readFileSync(path.join(base, loc, 'assistant.json'), 'utf8'));
+        expect(json.toolStatus).toBeDefined();
+        for (const tool of toolNames) {
+          expect(typeof json.toolStatus[tool]).toBe('string');
+          expect(json.toolStatus[tool].length).toBeGreaterThan(0);
+        }
+      }
     });
   });
 

--- a/api/src/assistant/assistant-v2.e2e.spec.ts
+++ b/api/src/assistant/assistant-v2.e2e.spec.ts
@@ -1,0 +1,771 @@
+/**
+ * AI Assistant V2 — end-to-end integration spec
+ *
+ * Covers the specific v2 Phase 2–4 surface that is not exercised by the existing
+ * orchestrator.service.spec.ts:
+ *   • tool_status SSE events (Phase 4 streaming)
+ *   • view_match_results (Phase 3 search tool)
+ *   • Remaining L3 confirm paths: shortlist_candidate, respond_to_lead,
+ *     place_order, request_service, send_supplier_inquiry,
+ *     create_replacement_request
+ *   • Enum-validation guard on create_replacement_request (urgency)
+ *   • Enum-validation guard on update_application_status (status)
+ *   • Tool-registry completeness (35 tools across all 7 roles)
+ *   • RESULT_CARD_TOOLS / TOOL_STATUS_LABELS consistency check
+ *
+ * All tests run in-process with mocked services — no database required.
+ */
+import { Test } from '@nestjs/testing';
+import { UserRole } from '@prisma/client';
+import { OrchestratorService } from './orchestrator.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { LlmClient } from '../ai/llm-client';
+import { UserContextService } from '../ai/knowledge/user-context.service';
+import { ToolHandlerRegistry } from './tools/tool-handler.registry';
+import { ProfileHandler } from './tools/handlers/profile.handler';
+import { LeadsHandler } from './tools/handlers/leads.handler';
+import { RecruitmentReadHandler } from './tools/handlers/recruitment.handler';
+import { MarketplaceReadHandler } from './tools/handlers/marketplace.handler';
+import { StaffingHandler } from './tools/handlers/staffing.handler';
+import { SupportHandler } from './tools/handlers/support.handler';
+import { SearchHandler } from './tools/handlers/search.handler';
+import { DraftsHandler } from './tools/handlers/drafts.handler';
+import { RecruitmentWriteHandler } from './tools/handlers/recruitment-write.handler';
+import { LeadsWriteHandler } from './tools/handlers/leads-write.handler';
+import { MarketplaceWriteHandler } from './tools/handlers/marketplace-write.handler';
+import { MessagingHandler } from './tools/handlers/messaging.handler';
+import { ReplacementsHandler } from './tools/handlers/replacements.handler';
+import { AdminHandler } from './tools/handlers/admin.handler';
+import { getToolsForRole } from './tools/tool-registry';
+
+const FOUNDATION_PRINCIPAL = { userId: 'user-1', role: UserRole.FOUNDATION, organizationId: 'org-1' };
+const EDUCATOR_PRINCIPAL = { userId: 'user-2', role: UserRole.EDUCATOR, organizationId: undefined };
+const PARENT_PRINCIPAL = { userId: 'user-3', role: UserRole.PARENT, organizationId: undefined };
+const SP_PRINCIPAL = { userId: 'user-5', role: UserRole.SERVICE_PROVIDER, organizationId: 'org-3' };
+const ADMIN_PRINCIPAL = { userId: 'admin-1', role: UserRole.ADMIN, organizationId: undefined };
+const CONVERSATION_ID = 'conv-e2e';
+
+function mockPrisma() {
+  return {
+    aIMessage: {
+      findMany: jest.fn().mockResolvedValue([]),
+      create: jest.fn().mockResolvedValue({ id: 'msg-1' }),
+    },
+    aIToolCall: {
+      create: jest.fn().mockResolvedValue({ id: 'tc-1' }),
+      update: jest.fn().mockResolvedValue({}),
+      findUnique: jest.fn().mockResolvedValue(null),
+    },
+    aIConversation: {
+      findUnique: jest.fn().mockResolvedValue({ userId: 'user-1', locale: 'en' }),
+    },
+    matchResult: {
+      findUnique: jest.fn().mockResolvedValue({ explanation: 'Good fit', totalScore: 88 }),
+    },
+    user: {
+      findUnique: jest.fn().mockResolvedValue({
+        firstName: 'Alice', lastName: 'Martin',
+        approvalStatus: null, email: 'alice@x.ch',
+      }),
+      count: jest.fn().mockResolvedValue(100),
+    },
+    parentLead: {
+      count: jest.fn().mockResolvedValue(5),
+      findMany: jest.fn().mockResolvedValue([
+        { id: 'lead-1', parentName: 'Jean Dupont', childAge: 2, status: 'NEW', preferredLocation: 'Vaud', createdAt: new Date() },
+      ]),
+    },
+    jobListing: { count: jest.fn().mockResolvedValue(3) },
+    order: {
+      count: jest.fn().mockResolvedValue(1),
+      findMany: jest.fn().mockResolvedValue([]),
+    },
+    jobApplication: {
+      count: jest.fn().mockResolvedValue(8),
+      findMany: jest.fn().mockResolvedValue([]),
+      findUnique: jest.fn().mockResolvedValue({ jobListing: { foundationId: 'org-1' } }),
+    },
+    product: {
+      count: jest.fn().mockResolvedValue(4),
+      findMany: jest.fn().mockResolvedValue([]),
+    },
+    serviceProvider: { findFirst: jest.fn().mockResolvedValue({ id: 'sp-1' }) },
+    service: {
+      count: jest.fn().mockResolvedValue(2),
+      findMany: jest.fn().mockResolvedValue([]),
+    },
+    serviceRequest: {
+      count: jest.fn().mockResolvedValue(1),
+      findMany: jest.fn().mockResolvedValue([]),
+    },
+    organization: { findMany: jest.fn().mockResolvedValue([]) },
+    featureFlag: { findMany: jest.fn().mockResolvedValue([]) },
+    systemSettings: { findMany: jest.fn().mockResolvedValue([]) },
+  };
+}
+
+describe('AI Assistant V2 — e2e integration', () => {
+  let service: OrchestratorService;
+  let prisma: ReturnType<typeof mockPrisma>;
+  let llm: { run: jest.Mock };
+  let sendEvent: jest.Mock;
+
+  let recruitmentMock: {
+    findAllCandidates: jest.Mock;
+    findAllJobListings: jest.Mock;
+    createJobListing: jest.Mock;
+    createJobApplication: jest.Mock;
+    saveCandidate: jest.Mock;
+    updateJobApplication: jest.Mock;
+  };
+  let marketplaceMock: {
+    findAllProducts: jest.Mock;
+    findAllServices: jest.Mock;
+    createOrder: jest.Mock;
+    createServiceRequest: jest.Mock;
+  };
+  let inquiryMock: { createInquiry: jest.Mock };
+  let leadsMock: { respondToLead: jest.Mock; createParentLead: jest.Mock };
+  let messagingMock: { createDirectMessage: jest.Mock };
+  let replacementsMock: { createRequest: jest.Mock };
+  let usersMock: { findAll: jest.Mock };
+  let supportMock: { createTicket: jest.Mock };
+  let staffingMock: { createRequest: jest.Mock; runMatching: jest.Mock; getMatches: jest.Mock; getRequest: jest.Mock };
+  let embeddingMock: { isReady: boolean; searchSemantic: jest.Mock };
+  let knowledgeMock: { search: jest.Mock; formatForPrompt: jest.Mock };
+
+  function mockLlmOnce(output: { message: string; toolCall?: unknown }) {
+    llm.run.mockResolvedValueOnce({ output, cacheHit: false, modelUsed: 'test' });
+  }
+
+  function buildRegistry(prismaImpl: any): ToolHandlerRegistry {
+    return new ToolHandlerRegistry(
+      new ProfileHandler(prismaImpl),
+      new LeadsHandler(prismaImpl),
+      new RecruitmentReadHandler(prismaImpl),
+      new MarketplaceReadHandler(prismaImpl),
+      new StaffingHandler(prismaImpl),
+      new SupportHandler(supportMock as any),
+      new SearchHandler(prismaImpl, knowledgeMock as any, embeddingMock as any, recruitmentMock as any, marketplaceMock as any, staffingMock as any),
+      new DraftsHandler(),
+      new RecruitmentWriteHandler(recruitmentMock as any, prismaImpl),
+      new LeadsWriteHandler(leadsMock as any, prismaImpl),
+      new MarketplaceWriteHandler(marketplaceMock as any, inquiryMock as any),
+      new MessagingHandler(messagingMock as any),
+      new ReplacementsHandler(replacementsMock as any),
+      new AdminHandler(usersMock as any, prismaImpl),
+    );
+  }
+
+  async function makeService(prismaOverride?: any) {
+    const prismaImpl = prismaOverride ?? prisma;
+    llm = { run: jest.fn() };
+    const module = await Test.createTestingModule({
+      providers: [
+        OrchestratorService,
+        { provide: PrismaService, useValue: prismaImpl },
+        { provide: LlmClient, useValue: llm },
+        { provide: UserContextService, useValue: {
+          build: jest.fn().mockResolvedValue({ profile: 'Alice | FOUNDATION', state: 'Leads: 5' }),
+        }},
+        { provide: ToolHandlerRegistry, useValue: buildRegistry(prismaImpl) },
+      ],
+    }).compile();
+    service = module.get(OrchestratorService);
+  }
+
+  beforeEach(async () => {
+    sendEvent = jest.fn();
+    prisma = mockPrisma() as any;
+    embeddingMock = { isReady: false, searchSemantic: jest.fn().mockResolvedValue([]) };
+    knowledgeMock = { search: jest.fn().mockReturnValue([]), formatForPrompt: jest.fn().mockReturnValue('') };
+    staffingMock = {
+      createRequest: jest.fn().mockResolvedValue({ id: 'sr-1', status: 'PARSED' }),
+      runMatching: jest.fn().mockResolvedValue(0),
+      getMatches: jest.fn().mockResolvedValue([]),
+      getRequest: jest.fn().mockResolvedValue({ roleRequired: 'EDE', canton: 'GE' }),
+    };
+    recruitmentMock = {
+      findAllCandidates: jest.fn().mockResolvedValue([]),
+      findAllJobListings: jest.fn().mockResolvedValue([]),
+      createJobListing: jest.fn().mockResolvedValue({ id: 'job-1', title: 'EDE 80%', status: 'PUBLISHED', location: 'Genève' }),
+      createJobApplication: jest.fn().mockResolvedValue({ id: 'app-1', status: 'PENDING' }),
+      saveCandidate: jest.fn().mockResolvedValue({ id: 'saved-1' }),
+      updateJobApplication: jest.fn().mockResolvedValue({ id: 'app-1', status: 'SHORTLISTED' }),
+    };
+    marketplaceMock = {
+      findAllProducts: jest.fn().mockResolvedValue([]),
+      findAllServices: jest.fn().mockResolvedValue([]),
+      createOrder: jest.fn().mockResolvedValue({ id: 'order-1', totalAmount: 120, status: 'PENDING' }),
+      createServiceRequest: jest.fn().mockResolvedValue({ id: 'sreq-1', status: 'PENDING' }),
+    };
+    inquiryMock = { createInquiry: jest.fn().mockResolvedValue({ id: 'inq-1' }) };
+    leadsMock = {
+      respondToLead: jest.fn().mockResolvedValue({ id: 'resp-1' }),
+      createParentLead: jest.fn().mockResolvedValue({ id: 'lead-1', status: 'NEW' }),
+    };
+    messagingMock = { createDirectMessage: jest.fn().mockResolvedValue({ id: 'dm-1' }) };
+    replacementsMock = { createRequest: jest.fn().mockResolvedValue({ id: 'rr-1', status: 'OPEN' }) };
+    usersMock = { findAll: jest.fn().mockResolvedValue({ data: [] }) };
+    supportMock = { createTicket: jest.fn().mockResolvedValue({ id: 'ticket-1', status: 'OPEN' }) };
+    await makeService();
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Phase 4: tool_status streaming
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('Phase 4 — tool_status SSE streaming', () => {
+    // Tools and the principal that can call them (role-restricted)
+    const RESULT_CARD_TOOL_CASES: [string, typeof FOUNDATION_PRINCIPAL | typeof EDUCATOR_PRINCIPAL | typeof PARENT_PRINCIPAL | typeof ADMIN_PRINCIPAL][] = [
+      ['search_candidates',     FOUNDATION_PRINCIPAL],
+      ['search_candidates_ai',  FOUNDATION_PRINCIPAL],
+      ['search_products',       FOUNDATION_PRINCIPAL],
+      ['search_services',       FOUNDATION_PRINCIPAL],
+      ['search_jobs',           EDUCATOR_PRINCIPAL],
+      ['search_foundations',    PARENT_PRINCIPAL],
+      ['find_foundation',       ADMIN_PRINCIPAL],
+      ['view_match_results',    FOUNDATION_PRINCIPAL],
+    ];
+
+    it.each(RESULT_CARD_TOOL_CASES)(
+      'emits tool_status{running} before executing %s',
+      async (toolName, principal) => {
+        mockLlmOnce({ message: 'Searching.', toolCall: { name: toolName, args: { query: 'test', limit: 1, requestId: 'sr-1', search: 'x' } } });
+        mockLlmOnce({ message: 'Done.', toolCall: null });
+
+        await service.run({ conversationId: CONVERSATION_ID, userMessage: 'search', principal, locale: 'en', sendEvent });
+
+        expect(sendEvent).toHaveBeenCalledWith('tool_status', expect.objectContaining({
+          toolName,
+          status: 'running',
+          label: expect.any(String),
+        }));
+      },
+    );
+
+    it('tool_status label for search_candidates_ai is "Matching candidates…"', async () => {
+      mockLlmOnce({ message: 'Searching.', toolCall: { name: 'search_candidates_ai', args: { rawText: 'EDE Geneva' } } });
+      mockLlmOnce({ message: 'Done.', toolCall: null });
+
+      await service.run({ conversationId: CONVERSATION_ID, userMessage: 'find EDE', principal: FOUNDATION_PRINCIPAL, locale: 'en', sendEvent });
+
+      expect(sendEvent).toHaveBeenCalledWith('tool_status', expect.objectContaining({
+        toolName: 'search_candidates_ai',
+        label: 'Matching candidates…',
+      }));
+    });
+
+    it('does NOT emit tool_status for non-result-card tools like get_my_leads', async () => {
+      mockLlmOnce({ message: 'Fetching.', toolCall: { name: 'get_my_leads', args: { limit: 5 } } });
+      mockLlmOnce({ message: 'Done.', toolCall: null });
+
+      await service.run({ conversationId: CONVERSATION_ID, userMessage: 'show leads', principal: FOUNDATION_PRINCIPAL, locale: 'en', sendEvent });
+
+      expect(sendEvent).not.toHaveBeenCalledWith('tool_status', expect.anything());
+    });
+
+    it('tool_status event precedes tool_result event', async () => {
+      mockLlmOnce({ message: 'Searching.', toolCall: { name: 'search_products', args: { query: 'paint', limit: 5 } } });
+      mockLlmOnce({ message: 'Found products.', toolCall: null });
+
+      await service.run({ conversationId: CONVERSATION_ID, userMessage: 'find paint', principal: FOUNDATION_PRINCIPAL, locale: 'en', sendEvent });
+
+      const calls = sendEvent.mock.calls.map((c: any[]) => c[0]);
+      const statusIdx = calls.indexOf('tool_status');
+      const resultIdx = calls.indexOf('tool_result');
+      expect(statusIdx).toBeGreaterThanOrEqual(0);
+      expect(resultIdx).toBeGreaterThan(statusIdx);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Phase 3: view_match_results
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('Phase 3 — view_match_results', () => {
+    it('emits tool_call, tool_status, and tool_result events', async () => {
+      staffingMock.getMatches.mockResolvedValue([
+        { educatorId: 'e-1', totalScore: 92, explanation: 'Excellent fit' },
+      ]);
+      staffingMock.getRequest.mockResolvedValue({ roleRequired: 'EDE', canton: 'GE' });
+
+      mockLlmOnce({ message: 'Fetching match results.', toolCall: { name: 'view_match_results', args: { requestId: 'sr-1' } } });
+      mockLlmOnce({ message: 'Here are your matches.', toolCall: null });
+
+      await service.run({ conversationId: CONVERSATION_ID, userMessage: 'show matches for sr-1', principal: FOUNDATION_PRINCIPAL, locale: 'en', sendEvent });
+
+      expect(sendEvent).toHaveBeenCalledWith('tool_call', expect.objectContaining({ toolName: 'view_match_results' }));
+      expect(sendEvent).toHaveBeenCalledWith('tool_status', expect.objectContaining({
+        toolName: 'view_match_results',
+        label: 'Fetching match results…',
+      }));
+      expect(sendEvent).toHaveBeenCalledWith('tool_result', expect.objectContaining({ toolName: 'view_match_results' }));
+    });
+
+    it('calls getRequest and getMatches with the provided requestId', async () => {
+      staffingMock.getMatches.mockResolvedValue([]);
+      staffingMock.getRequest.mockResolvedValue({ roleRequired: 'EDE', canton: 'GE' });
+      // Handler accepts 'staffingRequestId' or 'requestId' aliases
+      mockLlmOnce({ message: 'Fetching.', toolCall: { name: 'view_match_results', args: { staffingRequestId: 'sr-42', requestId: 'sr-42' } } });
+      mockLlmOnce({ message: 'No matches yet.', toolCall: null });
+
+      await service.run({ conversationId: CONVERSATION_ID, userMessage: 'matches for sr-42', principal: FOUNDATION_PRINCIPAL, locale: 'en', sendEvent });
+
+      // The handler should have resolved the request ID and called both methods
+      const getMatchesCalls = staffingMock.getMatches.mock.calls;
+      expect(getMatchesCalls.some((c: unknown[]) => c[0] === 'sr-42')).toBe(true);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Phase 2: remaining L3 confirm paths
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('Phase 2 — shortlist_candidate confirm', () => {
+    it('saves candidate shortlist via RecruitmentService on confirm', async () => {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-1' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-20',
+        conversationId: CONVERSATION_ID,
+        toolName: 'shortlist_candidate',
+        status: 'AWAITING_APPROVAL',
+        inputJson: { candidateId: 'user-99', jobListingId: 'job-1' },
+      });
+      await makeService(prisma);
+
+      const result = await service.confirmToolCall('tc-20', FOUNDATION_PRINCIPAL, 'en');
+
+      // Handler calls saveCandidate(foundationId, candidateId)
+      expect(recruitmentMock.saveCandidate).toHaveBeenCalledWith(
+        FOUNDATION_PRINCIPAL.organizationId,
+        'user-99',
+      );
+      expect(result.error).toBeUndefined();
+      expect(prisma.aIToolCall.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ status: 'EXECUTED' }) }),
+      );
+    });
+  });
+
+  describe('Phase 2 — respond_to_lead confirm', () => {
+    it('calls LeadsService.respondToLead on confirm', async () => {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-1' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-21',
+        conversationId: CONVERSATION_ID,
+        toolName: 'respond_to_lead',
+        status: 'AWAITING_APPROVAL',
+        inputJson: { leadId: 'lead-1', message: 'We have a spot available' },
+      });
+      await makeService(prisma);
+
+      const result = await service.confirmToolCall('tc-21', FOUNDATION_PRINCIPAL, 'en');
+
+      // Handler calls respondToLead(leadId, foundationId, status, message)
+      expect(leadsMock.respondToLead).toHaveBeenCalledWith(
+        'lead-1',
+        FOUNDATION_PRINCIPAL.organizationId,
+        expect.any(String),
+        'We have a spot available',
+      );
+      expect(result.error).toBeUndefined();
+    });
+  });
+
+  describe('Phase 2 — place_order confirm', () => {
+    it('creates an order via MarketplaceService on confirm', async () => {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-1' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-22',
+        conversationId: CONVERSATION_ID,
+        toolName: 'place_order',
+        status: 'AWAITING_APPROVAL',
+        inputJson: { productId: 'prod-1', quantity: 2 },
+      });
+      await makeService(prisma);
+
+      const result = await service.confirmToolCall('tc-22', FOUNDATION_PRINCIPAL, 'en');
+
+      // Handler resolves items from args and calls createOrder({ items, notes }, organizationId)
+      expect(marketplaceMock.createOrder).toHaveBeenCalledWith(
+        expect.objectContaining({ items: [expect.objectContaining({ productId: 'prod-1', quantity: 2 })] }),
+        FOUNDATION_PRINCIPAL.organizationId,
+      );
+      expect(result.error).toBeUndefined();
+    });
+  });
+
+  describe('Phase 2 — request_service confirm', () => {
+    it('creates a service request via MarketplaceService on confirm', async () => {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-1' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-23',
+        conversationId: CONVERSATION_ID,
+        toolName: 'request_service',
+        status: 'AWAITING_APPROVAL',
+        inputJson: { serviceId: 'svc-1', description: 'ASAP please' },
+      });
+      await makeService(prisma);
+
+      const result = await service.confirmToolCall('tc-23', FOUNDATION_PRINCIPAL, 'en');
+
+      // Handler calls createServiceRequest(organizationId, serviceId, description, scheduledAt)
+      expect(marketplaceMock.createServiceRequest).toHaveBeenCalledWith(
+        FOUNDATION_PRINCIPAL.organizationId,
+        'svc-1',
+        'ASAP please',
+        undefined,
+      );
+      expect(result.error).toBeUndefined();
+    });
+  });
+
+  describe('Phase 2 — send_supplier_inquiry confirm', () => {
+    it('creates an inquiry via InquiryService on confirm', async () => {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-1' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-24',
+        conversationId: CONVERSATION_ID,
+        toolName: 'send_supplier_inquiry',
+        status: 'AWAITING_APPROVAL',
+        inputJson: { supplierId: 'org-5', subject: 'Bulk pricing', message: 'Do you offer bulk discounts?' },
+      });
+      await makeService(prisma);
+
+      const result = await service.confirmToolCall('tc-24', FOUNDATION_PRINCIPAL, 'en');
+
+      // Handler calls createInquiry({ supplierId, message, subject, ... }, buyerOrgId)
+      expect(inquiryMock.createInquiry).toHaveBeenCalledWith(
+        expect.objectContaining({ subject: 'Bulk pricing', message: 'Do you offer bulk discounts?' }),
+        FOUNDATION_PRINCIPAL.organizationId,
+      );
+      expect(result.error).toBeUndefined();
+    });
+  });
+
+  describe('Phase 2 — create_replacement_request confirm', () => {
+    it('creates a replacement request via ReplacementsService on confirm', async () => {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-1' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-25',
+        conversationId: CONVERSATION_ID,
+        toolName: 'create_replacement_request',
+        status: 'AWAITING_APPROVAL',
+        inputJson: { role: 'EDE', startDate: '2026-06-10', urgency: 'URGENT', reason: 'Sick leave' },
+      });
+      await makeService(prisma);
+
+      const result = await service.confirmToolCall('tc-25', FOUNDATION_PRINCIPAL, 'en');
+
+      expect(replacementsMock.createRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ urgency: 'URGENT' }),
+        FOUNDATION_PRINCIPAL.organizationId,
+        FOUNDATION_PRINCIPAL.userId,
+      );
+      expect(result.error).toBeUndefined();
+    });
+
+    it('rejects create_replacement_request with an invalid urgency value', async () => {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-1' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-26',
+        conversationId: CONVERSATION_ID,
+        toolName: 'create_replacement_request',
+        status: 'AWAITING_APPROVAL',
+        inputJson: { role: 'EDE', startDate: '2026-06-10', urgency: 'HIGH', reason: 'Test' },
+      });
+      await makeService(prisma);
+
+      const result = await service.confirmToolCall('tc-26', FOUNDATION_PRINCIPAL, 'en');
+
+      expect(result.error).toBeDefined();
+      expect(replacementsMock.createRequest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Phase 2 — update_application_status enum validation', () => {
+    it('rejects an unrecognised status string', async () => {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-1' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-27',
+        conversationId: CONVERSATION_ID,
+        toolName: 'update_application_status',
+        status: 'AWAITING_APPROVAL',
+        inputJson: { applicationId: 'app-1', status: 'approved' },
+      });
+      (prisma.jobApplication as any).findUnique = jest.fn().mockResolvedValue({ jobListing: { foundationId: 'org-1' } });
+      await makeService(prisma);
+
+      const result = await service.confirmToolCall('tc-27', FOUNDATION_PRINCIPAL, 'en');
+
+      expect(result.error).toBeDefined();
+      expect(recruitmentMock.updateJobApplication).not.toHaveBeenCalled();
+    });
+
+    it('accepts case-insensitive status (shortlisted → SHORTLISTED)', async () => {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-1' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-28',
+        conversationId: CONVERSATION_ID,
+        toolName: 'update_application_status',
+        status: 'AWAITING_APPROVAL',
+        inputJson: { applicationId: 'app-1', status: 'shortlisted' },
+      });
+      (prisma.jobApplication as any).findUnique = jest.fn().mockResolvedValue({ jobListing: { foundationId: 'org-1' } });
+      await makeService(prisma);
+
+      const result = await service.confirmToolCall('tc-28', FOUNDATION_PRINCIPAL, 'en');
+
+      expect(result.error).toBeUndefined();
+      expect(recruitmentMock.updateJobApplication).toHaveBeenCalledWith('app-1', { status: 'SHORTLISTED' });
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Phase 4: rejectToolCall
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('rejectToolCall', () => {
+    it('marks an AWAITING_APPROVAL tool call as REJECTED without executing the handler', async () => {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-1' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-r1',
+        conversationId: CONVERSATION_ID,
+        toolName: 'post_job',
+        status: 'AWAITING_APPROVAL',
+        inputJson: { role: 'EDE', percentage: 80, location: 'Genève' },
+      });
+      await makeService(prisma);
+
+      await service.rejectToolCall('tc-r1', FOUNDATION_PRINCIPAL);
+
+      expect(prisma.aIToolCall.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ status: 'REJECTED' }) }),
+      );
+      expect(recruitmentMock.createJobListing).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Tool registry completeness
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('Tool registry', () => {
+    const NO_FLAGS = new Set<string>();
+
+    it('exposes 35 tool definitions across all roles', () => {
+      const allRoles = [
+        UserRole.FOUNDATION,
+        UserRole.EDUCATOR,
+        UserRole.PARENT,
+        UserRole.PRODUCT_SUPPLIER,
+        UserRole.SERVICE_PROVIDER,
+        UserRole.ADMIN,
+        UserRole.SUPER_ADMIN,
+      ];
+      const allToolNames = new Set<string>();
+      for (const role of allRoles) {
+        for (const tool of getToolsForRole(role, NO_FLAGS)) {
+          allToolNames.add(tool.name);
+        }
+      }
+      expect(allToolNames.size).toBe(35);
+    });
+
+    it('every role-exposed tool has a registered handler', async () => {
+      const allRoles = [
+        UserRole.FOUNDATION,
+        UserRole.EDUCATOR,
+        UserRole.PARENT,
+        UserRole.PRODUCT_SUPPLIER,
+        UserRole.SERVICE_PROVIDER,
+        UserRole.ADMIN,
+        UserRole.SUPER_ADMIN,
+      ];
+      const registry = (service as any).registry as ToolHandlerRegistry;
+      for (const role of allRoles) {
+        for (const tool of getToolsForRole(role, NO_FLAGS)) {
+          expect(registry.has(tool.name)).toBe(true);
+        }
+      }
+    });
+
+    it('all L3 tools are included in the universal tool list (send_message, contact_admin)', () => {
+      const universalTools = getToolsForRole(UserRole.FOUNDATION, NO_FLAGS).map((t) => t.name);
+      expect(universalTools).toContain('send_message');
+      expect(universalTools).toContain('contact_admin');
+    });
+
+    it('admin-only tools are not exposed to EDUCATOR', () => {
+      const educatorTools = getToolsForRole(UserRole.EDUCATOR, NO_FLAGS).map((t) => t.name);
+      expect(educatorTools).not.toContain('find_user');
+      expect(educatorTools).not.toContain('get_platform_stats');
+    });
+
+    it('educator-only tools are not exposed to PARENT', () => {
+      const parentTools = getToolsForRole(UserRole.PARENT, NO_FLAGS).map((t) => t.name);
+      expect(parentTools).not.toContain('apply_to_job');
+      expect(parentTools).not.toContain('get_my_applications');
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Cross-role security checks
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('Cross-role authorization', () => {
+    it('confirmToolCall rejects when conversation belongs to a different user', async () => {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-DIFFERENT' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-sec1',
+        conversationId: CONVERSATION_ID,
+        toolName: 'post_job',
+        status: 'AWAITING_APPROVAL',
+        inputJson: { role: 'EDE' },
+      });
+      await makeService(prisma);
+
+      await expect(service.confirmToolCall('tc-sec1', FOUNDATION_PRINCIPAL, 'en')).rejects.toThrow();
+    });
+
+    it('confirmToolCall returns existing result when status is already EXECUTED (idempotent)', async () => {
+      const storedOutput = { data: { id: 'job-1' }, total: 1 };
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-1' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-sec2',
+        conversationId: CONVERSATION_ID,
+        toolName: 'post_job',
+        status: 'EXECUTED',
+        outputJson: storedOutput,
+        inputJson: { role: 'EDE' },
+      });
+      await makeService(prisma);
+
+      const result = await service.confirmToolCall('tc-sec2', FOUNDATION_PRINCIPAL, 'en');
+
+      // Returns early with stored output — does not re-execute
+      expect(result.result).toEqual(storedOutput);
+      expect(recruitmentMock.createJobListing).not.toHaveBeenCalled();
+    });
+
+    it('confirmToolCall throws when status is REJECTED (cannot re-confirm)', async () => {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-1' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-sec3',
+        conversationId: CONVERSATION_ID,
+        toolName: 'post_job',
+        status: 'REJECTED',
+        inputJson: { role: 'EDE' },
+      });
+      await makeService(prisma);
+
+      await expect(service.confirmToolCall('tc-sec3', FOUNDATION_PRINCIPAL, 'en')).rejects.toThrow();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Per-role welcome chips — frontend constant validation
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('Per-role welcome suggestions', () => {
+    // These are checked by importing the data directly from the compiled source.
+    it('AssistantPanel exports suggestions for all 7 roles', async () => {
+      const fs = await import('fs');
+      const path = await import('path');
+      const panelSrc = fs.readFileSync(
+        path.join(__dirname, '../../..', 'frontend/components/assistant/AssistantPanel.tsx'),
+        'utf8',
+      );
+      const roles = ['FOUNDATION', 'EDUCATOR', 'PARENT', 'PRODUCT_SUPPLIER', 'SERVICE_PROVIDER', 'ADMIN', 'SUPER_ADMIN'];
+      for (const role of roles) {
+        expect(panelSrc).toContain(role);
+      }
+    });
+
+    it('translation files contain welcome keys for every role (en)', async () => {
+      const fs = await import('fs');
+      const path = await import('path');
+      const en = JSON.parse(
+        fs.readFileSync(
+          path.join(__dirname, '../../..', 'packages/translations/locales/en/assistant.json'),
+          'utf8',
+        ),
+      ) as Record<string, unknown>;
+
+      expect(en).toHaveProperty('welcome');
+      const welcome = en.welcome as Record<string, unknown>;
+      const expectedRoleKeys = ['foundation', 'educator', 'parent', 'supplier', 'serviceProvider', 'admin'];
+      for (const key of expectedRoleKeys) {
+        expect(welcome).toHaveProperty(key);
+      }
+    });
+
+    it('translation files have parity across en/fr/de (96 keys each)', async () => {
+      const fs = await import('fs');
+      const path = await import('path');
+      const countKeys = (obj: unknown): number => {
+        if (!obj || typeof obj !== 'object') return 1;
+        return Object.values(obj).reduce<number>((acc, v) => acc + countKeys(v), 0);
+      };
+      const base = path.join(__dirname, '../../..', 'packages/translations/locales');
+      const counts = ['en', 'fr', 'de'].map((l) =>
+        countKeys(JSON.parse(fs.readFileSync(path.join(base, l, 'assistant.json'), 'utf8'))),
+      );
+      expect(counts[0]).toBe(96);
+      expect(counts.every((c) => c === counts[0])).toBe(true);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // RESULT_CARD_TOOLS + TOOL_STATUS_LABELS consistency
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('RESULT_CARD_TOOLS / TOOL_STATUS_LABELS sync', () => {
+    it('every RESULT_CARD_TOOL has a TOOL_STATUS_LABEL', async () => {
+      const fs = await import('fs');
+      const path = await import('path');
+      const src = fs.readFileSync(
+        path.join(__dirname, 'orchestrator.service.ts'),
+        'utf8',
+      );
+
+      const resultCardMatch = src.match(/RESULT_CARD_TOOLS = new Set<string>\(\[([\s\S]*?)\]\)/);
+      expect(resultCardMatch).not.toBeNull();
+      const resultCardTools = (resultCardMatch![1].match(/'([^']+)'/g) ?? []).map((s) => s.replace(/'/g, ''));
+
+      const statusLabelsMatch = src.match(/TOOL_STATUS_LABELS: Record<string, string> = \{([\s\S]*?)\}/);
+      expect(statusLabelsMatch).not.toBeNull();
+      const statusLabelKeys = (statusLabelsMatch![1].match(/^\s+(\w+):/gm) ?? []).map((s) => s.trim().replace(':', ''));
+
+      for (const tool of resultCardTools) {
+        expect(statusLabelKeys).toContain(tool);
+      }
+    });
+
+    it('frontend ResultCards.tsx lists the same result-card tools as the backend', async () => {
+      const fs = await import('fs');
+      const path = await import('path');
+
+      const backendSrc = fs.readFileSync(path.join(__dirname, 'orchestrator.service.ts'), 'utf8');
+      const frontendSrc = fs.readFileSync(
+        path.join(__dirname, '../../..', 'frontend/components/assistant/ResultCards.tsx'),
+        'utf8',
+      );
+
+      const extract = (src: string) => {
+        const m = src.match(/RESULT_CARD_TOOLS[^=]*=.*?new Set[^(]*\(\[([\s\S]*?)\]\)/);
+        if (!m) return new Set<string>();
+        return new Set<string>((m[1].match(/'([^']+)'/g) ?? []).map((s) => s.replace(/'/g, '')));
+      };
+
+      const backendSet = extract(backendSrc);
+      const frontendSet = extract(frontendSrc);
+
+      expect(backendSet.size).toBeGreaterThan(0);
+      for (const tool of backendSet) {
+        expect(frontendSet).toContain(tool);
+      }
+    });
+  });
+});

--- a/api/src/assistant/assistant.module.ts
+++ b/api/src/assistant/assistant.module.ts
@@ -10,6 +10,10 @@ import { StaffingModule } from '../staffing/staffing.module';
 import { RecruitmentModule } from '../recruitment/recruitment.module';
 import { MarketplaceModule } from '../marketplace/marketplace.module';
 import { SupportModule } from '../support/support.module';
+import { LeadsModule } from '../leads/leads.module';
+import { MessagingModule } from '../messaging/messaging.module';
+import { ReplacementsModule } from '../replacements/replacements.module';
+import { UsersModule } from '../users/users.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { ToolHandlerRegistry } from './tools/tool-handler.registry';
 import { ProfileHandler } from './tools/handlers/profile.handler';
@@ -20,6 +24,12 @@ import { StaffingHandler } from './tools/handlers/staffing.handler';
 import { SupportHandler } from './tools/handlers/support.handler';
 import { SearchHandler } from './tools/handlers/search.handler';
 import { DraftsHandler } from './tools/handlers/drafts.handler';
+import { RecruitmentWriteHandler } from './tools/handlers/recruitment-write.handler';
+import { LeadsWriteHandler } from './tools/handlers/leads-write.handler';
+import { MarketplaceWriteHandler } from './tools/handlers/marketplace-write.handler';
+import { MessagingHandler } from './tools/handlers/messaging.handler';
+import { ReplacementsHandler } from './tools/handlers/replacements.handler';
+import { AdminHandler } from './tools/handlers/admin.handler';
 
 @Module({
   imports: [
@@ -29,6 +39,10 @@ import { DraftsHandler } from './tools/handlers/drafts.handler';
     RecruitmentModule,
     MarketplaceModule,
     SupportModule,
+    LeadsModule,
+    MessagingModule,
+    ReplacementsModule,
+    UsersModule,
   ],
   controllers: [AssistantController],
   providers: [
@@ -47,6 +61,12 @@ import { DraftsHandler } from './tools/handlers/drafts.handler';
     SupportHandler,
     SearchHandler,
     DraftsHandler,
+    RecruitmentWriteHandler,
+    LeadsWriteHandler,
+    MarketplaceWriteHandler,
+    MessagingHandler,
+    ReplacementsHandler,
+    AdminHandler,
   ],
   exports: [AssistantService],
 })

--- a/api/src/assistant/orchestrator.service.spec.ts
+++ b/api/src/assistant/orchestrator.service.spec.ts
@@ -13,6 +13,12 @@ import { StaffingHandler } from './tools/handlers/staffing.handler';
 import { SupportHandler } from './tools/handlers/support.handler';
 import { SearchHandler } from './tools/handlers/search.handler';
 import { DraftsHandler } from './tools/handlers/drafts.handler';
+import { RecruitmentWriteHandler } from './tools/handlers/recruitment-write.handler';
+import { LeadsWriteHandler } from './tools/handlers/leads-write.handler';
+import { MarketplaceWriteHandler } from './tools/handlers/marketplace-write.handler';
+import { MessagingHandler } from './tools/handlers/messaging.handler';
+import { ReplacementsHandler } from './tools/handlers/replacements.handler';
+import { AdminHandler } from './tools/handlers/admin.handler';
 
 const FOUNDATION_PRINCIPAL = { userId: 'user-1', role: UserRole.FOUNDATION, organizationId: 'org-1' };
 const EDUCATOR_PRINCIPAL = { userId: 'user-2', role: UserRole.EDUCATOR, organizationId: undefined };
@@ -39,7 +45,8 @@ function mockPrisma() {
       findUnique: jest.fn().mockResolvedValue({ explanation: 'Good fit', totalScore: 88 }),
     },
     user: {
-      findUnique: jest.fn().mockResolvedValue({ firstName: 'Alice', lastName: 'Martin', approvalStatus: null }),
+      findUnique: jest.fn().mockResolvedValue({ firstName: 'Alice', lastName: 'Martin', approvalStatus: null, email: 'alice@x.ch' }),
+      count: jest.fn().mockResolvedValue(42),
     },
     parentLead: {
       count: jest.fn().mockResolvedValue(3),
@@ -103,8 +110,25 @@ describe('OrchestratorService', () => {
     getMatches: jest.Mock;
     getRequest: jest.Mock;
   };
-  let recruitmentMock: { findAllCandidates: jest.Mock; findAllJobListings: jest.Mock };
-  let marketplaceMock: { findAllProducts: jest.Mock; findAllServices: jest.Mock };
+  let recruitmentMock: {
+    findAllCandidates: jest.Mock;
+    findAllJobListings: jest.Mock;
+    createJobListing: jest.Mock;
+    createJobApplication: jest.Mock;
+    saveCandidate: jest.Mock;
+    updateJobApplication: jest.Mock;
+  };
+  let marketplaceMock: {
+    findAllProducts: jest.Mock;
+    findAllServices: jest.Mock;
+    createOrder: jest.Mock;
+    createServiceRequest: jest.Mock;
+  };
+  let inquiryMock: { createInquiry: jest.Mock };
+  let leadsMock: { respondToLead: jest.Mock; createParentLead: jest.Mock };
+  let messagingMock: { createDirectMessage: jest.Mock };
+  let replacementsMock: { createRequest: jest.Mock };
+  let usersMock: { findAll: jest.Mock };
   let supportMock: { createTicket: jest.Mock };
   let embeddingMock: { isReady: boolean; searchSemantic: jest.Mock };
   let knowledgeMock: { search: jest.Mock; formatForPrompt: jest.Mock };
@@ -135,6 +159,12 @@ describe('OrchestratorService', () => {
         staffingMock as any,
       ),
       new DraftsHandler(),
+      new RecruitmentWriteHandler(recruitmentMock as any),
+      new LeadsWriteHandler(leadsMock as any, prismaImpl),
+      new MarketplaceWriteHandler(marketplaceMock as any, inquiryMock as any),
+      new MessagingHandler(messagingMock as any),
+      new ReplacementsHandler(replacementsMock as any),
+      new AdminHandler(usersMock as any, prismaImpl),
     );
   }
 
@@ -171,11 +201,25 @@ describe('OrchestratorService', () => {
     recruitmentMock = {
       findAllCandidates: jest.fn().mockResolvedValue([]),
       findAllJobListings: jest.fn().mockResolvedValue([]),
+      createJobListing: jest.fn().mockResolvedValue({ id: 'job-1', title: 'EDE 80%', status: 'PUBLISHED', location: 'Genève' }),
+      createJobApplication: jest.fn().mockResolvedValue({ id: 'app-1', status: 'PENDING' }),
+      saveCandidate: jest.fn().mockResolvedValue({ id: 'saved-1' }),
+      updateJobApplication: jest.fn().mockResolvedValue({ id: 'app-1', status: 'SHORTLISTED' }),
     };
     marketplaceMock = {
       findAllProducts: jest.fn().mockResolvedValue([]),
       findAllServices: jest.fn().mockResolvedValue([]),
+      createOrder: jest.fn().mockResolvedValue({ id: 'order-1', totalAmount: 120, status: 'PENDING' }),
+      createServiceRequest: jest.fn().mockResolvedValue({ id: 'sreq-1', status: 'PENDING' }),
     };
+    inquiryMock = { createInquiry: jest.fn().mockResolvedValue({ id: 'inq-1' }) };
+    leadsMock = {
+      respondToLead: jest.fn().mockResolvedValue({ id: 'resp-1' }),
+      createParentLead: jest.fn().mockResolvedValue({ id: 'lead-1', status: 'NEW', foundationId: 'org-9' }),
+    };
+    messagingMock = { createDirectMessage: jest.fn().mockResolvedValue({ id: 'dm-1' }) };
+    replacementsMock = { createRequest: jest.fn().mockResolvedValue({ id: 'rr-1', status: 'OPEN' }) };
+    usersMock = { findAll: jest.fn().mockResolvedValue({ data: [{ id: 'u-1', profileId: 'p-1', name: 'Bob', email: 'b@x.ch', role: 'EDUCATOR', orgName: null }] }) };
     supportMock = { createTicket: jest.fn().mockResolvedValue({ id: 'ticket-1', status: 'OPEN' }) };
     await makeService();
   });
@@ -366,6 +410,111 @@ describe('OrchestratorService', () => {
       expect(result.result).toBeDefined();
       expect(prisma.aIToolCall.update).toHaveBeenCalledWith(
         expect.objectContaining({ data: expect.objectContaining({ status: 'EXECUTED' }) }),
+      );
+    });
+  });
+
+  // ── Phase 2: L3 write actions ─────────────────────────────────────────────
+
+  describe('L3 write actions', () => {
+    it('post_job stops and emits an approval card without executing', async () => {
+      mockLlmSequence({
+        message: "I'll publish this job posting.",
+        toolCall: { name: 'post_job', args: { role: 'EDE', percentage: 80, location: 'Genève' } },
+      });
+      await service.run({ conversationId: CONVERSATION_ID, userMessage: 'Post an EDE 80% job in Geneva', principal: FOUNDATION_PRINCIPAL, locale: 'fr', sendEvent });
+
+      expect(sendEvent).toHaveBeenCalledWith('tool_call', expect.objectContaining({
+        toolName: 'post_job',
+        approvalRequired: true,
+        level: 'L3_EXECUTE',
+      }));
+      expect(recruitmentMock.createJobListing).not.toHaveBeenCalled();
+    });
+
+    it('confirmToolCall executes post_job with the foundation org and marks EXECUTED', async () => {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-1' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-9',
+        conversationId: CONVERSATION_ID,
+        toolName: 'post_job',
+        status: 'AWAITING_APPROVAL',
+        inputJson: { role: 'EDE', percentage: 80, location: 'Genève' },
+      });
+      await makeService(prisma);
+
+      const result = await service.confirmToolCall('tc-9', FOUNDATION_PRINCIPAL, 'fr');
+
+      expect(recruitmentMock.createJobListing).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'PUBLISHED' }),
+        FOUNDATION_PRINCIPAL.organizationId,
+      );
+      expect(result.result).toBeDefined();
+      expect(prisma.aIToolCall.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ status: 'EXECUTED' }) }),
+      );
+    });
+
+    it('send_message executes via MessagingService on confirm', async () => {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-1' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-10',
+        conversationId: CONVERSATION_ID,
+        toolName: 'send_message',
+        status: 'AWAITING_APPROVAL',
+        inputJson: { recipientUserId: 'user-77', content: 'Hello there' },
+      });
+      await makeService(prisma);
+
+      await service.confirmToolCall('tc-10', FOUNDATION_PRINCIPAL, 'fr');
+
+      expect(messagingMock.createDirectMessage).toHaveBeenCalledWith('user-1', 'user-77', 'Hello there');
+    });
+
+    it('apply_to_job uses the educator userId as candidate on confirm', async () => {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-2' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-11',
+        conversationId: CONVERSATION_ID,
+        toolName: 'apply_to_job',
+        status: 'AWAITING_APPROVAL',
+        inputJson: { jobListingId: 'job-55' },
+      });
+      await makeService(prisma);
+
+      await service.confirmToolCall('tc-11', EDUCATOR_PRINCIPAL, 'fr');
+
+      expect(recruitmentMock.createJobApplication).toHaveBeenCalledWith(
+        expect.objectContaining({ jobListingId: 'job-55' }),
+        EDUCATOR_PRINCIPAL.userId,
+      );
+    });
+  });
+
+  // ── Phase 3: admin completeness tools ─────────────────────────────────────
+
+  describe('admin tools', () => {
+    const ADMIN_PRINCIPAL = { userId: 'admin-1', role: UserRole.ADMIN, organizationId: undefined };
+
+    it('get_platform_stats aggregates counts', async () => {
+      mockLlmSequence(
+        { message: 'Fetching stats.', toolCall: { name: 'get_platform_stats', args: {} } },
+        { message: 'Here are the platform stats.', toolCall: null },
+      );
+      await service.run({ conversationId: CONVERSATION_ID, userMessage: 'platform stats', principal: ADMIN_PRINCIPAL, locale: 'en', sendEvent });
+      expect(prisma.user.count).toHaveBeenCalled();
+      expect(prisma.parentLead.count).toHaveBeenCalled();
+      expect(prisma.jobApplication.count).toHaveBeenCalled();
+    });
+
+    it('find_user queries UsersService.findAll', async () => {
+      mockLlmSequence(
+        { message: 'Searching users.', toolCall: { name: 'find_user', args: { search: 'bob' } } },
+        { message: 'Found 1 user.', toolCall: null },
+      );
+      await service.run({ conversationId: CONVERSATION_ID, userMessage: 'find user bob', principal: ADMIN_PRINCIPAL, locale: 'en', sendEvent });
+      expect(usersMock.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({ search: 'bob', page: 1 }),
       );
     });
   });

--- a/api/src/assistant/orchestrator.service.spec.ts
+++ b/api/src/assistant/orchestrator.service.spec.ts
@@ -68,6 +68,8 @@ function mockPrisma() {
       findMany: jest.fn().mockResolvedValue([
         { id: 'app-1', status: 'PENDING', createdAt: new Date(), jobListing: { title: 'EDE 80%', location: 'Lausanne', contractType: 'CDI' } },
       ]),
+      // Default: the application belongs to the foundation principal's org (org-1).
+      findUnique: jest.fn().mockResolvedValue({ jobListing: { foundationId: 'org-1' } }),
     },
     product: {
       count: jest.fn().mockResolvedValue(5),
@@ -159,7 +161,7 @@ describe('OrchestratorService', () => {
         staffingMock as any,
       ),
       new DraftsHandler(),
-      new RecruitmentWriteHandler(recruitmentMock as any),
+      new RecruitmentWriteHandler(recruitmentMock as any, prismaImpl),
       new LeadsWriteHandler(leadsMock as any, prismaImpl),
       new MarketplaceWriteHandler(marketplaceMock as any, inquiryMock as any),
       new MessagingHandler(messagingMock as any),
@@ -455,6 +457,25 @@ describe('OrchestratorService', () => {
       );
     });
 
+    it('submit_enquiry is rejected when no valid parent email is available', async () => {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-3' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-14',
+        conversationId: CONVERSATION_ID,
+        toolName: 'submit_enquiry',
+        status: 'AWAITING_APPROVAL',
+        inputJson: { childName: 'Léa', childAge: 2 },
+      });
+      // Parent profile has no email, and none supplied in args.
+      (prisma.user as any).findUnique = jest.fn().mockResolvedValue({ firstName: 'Pat', lastName: 'Doe', email: null });
+      await makeService(prisma);
+
+      const result = await service.confirmToolCall('tc-14', PARENT_PRINCIPAL, 'fr');
+
+      expect(result.error).toBeDefined();
+      expect(leadsMock.createParentLead).not.toHaveBeenCalled();
+    });
+
     it('send_message executes via MessagingService on confirm', async () => {
       prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-1' }) } as any;
       (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
@@ -469,6 +490,42 @@ describe('OrchestratorService', () => {
       await service.confirmToolCall('tc-10', FOUNDATION_PRINCIPAL, 'fr');
 
       expect(messagingMock.createDirectMessage).toHaveBeenCalledWith('user-1', 'user-77', 'Hello there');
+    });
+
+    it('update_application_status executes when the application belongs to the foundation', async () => {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-1' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-12',
+        conversationId: CONVERSATION_ID,
+        toolName: 'update_application_status',
+        status: 'AWAITING_APPROVAL',
+        inputJson: { applicationId: 'app-1', status: 'shortlisted' },
+      });
+      (prisma.jobApplication as any).findUnique = jest.fn().mockResolvedValue({ jobListing: { foundationId: 'org-1' } });
+      await makeService(prisma);
+
+      const result = await service.confirmToolCall('tc-12', FOUNDATION_PRINCIPAL, 'fr');
+
+      expect(recruitmentMock.updateJobApplication).toHaveBeenCalledWith('app-1', { status: 'SHORTLISTED' });
+      expect(result.error).toBeUndefined();
+    });
+
+    it('update_application_status is rejected when the application belongs to another foundation', async () => {
+      prisma.aIConversation = { findUnique: jest.fn().mockResolvedValue({ userId: 'user-1' }) } as any;
+      (prisma.aIToolCall as any).findUnique = jest.fn().mockResolvedValue({
+        id: 'tc-13',
+        conversationId: CONVERSATION_ID,
+        toolName: 'update_application_status',
+        status: 'AWAITING_APPROVAL',
+        inputJson: { applicationId: 'app-9', status: 'HIRED' },
+      });
+      (prisma.jobApplication as any).findUnique = jest.fn().mockResolvedValue({ jobListing: { foundationId: 'org-OTHER' } });
+      await makeService(prisma);
+
+      const result = await service.confirmToolCall('tc-13', FOUNDATION_PRINCIPAL, 'fr');
+
+      expect(result.error).toBeDefined();
+      expect(recruitmentMock.updateJobApplication).not.toHaveBeenCalled();
     });
 
     it('apply_to_job uses the educator userId as candidate on confirm', async () => {

--- a/api/src/assistant/orchestrator.service.ts
+++ b/api/src/assistant/orchestrator.service.ts
@@ -27,6 +27,8 @@ const MAX_TOOL_STEPS = 5;
 // Tools whose structured results the frontend renders as rich cards. For these
 // we emit tool_call + tool_result SSE events (in addition to feeding the result
 // back to the LLM so it can narrate a summary).
+// KEEP IN SYNC with RESULT_CARD_TOOLS in frontend/components/assistant/ResultCards.tsx
+// (which decides rendering) and TOOL_STATUS_LABELS below (running-status copy).
 const RESULT_CARD_TOOLS = new Set<string>([
   'search_candidates',
   'search_candidates_ai',

--- a/api/src/assistant/orchestrator.service.ts
+++ b/api/src/assistant/orchestrator.service.ts
@@ -35,7 +35,21 @@ const RESULT_CARD_TOOLS = new Set<string>([
   'search_jobs',
   'search_foundations',
   'find_foundation',
+  'view_match_results',
 ]);
+
+// Human-readable status shown while an L1 result-card tool is running, so the UI
+// can display "Searching candidates…" instead of a bare spinner (Phase 4).
+const TOOL_STATUS_LABELS: Record<string, string> = {
+  search_candidates: 'Searching candidates…',
+  search_candidates_ai: 'Matching candidates…',
+  search_products: 'Searching products…',
+  search_services: 'Searching services…',
+  search_jobs: 'Searching jobs…',
+  search_foundations: 'Searching foundations…',
+  find_foundation: 'Looking up the foundation…',
+  view_match_results: 'Fetching match results…',
+};
 
 @Injectable()
 export class OrchestratorService {
@@ -174,6 +188,14 @@ export class OrchestratorService {
           level,
           approvalRequired: false,
           args,
+        });
+        // Streaming execution status so the UI shows a meaningful label while the
+        // tool runs (Phase 4 reliability).
+        sendEvent('tool_status', {
+          toolCallId: toolCallRecord.id,
+          toolName,
+          status: 'running',
+          label: TOOL_STATUS_LABELS[toolName] ?? 'Working…',
         });
       }
 

--- a/api/src/assistant/tools/handlers/admin.handler.ts
+++ b/api/src/assistant/tools/handlers/admin.handler.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@nestjs/common';
+import { UserRole } from '@prisma/client';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { UsersService } from '../../../users/users.service';
+import {
+  AssistantPrincipal,
+  resolveLimit,
+  ToolHandler,
+  ToolResult,
+  ToolSuggestion,
+} from '../tool-handler.interface';
+
+const CONTACT_ADMIN: ToolSuggestion = {
+  label: 'File a support ticket for manual help',
+  actionType: 'contact_admin',
+};
+
+/**
+ * Admin-only read tools: user lookup and platform-wide stats. Used to answer
+ * operational questions and to resolve a user ID before messaging them.
+ */
+@Injectable()
+export class AdminHandler implements ToolHandler {
+  readonly toolNames = ['find_user', 'get_platform_stats'];
+
+  constructor(
+    private readonly users: UsersService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async execute(
+    toolName: string,
+    args: Record<string, unknown>,
+    _principal: AssistantPrincipal,
+  ): Promise<ToolResult> {
+    if (toolName === 'find_user') {
+      return this.findUser(args);
+    }
+    return this.getPlatformStats();
+  }
+
+  // ── find_user ─────────────────────────────────────────────────────────────
+  private async findUser(args: Record<string, unknown>): Promise<ToolResult> {
+    const limit = resolveLimit(args.limit);
+    const role = this.coerceRole(args.role);
+    const search = (args.search as string) || (args.query as string) || undefined;
+
+    const result = await this.users.findAll({ page: 1, limit, role, search });
+    const users = ((result as any)?.data ?? []).map((u: any) => ({
+      // profileId is the User.id used by messaging; expose it for send_message.
+      id: u.profileId ?? u.id,
+      name: u.name,
+      email: u.email,
+      role: u.role,
+      orgName: u.orgName ?? null,
+    }));
+    return {
+      data: { users },
+      total: users.length,
+      suggestions: users.length === 0 ? [CONTACT_ADMIN] : undefined,
+    };
+  }
+
+  private coerceRole(raw: unknown): UserRole | undefined {
+    if (typeof raw !== 'string') return undefined;
+    const upper = raw.toUpperCase();
+    return (Object.values(UserRole) as string[]).includes(upper) ? (upper as UserRole) : undefined;
+  }
+
+  // ── get_platform_stats ────────────────────────────────────────────────────
+  private async getPlatformStats(): Promise<ToolResult> {
+    const [activeUsers, openLeads, pendingApplications] = await Promise.all([
+      this.prisma.user.count({ where: { isActive: true } }),
+      this.prisma.parentLead.count({ where: { status: 'NEW' } }),
+      this.prisma.jobApplication.count({ where: { status: 'PENDING' } }),
+    ]);
+    return {
+      data: { activeUsers, openLeads, pendingApplications },
+      total: 1,
+      scope: 'platform-wide',
+    };
+  }
+}

--- a/api/src/assistant/tools/handlers/admin.handler.ts
+++ b/api/src/assistant/tools/handlers/admin.handler.ts
@@ -4,16 +4,11 @@ import { PrismaService } from '../../../prisma/prisma.service';
 import { UsersService } from '../../../users/users.service';
 import {
   AssistantPrincipal,
+  CONTACT_ADMIN_SUGGESTION as CONTACT_ADMIN,
   resolveLimit,
   ToolHandler,
   ToolResult,
-  ToolSuggestion,
 } from '../tool-handler.interface';
-
-const CONTACT_ADMIN: ToolSuggestion = {
-  label: 'File a support ticket for manual help',
-  actionType: 'contact_admin',
-};
 
 /**
  * Admin-only read tools: user lookup and platform-wide stats. Used to answer

--- a/api/src/assistant/tools/handlers/admin.handler.ts
+++ b/api/src/assistant/tools/handlers/admin.handler.ts
@@ -1,10 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { ForbiddenException, Injectable } from '@nestjs/common';
 import { UserRole } from '@prisma/client';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { UsersService } from '../../../users/users.service';
 import {
   AssistantPrincipal,
   CONTACT_ADMIN_SUGGESTION as CONTACT_ADMIN,
+  isAdminRole,
   resolveLimit,
   ToolHandler,
   ToolResult,
@@ -26,8 +27,14 @@ export class AdminHandler implements ToolHandler {
   async execute(
     toolName: string,
     args: Record<string, unknown>,
-    _principal: AssistantPrincipal,
+    principal: AssistantPrincipal,
   ): Promise<ToolResult> {
+    // Defense in depth: these tools are gated to ADMIN_ONLY in the tool registry,
+    // but enforce it here too so a future gating regression can't turn into a
+    // backend privilege escalation (platform-wide user search / stats).
+    if (!isAdminRole(principal.role)) {
+      throw new ForbiddenException('This action is restricted to administrators.');
+    }
     if (toolName === 'find_user') {
       return this.findUser(args);
     }

--- a/api/src/assistant/tools/handlers/leads-write.handler.ts
+++ b/api/src/assistant/tools/handlers/leads-write.handler.ts
@@ -14,6 +14,11 @@ const RESPONSE_STATUSES: LeadResponseStatus[] = [
   'ENROLLED',
 ];
 
+/** Minimal email sanity check (the DTO's @IsEmail is bypassed on this path). */
+function isValidEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
 /**
  * L3 lead write actions: a foundation responding to a parent lead, and a parent
  * submitting a new childcare enquiry. Both execute only after user confirmation.
@@ -79,7 +84,13 @@ export class LeadsWriteHandler implements ToolHandler {
       (args.parentName as string) ||
       `${user?.firstName ?? ''} ${user?.lastName ?? ''}`.trim() ||
       'Parent';
-    const parentEmail = (args.parentEmail as string) || user?.email || '';
+    // The handler bypasses the controller's ValidationPipe (@IsEmail on the DTO),
+    // and parentEmail is a NOT-NULL column — so validate here to avoid persisting
+    // an enquiry with a blank/garbage, unreachable email.
+    const parentEmail = ((args.parentEmail as string) || user?.email || '').trim();
+    if (!isValidEmail(parentEmail)) {
+      throw new Error('A valid parent email is required to submit an enquiry.');
+    }
 
     const childAge = args.childAge != null ? Number(args.childAge) : 0;
 

--- a/api/src/assistant/tools/handlers/leads-write.handler.ts
+++ b/api/src/assistant/tools/handlers/leads-write.handler.ts
@@ -3,6 +3,7 @@ import { LeadsService, LeadResponseStatus } from '../../../leads/leads.service';
 import { PrismaService } from '../../../prisma/prisma.service';
 import {
   AssistantPrincipal,
+  resolveOnBehalfOrgId,
   ToolHandler,
   ToolResult,
 } from '../tool-handler.interface';
@@ -48,7 +49,10 @@ export class LeadsWriteHandler implements ToolHandler {
     args: Record<string, unknown>,
     principal: AssistantPrincipal,
   ): Promise<ToolResult> {
-    const foundationId = (args.foundationId as string) || principal.organizationId;
+    // Pin to the caller's own org (admins may target another via find_foundation).
+    // The service authorises the lead against this foundationId, so it must not
+    // be spoofable from another tenant.
+    const foundationId = resolveOnBehalfOrgId(args, principal);
     if (!foundationId) {
       throw new Error('A foundationId is required to respond to a lead.');
     }

--- a/api/src/assistant/tools/handlers/leads-write.handler.ts
+++ b/api/src/assistant/tools/handlers/leads-write.handler.ts
@@ -1,0 +1,101 @@
+import { Injectable } from '@nestjs/common';
+import { LeadsService, LeadResponseStatus } from '../../../leads/leads.service';
+import { PrismaService } from '../../../prisma/prisma.service';
+import {
+  AssistantPrincipal,
+  ToolHandler,
+  ToolResult,
+} from '../tool-handler.interface';
+
+const RESPONSE_STATUSES: LeadResponseStatus[] = [
+  'INTERESTED',
+  'NOT_INTERESTED',
+  'NEEDS_MORE_INFO',
+  'ENROLLED',
+];
+
+/**
+ * L3 lead write actions: a foundation responding to a parent lead, and a parent
+ * submitting a new childcare enquiry. Both execute only after user confirmation.
+ */
+@Injectable()
+export class LeadsWriteHandler implements ToolHandler {
+  readonly toolNames = ['respond_to_lead', 'submit_enquiry'];
+
+  constructor(
+    private readonly leads: LeadsService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async execute(
+    toolName: string,
+    args: Record<string, unknown>,
+    principal: AssistantPrincipal,
+  ): Promise<ToolResult> {
+    if (toolName === 'respond_to_lead') {
+      return this.respondToLead(args, principal);
+    }
+    return this.submitEnquiry(args, principal);
+  }
+
+  // ── respond_to_lead (foundation) ──────────────────────────────────────────
+  private async respondToLead(
+    args: Record<string, unknown>,
+    principal: AssistantPrincipal,
+  ): Promise<ToolResult> {
+    const foundationId = (args.foundationId as string) || principal.organizationId;
+    if (!foundationId) {
+      throw new Error('A foundationId is required to respond to a lead.');
+    }
+    const leadId = (args.leadId as string) || (args.id as string);
+    if (!leadId) throw new Error('A leadId is required.');
+
+    const rawStatus = ((args.status as string) || 'INTERESTED').toUpperCase();
+    const status = (RESPONSE_STATUSES.includes(rawStatus as LeadResponseStatus)
+      ? rawStatus
+      : 'INTERESTED') as LeadResponseStatus;
+
+    const response = await this.leads.respondToLead(
+      leadId,
+      foundationId,
+      status,
+      (args.message as string) || undefined,
+    );
+    return { data: { leadId, status, responseId: (response as any)?.id ?? null }, total: 1 };
+  }
+
+  // ── submit_enquiry (parent) ───────────────────────────────────────────────
+  private async submitEnquiry(
+    args: Record<string, unknown>,
+    principal: AssistantPrincipal,
+  ): Promise<ToolResult> {
+    // Fall back to the parent's own profile for identity fields they did not
+    // restate in chat, so they don't have to repeat their name/email.
+    const user = await this.prisma.user.findUnique({
+      where: { id: principal.userId },
+      select: { firstName: true, lastName: true, email: true },
+    });
+    const parentName =
+      (args.parentName as string) ||
+      `${user?.firstName ?? ''} ${user?.lastName ?? ''}`.trim() ||
+      'Parent';
+    const parentEmail = (args.parentEmail as string) || user?.email || '';
+
+    const childAge = args.childAge != null ? Number(args.childAge) : 0;
+
+    const lead = await this.leads.createParentLead({
+      parentName,
+      parentEmail,
+      parentPhone: (args.parentPhone as string) || undefined,
+      childName: (args.childName as string) || 'Child',
+      childAge: Number.isFinite(childAge) ? childAge : 0,
+      message: (args.message as string) || undefined,
+      preferredLocation: (args.preferredLocation as string) || (args.location as string) || undefined,
+      foundationId: (args.foundationId as string) || undefined,
+    });
+    return {
+      data: { id: lead.id, status: lead.status, foundationId: lead.foundationId ?? null },
+      total: 1,
+    };
+  }
+}

--- a/api/src/assistant/tools/handlers/marketplace-write.handler.ts
+++ b/api/src/assistant/tools/handlers/marketplace-write.handler.ts
@@ -3,6 +3,7 @@ import { MarketplaceService } from '../../../marketplace/marketplace.service';
 import { InquiryService } from '../../../marketplace/inquiry.service';
 import {
   AssistantPrincipal,
+  resolveOnBehalfOrgId,
   ToolHandler,
   ToolResult,
 } from '../tool-handler.interface';
@@ -42,7 +43,7 @@ export class MarketplaceWriteHandler implements ToolHandler {
     args: Record<string, unknown>,
     principal: AssistantPrincipal,
   ): Promise<ToolResult> {
-    const organizationId = (args.organizationId as string) || principal.organizationId;
+    const organizationId = resolveOnBehalfOrgId(args, principal);
     if (!organizationId) {
       throw new Error('An organization is required to place an order.');
     }
@@ -77,7 +78,7 @@ export class MarketplaceWriteHandler implements ToolHandler {
     args: Record<string, unknown>,
     principal: AssistantPrincipal,
   ): Promise<ToolResult> {
-    const organizationId = (args.organizationId as string) || principal.organizationId;
+    const organizationId = resolveOnBehalfOrgId(args, principal);
     if (!organizationId) {
       throw new Error('An organization is required to request a service.');
     }
@@ -99,7 +100,7 @@ export class MarketplaceWriteHandler implements ToolHandler {
     args: Record<string, unknown>,
     principal: AssistantPrincipal,
   ): Promise<ToolResult> {
-    const buyerOrgId = (args.organizationId as string) || principal.organizationId;
+    const buyerOrgId = resolveOnBehalfOrgId(args, principal);
     if (!buyerOrgId) {
       throw new Error('An organization is required to send a supplier inquiry.');
     }

--- a/api/src/assistant/tools/handlers/marketplace-write.handler.ts
+++ b/api/src/assistant/tools/handlers/marketplace-write.handler.ts
@@ -1,0 +1,123 @@
+import { Injectable } from '@nestjs/common';
+import { MarketplaceService } from '../../../marketplace/marketplace.service';
+import { InquiryService } from '../../../marketplace/inquiry.service';
+import {
+  AssistantPrincipal,
+  ToolHandler,
+  ToolResult,
+} from '../tool-handler.interface';
+
+/**
+ * L3 marketplace write actions: placing product orders, requesting services, and
+ * sending formal supplier inquiries. Each executes only after user confirmation.
+ */
+@Injectable()
+export class MarketplaceWriteHandler implements ToolHandler {
+  readonly toolNames = ['place_order', 'request_service', 'send_supplier_inquiry'];
+
+  constructor(
+    private readonly marketplace: MarketplaceService,
+    private readonly inquiry: InquiryService,
+  ) {}
+
+  async execute(
+    toolName: string,
+    args: Record<string, unknown>,
+    principal: AssistantPrincipal,
+  ): Promise<ToolResult> {
+    switch (toolName) {
+      case 'place_order':
+        return this.placeOrder(args, principal);
+      case 'request_service':
+        return this.requestService(args, principal);
+      case 'send_supplier_inquiry':
+        return this.sendSupplierInquiry(args, principal);
+      default:
+        throw new Error(`MarketplaceWriteHandler cannot handle tool "${toolName}"`);
+    }
+  }
+
+  // ── place_order ───────────────────────────────────────────────────────────
+  private async placeOrder(
+    args: Record<string, unknown>,
+    principal: AssistantPrincipal,
+  ): Promise<ToolResult> {
+    const organizationId = (args.organizationId as string) || principal.organizationId;
+    if (!organizationId) {
+      throw new Error('An organization is required to place an order.');
+    }
+    const items = this.resolveOrderItems(args);
+    if (items.length === 0) {
+      throw new Error('At least one product (with quantity) is required to place an order.');
+    }
+    const order = await this.marketplace.createOrder(
+      { items, notes: (args.notes as string) || undefined },
+      organizationId,
+    );
+    return {
+      data: { id: order.id, totalAmount: (order as any).totalAmount ?? null, status: order.status },
+      total: 1,
+    };
+  }
+
+  /** Accept either a single productId+quantity or an items[] array. */
+  private resolveOrderItems(args: Record<string, unknown>): { productId: string; quantity: number }[] {
+    if (Array.isArray(args.items)) {
+      return (args.items as any[])
+        .filter((i) => i && i.productId)
+        .map((i) => ({ productId: String(i.productId), quantity: Math.max(1, Number(i.quantity) || 1) }));
+    }
+    const productId = (args.productId as string) || undefined;
+    if (!productId) return [];
+    return [{ productId, quantity: Math.max(1, Number(args.quantity) || 1) }];
+  }
+
+  // ── request_service ───────────────────────────────────────────────────────
+  private async requestService(
+    args: Record<string, unknown>,
+    principal: AssistantPrincipal,
+  ): Promise<ToolResult> {
+    const organizationId = (args.organizationId as string) || principal.organizationId;
+    if (!organizationId) {
+      throw new Error('An organization is required to request a service.');
+    }
+    const serviceId = (args.serviceId as string) || (args.id as string);
+    if (!serviceId) throw new Error('A serviceId is required.');
+
+    const scheduledAt = args.scheduledAt ? new Date(args.scheduledAt as string) : undefined;
+    const request = await this.marketplace.createServiceRequest(
+      organizationId,
+      serviceId,
+      (args.description as string) || undefined,
+      scheduledAt && !isNaN(scheduledAt.getTime()) ? scheduledAt : undefined,
+    );
+    return { data: { id: request.id, status: request.status, serviceId }, total: 1 };
+  }
+
+  // ── send_supplier_inquiry ─────────────────────────────────────────────────
+  private async sendSupplierInquiry(
+    args: Record<string, unknown>,
+    principal: AssistantPrincipal,
+  ): Promise<ToolResult> {
+    const buyerOrgId = (args.organizationId as string) || principal.organizationId;
+    if (!buyerOrgId) {
+      throw new Error('An organization is required to send a supplier inquiry.');
+    }
+    const supplierId = (args.supplierId as string) || undefined;
+    const message = (args.message as string) || undefined;
+    if (!supplierId) throw new Error('A supplierId is required.');
+    if (!message) throw new Error('An inquiry message is required.');
+
+    const created = await this.inquiry.createInquiry(
+      {
+        supplierId,
+        message,
+        subject: (args.subject as string) || undefined,
+        productInterest: (args.productInterest as string) || undefined,
+        quantity: args.quantity != null ? Number(args.quantity) : undefined,
+      },
+      buyerOrgId,
+    );
+    return { data: { id: (created as any).id, supplierId }, total: 1 };
+  }
+}

--- a/api/src/assistant/tools/handlers/messaging.handler.ts
+++ b/api/src/assistant/tools/handlers/messaging.handler.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { MessagingService } from '../../../messaging/messaging.service';
+import {
+  AssistantPrincipal,
+  ToolHandler,
+  ToolResult,
+} from '../tool-handler.interface';
+
+/**
+ * L3 messaging tool. Sends a direct message from the current user to another
+ * platform user. Universal — any role may message another user (e.g. an educator
+ * messaging a foundation, a parent messaging admin). Executes only after the user
+ * confirms.
+ */
+@Injectable()
+export class MessagingHandler implements ToolHandler {
+  readonly toolNames = ['send_message'];
+
+  constructor(private readonly messaging: MessagingService) {}
+
+  async execute(
+    _toolName: string,
+    args: Record<string, unknown>,
+    principal: AssistantPrincipal,
+  ): Promise<ToolResult> {
+    const receiverId = (args.recipientUserId as string) || (args.receiverId as string);
+    const content = (args.content as string) || (args.message as string) || '';
+    if (!receiverId) throw new Error('A recipient is required to send a message.');
+    if (!content.trim()) throw new Error('Message content is required.');
+
+    const message = await this.messaging.createDirectMessage(principal.userId, receiverId, content);
+    return {
+      data: { id: (message as any)?.id ?? null, receiverId },
+      total: 1,
+    };
+  }
+}

--- a/api/src/assistant/tools/handlers/recruitment-write.handler.ts
+++ b/api/src/assistant/tools/handlers/recruitment-write.handler.ts
@@ -1,8 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, ForbiddenException } from '@nestjs/common';
+import { ApplicationStatus } from '@prisma/client';
 import { RecruitmentService } from '../../../recruitment/recruitment.service';
+import { PrismaService } from '../../../prisma/prisma.service';
 import {
   AssistantPrincipal,
   isAdminRole,
+  resolveOnBehalfOrgId,
   ToolHandler,
   ToolResult,
 } from '../tool-handler.interface';
@@ -21,7 +24,10 @@ export class RecruitmentWriteHandler implements ToolHandler {
     'update_application_status',
   ];
 
-  constructor(private readonly recruitment: RecruitmentService) {}
+  constructor(
+    private readonly recruitment: RecruitmentService,
+    private readonly prisma: PrismaService,
+  ) {}
 
   async execute(
     toolName: string,
@@ -36,7 +42,7 @@ export class RecruitmentWriteHandler implements ToolHandler {
       case 'shortlist_candidate':
         return this.shortlistCandidate(args, principal);
       case 'update_application_status':
-        return this.updateApplicationStatus(args);
+        return this.updateApplicationStatus(args, principal);
       default:
         throw new Error(`RecruitmentWriteHandler cannot handle tool "${toolName}"`);
     }
@@ -49,9 +55,7 @@ export class RecruitmentWriteHandler implements ToolHandler {
   ): Promise<ToolResult> {
     // Admins may post on behalf of a foundation (resolve the ID with
     // find_foundation first); foundations post for their own org.
-    const foundationId =
-      (args.foundationId as string) ||
-      (!isAdminRole(principal.role) ? principal.organizationId : undefined);
+    const foundationId = resolveOnBehalfOrgId(args, principal);
     if (!foundationId) {
       throw new Error('A foundationId is required to post a job. Resolve it with find_foundation first.');
     }
@@ -127,12 +131,37 @@ export class RecruitmentWriteHandler implements ToolHandler {
   }
 
   // ── update_application_status (foundation) ────────────────────────────────
-  private async updateApplicationStatus(args: Record<string, unknown>): Promise<ToolResult> {
+  private async updateApplicationStatus(
+    args: Record<string, unknown>,
+    principal: AssistantPrincipal,
+  ): Promise<ToolResult> {
     const id = (args.applicationId as string) || (args.id as string);
-    const status = (args.status as string) || undefined;
+    const rawStatus = ((args.status as string) || '').toUpperCase();
     if (!id) throw new Error('An applicationId is required.');
-    if (!status) throw new Error('A target status is required.');
-    const updated = await this.recruitment.updateJobApplication(id, { status: status as any });
+    if (!rawStatus) throw new Error('A target status is required.');
+
+    const valid = Object.values(ApplicationStatus) as string[];
+    if (!valid.includes(rawStatus)) {
+      throw new Error(`Invalid application status "${rawStatus}". Must be one of: ${valid.join(', ')}.`);
+    }
+    const status = rawStatus as ApplicationStatus;
+
+    // Authorization: the service updates by ID with no scoping, so the handler
+    // must confirm the application belongs to the caller's foundation (admins
+    // may act on any). Without this a foundation could mutate another org's
+    // applications.
+    if (!isAdminRole(principal.role)) {
+      const application = await this.prisma.jobApplication.findUnique({
+        where: { id },
+        select: { jobListing: { select: { foundationId: true } } },
+      });
+      if (!application) throw new Error('Application not found.');
+      if (application.jobListing?.foundationId !== principal.organizationId) {
+        throw new ForbiddenException('You can only update applications for your own job listings.');
+      }
+    }
+
+    const updated = await this.recruitment.updateJobApplication(id, { status });
     return { data: { id, status: updated.status }, total: 1 };
   }
 }

--- a/api/src/assistant/tools/handlers/recruitment-write.handler.ts
+++ b/api/src/assistant/tools/handlers/recruitment-write.handler.ts
@@ -1,0 +1,138 @@
+import { Injectable } from '@nestjs/common';
+import { RecruitmentService } from '../../../recruitment/recruitment.service';
+import {
+  AssistantPrincipal,
+  isAdminRole,
+  ToolHandler,
+  ToolResult,
+} from '../tool-handler.interface';
+
+/**
+ * L3 recruitment write actions: posting jobs, applying, shortlisting, and moving
+ * applications through the hiring pipeline. Each runs only after the user
+ * confirms the action via the orchestrator's approval card.
+ */
+@Injectable()
+export class RecruitmentWriteHandler implements ToolHandler {
+  readonly toolNames = [
+    'post_job',
+    'apply_to_job',
+    'shortlist_candidate',
+    'update_application_status',
+  ];
+
+  constructor(private readonly recruitment: RecruitmentService) {}
+
+  async execute(
+    toolName: string,
+    args: Record<string, unknown>,
+    principal: AssistantPrincipal,
+  ): Promise<ToolResult> {
+    switch (toolName) {
+      case 'post_job':
+        return this.postJob(args, principal);
+      case 'apply_to_job':
+        return this.applyToJob(args, principal);
+      case 'shortlist_candidate':
+        return this.shortlistCandidate(args, principal);
+      case 'update_application_status':
+        return this.updateApplicationStatus(args);
+      default:
+        throw new Error(`RecruitmentWriteHandler cannot handle tool "${toolName}"`);
+    }
+  }
+
+  // ── post_job ──────────────────────────────────────────────────────────────
+  private async postJob(
+    args: Record<string, unknown>,
+    principal: AssistantPrincipal,
+  ): Promise<ToolResult> {
+    // Admins may post on behalf of a foundation (resolve the ID with
+    // find_foundation first); foundations post for their own org.
+    const foundationId =
+      (args.foundationId as string) ||
+      (!isAdminRole(principal.role) ? principal.organizationId : undefined);
+    if (!foundationId) {
+      throw new Error('A foundationId is required to post a job. Resolve it with find_foundation first.');
+    }
+
+    const role = (args.role as string) || undefined;
+    const percentage = args.percentage != null ? Number(args.percentage) : undefined;
+    const title =
+      (args.title as string) ||
+      [role, percentage ? `${percentage}%` : undefined].filter(Boolean).join(' ') ||
+      'New position';
+
+    const listing = await this.recruitment.createJobListing(
+      {
+        title,
+        description: (args.description as string) || undefined,
+        location: (args.location as string) || (args.canton as string) || undefined,
+        contractType: (args.contractType as any) || undefined,
+        startDate: (args.startDate as string) || undefined,
+        // Publish immediately so the posting is live once the user confirms.
+        status: 'PUBLISHED' as any,
+      },
+      foundationId,
+    );
+
+    return {
+      data: {
+        id: listing.id,
+        title: listing.title,
+        status: listing.status,
+        location: listing.location ?? null,
+      },
+      total: 1,
+    };
+  }
+
+  // ── apply_to_job (educator) ───────────────────────────────────────────────
+  private async applyToJob(
+    args: Record<string, unknown>,
+    principal: AssistantPrincipal,
+  ): Promise<ToolResult> {
+    const jobListingId = (args.jobListingId as string) || (args.jobId as string);
+    if (!jobListingId) {
+      throw new Error('A jobListingId is required to apply.');
+    }
+    const application = await this.recruitment.createJobApplication(
+      {
+        jobListingId,
+        coverLetter: (args.coverLetter as string) || undefined,
+      },
+      principal.userId,
+    );
+    return {
+      data: { id: application.id, status: application.status, jobListingId },
+      total: 1,
+    };
+  }
+
+  // ── shortlist_candidate (foundation) ──────────────────────────────────────
+  private async shortlistCandidate(
+    args: Record<string, unknown>,
+    principal: AssistantPrincipal,
+  ): Promise<ToolResult> {
+    const foundationId = (args.foundationId as string) || principal.organizationId;
+    if (!foundationId) {
+      throw new Error('A foundationId is required to shortlist a candidate.');
+    }
+    const candidateId = (args.candidateId as string) || (args.id as string);
+    if (!candidateId) {
+      throw new Error('A candidateId is required to shortlist a candidate.');
+    }
+    const saved = await this.recruitment.saveCandidate(foundationId, candidateId);
+    return { data: { candidateId, saved: Boolean(saved) }, total: 1 };
+  }
+
+  // ── update_application_status (foundation) ────────────────────────────────
+  private async updateApplicationStatus(args: Record<string, unknown>): Promise<ToolResult> {
+    const id = (args.applicationId as string) || (args.id as string);
+    const status = (args.status as string) || undefined;
+    if (!id) throw new Error('An applicationId is required.');
+    if (!status) throw new Error('A target status is required.');
+    const updated = await this.recruitment.updateJobApplication(id, { status: status as any });
+    return { data: { id, status: updated.status }, total: 1 };
+  }
+}

--- a/api/src/assistant/tools/handlers/recruitment-write.handler.ts
+++ b/api/src/assistant/tools/handlers/recruitment-write.handler.ts
@@ -9,6 +9,8 @@ import {
   ToolHandler,
   ToolResult,
 } from '../tool-handler.interface';
+// resolveOnBehalfOrgId pins non-admins to their own org and rejects cross-org
+// overrides, so foundationId can never be spoofed from another tenant.
 
 /**
  * L3 recruitment write actions: posting jobs, applying, shortlisting, and moving
@@ -118,7 +120,7 @@ export class RecruitmentWriteHandler implements ToolHandler {
     args: Record<string, unknown>,
     principal: AssistantPrincipal,
   ): Promise<ToolResult> {
-    const foundationId = (args.foundationId as string) || principal.organizationId;
+    const foundationId = resolveOnBehalfOrgId(args, principal);
     if (!foundationId) {
       throw new Error('A foundationId is required to shortlist a candidate.');
     }

--- a/api/src/assistant/tools/handlers/replacements.handler.ts
+++ b/api/src/assistant/tools/handlers/replacements.handler.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import { ReplacementsService } from '../../../replacements/replacements.service';
+import {
+  AssistantPrincipal,
+  isAdminRole,
+  ToolHandler,
+  ToolResult,
+} from '../tool-handler.interface';
+
+/**
+ * L3 replacement request creation. A foundation (or admin on its behalf) opens a
+ * replacement request for a date range/role. Executes only after confirmation.
+ */
+@Injectable()
+export class ReplacementsHandler implements ToolHandler {
+  readonly toolNames = ['create_replacement_request'];
+
+  constructor(private readonly replacements: ReplacementsService) {}
+
+  async execute(
+    _toolName: string,
+    args: Record<string, unknown>,
+    principal: AssistantPrincipal,
+  ): Promise<ToolResult> {
+    const foundationId =
+      (args.foundationId as string) ||
+      (!isAdminRole(principal.role) ? principal.organizationId : undefined);
+    if (!foundationId) {
+      throw new Error('A foundationId is required to create a replacement request.');
+    }
+    const startDate = (args.startDate as string) || undefined;
+    const endDate = (args.endDate as string) || startDate;
+    const role = (args.role as string) || undefined;
+    if (!startDate) throw new Error('A start date is required.');
+    if (!role) throw new Error('A role is required.');
+
+    const request = await this.replacements.createRequest(
+      {
+        startDate,
+        endDate: endDate as string,
+        role,
+        shiftStart: (args.shiftStart as string) || undefined,
+        shiftEnd: (args.shiftEnd as string) || undefined,
+        description: (args.description as string) || undefined,
+        location: (args.location as string) || undefined,
+        urgency: (args.urgency as any) || undefined,
+      },
+      foundationId,
+      principal.userId,
+    );
+    return {
+      data: { id: request.id, status: request.status, role, startDate, endDate },
+      total: 1,
+    };
+  }
+}

--- a/api/src/assistant/tools/handlers/replacements.handler.ts
+++ b/api/src/assistant/tools/handlers/replacements.handler.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@nestjs/common';
+import { UrgencyLevel } from '@prisma/client';
 import { ReplacementsService } from '../../../replacements/replacements.service';
 import {
   AssistantPrincipal,
-  isAdminRole,
+  resolveOnBehalfOrgId,
   ToolHandler,
   ToolResult,
 } from '../tool-handler.interface';
@@ -22,9 +23,7 @@ export class ReplacementsHandler implements ToolHandler {
     args: Record<string, unknown>,
     principal: AssistantPrincipal,
   ): Promise<ToolResult> {
-    const foundationId =
-      (args.foundationId as string) ||
-      (!isAdminRole(principal.role) ? principal.organizationId : undefined);
+    const foundationId = resolveOnBehalfOrgId(args, principal);
     if (!foundationId) {
       throw new Error('A foundationId is required to create a replacement request.');
     }
@@ -33,6 +32,18 @@ export class ReplacementsHandler implements ToolHandler {
     const role = (args.role as string) || undefined;
     if (!startDate) throw new Error('A start date is required.');
     if (!role) throw new Error('A role is required.');
+
+    // Validate the optional urgency against the enum so a bad LLM value yields a
+    // clear message instead of an opaque Prisma error.
+    let urgency: UrgencyLevel | undefined;
+    if (args.urgency != null && String(args.urgency).trim() !== '') {
+      const raw = String(args.urgency).toUpperCase();
+      const valid = Object.values(UrgencyLevel) as string[];
+      if (!valid.includes(raw)) {
+        throw new Error(`Invalid urgency "${raw}". Must be one of: ${valid.join(', ')}.`);
+      }
+      urgency = raw as UrgencyLevel;
+    }
 
     const request = await this.replacements.createRequest(
       {
@@ -43,7 +54,7 @@ export class ReplacementsHandler implements ToolHandler {
         shiftEnd: (args.shiftEnd as string) || undefined,
         description: (args.description as string) || undefined,
         location: (args.location as string) || undefined,
-        urgency: (args.urgency as any) || undefined,
+        urgency,
       },
       foundationId,
       principal.userId,

--- a/api/src/assistant/tools/handlers/search.handler.ts
+++ b/api/src/assistant/tools/handlers/search.handler.ts
@@ -7,16 +7,11 @@ import { MarketplaceService } from '../../../marketplace/marketplace.service';
 import { StaffingService } from '../../../staffing/staffing.service';
 import {
   AssistantPrincipal,
+  CONTACT_ADMIN_SUGGESTION as CONTACT_ADMIN,
   isAdminRole,
   ToolHandler,
   ToolResult,
-  ToolSuggestion,
 } from '../tool-handler.interface';
-
-const CONTACT_ADMIN: ToolSuggestion = {
-  label: 'Contact the admin team for help',
-  actionType: 'contact_admin',
-};
 
 /**
  * All search / lookup tools. Every search returns the standard envelope and,

--- a/api/src/assistant/tools/handlers/search.handler.ts
+++ b/api/src/assistant/tools/handlers/search.handler.ts
@@ -34,6 +34,7 @@ export class SearchHandler implements ToolHandler {
     'search_services',
     'search_jobs',
     'search_foundations',
+    'view_match_results',
   ];
 
   constructor(
@@ -69,6 +70,8 @@ export class SearchHandler implements ToolHandler {
         return this.searchJobs(args, locale);
       case 'search_foundations':
         return this.searchFoundations(args);
+      case 'view_match_results':
+        return this.viewMatchResults(args, principal);
       default:
         throw new Error(`SearchHandler cannot handle tool "${toolName}"`);
     }
@@ -327,6 +330,43 @@ export class SearchHandler implements ToolHandler {
         foundations.length === 0
           ? [
               { label: 'Broaden the canton or city', actionType: 'broaden_search' },
+              CONTACT_ADMIN,
+            ]
+          : undefined,
+    };
+  }
+
+  // ── view_match_results (fetch ranked matches for an existing request) ─────
+  private async viewMatchResults(
+    args: Record<string, unknown>,
+    principal: AssistantPrincipal,
+  ): Promise<ToolResult> {
+    const staffingRequestId = (args.staffingRequestId as string) || (args.requestId as string);
+    if (!staffingRequestId) {
+      return {
+        data: { candidates: [] },
+        total: 0,
+        suggestions: [CONTACT_ADMIN],
+      };
+    }
+    const matches = await this.staffing.getMatches(staffingRequestId, {
+      userId: principal.userId,
+      role: principal.role,
+      organizationId: principal.organizationId,
+    });
+    const candidates = matches.slice(0, 10).map((m: any) => ({
+      ...this.toCandidateCard(m.candidate),
+      matchResultId: m.id,
+      score: m.totalScore != null ? Math.round(m.totalScore) : undefined,
+    }));
+    return {
+      data: { candidates, staffingRequestId },
+      total: matches.length,
+      hasMore: matches.length > 10,
+      suggestions:
+        matches.length === 0
+          ? [
+              { label: 'Run a fresh AI search instead', actionType: 'broaden_search', payload: { tool: 'search_candidates_ai' } },
               CONTACT_ADMIN,
             ]
           : undefined,

--- a/api/src/assistant/tools/tool-handler.interface.ts
+++ b/api/src/assistant/tools/tool-handler.interface.ts
@@ -66,3 +66,29 @@ export function resolveLimit(raw: unknown, def = 5, max = 10): number {
   if (!Number.isFinite(n) || n <= 0) return def;
   return Math.min(Math.floor(n), max);
 }
+
+/**
+ * Shared "contact the admin team" suggestion — the universal final fallback so a
+ * search never dead-ends. Imported by every search/lookup handler rather than
+ * re-declared, so the copy stays consistent.
+ */
+export const CONTACT_ADMIN_SUGGESTION: ToolSuggestion = {
+  label: 'Contact the admin team for help',
+  actionType: 'contact_admin',
+};
+
+/**
+ * Resolve the organisation a write action runs against, honouring the
+ * admin-on-behalf-of pattern: an explicit `foundationId`/`organizationId` arg
+ * wins (admins resolve it via find_foundation); otherwise a non-admin acts for
+ * their own org, and an admin without an explicit target gets `undefined` (the
+ * handler then rejects, forcing the admin to name the org).
+ */
+export function resolveOnBehalfOrgId(
+  args: Record<string, unknown>,
+  principal: AssistantPrincipal,
+): string | undefined {
+  const explicit = (args.foundationId as string) || (args.organizationId as string);
+  if (explicit) return explicit;
+  return isAdminRole(principal.role) ? undefined : principal.organizationId;
+}

--- a/api/src/assistant/tools/tool-handler.interface.ts
+++ b/api/src/assistant/tools/tool-handler.interface.ts
@@ -1,3 +1,4 @@
+import { ForbiddenException } from '@nestjs/common';
 import { UserRole } from '@prisma/client';
 
 /**
@@ -79,16 +80,28 @@ export const CONTACT_ADMIN_SUGGESTION: ToolSuggestion = {
 
 /**
  * Resolve the organisation a write action runs against, honouring the
- * admin-on-behalf-of pattern: an explicit `foundationId`/`organizationId` arg
- * wins (admins resolve it via find_foundation); otherwise a non-admin acts for
- * their own org, and an admin without an explicit target gets `undefined` (the
- * handler then rejects, forcing the admin to name the org).
+ * admin-on-behalf-of pattern — but ONLY admins may target another org.
+ *
+ * - **Admins:** an explicit `foundationId`/`organizationId` arg wins (resolved
+ *   via find_foundation); without one they get `undefined`, so the handler
+ *   rejects and forces the admin to name the org.
+ * - **Non-admins:** always pinned to their own `principal.organizationId`. An
+ *   explicit override is allowed only if it matches their own org; a mismatch is
+ *   a cross-tenant attempt and is rejected. This closes the hole where a
+ *   foundation user could pass another foundation's ID to act on its behalf.
  */
 export function resolveOnBehalfOrgId(
   args: Record<string, unknown>,
   principal: AssistantPrincipal,
 ): string | undefined {
   const explicit = (args.foundationId as string) || (args.organizationId as string);
-  if (explicit) return explicit;
-  return isAdminRole(principal.role) ? undefined : principal.organizationId;
+  if (isAdminRole(principal.role)) {
+    return explicit || undefined;
+  }
+  if (explicit && explicit !== principal.organizationId) {
+    throw new ForbiddenException(
+      'You can only perform this action for your own organization.',
+    );
+  }
+  return principal.organizationId;
 }

--- a/api/src/assistant/tools/tool-handler.registry.ts
+++ b/api/src/assistant/tools/tool-handler.registry.ts
@@ -12,6 +12,12 @@ import { StaffingHandler } from './handlers/staffing.handler';
 import { SupportHandler } from './handlers/support.handler';
 import { SearchHandler } from './handlers/search.handler';
 import { DraftsHandler } from './handlers/drafts.handler';
+import { RecruitmentWriteHandler } from './handlers/recruitment-write.handler';
+import { LeadsWriteHandler } from './handlers/leads-write.handler';
+import { MarketplaceWriteHandler } from './handlers/marketplace-write.handler';
+import { MessagingHandler } from './handlers/messaging.handler';
+import { ReplacementsHandler } from './handlers/replacements.handler';
+import { AdminHandler } from './handlers/admin.handler';
 
 /**
  * Routes a tool name to its domain handler. Replaces the monolithic switch in
@@ -32,8 +38,29 @@ export class ToolHandlerRegistry {
     support: SupportHandler,
     search: SearchHandler,
     drafts: DraftsHandler,
+    recruitmentWrite: RecruitmentWriteHandler,
+    leadsWrite: LeadsWriteHandler,
+    marketplaceWrite: MarketplaceWriteHandler,
+    messaging: MessagingHandler,
+    replacements: ReplacementsHandler,
+    admin: AdminHandler,
   ) {
-    for (const handler of [profile, leads, recruitment, marketplace, staffing, support, search, drafts]) {
+    for (const handler of [
+      profile,
+      leads,
+      recruitment,
+      marketplace,
+      staffing,
+      support,
+      search,
+      drafts,
+      recruitmentWrite,
+      leadsWrite,
+      marketplaceWrite,
+      messaging,
+      replacements,
+      admin,
+    ]) {
       this.register(handler);
     }
   }

--- a/api/src/assistant/tools/tool-registry.ts
+++ b/api/src/assistant/tools/tool-registry.ts
@@ -82,6 +82,18 @@ export const TOOL_REGISTRY: ToolDefinition[] = [
     },
   },
 
+  {
+    name: 'send_message',
+    description:
+      'Send a direct message to another platform user. Use when the user wants to contact a foundation, candidate, supplier, or admin directly. Resolve the recipient first with find_user (admin) if only a name is known.',
+    level: 'L3_EXECUTE',
+    allowedRoles: ALL_ROLES,
+    inputSchema: {
+      recipientUserId: { type: 'string', description: 'The User ID of the message recipient' },
+      content: { type: 'string', description: 'The message body to send' },
+    },
+  },
+
   // ── Admin-only tools ───────────────────────────────────────────────────────
   {
     name: 'find_foundation',
@@ -91,6 +103,24 @@ export const TOOL_REGISTRY: ToolDefinition[] = [
     inputSchema: {
       query: { type: 'string', description: 'Organisation name or partial name to search for (e.g. "Kinderwelt", "Les Bout\'choux")' },
     },
+  },
+  {
+    name: 'find_user',
+    description: 'Search platform users by name or email. Returns matching users with their IDs — use before send_message to resolve a recipient.',
+    level: 'L1_ANSWER',
+    allowedRoles: ADMIN_ONLY,
+    inputSchema: {
+      search: { type: 'string', description: 'Name or email fragment to search for' },
+      role: { type: 'string', description: 'Optional role filter (e.g. EDUCATOR, FOUNDATION)' },
+      limit: { type: 'number', description: 'Max number of users to return (default 5)' },
+    },
+  },
+  {
+    name: 'get_platform_stats',
+    description: 'Get platform-wide operational counts: active users, open parent leads, and pending job applications.',
+    level: 'L1_ANSWER',
+    allowedRoles: ADMIN_ONLY,
+    inputSchema: {},
   },
 
   // ── Foundation tools ───────────────────────────────────────────────────────
@@ -171,6 +201,120 @@ export const TOOL_REGISTRY: ToolDefinition[] = [
     },
   },
   {
+    name: 'view_match_results',
+    description: 'Fetch the ranked candidate matches for an existing staffing request by its ID.',
+    level: 'L1_ANSWER',
+    allowedRoles: FOUNDATION_ADMIN,
+    featureFlag: 'v2_staffing_ia',
+    inputSchema: {
+      staffingRequestId: { type: 'string', description: 'The staffing request ID to fetch matches for' },
+    },
+  },
+  {
+    name: 'post_job',
+    description: 'Create and publish a job listing. Foundations post for their own org; admins may pass foundationId (resolve with find_foundation first).',
+    level: 'L3_EXECUTE',
+    allowedRoles: FOUNDATION_ADMIN,
+    featureFlag: 'v2_staffing_ia',
+    inputSchema: {
+      title: { type: 'string', description: 'Job title. If omitted, derived from role + percentage.' },
+      role: { type: 'string', description: 'Job role (e.g. EDE, ASE, ASSC)' },
+      percentage: { type: 'number', description: 'Work percentage (e.g. 80)' },
+      location: { type: 'string', description: 'Canton or city for the position' },
+      contractType: { type: 'string', description: 'Optional: CDI, CDD, FULL_TIME, PART_TIME, REPLACEMENT' },
+      startDate: { type: 'string', description: 'Optional ISO start date' },
+      description: { type: 'string', description: 'Job description / details' },
+      foundationId: { type: 'string', description: 'Optional: foundation org ID (admin only)' },
+    },
+  },
+  {
+    name: 'shortlist_candidate',
+    description: 'Add a candidate to the foundation shortlist (saved candidates).',
+    level: 'L3_EXECUTE',
+    allowedRoles: FOUNDATION_ADMIN,
+    featureFlag: 'v2_staffing_ia',
+    inputSchema: {
+      candidateId: { type: 'string', description: 'The candidate (User) ID to shortlist' },
+      foundationId: { type: 'string', description: 'Optional: foundation org ID (admin only)' },
+    },
+  },
+  {
+    name: 'update_application_status',
+    description: 'Move a job application to a new status: SHORTLISTED, INTERVIEW, OFFER, HIRED, REJECTED, REVIEWED, ACCEPTED.',
+    level: 'L3_EXECUTE',
+    allowedRoles: FOUNDATION_ADMIN,
+    inputSchema: {
+      applicationId: { type: 'string', description: 'The job application ID' },
+      status: { type: 'string', description: 'Target status (SHORTLISTED, INTERVIEW, OFFER, HIRED, REJECTED)' },
+    },
+  },
+  {
+    name: 'create_replacement_request',
+    description: 'Create a staff replacement request for a date range and role.',
+    level: 'L3_EXECUTE',
+    allowedRoles: FOUNDATION_ADMIN,
+    featureFlag: 'v2_replacement_module',
+    inputSchema: {
+      startDate: { type: 'string', description: 'Start date (ISO or YYYY-MM-DD)' },
+      endDate: { type: 'string', description: 'End date (defaults to startDate)' },
+      role: { type: 'string', description: 'Role needed (e.g. Educator, EDE, Assistant)' },
+      shiftStart: { type: 'string', description: 'Optional shift start time, e.g. 08:00' },
+      shiftEnd: { type: 'string', description: 'Optional shift end time, e.g. 17:00' },
+      description: { type: 'string', description: 'Optional details' },
+      location: { type: 'string', description: 'Optional location' },
+      urgency: { type: 'string', description: 'Optional: LOW, NORMAL, HIGH' },
+      foundationId: { type: 'string', description: 'Optional: foundation org ID (admin only)' },
+    },
+  },
+  {
+    name: 'respond_to_lead',
+    description: 'Send a foundation response to a parent lead (INTERESTED, NOT_INTERESTED, NEEDS_MORE_INFO, ENROLLED) with an optional message.',
+    level: 'L3_EXECUTE',
+    allowedRoles: FOUNDATION_ADMIN,
+    inputSchema: {
+      leadId: { type: 'string', description: 'The parent lead ID' },
+      status: { type: 'string', description: 'Response status: INTERESTED, NOT_INTERESTED, NEEDS_MORE_INFO, ENROLLED' },
+      message: { type: 'string', description: 'Optional message to the parent' },
+      foundationId: { type: 'string', description: 'Optional: foundation org ID (admin only)' },
+    },
+  },
+  {
+    name: 'place_order',
+    description: 'Place a product order with a supplier. All items must be from the same supplier.',
+    level: 'L3_EXECUTE',
+    allowedRoles: FOUNDATION_ADMIN,
+    inputSchema: {
+      productId: { type: 'string', description: 'Product ID to order (single-item shorthand)' },
+      quantity: { type: 'number', description: 'Quantity for the single product (default 1)' },
+      items: { type: 'array', description: 'Optional: array of { productId, quantity } for multi-item orders' },
+      notes: { type: 'string', description: 'Optional order notes' },
+    },
+  },
+  {
+    name: 'request_service',
+    description: 'Request a service from a provider, optionally with a description and scheduled date.',
+    level: 'L3_EXECUTE',
+    allowedRoles: FOUNDATION_ADMIN,
+    inputSchema: {
+      serviceId: { type: 'string', description: 'The service ID to request' },
+      description: { type: 'string', description: 'Optional description of the request' },
+      scheduledAt: { type: 'string', description: 'Optional ISO date/time to schedule the service' },
+    },
+  },
+  {
+    name: 'send_supplier_inquiry',
+    description: 'Send a formal inquiry to a supplier requesting a quote or information.',
+    level: 'L3_EXECUTE',
+    allowedRoles: FOUNDATION_ADMIN,
+    inputSchema: {
+      supplierId: { type: 'string', description: 'The supplier organisation ID' },
+      message: { type: 'string', description: 'The inquiry message' },
+      subject: { type: 'string', description: 'Optional subject line' },
+      productInterest: { type: 'string', description: 'Optional product of interest' },
+      quantity: { type: 'number', description: 'Optional quantity' },
+    },
+  },
+  {
     name: 'draft_job_post',
     description: 'Draft a job post pre-filled with details from the conversation.',
     level: 'L2_DRAFT',
@@ -211,6 +355,16 @@ export const TOOL_REGISTRY: ToolDefinition[] = [
     },
   },
   {
+    name: 'apply_to_job',
+    description: 'Submit an application to a job listing on behalf of the current educator, with an optional cover letter.',
+    level: 'L3_EXECUTE',
+    allowedRoles: EDUCATOR_ADMIN,
+    inputSchema: {
+      jobListingId: { type: 'string', description: 'The job listing ID to apply to' },
+      coverLetter: { type: 'string', description: 'Optional cover letter text' },
+    },
+  },
+  {
     name: 'get_my_applications',
     description: 'Fetch the current educator\'s job applications and their statuses.',
     level: 'L1_ANSWER',
@@ -231,6 +385,19 @@ export const TOOL_REGISTRY: ToolDefinition[] = [
       canton: { type: 'string', description: 'Swiss canton (e.g. VD, GE)' },
       city: { type: 'string', description: 'City or town name' },
       query: { type: 'string', description: 'Optional free-text foundation name' },
+    },
+  },
+  {
+    name: 'submit_enquiry',
+    description: 'Submit a childcare enquiry to a foundation on behalf of the current parent. Identity fields default to the parent\'s profile.',
+    level: 'L3_EXECUTE',
+    allowedRoles: PARENT_ADMIN,
+    inputSchema: {
+      foundationId: { type: 'string', description: 'Optional: the foundation to enquire with (resolve with search_foundations first)' },
+      childName: { type: 'string', description: "The child's name" },
+      childAge: { type: 'number', description: "The child's age in years" },
+      preferredLocation: { type: 'string', description: 'Preferred location / canton' },
+      message: { type: 'string', description: 'Message describing the childcare need' },
     },
   },
   {

--- a/docs/AI_ASSISTANT_BUILD_VS_PLAN.md
+++ b/docs/AI_ASSISTANT_BUILD_VS_PLAN.md
@@ -7,8 +7,8 @@ three planning documents against the code on this branch.
 **Reference documents:**
 - **Original plan** — `docs/AI_ASSISTANT_MASTER_PLAN.md` (strategic, layers, phases, post-v2 roadmap P1–P15)
 - **V2 plan** — `docs/AI_ASSISTANT_REDESIGN_V2.md` (tool catalog, no-results, L3 writes, phasing §9)
-- **Build handovers** — `AI_LAYER1_HANDOVER.md`, `AI_MVP_HANDOVER.md`,
-  `AI_ASSISTANT_V2_PHASE0-1_HANDOVER.md`, `AI_ASSISTANT_V2_PHASE2-4_HANDOVER.md`
+- **Build handovers** — `docs/AI_LAYER1_HANDOVER.md`, `docs/AI_MVP_HANDOVER.md`,
+  `docs/AI_ASSISTANT_V2_PHASE0-1_HANDOVER.md`, `docs/AI_ASSISTANT_V2_PHASE2-4_HANDOVER.md`
 
 **Legend:** ✅ built & tested · 🟡 partial / built-but-unhardened · ❌ not built
 

--- a/docs/AI_ASSISTANT_BUILD_VS_PLAN.md
+++ b/docs/AI_ASSISTANT_BUILD_VS_PLAN.md
@@ -1,0 +1,221 @@
+# AI Assistant — Build vs Plan Comparison & Handover
+
+**Date:** 2026-06-03 · **Branch:** `claude/jolly-maxwell-gYKT1`
+**Purpose:** Single source of truth for *what was planned* vs *what is actually built*, reconciling the
+three planning documents against the code on this branch.
+
+**Reference documents:**
+- **Original plan** — `docs/AI_ASSISTANT_MASTER_PLAN.md` (strategic, layers, phases, post-v2 roadmap P1–P15)
+- **V2 plan** — `docs/AI_ASSISTANT_REDESIGN_V2.md` (tool catalog, no-results, L3 writes, phasing §9)
+- **Build handovers** — `AI_LAYER1_HANDOVER.md`, `AI_MVP_HANDOVER.md`,
+  `AI_ASSISTANT_V2_PHASE0-1_HANDOVER.md`, `AI_ASSISTANT_V2_PHASE2-4_HANDOVER.md`
+
+**Legend:** ✅ built & tested · 🟡 partial / built-but-unhardened · ❌ not built
+
+---
+
+## 1. Executive summary
+
+The MVP (Layer 1 + staffing backend + conversation infra + assistant panel) and **v2 Phases 0–2** are
+fully built. **Phase 3 is built for its tool surface but not its hardening items.** **Phase 4 is one-third
+built** (streaming status only). The post-v2 roadmap (P1–P15) is untouched, as planned.
+
+| Phase | Scope | Status |
+|---|---|---|
+| MVP M0–M2 | Layer 1, staffing backend, conversation infra, assistant panel | ✅ |
+| **V2 Phase 0** | Handler registry, result envelope, `contact_admin`, prompt rules, `MAX_TOOL_STEPS=5` | ✅ |
+| **V2 Phase 1** | Real search (6 tools), no-results suggestions, result cards, EDU/PARENT roles | ✅ |
+| **V2 Phase 2** | 11 L3 write tools, rich preview cards | ✅ |
+| **V2 Phase 3** | `find_user`/`get_platform_stats`/`view_match_results` + welcome chips | ✅ |
+| V2 Phase 3 (hardening) | Rate limiting, per-user budget cap, AI-Ops Assistant tab, eval harness, onboarding tour | ❌ |
+| **V2 Phase 4** | Streaming `tool_status` | 🟡 (status done) |
+| V2 Phase 4 (rest) | Native function-calling, conversation persistence across refresh | ❌ |
+| Post-v2 P1–P15 | External routing, RAG, memory, embeddings, geocoding, WhatsApp, voice, CV parsing… | ❌ (by design) |
+
+**Tool count:** **35 tools built** across all 7 roles (v2 plan targeted "~45"; the gap is unbuilt post-v2
+tools like `search_hr_documents`, external-routing, e-learning — not missing core tools).
+
+---
+
+## 2. Architecture layers
+
+| Layer | Planned | Built |
+|---|---|---|
+| **L1 — Shared AI foundation** (`api/src/ai/`) | gateway, OpenRouter+Voyage adapters, circuit breaker, audit, budget, safety, result cache, agent registry, queues | ✅ — with gaps: `LlmClient.retrieve()` (RAG) ❌, geocoding processor ❌, vector ranking is a stub ❌ |
+| **L2 — Orchestrator** (`api/src/assistant/`) | intent → role-aware tool selection → approval gates → streaming | ✅ — per-domain `ToolHandlerRegistry`, `MAX_TOOL_STEPS=5`, SSE streaming, L3 confirm/reject endpoints |
+| **L3 — Specialist modules** | Staffing, Recruitment, Marketplace, Leads, Messaging, Support, Replacements | ✅ for everything wired to a tool. External Routing / HR-RAG / E-learning / WhatsApp modules ❌ (post-v2) |
+
+---
+
+## 3. Tool catalog — planned (v2 §5) vs built
+
+All 35 built tools, grouped by audience. Every tool has a handler registered in
+`tool-handler.registry.ts` and provided in `assistant.module.ts` (parity verified).
+
+### Universal (all roles)
+| Tool | Level | Status |
+|---|---|---|
+| `search_help_docs` | L1 | ✅ |
+| `get_my_profile` | L1 | ✅ |
+| `navigate_to` | L1 | ✅ |
+| `open_modal` | L1 | ✅ |
+| `contact_admin` | L3 | ✅ (never gated — escalation always available) |
+| `send_message` | L3 | ✅ (universal; recipient is a raw userId — see §6) |
+
+### Admin / Super-Admin
+| Tool | Level | Status |
+|---|---|---|
+| `find_foundation` | L1 | ✅ |
+| `find_user` | L1 | ✅ (Phase 3) |
+| `get_platform_stats` | L1 | ✅ (Phase 3) |
+
+### Foundation + Admin
+| Tool | Level | Flag | Status |
+|---|---|---|---|
+| `get_my_leads` | L1 | — | ✅ |
+| `get_my_orders` | L1 | — | ✅ |
+| `search_candidates` | L1 | `v2_staffing_ia` | ✅ |
+| `search_candidates_ai` | L1 | `v2_staffing_ia` | ✅ (sync parse→match→ranked) |
+| `search_products` / `search_services` | L1 | — | ✅ |
+| `explain_match` | L1 | `v2_staffing_ia` | ✅ |
+| `view_match_results` | L1 | `v2_staffing_ia` | ✅ (Phase 3) |
+| `post_job` | L3 | `v2_staffing_ia` | ✅ |
+| `shortlist_candidate` | L3 | `v2_staffing_ia` | ✅ |
+| `update_application_status` | L3 | — | ✅ (org-ownership enforced — see §6) |
+| `create_replacement_request` | L3 | `v2_replacement_module` | ✅ |
+| `respond_to_lead` | L3 | — | ✅ |
+| `place_order` / `request_service` / `send_supplier_inquiry` | L3 | — | ✅ |
+| `draft_job_post` / `draft_parent_reply` | L2 | `v2_staffing_ia` | ✅ (modal prefill) |
+
+### Educator
+| Tool | Level | Status |
+|---|---|---|
+| `search_jobs` | L1 | ✅ |
+| `apply_to_job` | L3 | ✅ |
+| `get_my_applications` | L1 | ✅ |
+
+### Parent
+| Tool | Level | Status |
+|---|---|---|
+| `search_foundations` | L1 | ✅ |
+| `submit_enquiry` | L3 | ✅ (email validated — see §6) |
+| `get_my_enquiries` | L1 | ✅ |
+
+### Supplier / Service Provider
+| Tool | Level | Status |
+|---|---|---|
+| `get_my_listings` | L1 | ✅ |
+| `get_my_service_requests` | L1 | ✅ |
+| `get_my_orders` | L1 | ✅ (shared with foundation) |
+
+**Retired:** `search_internal_candidates` (replaced by `search_candidates` + `search_candidates_ai`).
+
+---
+
+## 4. Phase-by-phase: planned vs built
+
+### Phase 0 — Foundation refactor ✅
+Planned (master §5 / v2 §9): handler registry, standard result envelope, `contact_admin`,
+no-results/escalation prompt rules, `MAX_TOOL_STEPS 3→5`, retire `search_internal_candidates`.
+**Built:** all of it. (Phase 0–1 handover.)
+
+### Phase 1 — Search done right ✅
+Planned: `search_candidates_ai`, `search_candidates`, `search_products`, `search_services`,
+`search_jobs`, `search_foundations`; `suggestions[]` on `total:0`; result cards; open to EDUCATOR/PARENT.
+**Built:** all of it, incl. `CandidateResultCard`/`JobListingCard`/`ProductCard`/`ServiceCard`/`NoResultsCard`.
+
+### Phase 2 — L3 write actions ✅
+Planned: `post_job`, `apply_to_job`, `shortlist_candidate`, `update_application_status`, `respond_to_lead`,
+`send_message`, `place_order`, `request_service`, `send_supplier_inquiry`, `create_replacement_request`,
+`submit_enquiry`; rich `ToolCallCard` previews.
+**Built:** all 11 tools + `ActionPreviewCard` (per-action labelled previews).
+
+### Phase 3 — Completeness + hardening 🟡
+| Item | Status |
+|---|---|
+| `find_user`, `get_platform_stats` | ✅ |
+| `view_match_results` | ✅ |
+| Per-role welcome suggestion chips | ✅ |
+| **Rate limiting per user (30 req/min, ThrottlerModule)** | ❌ |
+| **Daily per-user budget cap in `BudgetService`** | ❌ (L1 `BudgetService` exists; not wired per-user into the assistant) |
+| **AI-Ops dashboard "Assistant" tab** (conversation counts, top tools, latency) | ❌ |
+| **Eval harness `pnpm test:ai-eval`** (fixtures per agent per locale) | ❌ |
+| **Onboarding tour** for new assistant users | ❌ |
+
+> Note: the v2 redesign doc (§9) listed Phase 3 as *completeness only*; the master plan (§5) folded the
+> hardening items above into Phase 3. They remain unbuilt under either reading.
+
+### Phase 4 — Reliability upgrade 🟡
+| Item | Status |
+|---|---|
+| Streaming execution status (`tool_status` SSE → "Searching candidates…") | ✅ |
+| **Native OpenAI function-calling** (`tools[]` in `OpenRouterAdapter`, replace JSON-in-prompt) | ❌ — deliberately deferred; plan in Phase 2-4 handover §5 |
+| **Conversation history persisted across refresh** (sessionStorage / `AIContextMemory` hydration) | ❌ |
+
+---
+
+## 5. What still needs to be built (consolidated backlog)
+
+### A. Finish v2 Phase 3 (hardening — recommended before a wider beta)
+1. **Rate limiting** — `ThrottlerModule` guard on the assistant message endpoint (~30/min/user).
+2. **Per-user daily budget cap** — wire L1 `BudgetService` into the orchestrator; reject over-budget with a friendly message.
+3. **AI-Ops "Assistant" tab** — conversation counts, top tools, p50/p95 latency (`AiOperationsPage.tsx` — also still hardcoded-EN, needs `aiOperations.json` already present).
+4. **Eval harness** — `pnpm test:ai-eval` running golden fixtures per agent per locale.
+5. **Onboarding tour** for first-time assistant users.
+
+### B. Finish v2 Phase 4 (reliability)
+6. **Native function-calling** in `OpenRouterAdapter` (opt-in `useNativeTools` flag, generate `tools[]` from `TOOL_REGISTRY`, flip the assistant agent last, behind a flag, with a live smoke test). Detailed plan: Phase 2-4 handover §5.
+7. **Conversation persistence** across page refresh (hydrate from `AIMessage` / sessionStorage).
+
+### C. Open Layer-1 / MVP gaps (predate v2, still relevant)
+8. `LlmClient.retrieve()` — RAG retrieval (pgvector cosine on `KnowledgeDocument.embedding`). Blocks P2.
+9. **Geocoding worker** (`ai.geocode` processor) — queue exists, no processor. Blocks `earthdistance` perf win.
+10. **Vector ranking** — `HybridMatcherService` vector-similarity tiebreaker is a stub; `EducatorEmbedding` backfill not run.
+11. **`AiOperationsPage.tsx` i18n** — still hardcoded English (namespace `aiOperations.json` exists to receive keys).
+12. **Translation namespaces** — `aiTools.json` and `aiSafety.json` from the master plan were **not** created; tool/result strings were folded into `assistant.json`. Decide: adopt the planned split or document the consolidation.
+
+### D. Post-v2 roadmap (P1–P15 — untouched, by design)
+External Routing/JobUp (P1) · HR-Doc RAG (P2) · enhanced Parent-Lead agent (P3) · Memory/context store (P4) ·
+E-learning assistant (P6) · Admin demand analytics (P7) · Reactivation engine (P8) · Profile embeddings (P9) ·
+Geocoding (P10, = #9) · WhatsApp channel (P13) · CV parsing (P14) · Voice input (P15).
+*(P5/P11/P12 were pulled into v2 Phases 1–2 and are ✅ done.)*
+
+---
+
+## 6. Known issues / tech debt (current branch)
+
+Post-review fixes already applied this branch (Phase 2-4 handover §8):
+- ✅ `update_application_status` now enforces foundation ownership (was a cross-tenant write).
+- ✅ `submit_enquiry` validates `parentEmail` (bypassed the DTO's `@IsEmail`).
+- ✅ Enum validation for `status` / `urgency`; extracted shared `CONTACT_ADMIN_SUGGESTION` + `resolveOnBehalfOrgId()`.
+
+Still open:
+- `send_message` takes a raw `recipientUserId`; non-admins can't `find_user`, so cross-role messaging relies on an ID surfaced by a prior tool. A scoped `find_message_recipient` would close it.
+- `RESULT_CARD_TOOLS` is duplicated backend/frontend (now + `TOOL_STATUS_LABELS`); mitigated with "KEEP IN SYNC" comments, not a shared constant.
+- Webhook idempotency / `search_candidates_ai` double-match when Redis is enabled (Phase 0-1 handover §6).
+
+---
+
+## 7. Translation surfaces (master plan §3.2)
+
+| Surface | Status |
+|---|---|
+| A. UI strings (`assistant.json`, en/fr/de, 96 keys, parity) | ✅ |
+| B. AI prompts (localized `prompt.v1.ts`) | ✅ |
+| C. AI-generated content (model outputs in locale; `MatchResult.explanationLocale`) | ✅ |
+| D. Backend messages (`TranslationService`) | ✅ for shipped paths |
+| Planned `aiTools.json` / `aiSafety.json` namespaces | ❌ (folded into `assistant.json`) |
+| `aiOperations.json` wired into `AiOperationsPage.tsx` | ❌ (file exists, page still hardcoded EN) |
+
+---
+
+## 8. Quick verify
+
+```bash
+pnpm install
+cd api && npx tsc --noEmit -p tsconfig.json 2>&1 | grep '^src/' | grep 'error TS'   # → empty
+cd api && npx jest assistant                                                          # → 64 passing
+cd frontend && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -E 'assistant|ResultCards|ActionPreview'  # → empty
+# 35 built tools:
+node -e "const s=require('fs').readFileSync('api/src/assistant/tools/tool-registry.ts','utf8');console.log((s.match(/name:\s*'/g)||[]).length,'tool defs')"
+```

--- a/docs/AI_ASSISTANT_V2_PHASE2-4_HANDOVER.md
+++ b/docs/AI_ASSISTANT_V2_PHASE2-4_HANDOVER.md
@@ -137,7 +137,7 @@ exactly the failure class it's meant to remove. It belongs in its own PR with li
 
 ---
 
-## 8. Post-review fixes (this branch)
+## 7. Post-review fixes (this branch)
 
 Applied after the `feature-dev` quality review:
 
@@ -155,12 +155,34 @@ Applied after the `feature-dev` quality review:
 - **Drift guards.** Added "KEEP IN SYNC" comments tying the backend/frontend result-card lists together.
 
 A separate reviewer reported 5 "feature-flag mismatch" criticals; all were **false positives** (verified
-against `tool-registry.ts`) and the `respond_to_lead` "missing ownership check" was already enforced inside
-`LeadsService.respondToLead`. No changes made for those.
+against `tool-registry.ts`).
+
+### 7.1 CodeRabbit round (PR #663)
+
+- **Security — cross-tenant writes via `args.foundationId` (CRITICAL).** `resolveOnBehalfOrgId()` now
+  honours an explicit `foundationId`/`organizationId` override **only for admins**; a non-admin is pinned to
+  `principal.organizationId` and a mismatching override throws `ForbiddenException`. Routed the two handlers
+  that still inlined the unsafe `(args.foundationId) || principal.organizationId` pattern
+  (`shortlist_candidate`, `respond_to_lead`) and the three marketplace writes (`place_order`,
+  `request_service`, `send_supplier_inquiry`) through the hardened helper. (The earlier note claiming
+  `respond_to_lead` was "already safe inside `LeadsService`" was wrong — the service trusts its `foundationId`
+  argument, so the guard had to move up to the handler.) Covered by new cross-tenant rejection tests.
+- **Security — admin handler defense in depth.** `AdminHandler.execute()` now rejects non-admin principals
+  even though `find_user`/`get_platform_stats` are already gated to `ADMIN_ONLY` in the registry, so a future
+  gating regression can't become a backend privilege escalation. New tests.
+- **Localization — `tool_status` labels.** The progress labels were emitted in English and rendered verbatim,
+  so FR/DE users saw English. The frontend now translates by tool name via `toolStatus.<tool>` keys
+  (added to en/fr/de, 8 each; server label is the fallback).
+- **Tests/docs.** Tightened the welcome-suggestions check to the `SUGGESTIONS_BY_ROLE` literal; corrected the
+  `view_match_results` test (the handler calls `getMatches`, not `getRequest` — CodeRabbit's "assert
+  getRequest too" was a false positive); fixed handover section numbering and doc-path consistency.
+
+> **Open (asked, not yet decided):** whether `update_application_status` and `apply_to_job` should be gated
+> behind `v2_staffing_ia` like the adjacent staffing tools. They are currently ungated by design.
 
 ---
 
-## 7. How to verify
+## 8. How to verify
 
 ```bash
 pnpm install

--- a/docs/AI_ASSISTANT_V2_PHASE2-4_HANDOVER.md
+++ b/docs/AI_ASSISTANT_V2_PHASE2-4_HANDOVER.md
@@ -177,8 +177,10 @@ against `tool-registry.ts`).
   `view_match_results` test (the handler calls `getMatches`, not `getRequest` — CodeRabbit's "assert
   getRequest too" was a false positive); fixed handover section numbering and doc-path consistency.
 
-> **Open (asked, not yet decided):** whether `update_application_status` and `apply_to_job` should be gated
-> behind `v2_staffing_ia` like the adjacent staffing tools. They are currently ungated by design.
+> **Decided (PR #663):** `update_application_status` and `apply_to_job` stay **ungated**. `apply_to_job` is
+> core educator recruitment that predates v2, and `update_application_status` also drives the legacy statuses
+> (`REJECTED`/`REVIEWED`/`ACCEPTED`) which must keep working when `v2_staffing_ia` is off. CodeRabbit's
+> "gate these too" suggestion was reviewed and intentionally not applied.
 
 ---
 

--- a/docs/AI_ASSISTANT_V2_PHASE2-4_HANDOVER.md
+++ b/docs/AI_ASSISTANT_V2_PHASE2-4_HANDOVER.md
@@ -1,0 +1,148 @@
+# AI Assistant V2 — Phase 2 + 3 + 4 Handover
+
+**Branch:** `claude/jolly-maxwell-gYKT1`
+**Status:** Phases 2 + 3 complete; Phase 4 partially complete (streaming tool-status done, native
+function-calling deliberately deferred — see §5). Type-checked, tested (61 assistant tests passing), pushed.
+**Plan of record:** `docs/AI_ASSISTANT_REDESIGN_V2.md`
+**Prior handover:** `docs/AI_ASSISTANT_V2_PHASE0-1_HANDOVER.md` (read first — defines the architecture this builds on)
+
+---
+
+## 1. What this delivers
+
+Phases 0–1 made the assistant *search and escalate*. This work makes it **act**. The confirm→execute
+plumbing built in Phase 0 is now backed by 11 L3 write tools, so a user can do by typing nearly anything
+they can do by hand. Phase 3 adds admin completeness tools and per-role onboarding. Phase 4 adds streaming
+execution status.
+
+**Phase 2 — L3 write actions (the assistant is now autonomous)**
+- `post_job`, `apply_to_job`, `shortlist_candidate`, `update_application_status` (recruitment)
+- `respond_to_lead` (foundation), `submit_enquiry` (parent)
+- `send_message` (universal — any role → any user)
+- `place_order`, `request_service`, `send_supplier_inquiry` (marketplace)
+- `create_replacement_request` (gated `v2_replacement_module`)
+- **Rich per-action preview cards** — each L3 card shows a labelled field preview of exactly what will
+  happen before the user confirms (replaces the generic args line).
+
+**Phase 3 — Completeness**
+- `find_user`, `get_platform_stats` (admin)
+- `view_match_results` (ranked matches for an existing staffing request ID; renders candidate cards)
+- Per-role welcome suggestion chips (foundation / educator / parent / supplier / service-provider / admin)
+- `send_message` opened to all roles (educator/parent → foundation/admin etc.)
+
+**Phase 4 — Reliability (partial)**
+- Streaming tool-execution status: the orchestrator emits a `tool_status` SSE event when a result-card
+  tool starts, so the UI shows "Searching candidates…" instead of a bare spinner.
+- Native OpenAI function-calling: **deferred** — see §5 for the rationale and a concrete plan.
+
+---
+
+## 2. File map
+
+### Backend (`api/src/assistant/`)
+| File | Change |
+|---|---|
+| `tools/handlers/recruitment-write.handler.ts` | **NEW** — `post_job`, `apply_to_job`, `shortlist_candidate`, `update_application_status` |
+| `tools/handlers/leads-write.handler.ts` | **NEW** — `respond_to_lead`, `submit_enquiry` |
+| `tools/handlers/marketplace-write.handler.ts` | **NEW** — `place_order`, `request_service`, `send_supplier_inquiry` |
+| `tools/handlers/messaging.handler.ts` | **NEW** — `send_message` |
+| `tools/handlers/replacements.handler.ts` | **NEW** — `create_replacement_request` |
+| `tools/handlers/admin.handler.ts` | **NEW** — `find_user`, `get_platform_stats` |
+| `tools/handlers/search.handler.ts` | Added `view_match_results` |
+| `tools/tool-registry.ts` | Added 14 tool definitions (11 L3 writes + `find_user`, `get_platform_stats`, `view_match_results`) |
+| `tools/tool-handler.registry.ts` | Registers the 6 new handlers |
+| `assistant.module.ts` | Imports `LeadsModule`, `MessagingModule`, `ReplacementsModule`, `UsersModule`; provides new handlers |
+| `orchestrator.service.ts` | Emits `tool_status`; added `view_match_results` to `RESULT_CARD_TOOLS` |
+| `orchestrator.service.spec.ts` | Registry rebuilt with new handler mocks; +12 tests (L3 writes, admin tools) |
+| `../ai/agents/assistant-orchestrator/prompt.v1.ts` | WRITE-ACTION routing rules; `view_match_results`/`find_user`/`get_platform_stats` search rules |
+
+### Frontend (`frontend/`)
+| File | Change |
+|---|---|
+| `components/assistant/ActionPreviewCard.tsx` | **NEW** — per-L3-tool field preview, i18n labels |
+| `components/assistant/AssistantPanel.tsx` | ToolCallCard uses rich preview; per-role welcome chips; consumes `tool_status` |
+| `components/assistant/ResultCards.tsx` | `view_match_results` → candidate cards; `statusLabel` prop |
+| `services/assistantService.ts` | `ToolStatusEvent` + `onToolStatus` handler; `tool_status` SSE case |
+
+### Translations (`packages/translations/locales/{en,fr,de}/assistant.json`)
+Added `preview` (titles + 24 field labels + noDetails) and `welcome` per-role chips. **96 keys each, in parity.**
+
+---
+
+## 3. How L3 writes flow (unchanged plumbing, new tools)
+
+1. LLM proposes an L3 tool → orchestrator creates an `AIToolCall` (`AWAITING_APPROVAL`) and emits a
+   `tool_call` approval card. **Nothing executes.**
+2. Frontend renders `ToolCallCard` → `ActionPreviewCard` shows the labelled preview + Confirm/Cancel.
+3. **Confirm** (modal-less) → `POST .../tool-calls/:id/confirm` → `OrchestratorService.confirmToolCall()`
+   re-checks conversation ownership + role, runs the handler, marks `EXECUTED`, returns the result.
+   **Cancel** → `.../reject` marks `REJECTED`.
+
+No orchestrator changes were needed for execution — the Phase 0 confirm path runs any registered tool.
+
+---
+
+## 4. Conventions followed (keep these in future work)
+
+- **One handler per domain; read vs write split.** Read handlers (`recruitment.handler.ts`) stayed; writes
+  live in `*-write.handler.ts`. Register in `tool-handler.registry.ts` **and** `assistant.module.ts`.
+- **Admin-on-behalf-of pattern:** write handlers take `foundationId` from `args` (admin, resolved via
+  `find_foundation`) else `principal.organizationId` (own org). Mirrors `draft_job_post`.
+- **Every tool returns `ToolResult`.** Writes return `{ data: {…created}, total: 1 }`.
+- **Feature flags:** `post_job`/`shortlist_candidate`/`view_match_results` gated `v2_staffing_ia`;
+  `create_replacement_request` gated `v2_replacement_module`. `send_message`/`contact_admin` never gated.
+- **Result-card tools listed in two synced places:** `RESULT_CARD_TOOLS` (orchestrator) + `ResultCards.tsx`.
+- **Translations** in key-parity across en/fr/de (validate by diffing the three JSONs — `i18n-check.js`
+  is still absent in this checkout, see prior handover §6.3).
+
+---
+
+## 5. Phase 4 native function-calling — why deferred, and the plan
+
+**Done:** streaming `tool_status` events (concrete, tested, user-facing).
+
+**Deferred:** replacing JSON-in-prompt with OpenAI `tools[]` function-calling in `OpenRouterAdapter`.
+
+**Why:** this is not an assistant-scoped change — `LlmClient.run()` / `OpenRouterAdapter` is the shared
+gateway for **every** agent (staffing parser, knowledge embeddings, etc.). Swapping the request/response
+contract changes how all of them parse model output. It cannot be validated in this environment (no live
+OpenRouter key / model access), so shipping it blind risks a silent regression across the whole AI layer —
+exactly the failure class it's meant to remove. It belongs in its own PR with live-LLM smoke tests.
+
+**Concrete plan when picked up:**
+1. Add a `tools?: ToolSchema[]` param to the `LlmClient.run()` options and an opt-in `useNativeTools` flag
+   on the agent definition (default off → no behaviour change for existing agents).
+2. In `OpenRouterAdapter`, when `useNativeTools`, send `tools` + `tool_choice` and read
+   `choices[0].message.tool_calls` instead of parsing JSON from content. Map back to the existing
+   `{ message, toolCall }` schema so the orchestrator is untouched.
+3. Generate the `tools[]` schema from `TOOL_REGISTRY` (name/description/inputSchema already match the
+   OpenAI shape — `inputSchema` becomes `parameters.properties`).
+4. Flip `assistant-orchestrator` to `useNativeTools: true` last, behind a feature flag, after a live smoke
+   test confirms tool selection parity.
+
+---
+
+## 6. Known issues / follow-ups
+
+1. **`update_application_status` is not org-scoped in the handler** — it calls
+   `RecruitmentService.updateJobApplication(id, …)` directly. Role is re-checked on confirm, but a
+   foundation could target an application outside its own listings if the service layer doesn't enforce
+   ownership. Verify `updateJobApplication`'s authorization, or pass + check `foundationId` in the handler.
+2. **`send_message` recipient is a raw `recipientUserId`.** Non-admins can't `find_user`, so cross-role
+   messaging from educator/parent currently relies on an ID surfaced by a prior tool (e.g. a foundation
+   card). A future `find_message_recipient` scoped lookup would close this.
+3. **`RESULT_CARD_TOOLS` still duplicated** backend + frontend (prior handover §6.2 — unchanged).
+4. **Native function calling** — §5.
+
+---
+
+## 7. How to verify
+
+```bash
+pnpm install
+cd api && npx tsc --noEmit -p tsconfig.json 2>&1 | grep '^src/' | grep 'error TS'   # → empty
+cd api && npx jest assistant                                                          # → 61 passing
+cd frontend && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -E 'assistant|ResultCards|ActionPreview'  # → empty
+# Locale parity (en/fr/de → 96 each):
+node -e "const fs=require('fs');const k=o=>Object.entries(o).flatMap(([a,v])=>v&&typeof v=='object'?k(v).map(b=>a+'.'+b):[a]);console.log(['en','fr','de'].map(l=>k(JSON.parse(fs.readFileSync('packages/translations/locales/'+l+'/assistant.json'))).length))"
+```

--- a/docs/AI_ASSISTANT_V2_PHASE2-4_HANDOVER.md
+++ b/docs/AI_ASSISTANT_V2_PHASE2-4_HANDOVER.md
@@ -2,7 +2,8 @@
 
 **Branch:** `claude/jolly-maxwell-gYKT1`
 **Status:** Phases 2 + 3 complete; Phase 4 partially complete (streaming tool-status done, native
-function-calling deliberately deferred — see §5). Type-checked, tested (61 assistant tests passing), pushed.
+function-calling deliberately deferred — see §5). Type-checked, tested (64 assistant tests passing), pushed.
+Post-review fixes applied — see §8.
 **Plan of record:** `docs/AI_ASSISTANT_REDESIGN_V2.md`
 **Prior handover:** `docs/AI_ASSISTANT_V2_PHASE0-1_HANDOVER.md` (read first — defines the architecture this builds on)
 
@@ -124,15 +125,38 @@ exactly the failure class it's meant to remove. It belongs in its own PR with li
 
 ## 6. Known issues / follow-ups
 
-1. **`update_application_status` is not org-scoped in the handler** — it calls
-   `RecruitmentService.updateJobApplication(id, …)` directly. Role is re-checked on confirm, but a
-   foundation could target an application outside its own listings if the service layer doesn't enforce
-   ownership. Verify `updateJobApplication`'s authorization, or pass + check `foundationId` in the handler.
-2. **`send_message` recipient is a raw `recipientUserId`.** Non-admins can't `find_user`, so cross-role
+> A `feature-dev` code review (3 reviewers) ran against this build. Verified findings were **fixed**
+> in this branch (see §8); the items below are what remains.
+
+1. **`send_message` recipient is a raw `recipientUserId`.** Non-admins can't `find_user`, so cross-role
    messaging from educator/parent currently relies on an ID surfaced by a prior tool (e.g. a foundation
    card). A future `find_message_recipient` scoped lookup would close this.
-3. **`RESULT_CARD_TOOLS` still duplicated** backend + frontend (prior handover §6.2 — unchanged).
-4. **Native function calling** — §5.
+2. **`RESULT_CARD_TOOLS` is duplicated** backend + frontend (now also `TOOL_STATUS_LABELS`). Mitigated with
+   cross-reference "KEEP IN SYNC" comments; a shared `packages/` constant would remove the drift entirely.
+3. **Native function calling** — §5.
+
+---
+
+## 8. Post-review fixes (this branch)
+
+Applied after the `feature-dev` quality review:
+
+- **Security — `update_application_status` cross-tenant write (CRITICAL).** The handler now loads the
+  application's `jobListing.foundationId` and rejects (`ForbiddenException`) unless it matches the caller's
+  org (admins exempt). The service updates by ID with no scoping, so the guard lives in the handler.
+  Covered by two new tests (own-org succeeds, other-org rejected).
+- **Data integrity — `submit_enquiry` blank email (CRITICAL).** This path bypasses the DTO's `@IsEmail`;
+  the handler now validates the resolved `parentEmail` and rejects an invalid/blank one (new test).
+- **Robustness — enum validation.** `update_application_status` validates against `ApplicationStatus` and
+  `create_replacement_request` validates `urgency` against `UrgencyLevel`, returning a clear message
+  instead of an opaque Prisma error.
+- **DRY.** Extracted `CONTACT_ADMIN_SUGGESTION` and `resolveOnBehalfOrgId()` into `tool-handler.interface.ts`
+  (were duplicated, with inconsistent copy, across handlers).
+- **Drift guards.** Added "KEEP IN SYNC" comments tying the backend/frontend result-card lists together.
+
+A separate reviewer reported 5 "feature-flag mismatch" criticals; all were **false positives** (verified
+against `tool-registry.ts`) and the `respond_to_lead` "missing ownership check" was already enforced inside
+`LeadsService.respondToLead`. No changes made for those.
 
 ---
 
@@ -141,7 +165,7 @@ exactly the failure class it's meant to remove. It belongs in its own PR with li
 ```bash
 pnpm install
 cd api && npx tsc --noEmit -p tsconfig.json 2>&1 | grep '^src/' | grep 'error TS'   # → empty
-cd api && npx jest assistant                                                          # → 61 passing
+cd api && npx jest assistant                                                          # → 64 passing
 cd frontend && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -E 'assistant|ResultCards|ActionPreview'  # → empty
 # Locale parity (en/fr/de → 96 each):
 node -e "const fs=require('fs');const k=o=>Object.entries(o).flatMap(([a,v])=>v&&typeof v=='object'?k(v).map(b=>a+'.'+b):[a]);console.log(['en','fr','de'].map(l=>k(JSON.parse(fs.readFileSync('packages/translations/locales/'+l+'/assistant.json'))).length))"

--- a/frontend/components/assistant/ActionPreviewCard.tsx
+++ b/frontend/components/assistant/ActionPreviewCard.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+// ─── Per-action preview field definitions ────────────────────────────────────
+//
+// L3 tools mutate platform state, so before executing we show the user a concrete
+// preview of what will happen. Each tool maps its raw args to a labelled field
+// list. Fields with no value are skipped so the card stays clean.
+
+type FieldDef = { key: string; labelKey: string; fallback: string; long?: boolean };
+
+const PREVIEWS: Record<string, { titleKey: string; titleFallback: string; fields: FieldDef[] }> = {
+  post_job: {
+    titleKey: 'preview.postJob',
+    titleFallback: 'Publish job listing',
+    fields: [
+      { key: 'title', labelKey: 'preview.field.title', fallback: 'Title' },
+      { key: 'role', labelKey: 'preview.field.role', fallback: 'Role' },
+      { key: 'percentage', labelKey: 'preview.field.percentage', fallback: 'Percentage' },
+      { key: 'location', labelKey: 'preview.field.location', fallback: 'Location' },
+      { key: 'contractType', labelKey: 'preview.field.contract', fallback: 'Contract' },
+      { key: 'startDate', labelKey: 'preview.field.startDate', fallback: 'Start date' },
+      { key: 'description', labelKey: 'preview.field.description', fallback: 'Description', long: true },
+    ],
+  },
+  send_message: {
+    titleKey: 'preview.sendMessage',
+    titleFallback: 'Send message',
+    fields: [
+      { key: 'recipientUserId', labelKey: 'preview.field.recipient', fallback: 'Recipient' },
+      { key: 'content', labelKey: 'preview.field.message', fallback: 'Message', long: true },
+    ],
+  },
+  contact_admin: {
+    titleKey: 'preview.contactAdmin',
+    titleFallback: 'File support ticket',
+    fields: [
+      { key: 'subject', labelKey: 'preview.field.subject', fallback: 'Subject' },
+      { key: 'message', labelKey: 'preview.field.message', fallback: 'Message', long: true },
+      { key: 'priority', labelKey: 'preview.field.priority', fallback: 'Priority' },
+    ],
+  },
+  place_order: {
+    titleKey: 'preview.placeOrder',
+    titleFallback: 'Place order',
+    fields: [
+      { key: 'productId', labelKey: 'preview.field.product', fallback: 'Product' },
+      { key: 'quantity', labelKey: 'preview.field.quantity', fallback: 'Quantity' },
+      { key: 'notes', labelKey: 'preview.field.notes', fallback: 'Notes', long: true },
+    ],
+  },
+  request_service: {
+    titleKey: 'preview.requestService',
+    titleFallback: 'Request service',
+    fields: [
+      { key: 'serviceId', labelKey: 'preview.field.service', fallback: 'Service' },
+      { key: 'scheduledAt', labelKey: 'preview.field.scheduledAt', fallback: 'Scheduled' },
+      { key: 'description', labelKey: 'preview.field.description', fallback: 'Description', long: true },
+    ],
+  },
+  send_supplier_inquiry: {
+    titleKey: 'preview.supplierInquiry',
+    titleFallback: 'Send supplier inquiry',
+    fields: [
+      { key: 'subject', labelKey: 'preview.field.subject', fallback: 'Subject' },
+      { key: 'productInterest', labelKey: 'preview.field.product', fallback: 'Product' },
+      { key: 'quantity', labelKey: 'preview.field.quantity', fallback: 'Quantity' },
+      { key: 'message', labelKey: 'preview.field.message', fallback: 'Message', long: true },
+    ],
+  },
+  apply_to_job: {
+    titleKey: 'preview.applyToJob',
+    titleFallback: 'Apply to job',
+    fields: [
+      { key: 'jobListingId', labelKey: 'preview.field.job', fallback: 'Job' },
+      { key: 'coverLetter', labelKey: 'preview.field.coverLetter', fallback: 'Cover letter', long: true },
+    ],
+  },
+  shortlist_candidate: {
+    titleKey: 'preview.shortlist',
+    titleFallback: 'Shortlist candidate',
+    fields: [{ key: 'candidateId', labelKey: 'preview.field.candidate', fallback: 'Candidate' }],
+  },
+  update_application_status: {
+    titleKey: 'preview.updateStatus',
+    titleFallback: 'Update application status',
+    fields: [
+      { key: 'applicationId', labelKey: 'preview.field.application', fallback: 'Application' },
+      { key: 'status', labelKey: 'preview.field.status', fallback: 'New status' },
+    ],
+  },
+  respond_to_lead: {
+    titleKey: 'preview.respondToLead',
+    titleFallback: 'Respond to parent lead',
+    fields: [
+      { key: 'status', labelKey: 'preview.field.status', fallback: 'Response' },
+      { key: 'message', labelKey: 'preview.field.message', fallback: 'Message', long: true },
+    ],
+  },
+  create_replacement_request: {
+    titleKey: 'preview.replacement',
+    titleFallback: 'Create replacement request',
+    fields: [
+      { key: 'role', labelKey: 'preview.field.role', fallback: 'Role' },
+      { key: 'startDate', labelKey: 'preview.field.startDate', fallback: 'Start date' },
+      { key: 'endDate', labelKey: 'preview.field.endDate', fallback: 'End date' },
+      { key: 'urgency', labelKey: 'preview.field.urgency', fallback: 'Urgency' },
+      { key: 'description', labelKey: 'preview.field.description', fallback: 'Description', long: true },
+    ],
+  },
+  submit_enquiry: {
+    titleKey: 'preview.submitEnquiry',
+    titleFallback: 'Submit childcare enquiry',
+    fields: [
+      { key: 'childName', labelKey: 'preview.field.childName', fallback: 'Child' },
+      { key: 'childAge', labelKey: 'preview.field.childAge', fallback: 'Age' },
+      { key: 'preferredLocation', labelKey: 'preview.field.location', fallback: 'Location' },
+      { key: 'message', labelKey: 'preview.field.message', fallback: 'Message', long: true },
+    ],
+  },
+};
+
+/** Whether a rich preview is defined for this L3 tool. */
+export function hasActionPreview(toolName: string): boolean {
+  return toolName in PREVIEWS;
+}
+
+function formatValue(v: unknown): string {
+  if (v == null) return '';
+  if (typeof v === 'string') return v;
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  return JSON.stringify(v);
+}
+
+interface ActionPreviewCardProps {
+  toolName: string;
+  args: Record<string, unknown>;
+}
+
+/**
+ * Rich, per-action preview of an L3 tool's effect, shown above the Confirm /
+ * Cancel buttons so the user sees exactly what will happen before approving.
+ */
+export const ActionPreviewCard: React.FC<ActionPreviewCardProps> = ({ toolName, args }) => {
+  const { t } = useTranslation('assistant');
+  const spec = PREVIEWS[toolName];
+  if (!spec) return null;
+
+  const rows = spec.fields
+    .map((f) => ({ ...f, value: formatValue(args?.[f.key]) }))
+    .filter((f) => f.value.trim().length > 0);
+
+  return (
+    <div className="mb-2 rounded-md bg-gray-50 p-2">
+      <p className="mb-1 text-xs font-semibold text-swiss-charcoal">
+        {t(spec.titleKey, spec.titleFallback)}
+      </p>
+      {rows.length === 0 ? (
+        <p className="text-xs text-gray-400">{t('preview.noDetails', 'Confirm to proceed.')}</p>
+      ) : (
+        <dl className="space-y-0.5">
+          {rows.map((f) => (
+            <div key={f.key} className={f.long ? '' : 'flex gap-1'}>
+              <dt className="flex-shrink-0 text-xs font-medium text-gray-500">
+                {t(f.labelKey, f.fallback)}:
+              </dt>
+              <dd className={`text-xs text-gray-700 ${f.long ? 'mt-0.5 line-clamp-3 whitespace-pre-wrap' : 'truncate'}`}>
+                {f.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </div>
+  );
+};

--- a/frontend/components/assistant/AssistantPanel.tsx
+++ b/frontend/components/assistant/AssistantPanel.tsx
@@ -75,6 +75,7 @@ const SUGGESTIONS_BY_ROLE: Record<string, { key: string; fallback: string }[]> =
     { key: 'welcome.admin.findCandidate', fallback: 'Find candidates for a foundation' },
   ],
 };
+// SUPER_ADMIN shares the ADMIN suggestion set (same operator capabilities here).
 SUGGESTIONS_BY_ROLE[UserRole.SUPER_ADMIN] = SUGGESTIONS_BY_ROLE[UserRole.ADMIN];
 
 const DEFAULT_SUGGESTIONS = [

--- a/frontend/components/assistant/AssistantPanel.tsx
+++ b/frontend/components/assistant/AssistantPanel.tsx
@@ -15,6 +15,8 @@ import {
 import { useAppContext } from '../../contexts/AppContext';
 import { AssistantModalHandler } from './AssistantModalHandler';
 import { SearchResultCards, isResultCardTool } from './ResultCards';
+import { ActionPreviewCard, hasActionPreview } from './ActionPreviewCard';
+import { UserRole } from '../../types';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -24,6 +26,7 @@ interface Message {
   text: string;
   toolCall?: ToolCallEvent;
   toolResult?: ToolResultEvent;
+  toolStatus?: string;
   cancelled?: boolean;
 }
 
@@ -38,11 +41,50 @@ function genId(): string {
   return Math.random().toString(36).slice(2, 10);
 }
 
-const SUGGESTION_KEYS = [
-  { key: 'welcome.suggestion1', fallback: 'Find me an educator' },
-  { key: 'welcome.suggestion2', fallback: 'Draft a job post' },
-  { key: 'welcome.suggestion3', fallback: 'How do I add a staff request?' },
+// Per-role welcome suggestion chips. Each entry is a translation key + fallback;
+// the set shown reflects what the assistant can actually do for that role.
+const SUGGESTIONS_BY_ROLE: Record<string, { key: string; fallback: string }[]> = {
+  [UserRole.FOUNDATION]: [
+    { key: 'welcome.foundation.findCandidate', fallback: 'Find me an EDE in Geneva at 80%' },
+    { key: 'welcome.foundation.postJob', fallback: 'Post a job for an educator' },
+    { key: 'welcome.foundation.respondLead', fallback: 'Show my parent leads' },
+  ],
+  [UserRole.EDUCATOR]: [
+    { key: 'welcome.educator.findJob', fallback: 'Find childcare jobs near me' },
+    { key: 'welcome.educator.myApplications', fallback: 'Show my applications' },
+    { key: 'welcome.educator.help', fallback: 'How do I apply to a job?' },
+  ],
+  [UserRole.PARENT]: [
+    { key: 'welcome.parent.findFoundation', fallback: 'Find a crèche in my canton' },
+    { key: 'welcome.parent.submitEnquiry', fallback: 'Submit a childcare enquiry' },
+    { key: 'welcome.parent.myEnquiries', fallback: 'Show my enquiries' },
+  ],
+  [UserRole.PRODUCT_SUPPLIER]: [
+    { key: 'welcome.supplier.myListings', fallback: 'Show my product listings' },
+    { key: 'welcome.supplier.myOrders', fallback: 'Show my incoming orders' },
+    { key: 'welcome.supplier.help', fallback: 'How do I add a product?' },
+  ],
+  [UserRole.SERVICE_PROVIDER]: [
+    { key: 'welcome.serviceProvider.myListings', fallback: 'Show my service listings' },
+    { key: 'welcome.serviceProvider.myRequests', fallback: 'Show my service requests' },
+    { key: 'welcome.serviceProvider.help', fallback: 'How do I add a service?' },
+  ],
+  [UserRole.ADMIN]: [
+    { key: 'welcome.admin.stats', fallback: 'Show platform stats' },
+    { key: 'welcome.admin.findUser', fallback: 'Find a user by name' },
+    { key: 'welcome.admin.findCandidate', fallback: 'Find candidates for a foundation' },
+  ],
+};
+SUGGESTIONS_BY_ROLE[UserRole.SUPER_ADMIN] = SUGGESTIONS_BY_ROLE[UserRole.ADMIN];
+
+const DEFAULT_SUGGESTIONS = [
+  { key: 'welcome.suggestion1', fallback: 'What can you help me with?' },
+  { key: 'welcome.suggestion2', fallback: 'How do I use this platform?' },
 ];
+
+function getSuggestionsForRole(role?: UserRole | string | null) {
+  return (role && SUGGESTIONS_BY_ROLE[role as string]) || DEFAULT_SUGGESTIONS;
+}
 
 // ─── ToolCallCard ─────────────────────────────────────────────────────────────
 
@@ -57,6 +99,7 @@ interface ToolCallCardProps {
 const ToolCallCard: React.FC<ToolCallCardProps> = ({ toolCall, result, cancelled, onConfirm, onCancel }) => {
   const { t } = useTranslation('assistant');
 
+  const showRichPreview = hasActionPreview(toolCall.toolName);
   const argsPreview = Object.entries(toolCall.args || {})
     .slice(0, 3)
     .map(([k, v]) => `${k}: ${typeof v === 'string' ? v : JSON.stringify(v)}`)
@@ -76,9 +119,11 @@ const ToolCallCard: React.FC<ToolCallCardProps> = ({ toolCall, result, cancelled
         </span>
       </div>
 
-      {/* Args preview */}
-      {argsPreview && (
-        <p className="mb-2 truncate text-xs text-gray-500">{argsPreview}</p>
+      {/* Preview: rich per-action card when available, else a compact args line */}
+      {showRichPreview ? (
+        <ActionPreviewCard toolName={toolCall.toolName} args={toolCall.args || {}} />
+      ) : (
+        argsPreview && <p className="mb-2 truncate text-xs text-gray-500">{argsPreview}</p>
       )}
 
       {/* Result / error */}
@@ -123,10 +168,12 @@ const ToolCallCard: React.FC<ToolCallCardProps> = ({ toolCall, result, cancelled
 
 interface WelcomeScreenProps {
   onSuggestion: (text: string) => void;
+  role?: UserRole | string | null;
 }
 
-const WelcomeScreen: React.FC<WelcomeScreenProps> = ({ onSuggestion }) => {
+const WelcomeScreen: React.FC<WelcomeScreenProps> = ({ onSuggestion, role }) => {
   const { t } = useTranslation('assistant');
+  const suggestions = getSuggestionsForRole(role);
 
   return (
     <div className="flex flex-1 flex-col items-center justify-center px-6 py-8 text-center">
@@ -143,7 +190,7 @@ const WelcomeScreen: React.FC<WelcomeScreenProps> = ({ onSuggestion }) => {
         )}
       </p>
       <div className="flex flex-wrap justify-center gap-2">
-        {SUGGESTION_KEYS.map(({ key, fallback }) => (
+        {suggestions.map(({ key, fallback }) => (
           <button
             key={key}
             onClick={() => onSuggestion(t(key, fallback))}
@@ -162,7 +209,7 @@ const WelcomeScreen: React.FC<WelcomeScreenProps> = ({ onSuggestion }) => {
 export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose }) => {
   const { t } = useTranslation('assistant');
   const { getToken } = useAuth();
-  const { language } = useAppContext();
+  const { language, currentUser } = useAppContext();
 
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
@@ -247,6 +294,13 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose 
           setMessages((prev) =>
             prev.map((m) =>
               m.id === result.toolCallId ? { ...m, toolResult: result } : m
+            )
+          );
+        },
+        onToolStatus: (status) => {
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === status.toolCallId ? { ...m, toolStatus: status.label } : m
             )
           );
         },
@@ -389,7 +443,7 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose 
           <div className="flex flex-1 flex-col overflow-y-auto px-4 py-4">
             {/* Welcome screen */}
             {messages.length === 0 && !isStreaming && (
-              <WelcomeScreen onSuggestion={(text) => handleSend(text)} />
+              <WelcomeScreen onSuggestion={(text) => handleSend(text)} role={currentUser?.role} />
             )}
 
             {/* Chat bubbles */}
@@ -402,6 +456,7 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose 
                       key={msg.id}
                       toolName={msg.toolCall.toolName}
                       result={msg.toolResult}
+                      statusLabel={msg.toolStatus}
                     />
                   );
                 }

--- a/frontend/components/assistant/AssistantPanel.tsx
+++ b/frontend/components/assistant/AssistantPanel.tsx
@@ -299,9 +299,12 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose 
           );
         },
         onToolStatus: (status) => {
+          // The backend label is English; translate by tool name into the user's
+          // locale, falling back to the server label if a key is missing.
+          const label = t(`toolStatus.${status.toolName}`, status.label);
           setMessages((prev) =>
             prev.map((m) =>
-              m.id === status.toolCallId ? { ...m, toolStatus: status.label } : m
+              m.id === status.toolCallId ? { ...m, toolStatus: label } : m
             )
           );
         },

--- a/frontend/components/assistant/ResultCards.tsx
+++ b/frontend/components/assistant/ResultCards.tsx
@@ -194,6 +194,7 @@ const RESULT_CARD_TOOLS = new Set([
   'search_jobs',
   'search_foundations',
   'find_foundation',
+  'view_match_results',
 ]);
 
 export function isResultCardTool(toolName: string): boolean {
@@ -203,18 +204,22 @@ export function isResultCardTool(toolName: string): boolean {
 interface SearchResultCardsProps {
   toolName: string;
   result?: ToolResultEvent;
+  /** Live status label streamed while the tool runs (e.g. "Searching candidates…"). */
+  statusLabel?: string;
 }
 
 /**
  * Renders the appropriate result cards (or a NoResultsCard) for a search tool's
  * structured result. Falls back to nothing while the result is still pending.
  */
-export const SearchResultCards: React.FC<SearchResultCardsProps> = ({ toolName, result }) => {
+export const SearchResultCards: React.FC<SearchResultCardsProps> = ({ toolName, result, statusLabel }) => {
   const { t } = useTranslation('assistant');
 
   if (!result) {
     return (
-      <p className="my-2 text-xs text-gray-400">{t('results.searching', 'Searching…')}</p>
+      <p className="my-2 text-xs text-gray-400">
+        {statusLabel ?? t('results.searching', 'Searching…')}
+      </p>
     );
   }
   if (result.error) {
@@ -236,7 +241,8 @@ export const SearchResultCards: React.FC<SearchResultCardsProps> = ({ toolName, 
 
   switch (toolName) {
     case 'search_candidates':
-    case 'search_candidates_ai': {
+    case 'search_candidates_ai':
+    case 'view_match_results': {
       const items = (data.candidates as CandidateItem[]) ?? [];
       return <>{items.filter(Boolean).map((c) => <CandidateResultCard key={c.id} c={c} />)}</>;
     }

--- a/frontend/components/assistant/ResultCards.tsx
+++ b/frontend/components/assistant/ResultCards.tsx
@@ -186,6 +186,9 @@ const NoResultsCard: React.FC<{ message: string; suggestions?: ToolEnvelope['sug
 
 // ─── Dispatcher ──────────────────────────────────────────────────────────────
 
+// KEEP IN SYNC with RESULT_CARD_TOOLS (and TOOL_STATUS_LABELS) in
+// api/src/assistant/orchestrator.service.ts — the backend decides which tools
+// emit card events; this set decides which ones render cards.
 const RESULT_CARD_TOOLS = new Set([
   'search_candidates',
   'search_candidates_ai',

--- a/frontend/services/assistantService.ts
+++ b/frontend/services/assistantService.ts
@@ -24,11 +24,19 @@ export interface ModalActionEvent {
   prefill: Record<string, unknown>;
 }
 
+export interface ToolStatusEvent {
+  toolCallId: string;
+  toolName: string;
+  status: string;
+  label: string;
+}
+
 export interface StreamHandlers {
   onToken: (text: string) => void;
   onToolCall: (toolCall: ToolCallEvent) => void;
   onToolResult: (result: ToolResultEvent) => void;
   onModalAction: (action: ModalActionEvent) => void;
+  onToolStatus?: (status: ToolStatusEvent) => void;
   onDone: () => void;
   onError: (msg: string) => void;
 }
@@ -210,6 +218,9 @@ export async function streamMessage(
             break;
           case 'tool_result':
             handlers.onToolResult(parsed as unknown as ToolResultEvent);
+            break;
+          case 'tool_status':
+            handlers.onToolStatus?.(parsed as unknown as ToolStatusEvent);
             break;
           case 'modal_action':
             handlers.onModalAction(parsed as unknown as ModalActionEvent);

--- a/packages/translations/locales/de/assistant.json
+++ b/packages/translations/locales/de/assistant.json
@@ -104,6 +104,16 @@
     "draftJobPost": "Stellenanzeige wird erstellt…",
     "draftParentReply": "Antwort wird verfasst…"
   },
+  "toolStatus": {
+    "search_candidates": "Kandidaten werden gesucht…",
+    "search_candidates_ai": "Kandidaten werden abgeglichen…",
+    "search_products": "Produkte werden gesucht…",
+    "search_services": "Dienstleistungen werden gesucht…",
+    "search_jobs": "Stellenangebote werden gesucht…",
+    "search_foundations": "Stiftungen werden gesucht…",
+    "find_foundation": "Stiftung wird gesucht…",
+    "view_match_results": "Übereinstimmungen werden geladen…"
+  },
   "toolCard": {
     "confirm": "Bestätigen",
     "cancel": "Abbrechen",

--- a/packages/translations/locales/de/assistant.json
+++ b/packages/translations/locales/de/assistant.json
@@ -15,6 +15,80 @@
       "staffing": "Erzieher für nächste Woche suchen",
       "jobPost": "Stellenanzeige erstellen",
       "help": "Wie veröffentliche ich eine Stellenanzeige?"
+    },
+    "suggestion1": "Wobei können Sie mir helfen?",
+    "suggestion2": "Wie nutze ich diese Plattform?",
+    "foundation": {
+      "findCandidate": "EDE in Genf zu 80% suchen",
+      "postJob": "Stelle für einen Erzieher ausschreiben",
+      "respondLead": "Meine Eltern-Anfragen anzeigen"
+    },
+    "educator": {
+      "findJob": "Stellen in meiner Nähe finden",
+      "myApplications": "Meine Bewerbungen anzeigen",
+      "help": "Wie bewerbe ich mich auf eine Stelle?"
+    },
+    "parent": {
+      "findFoundation": "Eine Kita in meinem Kanton finden",
+      "submitEnquiry": "Betreuungsanfrage einreichen",
+      "myEnquiries": "Meine Anfragen anzeigen"
+    },
+    "supplier": {
+      "myListings": "Meine Produktangebote anzeigen",
+      "myOrders": "Meine eingehenden Bestellungen anzeigen",
+      "help": "Wie füge ich ein Produkt hinzu?"
+    },
+    "serviceProvider": {
+      "myListings": "Meine Dienstleistungen anzeigen",
+      "myRequests": "Meine Serviceanfragen anzeigen",
+      "help": "Wie füge ich eine Dienstleistung hinzu?"
+    },
+    "admin": {
+      "stats": "Plattformstatistiken anzeigen",
+      "findUser": "Benutzer nach Namen suchen",
+      "findCandidate": "Kandidaten für eine Stiftung suchen"
+    }
+  },
+  "preview": {
+    "postJob": "Stellenanzeige veröffentlichen",
+    "sendMessage": "Nachricht senden",
+    "contactAdmin": "Support-Ticket erstellen",
+    "placeOrder": "Bestellung aufgeben",
+    "requestService": "Dienstleistung anfragen",
+    "supplierInquiry": "Lieferantenanfrage senden",
+    "applyToJob": "Auf Stelle bewerben",
+    "shortlist": "Kandidat vormerken",
+    "updateStatus": "Bewerbungsstatus ändern",
+    "respondToLead": "Auf Eltern-Anfrage antworten",
+    "replacement": "Vertretungsanfrage erstellen",
+    "submitEnquiry": "Betreuungsanfrage einreichen",
+    "noDetails": "Zum Fortfahren bestätigen.",
+    "field": {
+      "title": "Titel",
+      "role": "Rolle",
+      "percentage": "Prozentsatz",
+      "location": "Ort",
+      "contract": "Vertrag",
+      "startDate": "Startdatum",
+      "endDate": "Enddatum",
+      "description": "Beschreibung",
+      "recipient": "Empfänger",
+      "message": "Nachricht",
+      "subject": "Betreff",
+      "priority": "Priorität",
+      "product": "Produkt",
+      "quantity": "Menge",
+      "notes": "Notizen",
+      "service": "Dienstleistung",
+      "scheduledAt": "Geplant",
+      "job": "Stelle",
+      "coverLetter": "Anschreiben",
+      "candidate": "Kandidat",
+      "application": "Bewerbung",
+      "status": "Status",
+      "urgency": "Dringlichkeit",
+      "childName": "Kind",
+      "childAge": "Alter"
     }
   },
   "tool": {

--- a/packages/translations/locales/en/assistant.json
+++ b/packages/translations/locales/en/assistant.json
@@ -104,6 +104,16 @@
     "draftJobPost": "Drafting job post…",
     "draftParentReply": "Drafting reply…"
   },
+  "toolStatus": {
+    "search_candidates": "Searching candidates…",
+    "search_candidates_ai": "Matching candidates…",
+    "search_products": "Searching products…",
+    "search_services": "Searching services…",
+    "search_jobs": "Searching jobs…",
+    "search_foundations": "Searching foundations…",
+    "find_foundation": "Looking up the foundation…",
+    "view_match_results": "Fetching match results…"
+  },
   "toolCard": {
     "confirm": "Confirm",
     "cancel": "Cancel",

--- a/packages/translations/locales/en/assistant.json
+++ b/packages/translations/locales/en/assistant.json
@@ -15,6 +15,80 @@
       "staffing": "Find me an educator for next week",
       "jobPost": "Draft a job post",
       "help": "How do I publish a job listing?"
+    },
+    "suggestion1": "What can you help me with?",
+    "suggestion2": "How do I use this platform?",
+    "foundation": {
+      "findCandidate": "Find me an EDE in Geneva at 80%",
+      "postJob": "Post a job for an educator",
+      "respondLead": "Show my parent leads"
+    },
+    "educator": {
+      "findJob": "Find childcare jobs near me",
+      "myApplications": "Show my applications",
+      "help": "How do I apply to a job?"
+    },
+    "parent": {
+      "findFoundation": "Find a crèche in my canton",
+      "submitEnquiry": "Submit a childcare enquiry",
+      "myEnquiries": "Show my enquiries"
+    },
+    "supplier": {
+      "myListings": "Show my product listings",
+      "myOrders": "Show my incoming orders",
+      "help": "How do I add a product?"
+    },
+    "serviceProvider": {
+      "myListings": "Show my service listings",
+      "myRequests": "Show my service requests",
+      "help": "How do I add a service?"
+    },
+    "admin": {
+      "stats": "Show platform stats",
+      "findUser": "Find a user by name",
+      "findCandidate": "Find candidates for a foundation"
+    }
+  },
+  "preview": {
+    "postJob": "Publish job listing",
+    "sendMessage": "Send message",
+    "contactAdmin": "File support ticket",
+    "placeOrder": "Place order",
+    "requestService": "Request service",
+    "supplierInquiry": "Send supplier inquiry",
+    "applyToJob": "Apply to job",
+    "shortlist": "Shortlist candidate",
+    "updateStatus": "Update application status",
+    "respondToLead": "Respond to parent lead",
+    "replacement": "Create replacement request",
+    "submitEnquiry": "Submit childcare enquiry",
+    "noDetails": "Confirm to proceed.",
+    "field": {
+      "title": "Title",
+      "role": "Role",
+      "percentage": "Percentage",
+      "location": "Location",
+      "contract": "Contract",
+      "startDate": "Start date",
+      "endDate": "End date",
+      "description": "Description",
+      "recipient": "Recipient",
+      "message": "Message",
+      "subject": "Subject",
+      "priority": "Priority",
+      "product": "Product",
+      "quantity": "Quantity",
+      "notes": "Notes",
+      "service": "Service",
+      "scheduledAt": "Scheduled",
+      "job": "Job",
+      "coverLetter": "Cover letter",
+      "candidate": "Candidate",
+      "application": "Application",
+      "status": "Status",
+      "urgency": "Urgency",
+      "childName": "Child",
+      "childAge": "Age"
     }
   },
   "tool": {

--- a/packages/translations/locales/fr/assistant.json
+++ b/packages/translations/locales/fr/assistant.json
@@ -104,6 +104,16 @@
     "draftJobPost": "Rédaction de l'offre…",
     "draftParentReply": "Rédaction de la réponse…"
   },
+  "toolStatus": {
+    "search_candidates": "Recherche de candidats…",
+    "search_candidates_ai": "Mise en correspondance des candidats…",
+    "search_products": "Recherche de produits…",
+    "search_services": "Recherche de services…",
+    "search_jobs": "Recherche d’offres d’emploi…",
+    "search_foundations": "Recherche de fondations…",
+    "find_foundation": "Recherche de la fondation…",
+    "view_match_results": "Récupération des correspondances…"
+  },
   "toolCard": {
     "confirm": "Confirmer",
     "cancel": "Annuler",

--- a/packages/translations/locales/fr/assistant.json
+++ b/packages/translations/locales/fr/assistant.json
@@ -15,6 +15,80 @@
       "staffing": "Trouver un éducateur pour la semaine prochaine",
       "jobPost": "Rédiger une offre d'emploi",
       "help": "Comment publier une offre d'emploi ?"
+    },
+    "suggestion1": "Comment pouvez-vous m'aider ?",
+    "suggestion2": "Comment utiliser cette plateforme ?",
+    "foundation": {
+      "findCandidate": "Trouver une EDE à Genève à 80%",
+      "postJob": "Publier une offre pour un éducateur",
+      "respondLead": "Afficher mes demandes de parents"
+    },
+    "educator": {
+      "findJob": "Trouver des emplois près de chez moi",
+      "myApplications": "Afficher mes candidatures",
+      "help": "Comment postuler à une offre ?"
+    },
+    "parent": {
+      "findFoundation": "Trouver une crèche dans mon canton",
+      "submitEnquiry": "Soumettre une demande de garde",
+      "myEnquiries": "Afficher mes demandes"
+    },
+    "supplier": {
+      "myListings": "Afficher mes produits",
+      "myOrders": "Afficher mes commandes entrantes",
+      "help": "Comment ajouter un produit ?"
+    },
+    "serviceProvider": {
+      "myListings": "Afficher mes services",
+      "myRequests": "Afficher mes demandes de service",
+      "help": "Comment ajouter un service ?"
+    },
+    "admin": {
+      "stats": "Afficher les statistiques de la plateforme",
+      "findUser": "Trouver un utilisateur par nom",
+      "findCandidate": "Trouver des candidats pour une fondation"
+    }
+  },
+  "preview": {
+    "postJob": "Publier l'offre d'emploi",
+    "sendMessage": "Envoyer le message",
+    "contactAdmin": "Créer un ticket de support",
+    "placeOrder": "Passer la commande",
+    "requestService": "Demander le service",
+    "supplierInquiry": "Envoyer une demande au fournisseur",
+    "applyToJob": "Postuler à l'offre",
+    "shortlist": "Présélectionner le candidat",
+    "updateStatus": "Mettre à jour le statut de la candidature",
+    "respondToLead": "Répondre à la demande du parent",
+    "replacement": "Créer une demande de remplacement",
+    "submitEnquiry": "Soumettre une demande de garde",
+    "noDetails": "Confirmez pour continuer.",
+    "field": {
+      "title": "Titre",
+      "role": "Rôle",
+      "percentage": "Pourcentage",
+      "location": "Lieu",
+      "contract": "Contrat",
+      "startDate": "Date de début",
+      "endDate": "Date de fin",
+      "description": "Description",
+      "recipient": "Destinataire",
+      "message": "Message",
+      "subject": "Objet",
+      "priority": "Priorité",
+      "product": "Produit",
+      "quantity": "Quantité",
+      "notes": "Notes",
+      "service": "Service",
+      "scheduledAt": "Planifié",
+      "job": "Offre",
+      "coverLetter": "Lettre de motivation",
+      "candidate": "Candidat",
+      "application": "Candidature",
+      "status": "Statut",
+      "urgency": "Urgence",
+      "childName": "Enfant",
+      "childAge": "Âge"
     }
   },
   "tool": {


### PR DESCRIPTION
## Summary

Completes AI Assistant V2 Phases 2, 3, and partial Phase 4 by adding 11 L3 write tools (recruitment, leads, marketplace, messaging, replacements), admin-only read tools, per-role welcome suggestions, and streaming tool-execution status events. The assistant can now act autonomously on user requests across all major platform domains.

## Key Changes

### Backend (`api/src/assistant/`)

**New write handlers** (each executes only after user confirmation via approval card):
- `RecruitmentWriteHandler` — `post_job`, `apply_to_job`, `shortlist_candidate`, `update_application_status`
- `LeadsWriteHandler` — `respond_to_lead`, `submit_enquiry`
- `MarketplaceWriteHandler` — `place_order`, `request_service`, `send_supplier_inquiry`
- `MessagingHandler` — `send_message` (universal, any role → any user)
- `ReplacementsHandler` — `create_replacement_request` (gated `v2_replacement_module`)
- `AdminHandler` — `find_user`, `get_platform_stats` (admin-only)

**Tool registry & orchestrator updates:**
- Added 14 new tool definitions to `tool-registry.ts` (11 L3 writes + 3 admin reads)
- Registered all handlers in `ToolHandlerRegistry` and `assistant.module.ts`
- Added `view_match_results` to `SearchHandler` (Phase 3 — ranked matches for staffing request)
- Implemented streaming `tool_status` SSE events for result-card tools (Phase 4 partial)
- Enum validation guards on `create_replacement_request` (urgency) and `update_application_status` (status)

**Shared utilities:**
- Extracted `CONTACT_ADMIN_SUGGESTION` constant to `tool-handler.interface.ts` for consistency across handlers
- Added `resolveOnBehalfOrgId()` helper for admin-on-behalf flows

### Frontend (`frontend/components/assistant/`)

**Rich action preview cards:**
- New `ActionPreviewCard.tsx` — per-tool field definitions (title + labelled fields) for L3 actions
- Replaces generic args display with concrete preview (e.g., "Publish job listing" with title, role, location, etc.)
- Integrated into `AssistantPanel.tsx` via `hasActionPreview()` dispatcher

**Per-role welcome suggestions:**
- `AssistantPanel.tsx` — `SUGGESTIONS_BY_ROLE` map (Foundation, Educator, Parent, Supplier, Service Provider, Admin)
- Each role shows 3 contextual suggestion chips reflecting what the assistant can do for them
- Fallback to generic suggestions if role not found

**Streaming status display:**
- `assistantService.ts` — new `ToolStatusEvent` interface
- `AssistantPanel.tsx` — displays "Searching candidates…" etc. while result-card tools execute
- Status event precedes tool_result event in SSE stream

### Translations (`packages/translations/locales/`)

- Added per-role welcome suggestion keys (en, fr, de)
- Added action preview field labels (preview.field.*, preview.postJob, preview.sendMessage, etc.)
- Covers all 11 L3 write tools + admin tools

### Tests

- New `assistant-v2.e2e.spec.ts` (771 lines) — comprehensive e2e coverage of Phases 2–4:
  - Tool-status SSE streaming for all result-card tools
  - `view_match_results` Phase 3 search tool
  - All 7 L3 confirm paths (shortlist, respond, place order, request service, send inquiry, replacement)
  - Enum-validation guards (urgency, status)
  - Tool-registry completeness (35 tools across 7 roles)
  - `RESULT_CARD_TOOLS` / `TOOL_STATUS_LABELS` consistency
- Updated `orchestrator.service.spec.ts` — added mocks for all

https://claude.ai/code/session_01GPNaCLRCtyoGKpg7pRaLBB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Assistant now supports write actions: send messages, post jobs, apply to jobs, place orders, request services, respond to leads, submit childcare enquiries, create replacement requests, and shortlist candidates
  * Added "view match results" tool to display staffing request matches
  * Added admin tools: user lookup and platform-wide statistics
  * Enhanced action confirmations with preview cards and real-time execution status labels
  * Expanded multilingual support across English, French, and German

<!-- end of auto-generated comment: release notes by coderabbit.ai -->