### PR TITLE
Add contextual thinking labels and next-step suggestions to assistant

### DIFF
--- a/api/prisma/migrations/20260604000000_add_cv_url_to_job_applications/migration.sql
+++ b/api/prisma/migrations/20260604000000_add_cv_url_to_job_applications/migration.sql
@@ -1,0 +1,4 @@
+-- Add cvUrl and cvAssetId columns that are referenced in the Prisma schema
+-- but were missing from the initial job_applications table definition.
+ALTER TABLE "job_applications" ADD COLUMN IF NOT EXISTS "cvUrl" TEXT;
+ALTER TABLE "job_applications" ADD COLUMN IF NOT EXISTS "cvAssetId" TEXT;

--- a/api/src/ai/agents/assistant-orchestrator/prompt.v1.ts
+++ b/api/src/ai/agents/assistant-orchestrator/prompt.v1.ts
@@ -25,6 +25,10 @@ ${contextBlock}
 A tool has been executed. Use the result below to give a clear, direct, helpful answer.
 Do NOT call another tool. Set toolCall to null.
 
+NEXT STEPS RULE: When it would be helpful to offer the user a concrete follow-up action,
+include up to 3 short action labels in the nextSteps array (e.g. ["Broaden search", "Contact admin", "Post a job"]).
+Only add nextSteps when there is a genuine, relevant next action the user might want.
+
 CONVERSATION SO FAR:
 ${input.conversationHistory}
 
@@ -33,7 +37,7 @@ USER MESSAGE: ${input.userMessage}
 TOOL RESULT:
 ${input.toolResult}
 
-Respond with JSON: {"message": "...", "toolCall": null}`;
+Respond with JSON: {"message": "...", "toolCall": null, "nextSteps": ["..."] | []}`;
   }
 
   const toolSection = input.availableTools
@@ -81,9 +85,21 @@ WRITE-ACTION RULES (all L3 — confirm before executing):
 - Message another user directly (any role) → send_message. If only a name is known and you are an admin, resolve the recipient with find_user first.
 
 NO-RESULTS RULE:
-- When any search returns total: 0, present each item in its suggestions[] as a
-  concrete option the user can take. Always offer contact_admin last.
-  Never say "the tool encountered an error" or "please try again later".
+- When any search returns total: 0, do NOT list what the user CAN do as instructions.
+  Instead, ask the user what they would prefer. For example:
+  "I didn't find any results. Would you like me to broaden the search, send a supplier inquiry for a quote, or contact the admin team?"
+  Then include the concrete follow-up options in nextSteps so the user can click one.
+  Always include "Contact admin" as the last nextSteps option.
+
+CLARIFICATION RULE:
+- Before running contact_admin, check whether the conversation already contains enough
+  detail for the ticket (subject + a body of at least one sentence). If not, ask the
+  user first: "What details would you like me to include in the message to admin?"
+  Wait for their reply before calling contact_admin. Do not call the tool until you
+  have enough information.
+- Before running send_message, if no message body is known, ask: "What would you like
+  to say in your message?"
+- For all other L3 tools, ask for any critical missing parameter before proceeding.
 
 WRITE ACTIONS:
 - All L3 tools show a confirmation card before executing. When you are about to
@@ -93,11 +109,16 @@ WRITE ACTIONS:
 
 ESCALATION RULE:
 - If a user expresses frustration, has a complaint, or says "I need to speak to
-  someone / contact admin / report a problem" — use contact_admin. Pre-fill the
-  subject and body using context from the conversation so the user does not have
-  to repeat themselves.
+  someone / contact admin / report a problem" — apply the CLARIFICATION RULE first
+  to gather enough detail, then use contact_admin. Pre-fill the subject and body
+  using context from the conversation so the user does not have to repeat themselves.
 
