### PR TITLE
Replace external avatar service with SVG-based fallback utility

### DIFF
--- a/admin/public/logo.svg
+++ b/admin/public/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 60" fill="none">
+  <rect x="4" y="4" width="52" height="52" rx="13" fill="#48CFAE"/>
+  <text x="30" y="38" font-family="Arial Black, Arial, sans-serif" font-size="25" font-weight="900" fill="white" text-anchor="middle">PC</text>
+  <text x="70" y="27" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#1F2937">ProCreche</text>
+  <text x="70" y="46" font-family="Arial, sans-serif" font-size="10.5" font-weight="400" fill="#6B7280" letter-spacing="2">ADMIN</text>
+</svg>

--- a/admin/src/components/Sidebar.tsx
+++ b/admin/src/components/Sidebar.tsx
@@ -225,15 +225,11 @@ const Sidebar: React.FC<SidebarProps> = ({ sidebarOpen, setSidebarOpen }) => {
   const SidebarContent = () => (
     <div className="w-full bg-white border-r border-gray-200/80 flex flex-col shadow-sm h-full">
       <div className="h-20 flex items-center justify-center px-6 border-b border-gray-200/80">
-        {adminLogoUrl ? (
-          <img
-            src={adminLogoUrl}
-            alt={t('admin:sidebar.adminLogo', 'Admin Logo')}
-            className="h-[69px] w-auto"
-          />
-        ) : (
-          <Shield className="h-[69px] w-[69px] text-swiss-mint" />
-        )}
+        <img
+          src={adminLogoUrl || '/logo.svg'}
+          alt={t('admin:sidebar.adminLogo', 'Admin Logo')}
+          className="h-[69px] w-auto"
+        />
       </div>
 
       <nav className="flex-1 p-4 space-y-1.5 overflow-y-auto">

--- a/frontend/components/layout/Navbar.tsx
+++ b/frontend/components/layout/Navbar.tsx
@@ -202,7 +202,7 @@ const Navbar: React.FC<NavbarProps> = ({ onMobileMenuToggle }) => {
               >
                 <img 
                   className="h-8 w-8 sm:h-9 sm:w-9 lg:h-10 lg:w-10 rounded-full border-2 border-transparent hover:border-swiss-mint/30" 
-                  src={currentUser.avatarUrl || `https://ui-avatars.com/api/?name=${currentUser.name.replace(' ', '+')}&background=48CFAE&color=fff&rounded=true&size=128`}
+                  src={currentUser.avatarUrl || getAvatarFallback(currentUser.name)}
                   alt={currentUser.name} 
                 />
                 <span className="ml-2 lg:ml-2.5 hidden lg:block text-swiss-charcoal font-medium text-sm">{currentUser.name}</span>

--- a/frontend/components/layout/Navbar.tsx
+++ b/frontend/components/layout/Navbar.tsx
@@ -12,6 +12,7 @@ import { useNotifications } from '../../contexts/NotificationContext';
 import { useInAppNotifications } from '../../contexts/InAppNotificationContext';
 import LanguageSwitcher from '../../components/ui/LanguageSwitcher';
 import { useTranslation } from 'react-i18next';
+import { getAvatarFallback } from '../../utils/avatar';
 
 interface NavbarProps {
   onMobileMenuToggle: () => void;

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -9,6 +9,7 @@ import { UserRole } from '../../types';
 import { useTranslation } from 'react-i18next'; // Import useTranslation
 import { TFunction } from 'i18next'; // Import TFunction for typing
 import { getHomePath } from '../../utils/navigation';
+import { getAvatarFallback } from '../../utils/avatar';
 
 interface NavItem {
   path: string;

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -307,7 +307,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onLinkClick, isMobileView }) => {
       <div className="p-3 lg:p-5 border-t border-gray-200/80 mt-auto">
         {currentUser && (
            <div className="flex items-center mb-3 lg:mb-4">
-            <img src={currentUser.avatarUrl || `https://ui-avatars.com/api/?name=${currentUser.name.replace(' ', '+')}&background=48CFAE&color=fff&rounded=true&size=128`} alt={currentUser.name} className="w-9 lg:w-11 h-9 lg:h-11 rounded-full mr-2 lg:mr-3 border-2 border-swiss-mint/30" />
+            <img src={currentUser.avatarUrl || getAvatarFallback(currentUser.name)} alt={currentUser.name} className="w-9 lg:w-11 h-9 lg:h-11 rounded-full mr-2 lg:mr-3 border-2 border-swiss-mint/30" />
             <div className="min-w-0 flex-1">
               <p className="text-sm lg:text-base font-semibold text-swiss-charcoal truncate">{currentUser.name}</p>
               <p className="text-xs text-gray-500 truncate">{translateUserRole(currentUser.role, t)}</p>

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -203,21 +203,17 @@ const Sidebar: React.FC<SidebarProps> = ({ onLinkClick, isMobileView }) => {
   const hasSubscription = currentUser && [UserRole.FOUNDATION, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER].includes(currentUser.role);
 
   const renderLogo = (imageClassName: string, placeholderClassName: string) => {
-    if (sidebarLogoUrl) {
-      return (
-        <img
-          src={sidebarLogoUrl}
-          alt={settings?.siteName || t('appName')}
-          className={imageClassName}
-        />
-      );
-    }
-
-    if (loading) {
+    if (loading && !sidebarLogoUrl) {
       return <span className={placeholderClassName} aria-hidden="true" />;
     }
 
-    return <SquaresPlusIcon className={placeholderClassName} />;
+    return (
+      <img
+        src={sidebarLogoUrl || '/logo.svg'}
+        alt={settings?.siteName || t('appName')}
+        className={imageClassName}
+      />
+    );
   };
 
 

--- a/frontend/components/marketplace/SupplierCard.tsx
+++ b/frontend/components/marketplace/SupplierCard.tsx
@@ -5,6 +5,7 @@ import Button from '../ui/Button';
 import RatingStars from '../ui/RatingStars';
 import { BuildingStorefrontIcon, EyeIcon, TagIcon } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
+import { getAvatarFallback } from '../../utils/avatar';
 
 interface SupplierCardProps {
   supplier: Organization;

--- a/frontend/components/marketplace/SupplierCard.tsx
+++ b/frontend/components/marketplace/SupplierCard.tsx
@@ -56,7 +56,7 @@ const SupplierCard: React.FC<SupplierCardProps> = ({ supplier, onViewProfile }) 
     <Card className="flex flex-col group" hoverEffect>
       <div className="relative p-4 border-b border-gray-200 bg-gray-50/50">
         <img 
-          src={supplier.logoUrl || `https://ui-avatars.com/api/?name=${encodeURIComponent(supplier.name)}&background=E0E7FF&color=4F46E5&size=128`} 
+          src={supplier.logoUrl || getAvatarFallback(supplier.name, 'E0E7FF', '4F46E5')}
           alt={`${supplier.name} logo`} 
           className="w-20 h-20 rounded-full mx-auto object-contain border-2 border-white shadow-md bg-white"
         />

--- a/frontend/components/messaging/CreateGroupChatModal.tsx
+++ b/frontend/components/messaging/CreateGroupChatModal.tsx
@@ -8,6 +8,7 @@ import { XMarkIcon } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@clerk/clerk-react';
 import { messagingService } from '../../services/messagingService';
+import { getAvatarFallback } from '../../utils/avatar';
 
 interface CreateGroupChatModalProps {
   isOpen: boolean;
@@ -207,7 +208,7 @@ const CreateGroupChatModal: React.FC<CreateGroupChatModalProps> = ({ isOpen, onC
                       onChange={() => handleUserToggle(user)}
                       className="h-4 w-4 text-swiss-mint border-gray-300 rounded focus:ring-swiss-mint"
                     />
-                    <img src={user.avatarUrl || `https://ui-avatars.com/api/?name=${encodeURIComponent(user.name)}&background=48CFAE&color=ffffff`} alt={user.name} className="w-6 h-6 rounded-full mx-2" />
+                    <img src={user.avatarUrl || getAvatarFallback(user.name)} alt={user.name} className="w-6 h-6 rounded-full mx-2" />
                     <span className="text-sm text-gray-700">{user.name}</span>
                     {user.orgName && (
                       <span className="text-xs text-gray-500 ml-2">({user.orgName})</span>

--- a/frontend/components/profile/edit/EducatorProfileForm.tsx
+++ b/frontend/components/profile/edit/EducatorProfileForm.tsx
@@ -20,6 +20,7 @@ import {
   TrashIcon,
 } from '@heroicons/react/24/outline';
 import Button from '../../ui/Button';
+import { getAvatarFallback } from '../../../utils/avatar';
 
 const MAX_DOCUMENTS = 5;
 
@@ -206,7 +207,7 @@ const EducatorProfileForm: React.FC<EducatorProfileFormProps> = ({ formData, onC
   };
 
   const avatarUrl = formData.avatarUrl || currentUser?.avatarUrl || 
-    `https://ui-avatars.com/api/?name=${encodeURIComponent((formData.firstName || '') + ' ' + (formData.lastName || ''))}&background=48CFAE&color=fff&size=128&rounded=true`;
+    getAvatarFallback((formData.firstName || '') + ' ' + (formData.lastName || ''));
 
   const coverImageUrl = formData.coverImageUrl || currentUser?.orgCoverImageUrl || 
     'https://images.unsplash.com/photo-1503676260728-4c8c0c7832a6?auto=format&fit=crop&w=1600&q=80';

--- a/frontend/components/profile/edit/FoundationProfileForm.tsx
+++ b/frontend/components/profile/edit/FoundationProfileForm.tsx
@@ -12,6 +12,7 @@ import {
   MapPinIcon,
   AcademicCapIcon,
 } from '@heroicons/react/24/outline';
+import { getAvatarFallback } from '../../../utils/avatar';
 
 // Intentionally hardcoded labels (do not translate)
 const SUPPORTED_LANGUAGES_OPTIONS: { label: string; value: SupportedLanguage }[] = [
@@ -45,7 +46,7 @@ const FoundationProfileForm: React.FC<FoundationProfileFormProps> = ({ formData,
   const translatedLanguageOptions = SUPPORTED_LANGUAGES_OPTIONS;
 
   const logoUrl = formData.logoUrl || currentUser?.orgLogoUrl || 
-    `https://ui-avatars.com/api/?name=${encodeURIComponent(formData.companyName || 'Organization')}&background=2DD4BF&color=ffffff&size=128&rounded=true`;
+    getAvatarFallback(formData.companyName || 'Organization', '2DD4BF', 'ffffff');
   
   const coverImageUrl = formData.coverImageUrl || currentUser?.orgCoverImageUrl || 
     'https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1600&q=80';

--- a/frontend/components/profile/edit/ServiceProviderProfileForm.tsx
+++ b/frontend/components/profile/edit/ServiceProviderProfileForm.tsx
@@ -12,6 +12,7 @@ import {
   MapPinIcon,
   BriefcaseIcon,
 } from '@heroicons/react/24/outline';
+import { getAvatarFallback } from '../../../utils/avatar';
 
 // Intentionally hardcoded labels (do not translate)
 const SUPPORTED_LANGUAGES_OPTIONS: { label: string; value: SupportedLanguage }[] = [
@@ -93,7 +94,7 @@ const ServiceProviderProfileForm: React.FC<ServiceProviderProfileFormProps> = ({
   };
 
   const logoUrl = formData.logoUrl || currentUser?.orgLogoUrl || 
-    `https://ui-avatars.com/api/?name=${encodeURIComponent(formData.companyName || 'Service Provider')}&background=2DD4BF&color=ffffff&size=128&rounded=true`;
+    getAvatarFallback(formData.companyName || 'Service Provider', '2DD4BF', 'ffffff');
   
   const coverImageUrl = formData.coverImageUrl || currentUser?.orgCoverImageUrl || 
     'https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1600&q=80';

--- a/frontend/components/profile/edit/SupplierProfileForm.tsx
+++ b/frontend/components/profile/edit/SupplierProfileForm.tsx
@@ -12,6 +12,7 @@ import {
   MapPinIcon,
   ShoppingCartIcon,
 } from '@heroicons/react/24/outline';
+import { getAvatarFallback } from '../../../utils/avatar';
 
 // Intentionally hardcoded labels (do not translate)
 const SUPPORTED_LANGUAGES_OPTIONS: { label: string; value: SupportedLanguage }[] = [
@@ -45,7 +46,7 @@ const SupplierProfileForm: React.FC<SupplierProfileFormProps> = ({ formData, onC
   const translatedLanguageOptions = SUPPORTED_LANGUAGES_OPTIONS;
 
   const logoUrl = formData.logoUrl || currentUser?.orgLogoUrl || 
-    `https://ui-avatars.com/api/?name=${encodeURIComponent(formData.companyName || 'Supplier')}&background=2DD4BF&color=ffffff&size=128&rounded=true`;
+    getAvatarFallback(formData.companyName || 'Supplier', '2DD4BF', 'ffffff');
   
   const coverImageUrl = formData.coverImageUrl || currentUser?.orgCoverImageUrl || 
     'https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1600&q=80';

--- a/frontend/components/profile/edit/shared/AvatarSection.tsx
+++ b/frontend/components/profile/edit/shared/AvatarSection.tsx
@@ -3,6 +3,7 @@ import { CameraIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
 import { useAuthenticatedApi } from '../../../../hooks/useAuthenticatedApi';
 import ImageCropperModal, { ImageCropPreset, IMAGE_CROP_PRESETS } from '../../../shared/ImageCropperModal';
+import { getAvatarFallback } from '../../../../utils/avatar';
 
 interface AvatarSectionProps {
   avatarUrl: string | null;
@@ -113,7 +114,7 @@ const AvatarSection: React.FC<AvatarSectionProps> = ({
   };
 
   const displayUrl = previewUrl || avatarUrl || 
-    'https://ui-avatars.com/api/?name=Profile&background=2DD4BF&color=ffffff&size=128&rounded=true';
+    getAvatarFallback('Profile', '2DD4BF', 'ffffff');
 
   const isCircular = variant === 'avatar' || cropPreset === 'AVATAR';
 

--- a/frontend/components/recruitment/JobDetailModal.tsx
+++ b/frontend/components/recruitment/JobDetailModal.tsx
@@ -6,6 +6,7 @@ import { XMarkIcon, BriefcaseIcon, MapPinIcon, CalendarDaysIcon, ListBulletIcon,
 import { useTranslation } from 'react-i18next';
 import Card from '../ui/Card';
 import JobApplicationModal from './JobApplicationModal';
+import { getAvatarFallback } from '../../utils/avatar';
 
 interface JobDetailModalProps {
   isOpen: boolean;

--- a/frontend/components/recruitment/JobDetailModal.tsx
+++ b/frontend/components/recruitment/JobDetailModal.tsx
@@ -80,7 +80,7 @@ const JobDetailModal: React.FC<JobDetailModalProps> = ({ isOpen, onClose, job, o
         <div className="flex justify-between items-start px-6 py-4 border-b border-gray-200 bg-white flex-shrink-0">
           <div className="flex items-center">
               <img
-                src={`https://ui-avatars.com/api/?name=${encodeURIComponent(job.foundationName || job.title)}`}
+                src={getAvatarFallback(job.foundationName || job.title)}
                 alt={`${job.foundationName} logo`}
                 className="w-20 h-20 rounded-lg mr-4 border bg-white"
               />

--- a/frontend/components/settings/sections/CompanyProfileSettings.tsx
+++ b/frontend/components/settings/sections/CompanyProfileSettings.tsx
@@ -24,6 +24,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../../../contexts/AppContext';
 import { toggleMultiSelectWithAll } from '../../../utils/regionSelection';
+import { getAvatarFallback } from '../../../utils/avatar';
 
 interface CompanyProfileSettingsProps {
   settings: SettingsFormData;
@@ -109,7 +110,7 @@ const CompanyProfileSettings: React.FC<CompanyProfileSettingsProps> = ({ setting
   const isServiceProvider = userRole === UserRole.SERVICE_PROVIDER;
 
   const logoUrl = settings.logoUrl || currentUser?.orgLogoUrl || 
-    `https://ui-avatars.com/api/?name=${encodeURIComponent(settings.companyName || 'Organization')}&background=2DD4BF&color=ffffff&size=128&rounded=true`;
+    getAvatarFallback(settings.companyName || 'Organization', '2DD4BF', 'ffffff');
   
   const coverImageUrl = settings.coverImageUrl || currentUser?.orgCoverImageUrl || 
     'https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1600&q=80';

--- a/frontend/components/settings/sections/EducatorProfileSettings.tsx
+++ b/frontend/components/settings/sections/EducatorProfileSettings.tsx
@@ -25,6 +25,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAppContext } from '../../../contexts/AppContext';
 import { useAuthenticatedApi } from '../../../hooks/useAuthenticatedApi';
+import { getAvatarFallback } from '../../../utils/avatar';
 import {
   certificationItemsFromNames,
   createTempId,
@@ -400,7 +401,7 @@ const EducatorProfileSettings: React.FC<EducatorProfileSettingsProps> = ({ setti
 
   // Use avatarUrl from settings (computed from asset relation on backend)
   const avatarUrl = settings.avatarUrl || currentUser?.avatarUrl || 
-    `https://ui-avatars.com/api/?name=${encodeURIComponent(profileData.firstName + ' ' + profileData.lastName)}&background=48CFAE&color=fff&size=128&rounded=true`;
+    getAvatarFallback(profileData.firstName + ' ' + profileData.lastName);
 
   return (
     <SettingsSectionWrapper title={t('settings:page.educatorProfile', 'Profile Information')} icon={UserCircleIcon}>

--- a/frontend/components/shared/LogoLink.tsx
+++ b/frontend/components/shared/LogoLink.tsx
@@ -39,7 +39,7 @@ const LogoLink: React.FC<LogoLinkProps> = ({
   if (showFallback) {
     return (
       <Link to={to} aria-label={ariaLabel} className={className}>
-        {fallback ?? (FallbackIcon ? <FallbackIcon className={iconClassName} /> : null)}
+        {fallback ?? <img src="/logo.svg" alt={altText} className={imageClassName} />}
       </Link>
     );
   }

--- a/frontend/pages/MarketplacePage.tsx
+++ b/frontend/pages/MarketplacePage.tsx
@@ -14,6 +14,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { formatServiceCategory, formatServiceDeliveryType } from '../utils/serviceFormatting';
 import { marketplaceService } from '../services/marketplaceService';
+import { getAvatarFallback } from '../utils/avatar';
 
 // Loading skeleton component
 const CardSkeleton: React.FC = () => (
@@ -56,7 +57,7 @@ const ServiceProviderCard: React.FC<{
     <Card className="flex flex-col group" hoverEffect>
       <div className="relative p-4 border-b border-gray-200 bg-gray-50/50">
         <img 
-          src={provider.logoUrl || `https://ui-avatars.com/api/?name=${encodeURIComponent(provider.name)}&background=D1FAE5&color=059669&size=128`} 
+          src={provider.logoUrl || getAvatarFallback(provider.name, 'D1FAE5', '059669')} 
           alt={`${provider.name} logo`} 
           className="w-20 h-20 rounded-full mx-auto object-contain border-2 border-white shadow-md bg-white"
         />

--- a/frontend/pages/ProfilePage.tsx
+++ b/frontend/pages/ProfilePage.tsx
@@ -14,6 +14,7 @@ import { UserRole } from '../types';
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
 import OrganizationPublicProfile from '../components/profile/OrganizationPublicProfile';
+import { getAvatarFallback } from '../utils/avatar';
 
 const ProfilePage: React.FC = () => {
   const { currentUser } = useAppContext();
@@ -95,7 +96,7 @@ const ProfilePage: React.FC = () => {
 
   const avatarUrl =
     currentUser.avatarUrl ||
-    `https://ui-avatars.com/api/?name=${encodeURIComponent(currentUser.name || currentUser.email)}&background=48CFAE&color=ffffff&size=128&rounded=true`;
+    getAvatarFallback(currentUser.name || currentUser.email);
 
   return (
     <div className="p-8 space-y-6 bg-page-bg min-h-full">

--- a/frontend/pages/UsersPage.tsx
+++ b/frontend/pages/UsersPage.tsx
@@ -9,6 +9,7 @@ import { MagnifyingGlassIcon, FunnelIcon, PencilIcon, PlusIcon, TrashIcon, Check
 import { useAppContext } from '../contexts/AppContext';
 import { useTranslation } from 'react-i18next';
 import { useAuthenticatedApi } from '../hooks/useAuthenticatedApi';
+import { getAvatarFallback } from '../utils/avatar';
 
 // Maximum users fetched per request. Referenced in the truncation warning message.
 const PAGE_LIMIT = 100;
@@ -84,7 +85,7 @@ const UserRow: React.FC<UserRowProps> = ({ user, onUserSelect, onDeleteUser, isS
   };
 
   const displayName = user.name || user.email || 'Unknown';
-  const fallbackAvatarUrl = `https://ui-avatars.com/api/?${new URLSearchParams({ name: displayName, background: '48CFAE', color: 'fff' }).toString()}`;
+  const fallbackAvatarUrl = getAvatarFallback(displayName);
 
   return (
     <tr className="hover:bg-gray-50 transition-colors cursor-pointer" onClick={() => onUserSelect(user)}>
@@ -165,7 +166,7 @@ const UserDetailDrawer: React.FC<UserDetailDrawerProps> = ({ user, onClose, onUp
   };
 
   const displayName = user.name || user.email || 'Unknown';
-  const fallbackAvatarUrl = `https://ui-avatars.com/api/?${new URLSearchParams({ name: displayName, background: '48CFAE', color: 'fff' }).toString()}`;
+  const fallbackAvatarUrl = getAvatarFallback(displayName);
 
   return (
     <div

--- a/frontend/pages/candidate/CandidateProfilePage.tsx
+++ b/frontend/pages/candidate/CandidateProfilePage.tsx
@@ -21,6 +21,7 @@ import { useAppContext } from '../../contexts/AppContext';
 import { useMessaging } from '../../contexts/MessagingContext';
 import { useRecruitmentApi } from '../../hooks/useRecruitmentApi';
 import { useTranslation } from 'react-i18next';
+import { getAvatarFallback } from '../../utils/avatar';
 
 const SectionCard: React.FC<{ title: string; icon: React.ElementType; children: React.ReactNode }> = ({
   title,
@@ -159,7 +160,7 @@ const CandidateProfilePage: React.FC = () => {
       <Card className="p-6">
         <div className="flex flex-col sm:flex-row items-center sm:items-start">
           <img
-            src={avatarUrl || `https://ui-avatars.com/api/?name=${encodeURIComponent(name)}&background=48CFAE&color=fff&size=128`}
+            src={avatarUrl || getAvatarFallback(name)}
             alt={name}
             className="w-32 h-32 rounded-full border-4 border-white shadow-lg mb-4 sm:mb-0 sm:mr-6 flex-shrink-0 bg-gray-200"
           />

--- a/frontend/pages/educator/EducatorPendingApprovalPage.tsx
+++ b/frontend/pages/educator/EducatorPendingApprovalPage.tsx
@@ -19,19 +19,18 @@ const EducatorPendingApprovalPage: React.FC = () => {
         </div>
 
         <h1 className="text-2xl font-bold text-gray-900 mb-3">
-          Profile Under Review
+          {t('educatorPendingApprovalPage.title')}
         </h1>
         <p className="text-gray-600 mb-6">
-          Thank you for signing up as an educator! Your profile is currently being reviewed by our team.
-          You will receive an email once your application has been processed.
+          {t('educatorPendingApprovalPage.description')}
         </p>
 
         <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6 text-left space-y-2">
-          <p className="text-sm font-medium text-amber-800">What happens next?</p>
+          <p className="text-sm font-medium text-amber-800">{t('educatorPendingApprovalPage.whatHappensNext')}</p>
           <ul className="text-sm text-amber-700 space-y-1 list-disc list-inside">
-            <li>Our team reviews your submitted profile</li>
-            <li>You receive an approval or feedback email</li>
-            <li>Once approved, you get full access to the platform</li>
+            <li>{t('educatorPendingApprovalPage.step1')}</li>
+            <li>{t('educatorPendingApprovalPage.step2')}</li>
+            <li>{t('educatorPendingApprovalPage.step3')}</li>
           </ul>
         </div>
 
@@ -40,17 +39,17 @@ const EducatorPendingApprovalPage: React.FC = () => {
             <UserCircleIcon className="w-5 h-5 text-swiss-mint mt-0.5 flex-shrink-0" />
             <div className="flex-1">
               <p className="text-sm font-semibold text-swiss-charcoal mb-1">
-                Complete your profile
+                {t('educatorPendingApprovalPage.completeProfile')}
               </p>
               <p className="text-sm text-gray-600 mb-3">
-                While you wait for approval, make sure your profile is complete and up to date. A complete profile increases your chances of being matched with the right opportunities.
+                {t('educatorPendingApprovalPage.completeProfileDesc')}
               </p>
               <button
                 onClick={() => navigate('/educator/profile')}
                 className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-swiss-mint text-white text-sm font-medium hover:bg-opacity-90 transition-colors"
               >
                 <UserCircleIcon className="w-4 h-4" />
-                {t('educatorProfilePage.goToMyProfile', 'Go to My Profile')}
+                {t('educatorProfilePage.goToMyProfile')}
               </button>
             </div>
           </div>
@@ -62,13 +61,13 @@ const EducatorPendingApprovalPage: React.FC = () => {
             className="inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors"
           >
             <EnvelopeIcon className="w-4 h-4" />
-            Contact Support
+            {t('educatorPendingApprovalPage.contactSupport')}
           </a>
           <button
             onClick={() => signOut().catch((err) => console.error('Sign out failed:', err))}
             className="px-5 py-2.5 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors"
           >
-            Sign Out
+            {t('educatorPendingApprovalPage.signOut')}
           </button>
         </div>
       </div>

--- a/frontend/pages/educator/EducatorProfilePage.tsx
+++ b/frontend/pages/educator/EducatorProfilePage.tsx
@@ -16,6 +16,7 @@ import { useNotifications } from '../../contexts/NotificationContext';
 import { useAuthenticatedApi } from '../../hooks/useAuthenticatedApi';
 import FileUploadZone from '../../components/ui/FileUploadZone';
 import { WorkExperienceItem, EducationItem, CertificationItem, DocumentItem } from '../../types';
+import { getAvatarFallback } from '../../utils/avatar';
 
 const MAX_DOCUMENTS = 5;
 
@@ -416,7 +417,7 @@ const EducatorProfilePage: React.FC = () => {
   const hasStructuredEducation = educationItems.length > 0;
 
   const fullName = `${profile.firstName} ${profile.lastName}`.trim() || t('educatorProfilePage.unnamed', 'Unnamed Educator');
-  const avatarUrl = profile.avatarUrl || `https://ui-avatars.com/api/?name=${encodeURIComponent(fullName)}&background=48CFAE&color=fff&size=128`;
+  const avatarUrl = profile.avatarUrl || getAvatarFallback(fullName);
   const roleDisplay = profile.jobRole
     ? profile.jobRole
     : t('educatorProfilePage.roleNotProvided', 'Role not provided');

--- a/frontend/pages/partner/PartnerDetailPage.tsx
+++ b/frontend/pages/partner/PartnerDetailPage.tsx
@@ -28,6 +28,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useOrganizationMessaging } from '../../hooks/useOrganizationMessaging';
 import ActiveClientToggle from '../../components/shared/ActiveClientToggle';
+import { getAvatarFallback } from '../../utils/avatar';
 import OrganizationDocumentsList from '../../components/profile/OrganizationDocumentsList';
 import PromoCodesDisplaySection from '../../components/profile/PromoCodesDisplaySection';
 import { formatServiceCategoryForService, formatServiceDeliveryType, formatCategory } from '../../utils/serviceFormatting';
@@ -310,7 +311,7 @@ const PartnerDetailPage: React.FC = () => {
       : t('common:userRoles.Foundation');
 
   const coverImageUrl = partner.coverImageUrl || `https://picsum.photos/seed/${partner.id}Cover/1200/300`;
-  const logoUrl = partner.logoUrl || `https://ui-avatars.com/api/?name=${encodeURIComponent(partner.name)}&background=E0E7FF&color=4F46E5&size=128`;
+  const logoUrl = partner.logoUrl || getAvatarFallback(partner.name, 'E0E7FF', '4F46E5');
 
   return (
     <div className="space-y-6">

--- a/frontend/pages/profile/EducatorProfileViewPage.tsx
+++ b/frontend/pages/profile/EducatorProfileViewPage.tsx
@@ -21,6 +21,7 @@ import { useRecruitmentApi } from '../../hooks/useRecruitmentApi';
 import { CandidateProfile, UserRole } from '../../types';
 import { useAppContext } from '../../contexts/AppContext';
 import { useMessaging } from '../../contexts/MessagingContext';
+import { getAvatarFallback } from '../../utils/avatar';
 
 const SectionCard: React.FC<{ title: string; icon: React.ElementType; children: React.ReactNode }> = ({
   title,
@@ -182,7 +183,7 @@ const EducatorProfileViewPage: React.FC = () => {
           <div className="absolute bottom-0 left-6 transform translate-y-1/2">
             <div className="relative">
               <img
-                src={avatarUrl || `https://ui-avatars.com/api/?name=${encodeURIComponent(name)}&background=48CFAE&color=fff&size=160&rounded=true`}
+                src={avatarUrl || getAvatarFallback(name)}
                 alt={name}
                 className="w-32 h-32 rounded-full border-4 border-white shadow-xl bg-white object-cover"
               />

--- a/frontend/pages/profile/OrganizationProfileViewPage.tsx
+++ b/frontend/pages/profile/OrganizationProfileViewPage.tsx
@@ -10,6 +10,7 @@ import { useAuthenticatedApi } from '../../hooks/useAuthenticatedApi';
 import { Organization, UserRole } from '../../types';
 import { useAppContext } from '../../contexts/AppContext';
 import { useOrganizationMessaging } from '../../hooks/useOrganizationMessaging';
+import { getAvatarFallback } from '../../utils/avatar';
 
 const OrganizationProfileViewPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -185,7 +186,7 @@ const OrganizationProfileViewPage: React.FC = () => {
           <div className="absolute bottom-0 left-6 transform translate-y-1/2">
             <div className="relative">
               <img
-                src={organization.logoUrl || `https://ui-avatars.com/api/?name=${encodeURIComponent(organization.name)}&background=2DD4BF&color=ffffff&size=160&rounded=true`}
+                src={organization.logoUrl || getAvatarFallback(organization.name, '2DD4BF', 'ffffff')}
                 alt={`${organization.name} logo`}
                 className="w-32 h-32 rounded-full border-4 border-white shadow-xl bg-white object-cover"
               />

--- a/frontend/pages/service-provider/ServiceProviderOrganisationProfilePage.tsx
+++ b/frontend/pages/service-provider/ServiceProviderOrganisationProfilePage.tsx
@@ -25,6 +25,7 @@ import ProfileDocumentsSettings from '../../components/settings/sections/Profile
 import PromoCodesDisplaySection from '../../components/profile/PromoCodesDisplaySection';
 import { UserRole } from '../../types';
 import { openExternalUrl, toExternalUrl } from '../../utils/url';
+import { getAvatarFallback } from '../../utils/avatar';
 
 interface ServiceProviderSettingsData {
   companyName?: string;
@@ -304,7 +305,7 @@ const ServiceProviderOrganisationProfilePage: React.FC = () => {
   const websiteHref = toExternalUrl(websiteUrl);
 
   const logoUrl = serviceProviderSettings?.logoUrl || organizationDetails?.logoUrl || currentUser?.orgLogoUrl ||
-    `https://ui-avatars.com/api/?name=${encodeURIComponent(organizationName)}&background=2DD4BF&color=ffffff&size=128&rounded=true`;
+    getAvatarFallback(organizationName, '2DD4BF', 'ffffff');
   
   const coverImageUrl = serviceProviderSettings?.coverImageUrl || organizationDetails?.coverImageUrl || currentUser?.orgCoverImageUrl ||
     'https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1600&q=80';

--- a/frontend/pages/supplier/SupplierOrganisationProfilePage.tsx
+++ b/frontend/pages/supplier/SupplierOrganisationProfilePage.tsx
@@ -26,6 +26,7 @@ import ProfileDocumentsSettings from '../../components/settings/sections/Profile
 import PromoCodesDisplaySection from '../../components/profile/PromoCodesDisplaySection';
 import { UserRole } from '../../types';
 import { openExternalUrl, toExternalUrl } from '../../utils/url';
+import { getAvatarFallback } from '../../utils/avatar';
 
 interface SupplierSettingsData {
   companyName?: string;
@@ -297,7 +298,7 @@ const SupplierOrganisationProfilePage: React.FC = () => {
   const websiteHref = toExternalUrl(websiteUrl);
 
   const logoUrl = supplierSettings?.logoUrl || organizationDetails?.logoUrl || currentUser?.orgLogoUrl ||
-    `https://ui-avatars.com/api/?name=${encodeURIComponent(organizationName)}&background=2DD4BF&color=ffffff&size=128&rounded=true`;
+    getAvatarFallback(organizationName, '2DD4BF', 'ffffff');
   
   const coverImageUrl = supplierSettings?.coverImageUrl || organizationDetails?.coverImageUrl || currentUser?.orgCoverImageUrl ||
     'https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1600&q=80';

--- a/frontend/providers/AuthProvider.tsx
+++ b/frontend/providers/AuthProvider.tsx
@@ -11,6 +11,7 @@ import { useUser, useAuth, ClerkProvider, useClerk } from '@clerk/clerk-react';
 import { Organization, User, UserRole } from '../types';
 import { API_ENDPOINTS } from '../services/api-endpoints';
 import { apiService, ApiError } from '../services/api';
+import { getAvatarFallback } from '../utils/avatar';
 
 const BACKEND_SYNC_ERROR_KEY = 'common:loginPage.backendSyncError';
 const BACKEND_USER_CREATION_ERROR_KEY = 'common:loginPage.backendUserCreationError';
@@ -123,7 +124,7 @@ const AuthProviderInner: React.FC<AuthProviderProps> = ({ children }) => {
         user.avatarAsset?.publicUrl ??
         user.avatarUrl ??
         primaryOrganization?.logoUrl ??
-        `https://ui-avatars.com/api/?name=${encodeURIComponent(derivedName)}&background=48CFAE&color=ffffff&size=128&rounded=true`;
+        getAvatarFallback(derivedName);
 
       return {
         ...user,

--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 60" fill="none">
+  <rect x="4" y="4" width="52" height="52" rx="13" fill="#48CFAE"/>
+  <text x="30" y="38" font-family="Arial Black, Arial, sans-serif" font-size="25" font-weight="900" fill="white" text-anchor="middle">PC</text>
+  <text x="70" y="27" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#1F2937">ProCreche</text>
+  <text x="70" y="46" font-family="Arial, sans-serif" font-size="10.5" font-weight="400" fill="#6B7280" letter-spacing="2">SOLUTIONS</text>
+</svg>

--- a/frontend/utils/avatar.ts
+++ b/frontend/utils/avatar.ts
@@ -1,0 +1,14 @@
+const getInitials = (name: string): string =>
+  name
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word[0])
+    .slice(0, 2)
+    .join('')
+    .toUpperCase();
+
+export const getAvatarFallback = (name: string, background = '48CFAE', color = 'fff'): string => {
+  const initials = getInitials(name) || '?';
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128"><rect width="128" height="128" rx="64" fill="#${background}"/><text x="64" y="64" font-family="Arial,sans-serif" font-size="48" font-weight="600" fill="#${color}" text-anchor="middle" dominant-baseline="central">${initials}</text></svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+};

--- a/packages/translations/locales/de/dashboard.json
+++ b/packages/translations/locales/de/dashboard.json
@@ -142,6 +142,18 @@
     "title": "Stellenangebote",
     "unknownFoundation": "Unbekannte Stiftung"
   },
+  "educatorPendingApprovalPage": {
+    "title": "Profil wird überprüft",
+    "description": "Vielen Dank für Ihre Registrierung als Erzieher/in! Ihr Profil wird derzeit von unserem Team geprüft. Sie erhalten eine E-Mail, sobald Ihre Bewerbung bearbeitet wurde.",
+    "whatHappensNext": "Was passiert als Nächstes?",
+    "step1": "Unser Team prüft Ihr eingereichtes Profil",
+    "step2": "Sie erhalten eine Genehmigungs- oder Feedback-E-Mail",
+    "step3": "Nach der Genehmigung erhalten Sie vollen Zugang zur Plattform",
+    "completeProfile": "Vervollständigen Sie Ihr Profil",
+    "completeProfileDesc": "Stellen Sie während der Wartezeit auf die Genehmigung sicher, dass Ihr Profil vollständig und aktuell ist. Ein vollständiges Profil erhöht Ihre Chancen, mit den richtigen Möglichkeiten zusammengeführt zu werden.",
+    "contactSupport": "Support kontaktieren",
+    "signOut": "Abmelden"
+  },
   "educatorProfilePage": {
     "availability": {
       "ageGroups": "Altersgruppen",

--- a/packages/translations/locales/en/dashboard.json
+++ b/packages/translations/locales/en/dashboard.json
@@ -382,6 +382,18 @@
     "title": "Job Listings",
     "unknownFoundation": "Unknown foundation"
   },
+  "educatorPendingApprovalPage": {
+    "title": "Profile Under Review",
+    "description": "Thank you for signing up as an educator! Your profile is currently being reviewed by our team. You will receive an email once your application has been processed.",
+    "whatHappensNext": "What happens next?",
+    "step1": "Our team reviews your submitted profile",
+    "step2": "You receive an approval or feedback email",
+    "step3": "Once approved, you get full access to the platform",
+    "completeProfile": "Complete your profile",
+    "completeProfileDesc": "While you wait for approval, make sure your profile is complete and up to date. A complete profile increases your chances of being matched with the right opportunities.",
+    "contactSupport": "Contact Support",
+    "signOut": "Sign Out"
+  },
   "educatorProfilePage": {
     "availability": {
       "ageGroups": "Age Groups",

--- a/packages/translations/locales/fr/dashboard.json
+++ b/packages/translations/locales/fr/dashboard.json
@@ -141,6 +141,18 @@
     "title": "Offres d'emploi",
     "unknownFoundation": "Fondation inconnue"
   },
+  "educatorPendingApprovalPage": {
+    "title": "Profil en cours d'examen",
+    "description": "Merci de vous être inscrit(e) en tant qu'éducateur/éducatrice ! Votre profil est actuellement examiné par notre équipe. Vous recevrez un e-mail une fois votre candidature traitée.",
+    "whatHappensNext": "Et ensuite ?",
+    "step1": "Notre équipe examine votre profil soumis",
+    "step2": "Vous recevez un e-mail d'approbation ou de retour",
+    "step3": "Une fois approuvé(e), vous avez pleinement accès à la plateforme",
+    "completeProfile": "Complétez votre profil",
+    "completeProfileDesc": "En attendant l'approbation, assurez-vous que votre profil est complet et à jour. Un profil complet augmente vos chances d'être mis(e) en relation avec les bonnes opportunités.",
+    "contactSupport": "Contacter le support",
+    "signOut": "Se déconnecter"
+  },
   "educatorProfilePage": {
     "availability": {
       "ageGroups": "Groupes d'âge",


### PR DESCRIPTION
## Summary
Replaces all hardcoded `ui-avatars.com` API calls with a new `getAvatarFallback()` utility that generates SVG-based avatar fallbacks using user initials. This reduces external service dependencies and improves performance by eliminating network requests for placeholder avatars.

## Key Changes

- **New utility:** `frontend/utils/avatar.ts` exports `getAvatarFallback(name, background, color)` which generates a data URI SVG with user initials
- **Logo fallbacks:** Updated `Sidebar.tsx` (frontend), `admin/src/components/Sidebar.tsx`, and `LogoLink.tsx` to use `/logo.svg` as fallback instead of conditional icon rendering
- **Avatar replacements:** Replaced all `https://ui-avatars.com/api/?...` calls across 18+ components and pages with `getAvatarFallback()`:
  - Profile forms (Educator, Foundation, Service Provider, Supplier)
  - User management (UsersPage, UserDetailDrawer)
  - Messaging (CreateGroupChatModal)
  - Marketplace and recruitment views
  - Profile pages and detail modals
  - Settings sections
  - AuthProvider (fallback avatar generation)
- **Logo assets:** Added `frontend/public/logo.svg` and `admin/public/logo.svg` (ProCreche branding)
- **i18n:** Added `educatorPendingApprovalPage` translation keys (en, de, fr) for the educator pending approval page
- **Educator pending approval page:** Converted all hardcoded strings to i18n keys for full localization support

## Implementation Details

- SVG generation uses `encodeURIComponent()` to safely embed initials in data URIs
- Initials extracted from name by splitting on whitespace, taking first letter of first two words, uppercased
- Fallback to `?` if name is empty
- Maintains existing color scheme (`48CFAE` for users, `2DD4BF` for organizations)
- Logo rendering simplified: always attempts to load image, falls back to `/logo.svg` instead of conditional icon

https://claude.ai/code/session_01Xwyvd4TGGSFbzkZ2mdyLHy