-ADMIN RULE — FOUNDATION LOOKUP: When an ADMIN or SUPER_ADMIN mentions a foundation or organisation by name (e.g. "for Kinderwelt", "post a job for Les Bout'choux") and no foundationId is in context, you MUST call find_foundation first to resolve the name to an ID. Then use that ID in the subsequent tool call. Never guess or invent a foundationId.`
+ADMIN RULE — FOUNDATION LOOKUP: When an ADMIN or SUPER_ADMIN mentions a foundation or organisation by name (e.g. "for Kinderwelt", "post a job for Les Bout'choux") and no foundationId is in context, you MUST call find_foundation first to resolve the name to an ID. Then use that ID in the subsequent tool call. Never guess or invent a foundationId.
+
+NEXT STEPS RULE: When your final message has no toolCall and it would be helpful to
+offer follow-up actions, include up to 3 short labels in nextSteps
+(e.g. ["Broaden search", "Contact admin", "Post a job"]).
+Only add nextSteps that are genuinely relevant to what just happened.`
     : '';
 
   const priorToolResults = input.toolResult
@@ -119,7 +140,7 @@ USER MESSAGE: ${input.userMessage}
 
 Be concise. Always respond in ${lang}. Your ENTIRE response must be a single valid JSON object — no preamble, no trailing text.
 
-Respond with JSON: {"message": "...", "toolCall": {"name": "...", "args": {...}} | null}`;
+Respond with JSON: {"message": "...", "toolCall": {"name": "...", "args": {...}} | null, "nextSteps": ["..."] | []}`;
 }
 
 function buildContextBlock(input: {

--- a/api/src/ai/agents/assistant-orchestrator/schema.ts
+++ b/api/src/ai/agents/assistant-orchestrator/schema.ts
@@ -6,6 +6,7 @@ export const AssistantOrchestratorSchema = z.object({
     .object({ name: z.string(), args: z.record(z.string(), z.unknown()) })
     .nullable()
     .optional(),
+  nextSteps: z.array(z.string()).optional(),
 });
 
 export type AssistantOrchestratorOutput = z.infer<typeof AssistantOrchestratorSchema>;

--- a/api/src/ai/agents/assistant-orchestrator/schema.ts
+++ b/api/src/ai/agents/assistant-orchestrator/schema.ts
@@ -6,7 +6,7 @@ export const AssistantOrchestratorSchema = z.object({
     .object({ name: z.string(), args: z.record(z.string(), z.unknown()) })
     .nullable()
     .optional(),
-  nextSteps: z.array(z.string()).optional(),
+  nextSteps: z.array(z.string().min(1)).max(3).optional(),
 });
 
 export type AssistantOrchestratorOutput = z.infer<typeof AssistantOrchestratorSchema>;

--- a/api/src/assistant/orchestrator.service.ts
+++ b/api/src/assistant/orchestrator.service.ts
@@ -121,6 +121,9 @@ export class OrchestratorService {
       // No tool call → stream the answer and persist
       if (!output.toolCall) {
         sendEvent('token', { text: output.message });
+        if (output.nextSteps?.length) {
+          sendEvent('next_steps', { nextSteps: output.nextSteps });
+        }
         await this.prisma.aIMessage.create({
           data: { conversationId, sender: AIMessageSender.ASSISTANT, content: output.message },
         });

--- a/api/src/recruitment/recruitment.service.ts
+++ b/api/src/recruitment/recruitment.service.ts
@@ -83,11 +83,6 @@ export class RecruitmentService {
       },
       include: {
         foundation: true,
-        applications: {
-          include: {
-            candidate: true,
-          },
-        },
       },
     });
 

--- a/frontend/components/assistant/AssistantPanel.tsx
+++ b/frontend/components/assistant/AssistantPanel.tsx
@@ -43,22 +43,31 @@ function genId(): string {
 }
 
 /**
- * Returns a contextual label shown in the thinking bubble while the backend
- * processes a request. Inferred from keywords in the user's message so the
- * spinner feels more responsive even before the first token arrives.
+ * Returns a translation key + English fallback for the contextual thinking
+ * label inferred from the user's message. The caller is responsible for
+ * calling t(key, fallback) so the label is always rendered in the user's locale.
  */
-function getThinkingLabel(userMessage: string): string {
+function getThinkingLabelKey(userMessage: string): { key: string; fallback: string } {
   const m = userMessage.toLowerCase();
-  if (/find|search|look.*(for|up)|candidate|staff|educator|ede/.test(m)) return 'Searching available staff…';
-  if (/post.*job|create.*job|publish.*job|job.*post|new.*position/.test(m)) return 'Preparing job posting…';
-  if (/replace|replacement|cover/.test(m)) return 'Checking replacement options…';
-  if (/apply|application|my.*applic/.test(m)) return 'Reviewing applications…';
-  if (/product|food|supply|supplier|order/.test(m)) return 'Searching marketplace…';
-  if (/service|provider/.test(m)) return 'Searching services…';
-  if (/message|send.*to|write.*to/.test(m)) return 'Composing message…';
-  if (/admin|support|ticket|report/.test(m)) return 'Preparing your request…';
-  if (/foundation|crèche|creche|childcare/.test(m)) return 'Searching foundations…';
-  return 'Processing your request…';
+  if (/find|search|look.*(for|up)|candidate|staff|educator|ede/.test(m))
+    return { key: 'thinking.searchStaff', fallback: 'Searching available staff…' };
+  if (/post.*job|create.*job|publish.*job|job.*post|new.*position/.test(m))
+    return { key: 'thinking.prepareJob', fallback: 'Preparing job posting…' };
+  if (/replace|replacement|cover/.test(m))
+    return { key: 'thinking.replacement', fallback: 'Checking replacement options…' };
+  if (/apply|application|my.*applic/.test(m))
+    return { key: 'thinking.applications', fallback: 'Reviewing applications…' };
+  if (/product|food|supply|supplier|order/.test(m))
+    return { key: 'thinking.marketplace', fallback: 'Searching marketplace…' };
+  if (/service|provider/.test(m))
+    return { key: 'thinking.services', fallback: 'Searching services…' };
+  if (/message|send.*to|write.*to/.test(m))
+    return { key: 'thinking.message', fallback: 'Composing message…' };
+  if (/admin|support|ticket|report/.test(m))
+    return { key: 'thinking.admin', fallback: 'Preparing your request…' };
+  if (/foundation|crèche|creche|childcare/.test(m))
+    return { key: 'thinking.foundations', fallback: 'Searching foundations…' };
+  return { key: 'thinking.default', fallback: 'Processing your request…' };
 }
 
 // Per-role welcome suggestion chips.
@@ -285,7 +294,7 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose 
   const [inputText, setInputText] = useState('');
   const [isStreaming, setIsStreaming] = useState(false);
   const [pendingAssistantText, setPendingAssistantText] = useState('');
-  const [thinkingLabel, setThinkingLabel] = useState('Thinking…');
+  const [thinkingLabel, setThinkingLabel] = useState(() => t('panel.thinking', 'Thinking…'));
   const [initError, setInitError] = useState<string | null>(null);
   const [pendingModal, setPendingModal] = useState<{ modal: string; prefill: Record<string, unknown> } | null>(null);
 
@@ -354,7 +363,8 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose 
       setMessages((prev) => [...prev, { id: genId(), sender: 'user', text: msg }]);
       setIsStreaming(true);
       setPendingAssistantText('');
-      setThinkingLabel(getThinkingLabel(msg));
+      const labelKey = getThinkingLabelKey(msg);
+      setThinkingLabel(t(labelKey.key, labelKey.fallback));
 
       await streamMessage(getToken, conversationId, msg, {
         onToken: (chunk) => {
@@ -382,7 +392,7 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose 
           );
         },
         onNextSteps: (event) => {
-          pendingNextStepsRef.current = event.nextSteps;
+          pendingNextStepsRef.current = [...pendingNextStepsRef.current, ...event.nextSteps];
         },
         onModalAction: (action) => {
           setPendingModal(action);

--- a/frontend/components/assistant/AssistantPanel.tsx
+++ b/frontend/components/assistant/AssistantPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { XMarkIcon, PaperAirplaneIcon, SparklesIcon, CheckIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon, PaperAirplaneIcon, SparklesIcon } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@clerk/clerk-react';
 import ReactMarkdown from 'react-markdown';
@@ -28,6 +28,7 @@ interface Message {
   toolResult?: ToolResultEvent;
   toolStatus?: string;
   cancelled?: boolean;
+  nextSteps?: string[];
 }
 
 interface AssistantPanelProps {
@@ -35,14 +36,32 @@ interface AssistantPanelProps {
   onClose: () => void;
 }
 
-// ─── Helper ──────────────────────────────────────────────────────────────────
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function genId(): string {
   return Math.random().toString(36).slice(2, 10);
 }
 
-// Per-role welcome suggestion chips. Each entry is a translation key + fallback;
-// the set shown reflects what the assistant can actually do for that role.
+/**
+ * Returns a contextual label shown in the thinking bubble while the backend
+ * processes a request. Inferred from keywords in the user's message so the
+ * spinner feels more responsive even before the first token arrives.
+ */
+function getThinkingLabel(userMessage: string): string {
+  const m = userMessage.toLowerCase();
+  if (/find|search|look.*(for|up)|candidate|staff|educator|ede/.test(m)) return 'Searching available staff…';
+  if (/post.*job|create.*job|publish.*job|job.*post|new.*position/.test(m)) return 'Preparing job posting…';
+  if (/replace|replacement|cover/.test(m)) return 'Checking replacement options…';
+  if (/apply|application|my.*applic/.test(m)) return 'Reviewing applications…';
+  if (/product|food|supply|supplier|order/.test(m)) return 'Searching marketplace…';
+  if (/service|provider/.test(m)) return 'Searching services…';
+  if (/message|send.*to|write.*to/.test(m)) return 'Composing message…';
+  if (/admin|support|ticket|report/.test(m)) return 'Preparing your request…';
+  if (/foundation|crèche|creche|childcare/.test(m)) return 'Searching foundations…';
+  return 'Processing your request…';
+}
+
+// Per-role welcome suggestion chips.
 const SUGGESTIONS_BY_ROLE: Record<string, { key: string; fallback: string }[]> = {
   [UserRole.FOUNDATION]: [
     { key: 'welcome.foundation.findCandidate', fallback: 'Find me an EDE in Geneva at 80%' },
@@ -75,7 +94,6 @@ const SUGGESTIONS_BY_ROLE: Record<string, { key: string; fallback: string }[]> =
     { key: 'welcome.admin.findCandidate', fallback: 'Find candidates for a foundation' },
   ],
 };
-// SUPER_ADMIN shares the ADMIN suggestion set (same operator capabilities here).
 SUGGESTIONS_BY_ROLE[UserRole.SUPER_ADMIN] = SUGGESTIONS_BY_ROLE[UserRole.ADMIN];
 
 const DEFAULT_SUGGESTIONS = [
@@ -111,7 +129,6 @@ const ToolCallCard: React.FC<ToolCallCardProps> = ({ toolCall, result, cancelled
 
   return (
     <div className="my-2 max-w-xs rounded-lg border border-swiss-teal/30 bg-white p-3 text-sm shadow-sm">
-      {/* Tool name header */}
       <div className="mb-1 flex items-center gap-2">
         <SparklesIcon className="h-3.5 w-3.5 flex-shrink-0 text-swiss-teal" aria-hidden="true" />
         <span className="font-medium text-swiss-charcoal">{toolCall.toolName}</span>
@@ -120,26 +137,22 @@ const ToolCallCard: React.FC<ToolCallCardProps> = ({ toolCall, result, cancelled
         </span>
       </div>
 
-      {/* Preview: rich per-action card when available, else a compact args line */}
       {showRichPreview ? (
         <ActionPreviewCard toolName={toolCall.toolName} args={toolCall.args || {}} />
       ) : (
         argsPreview && <p className="mb-2 truncate text-xs text-gray-500">{argsPreview}</p>
       )}
 
-      {/* Result / error */}
       {hasResult && (
         <div className={`mb-2 rounded px-2 py-1 text-xs ${hasError ? 'bg-red-50 text-red-600' : 'bg-green-50 text-green-700'}`}>
           {hasError ? result!.error : t('toolCard.success', 'Done')}
         </div>
       )}
 
-      {/* Cancelled indicator */}
       {cancelled && !hasResult && (
         <p className="text-xs text-gray-400">{t('toolCard.cancelled', 'Cancelled')}</p>
       )}
 
-      {/* Approval buttons — only shown when not yet resolved or cancelled */}
       {toolCall.approvalRequired && !hasResult && !cancelled && (
         <div className="flex gap-2">
           <button
@@ -157,13 +170,33 @@ const ToolCallCard: React.FC<ToolCallCardProps> = ({ toolCall, result, cancelled
         </div>
       )}
 
-      {/* L1/auto-execute indicator */}
       {!toolCall.approvalRequired && !hasResult && !cancelled && (
         <p className="text-xs text-gray-400">{t('toolCard.autoExecuting', 'Executing…')}</p>
       )}
     </div>
   );
 };
+
+// ─── NextStepChips ────────────────────────────────────────────────────────────
+
+interface NextStepChipsProps {
+  steps: string[];
+  onSelect: (step: string) => void;
+}
+
+const NextStepChips: React.FC<NextStepChipsProps> = ({ steps, onSelect }) => (
+  <div className="mb-3 flex flex-wrap gap-2 pl-1">
+    {steps.map((step) => (
+      <button
+        key={step}
+        onClick={() => onSelect(step)}
+        className="rounded-full border border-swiss-teal/50 bg-swiss-teal/5 px-3 py-1 text-xs font-medium text-swiss-teal transition-colors hover:bg-swiss-teal/15 focus:outline-none focus:ring-2 focus:ring-swiss-teal/40"
+      >
+        {step}
+      </button>
+    ))}
+  </div>
+);
 
 // ─── WelcomeScreen ────────────────────────────────────────────────────────────
 
@@ -205,6 +238,41 @@ const WelcomeScreen: React.FC<WelcomeScreenProps> = ({ onSuggestion, role }) => 
   );
 };
 
+// ─── ThinkingBubble ───────────────────────────────────────────────────────────
+
+interface ThinkingBubbleProps {
+  text: string;
+  label: string;
+}
+
+const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({ text, label }) => (
+  <div className="mb-3 flex justify-start">
+    <div className="max-w-[85%] rounded-xl bg-gray-100 px-4 py-2 text-sm leading-relaxed text-swiss-charcoal">
+      {text ? (
+        <ReactMarkdown
+          components={{
+            p: ({ children }) => <p className="mb-1 last:mb-0">{children}</p>,
+            strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+            ul: ({ children }) => <ul className="ml-4 mt-1 list-disc space-y-0.5">{children}</ul>,
+            ol: ({ children }) => <ol className="ml-4 mt-1 list-decimal space-y-0.5">{children}</ol>,
+            li: ({ children }) => <li>{children}</li>,
+            a: ({ href, children }) => (
+              <a href={href} className="underline hover:opacity-80" target="_blank" rel="noreferrer">
+                {children}
+              </a>
+            ),
+          }}
+        >
+          {text}
+        </ReactMarkdown>
+      ) : (
+        <span className="text-gray-400">{label}</span>
+      )}
+      <span className="ml-0.5 inline-block h-3.5 w-0.5 animate-pulse bg-swiss-teal align-middle" />
+    </div>
+  </div>
+);
+
 // ─── AssistantPanel ───────────────────────────────────────────────────────────
 
 export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose }) => {
@@ -217,27 +285,26 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose 
   const [inputText, setInputText] = useState('');
   const [isStreaming, setIsStreaming] = useState(false);
   const [pendingAssistantText, setPendingAssistantText] = useState('');
+  const [thinkingLabel, setThinkingLabel] = useState('Thinking…');
   const [initError, setInitError] = useState<string | null>(null);
   const [pendingModal, setPendingModal] = useState<{ modal: string; prefill: Record<string, unknown> } | null>(null);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  // Track whether onDone has already been called for the current stream to avoid double-flush
   const doneFiredRef = useRef(false);
+  // Accumulates nextSteps from SSE until flush time
+  const pendingNextStepsRef = useRef<string[]>([]);
 
-  // Scroll to bottom whenever messages change
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, pendingAssistantText]);
 
-  // Focus textarea when panel opens
   useEffect(() => {
     if (isOpen) {
       setTimeout(() => textareaRef.current?.focus(), 150);
     }
   }, [isOpen]);
 
-  // Initialise conversation on first open
   useEffect(() => {
     if (!isOpen || conversationId) return;
 
@@ -254,11 +321,18 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose 
   // ─── Flush pending streaming text into messages ───────────────────────────
 
   const flushPending = useCallback(() => {
+    const steps = pendingNextStepsRef.current;
+    pendingNextStepsRef.current = [];
     setPendingAssistantText((prev) => {
       if (prev.trim()) {
         setMessages((msgs) => [
           ...msgs,
-          { id: genId(), sender: 'assistant', text: prev },
+          {
+            id: genId(),
+            sender: 'assistant',
+            text: prev,
+            nextSteps: steps.length > 0 ? steps : undefined,
+          },
         ]);
       }
       return '';
@@ -275,11 +349,12 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose 
 
       setInputText('');
       doneFiredRef.current = false;
+      pendingNextStepsRef.current = [];
 
-      // Append user message
       setMessages((prev) => [...prev, { id: genId(), sender: 'user', text: msg }]);
       setIsStreaming(true);
       setPendingAssistantText('');
+      setThinkingLabel(getThinkingLabel(msg));
 
       await streamMessage(getToken, conversationId, msg, {
         onToken: (chunk) => {
@@ -299,14 +374,15 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose 
           );
         },
         onToolStatus: (status) => {
-          // The backend label is English; translate by tool name into the user's
-          // locale, falling back to the server label if a key is missing.
           const label = t(`toolStatus.${status.toolName}`, status.label);
           setMessages((prev) =>
             prev.map((m) =>
               m.id === status.toolCallId ? { ...m, toolStatus: label } : m
             )
           );
+        },
+        onNextSteps: (event) => {
+          pendingNextStepsRef.current = event.nextSteps;
         },
         onModalAction: (action) => {
           setPendingModal(action);
@@ -324,10 +400,11 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose 
           ]);
           setIsStreaming(false);
           setPendingAssistantText('');
+          pendingNextStepsRef.current = [];
         },
       });
     },
-    [inputText, isStreaming, conversationId, getToken, flushPending]
+    [inputText, isStreaming, conversationId, getToken, flushPending, t]
   );
 
   const handleKeyDown = useCallback(
@@ -342,7 +419,6 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose 
 
   const handleToolConfirm = useCallback(
     async (toolCall: ToolCallEvent) => {
-      // Tools with a modal open a pre-filled form for the user to submit.
       if (toolCall.modal) {
         setPendingModal({
           modal: toolCall.modal,
@@ -350,7 +426,6 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose 
         });
         return;
       }
-      // Modal-less L3 tools (e.g. contact_admin) execute server-side on confirm.
       if (!conversationId) return;
       try {
         const res = await confirmToolCall(getToken, conversationId, toolCall.toolCallId);
@@ -399,20 +474,17 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose 
 
   return (
     <>
-      {/* Modal handler */}
       <AssistantModalHandler
         pendingModal={pendingModal}
         onHandled={() => setPendingModal(null)}
       />
 
-      {/* Backdrop (mobile) */}
       <div
         className="fixed inset-0 z-40 bg-black/20 backdrop-blur-sm md:hidden"
         onClick={onClose}
         aria-hidden="true"
       />
 
-      {/* Panel */}
       <div
         role="dialog"
         aria-modal="true"
@@ -436,24 +508,19 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose 
 
         {/* Body */}
         <div className="flex flex-1 flex-col overflow-hidden">
-          {/* Error banner */}
           {initError && (
             <div className="border-b border-red-100 bg-red-50 px-4 py-2 text-sm text-red-600">
               {initError}
             </div>
           )}
 
-          {/* Messages area */}
           <div className="flex flex-1 flex-col overflow-y-auto px-4 py-4">
-            {/* Welcome screen */}
             {messages.length === 0 && !isStreaming && (
               <WelcomeScreen onSuggestion={(text) => handleSend(text)} role={currentUser?.role} />
             )}
 
-            {/* Chat bubbles */}
             {messages.map((msg) => {
               if (msg.toolCall) {
-                // Search tools render rich result cards instead of the generic card.
                 if (isResultCardTool(msg.toolCall.toolName)) {
                   return (
                     <SearchResultCards
@@ -479,69 +546,48 @@ export const AssistantPanel: React.FC<AssistantPanelProps> = ({ isOpen, onClose 
               if (!msg.text) return null;
 
               return (
-                <div
-                  key={msg.id}
-                  className={`mb-3 flex ${msg.sender === 'user' ? 'justify-end' : 'justify-start'}`}
-                >
-                  <div
-                    className={`max-w-[85%] rounded-xl px-4 py-2 text-sm leading-relaxed ${
-                      msg.sender === 'user'
-                        ? 'bg-swiss-teal text-white'
-                        : 'bg-gray-100 text-swiss-charcoal'
-                    }`}
-                  >
-                    {msg.sender === 'assistant' ? (
-                      <ReactMarkdown
-                        components={{
-                          p: ({ children }) => <p className="mb-1 last:mb-0">{children}</p>,
-                          strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
-                          ul: ({ children }) => <ul className="ml-4 mt-1 list-disc space-y-0.5">{children}</ul>,
-                          ol: ({ children }) => <ol className="ml-4 mt-1 list-decimal space-y-0.5">{children}</ol>,
-                          li: ({ children }) => <li>{children}</li>,
-                          a: ({ href, children }) => (
-                            <a href={href} className="underline hover:opacity-80" target="_blank" rel="noreferrer">
-                              {children}
-                            </a>
-                          ),
-                        }}
-                      >
-                        {msg.text}
-                      </ReactMarkdown>
-                    ) : (
-                      msg.text
-                    )}
+                <React.Fragment key={msg.id}>
+                  <div className={`mb-2 flex ${msg.sender === 'user' ? 'justify-end' : 'justify-start'}`}>
+                    <div
+                      className={`max-w-[85%] rounded-xl px-4 py-2 text-sm leading-relaxed ${
+                        msg.sender === 'user'
+                          ? 'bg-swiss-teal text-white'
+                          : 'bg-gray-100 text-swiss-charcoal'
+                      }`}
+                    >
+                      {msg.sender === 'assistant' ? (
+                        <ReactMarkdown
+                          components={{
+                            p: ({ children }) => <p className="mb-1 last:mb-0">{children}</p>,
+                            strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+                            ul: ({ children }) => <ul className="ml-4 mt-1 list-disc space-y-0.5">{children}</ul>,
+                            ol: ({ children }) => <ol className="ml-4 mt-1 list-decimal space-y-0.5">{children}</ol>,
+                            li: ({ children }) => <li>{children}</li>,
+                            a: ({ href, children }) => (
+                              <a href={href} className="underline hover:opacity-80" target="_blank" rel="noreferrer">
+                                {children}
+                              </a>
+                            ),
+                          }}
+                        >
+                          {msg.text}
+                        </ReactMarkdown>
+                      ) : (
+                        msg.text
+                      )}
+                    </div>
                   </div>
-                </div>
+                  {/* Clickable next-step chips below the assistant message */}
+                  {msg.sender === 'assistant' && msg.nextSteps && msg.nextSteps.length > 0 && (
+                    <NextStepChips steps={msg.nextSteps} onSelect={(step) => handleSend(step)} />
+                  )}
+                </React.Fragment>
               );
             })}
 
-            {/* Streaming bubble with blinking cursor */}
+            {/* Streaming bubble with contextual thinking label */}
             {isStreaming && (
-              <div className="mb-3 flex justify-start">
-                <div className="max-w-[85%] rounded-xl bg-gray-100 px-4 py-2 text-sm leading-relaxed text-swiss-charcoal">
-                  {pendingAssistantText ? (
-                    <ReactMarkdown
-                      components={{
-                        p: ({ children }) => <p className="mb-1 last:mb-0">{children}</p>,
-                        strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
-                        ul: ({ children }) => <ul className="ml-4 mt-1 list-disc space-y-0.5">{children}</ul>,
-                        ol: ({ children }) => <ol className="ml-4 mt-1 list-decimal space-y-0.5">{children}</ol>,
-                        li: ({ children }) => <li>{children}</li>,
-                        a: ({ href, children }) => (
-                          <a href={href} className="underline hover:opacity-80" target="_blank" rel="noreferrer">
-                            {children}
-                          </a>
-                        ),
-                      }}
-                    >
-                      {pendingAssistantText}
-                    </ReactMarkdown>
-                  ) : (
-                    <span className="text-gray-400">{t('panel.thinking', 'Thinking…')}</span>
-                  )}
-                  <span className="ml-0.5 inline-block h-3.5 w-0.5 animate-pulse bg-swiss-teal align-middle" />
-                </div>
-              </div>
+              <ThinkingBubble text={pendingAssistantText} label={thinkingLabel} />
             )}
 
             <div ref={messagesEndRef} />

--- a/frontend/services/assistantService.ts
+++ b/frontend/services/assistantService.ts
@@ -31,12 +31,17 @@ export interface ToolStatusEvent {
   label: string;
 }
 
+export interface NextStepsEvent {
+  nextSteps: string[];
+}
+
 export interface StreamHandlers {
   onToken: (text: string) => void;
   onToolCall: (toolCall: ToolCallEvent) => void;
   onToolResult: (result: ToolResultEvent) => void;
   onModalAction: (action: ModalActionEvent) => void;
   onToolStatus?: (status: ToolStatusEvent) => void;
+  onNextSteps?: (event: NextStepsEvent) => void;
   onDone: () => void;
   onError: (msg: string) => void;
 }
@@ -221,6 +226,9 @@ export async function streamMessage(
             break;
           case 'tool_status':
             handlers.onToolStatus?.(parsed as unknown as ToolStatusEvent);
+            break;
+          case 'next_steps':
+            handlers.onNextSteps?.(parsed as unknown as NextStepsEvent);
             break;
           case 'modal_action':
             handlers.onModalAction(parsed as unknown as ModalActionEvent);


### PR DESCRIPTION
## Summary

Enhances the assistant panel with smarter UX feedback during processing and actionable follow-up suggestions. Users now see contextual "thinking" labels that reflect what the assistant is working on (e.g., "Searching available staff…"), and assistant responses can include clickable next-step chips for common follow-up actions.

## Key Changes

- **Contextual thinking labels:** Added `getThinkingLabel()` function that infers the assistant's current task from keywords in the user's message, replacing the generic "Thinking…" placeholder with task-specific labels like "Searching available staff…", "Preparing job posting…", etc.

- **Next-step suggestions:** 
  - Extended `Message` interface with optional `nextSteps: string[]` field
  - Created `NextStepChips` component to render clickable follow-up action buttons below assistant messages
  - Added `ThinkingBubble` component to consolidate streaming bubble rendering with thinking label support
  - Integrated `onNextSteps` SSE handler to capture next-step suggestions from the backend

- **Backend prompt updates:**
  - Added `NEXT STEPS RULE` to guide the assistant in suggesting up to 3 relevant follow-up actions when helpful
  - Updated `NO-RESULTS RULE` to ask users what they prefer instead of listing instructions, with options presented as clickable next-steps
  - Added `CLARIFICATION RULE` to gather missing details before executing L3 tools (contact_admin, send_message)
  - Updated response schema to include optional `nextSteps` array in JSON output

- **Schema & service updates:**
  - Extended `AssistantOrchestratorSchema` to validate `nextSteps` field
  - Added `NextStepsEvent` interface and `onNextSteps` handler to `StreamHandlers`
  - Updated orchestrator to emit `next_steps` SSE events when present in assistant output
  - Removed unused `CheckIcon` import

- **Database migration:** Added missing `cvUrl` and `cvAssetId` columns to `job_applications` table (referenced in schema but absent from initial definition)

- **Code cleanup:** Removed redundant comments and unused `applications` include from recruitment service query

## Implementation Details

- Thinking labels are determined client-side before the stream begins, making the UI feel more responsive
- Next-steps are accumulated during streaming and flushed into the message when the response completes
- Clicking a next-step chip sends it as a new user message, maintaining conversation flow
- All changes are backward-compatible; messages without `nextSteps` render normally

https://claude.ai/code/session_01Ar2BtXwfUan6xCbcb6h6hx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Assistant panel now displays contextual next-step suggestions after responses, providing guided navigation and actionable follow-up options.
  * Job applications now support CV URLs for easier document management.

* **Improvements**
  * Enhanced assistant prompting with structured follow-up guidance and improved handling of missing information requests.
  * Optimized job listing retrieval for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->