### PR TITLE
Add campaign scheduling support to mailing module

### DIFF
--- a/admin/src/components/mailing/ComposeEmailModal.tsx
+++ b/admin/src/components/mailing/ComposeEmailModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { X, Send, Eye, FileText, Save } from 'lucide-react'
+import { X, Send, Eye, FileText, Save, Calendar } from 'lucide-react'
 
 const MAILING_TEMPLATES_ENABLED = import.meta.env.VITE_MAILING_TEMPLATES !== 'false'
 import { toast } from 'sonner'
@@ -12,7 +12,7 @@ import EmailPreview from './EmailPreview'
 interface Props {
   isOpen: boolean
   onClose: () => void
-  onSend: (subject: string, bodyHtml: string, extraEmails: string[]) => Promise<void>
+  onSend: (subject: string, bodyHtml: string, extraEmails: string[], scheduledAt?: string) => Promise<void>
   loading: boolean
   recipientCount: number
 }
@@ -43,6 +43,8 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
   const [savingTemplate, setSavingTemplate] = useState(false)
   const [extraEmailsRaw, setExtraEmailsRaw] = useState('')
   const [showExtraEmails, setShowExtraEmails] = useState(false)
+  const [scheduleEnabled, setScheduleEnabled] = useState(false)
+  const [scheduledAt, setScheduledAt] = useState('')
 
   if (!isOpen) return null
 
@@ -200,6 +202,37 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
               )}
             </div>
 
+            <div className="border border-gray-200 rounded-md p-3 space-y-2">
+              <div className="flex items-center justify-between">
+                <label className="text-sm font-medium text-gray-700 flex items-center gap-1.5">
+                  <Calendar className="w-4 h-4 text-gray-400" />
+                  {t('admin:mailing.compose.scheduleTitle', 'Schedule for later')}
+                </label>
+                <button
+                  type="button"
+                  onClick={() => { setScheduleEnabled((v) => !v); setScheduledAt('') }}
+                  className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${scheduleEnabled ? 'bg-blue-600' : 'bg-gray-200'}`}
+                  aria-pressed={scheduleEnabled}
+                >
+                  <span className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${scheduleEnabled ? 'translate-x-4' : 'translate-x-1'}`} />
+                </button>
+              </div>
+              {scheduleEnabled && (
+                <div className="space-y-1">
+                  <input
+                    type="datetime-local"
+                    value={scheduledAt}
+                    min={new Date(Date.now() + 60_000).toISOString().slice(0, 16)}
+                    onChange={(e) => setScheduledAt(e.target.value)}
+                    className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
+                  />
+                  <p className="text-xs text-gray-400">
+                    {t('admin:mailing.compose.scheduleHint', 'The newsletter will be sent automatically at the selected time.')}
+                  </p>
+                </div>
+              )}
+            </div>
+
             <div>
               <label className="text-xs text-gray-500 block mb-1">{t('admin:mailing.compose.tokens')}</label>
               <div className="flex flex-wrap gap-1.5">
@@ -263,13 +296,18 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
             <button
               onClick={() => {
                 const validExtras = [...new Set(parseExtraEmails(extraEmailsRaw))].filter((e) => EMAIL_REGEX.test(e))
-                onSend(subject, bodyHtml, validExtras)
+                const isoScheduledAt = scheduleEnabled && scheduledAt ? new Date(scheduledAt).toISOString() : undefined
+                onSend(subject, bodyHtml, validExtras, isoScheduledAt)
               }}
-              disabled={!subject.trim() || !bodyHtml.trim() || loading}
+              disabled={!subject.trim() || !bodyHtml.trim() || loading || (scheduleEnabled && !scheduledAt)}
               className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
             >
-              <Send className="w-4 h-4" />
-              {loading ? t('admin:mailing.compose.creating') : t('admin:mailing.compose.send')}
+              {scheduleEnabled ? <Calendar className="w-4 h-4" /> : <Send className="w-4 h-4" />}
+              {loading
+                ? t('admin:mailing.compose.creating')
+                : scheduleEnabled
+                ? t('admin:mailing.compose.schedule', 'Schedule')
+                : t('admin:mailing.compose.send')}
             </button>
           </div>
         </div>

--- a/admin/src/components/mailing/ComposeEmailModal.tsx
+++ b/admin/src/components/mailing/ComposeEmailModal.tsx
@@ -222,7 +222,11 @@ const ComposeEmailModal: React.FC<Props> = ({ isOpen, onClose, onSend, loading, 
                   <input
                     type="datetime-local"
                     value={scheduledAt}
-                    min={new Date(Date.now() + 60_000).toISOString().slice(0, 16)}
+                    min={(() => {
+                      const d = new Date(Date.now() + 60_000)
+                      const pad = (n: number) => String(n).padStart(2, '0')
+                      return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+                    })()}
                     onChange={(e) => setScheduledAt(e.target.value)}
                     className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:ring-blue-500 focus:border-blue-500"
                   />

--- a/admin/src/pages/MailingCampaignDetail.tsx
+++ b/admin/src/pages/MailingCampaignDetail.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
-  ArrowLeft, Send, XCircle, CheckCircle, AlertTriangle, Clock, Loader2, Mail,
+  ArrowLeft, Send, XCircle, CheckCircle, AlertTriangle, Clock, Loader2, Mail, Calendar,
 } from 'lucide-react'
 import DOMPurify from 'dompurify'
 import { toast } from 'sonner'
@@ -15,6 +15,7 @@ import SendProgressOverlay from '../components/mailing/SendProgressOverlay'
 
 const statusConfig: Record<string, { icon: React.ElementType; color: string; bg: string }> = {
   DRAFT: { icon: Clock, color: 'text-gray-600', bg: 'bg-gray-100' },
+  SCHEDULED: { icon: Calendar, color: 'text-purple-600', bg: 'bg-purple-100' },
   SENDING: { icon: Loader2, color: 'text-blue-600', bg: 'bg-blue-100' },
   SENT: { icon: CheckCircle, color: 'text-green-600', bg: 'bg-green-100' },
   FAILED: { icon: AlertTriangle, color: 'text-red-600', bg: 'bg-red-100' },
@@ -37,7 +38,7 @@ const MailingCampaignDetailPage: React.FC = () => {
     enabled: !!id,
     refetchInterval: (query) => {
       const d = query.state.data as CampaignType | undefined
-      return d?.status === 'SENDING' ? 3000 : false
+      return d?.status === 'SENDING' || d?.status === 'SCHEDULED' ? 5000 : false
     },
   })
 
@@ -57,7 +58,7 @@ const MailingCampaignDetailPage: React.FC = () => {
       : 0
 
   const canResume = campaign.status === 'DRAFT' || campaign.status === 'SENDING'
-  const canCancel = campaign.status === 'DRAFT' || campaign.status === 'SENDING'
+  const canCancel = campaign.status === 'DRAFT' || campaign.status === 'SCHEDULED' || campaign.status === 'SENDING'
 
   const handleCancel = async () => {
     if (!confirm('Cancel this campaign? This cannot be undone.')) return
@@ -89,6 +90,9 @@ const MailingCampaignDetailPage: React.FC = () => {
           <p className="text-sm text-gray-500 mt-1">
             Created {new Date(campaign.createdAt).toLocaleString()}
             {campaign.segment && <> &middot; Segment: {campaign.segment.name}</>}
+            {(campaign as any).scheduledAt && (
+              <> &middot; <span className="text-purple-600 font-medium">Scheduled: {new Date((campaign as any).scheduledAt).toLocaleString()}</span></>
+            )}
           </p>
         </div>
         <div className="flex items-center gap-2">

--- a/admin/src/pages/MailingCampaignDetail.tsx
+++ b/admin/src/pages/MailingCampaignDetail.tsx
@@ -90,8 +90,8 @@ const MailingCampaignDetailPage: React.FC = () => {
           <p className="text-sm text-gray-500 mt-1">
             Created {new Date(campaign.createdAt).toLocaleString()}
             {campaign.segment && <> &middot; Segment: {campaign.segment.name}</>}
-            {(campaign as any).scheduledAt && (
-              <> &middot; <span className="text-purple-600 font-medium">Scheduled: {new Date((campaign as any).scheduledAt).toLocaleString()}</span></>
+            {campaign.scheduledAt && (
+              <> &middot; <span className="text-purple-600 font-medium">Scheduled: {new Date(campaign.scheduledAt).toLocaleString()}</span></>
             )}
           </p>
         </div>

--- a/admin/src/pages/MailingList.tsx
+++ b/admin/src/pages/MailingList.tsx
@@ -40,6 +40,7 @@ const TAB_KEYS = MAILING_TEMPLATES_ENABLED
 const statusBadge = (status: string) => {
   const map: Record<string, string> = {
     DRAFT: 'bg-gray-100 text-gray-600',
+    SCHEDULED: 'bg-purple-100 text-purple-700',
     SENDING: 'bg-blue-100 text-blue-700',
     SENT: 'bg-green-100 text-green-700',
     FAILED: 'bg-red-100 text-red-700',
@@ -251,7 +252,7 @@ const MailingListPage: React.FC = () => {
     }
   }, [apiClient, filters, preview?.count])
 
-  const handleCreateCampaign = useCallback(async (subject: string, bodyHtml: string, extraEmails: string[]) => {
+  const handleCreateCampaign = useCallback(async (subject: string, bodyHtml: string, extraEmails: string[], scheduledAt?: string) => {
     setActionLoading(true)
     try {
       const res = await apiService.mailingCreateCampaign(apiClient, {
@@ -259,19 +260,26 @@ const MailingListPage: React.FC = () => {
         bodyHtml,
         filters,
         ...(extraEmails.length > 0 ? { extraEmails } : {}),
+        ...(scheduledAt ? { scheduledAt } : {}),
       })
       const campaignId = res.data?.campaignId
-      toast.success('Campaign created')
-      setComposeModalOpen(false)
-      if (campaignId) {
-        setSendingCampaignId(campaignId)
+      if (scheduledAt) {
+        toast.success(`Campaign scheduled for ${new Date(scheduledAt).toLocaleString()}`)
+        setComposeModalOpen(false)
+        queryClient.invalidateQueries({ queryKey: ['mailing-campaigns'] })
+      } else {
+        toast.success('Campaign created')
+        setComposeModalOpen(false)
+        if (campaignId) {
+          setSendingCampaignId(campaignId)
+        }
       }
     } catch (err: any) {
       toast.error(err?.response?.data?.message || 'Failed to create campaign')
     } finally {
       setActionLoading(false)
     }
-  }, [apiClient, filters])
+  }, [apiClient, filters, queryClient])
 
   const handleDeleteSegment = useCallback(async (id: string) => {
     if (!confirm(t('admin:mailing.segment.deleteConfirm'))) return
@@ -289,7 +297,7 @@ const MailingListPage: React.FC = () => {
     setActiveTab('build')
   }, [])
 
-  const handleCreateListCampaign = useCallback(async (subject: string, bodyHtml: string, extraEmails: string[]) => {
+  const handleCreateListCampaign = useCallback(async (subject: string, bodyHtml: string, extraEmails: string[], scheduledAt?: string) => {
     if (!activeList) return
     setActionLoading(true)
     try {
@@ -298,17 +306,24 @@ const MailingListPage: React.FC = () => {
         bodyHtml,
         customListId: activeList.id,
         ...(extraEmails.length > 0 ? { extraEmails } : {}),
+        ...(scheduledAt ? { scheduledAt } : {}),
       })
       const campaignId = res.data?.campaignId
-      toast.success('Campaign created')
-      setListComposeModalOpen(false)
-      if (campaignId) setSendingCampaignId(campaignId)
+      if (scheduledAt) {
+        toast.success(`Campaign scheduled for ${new Date(scheduledAt).toLocaleString()}`)
+        setListComposeModalOpen(false)
+        queryClient.invalidateQueries({ queryKey: ['mailing-campaigns'] })
+      } else {
+        toast.success('Campaign created')
+        setListComposeModalOpen(false)
+        if (campaignId) setSendingCampaignId(campaignId)
+      }
     } catch (err: any) {
       toast.error(err?.response?.data?.message || 'Failed to create campaign')
     } finally {
       setActionLoading(false)
     }
-  }, [apiClient, activeList])
+  }, [apiClient, activeList, queryClient])
 
   const handleExportList = useCallback(async (format: 'csv' | 'xlsx', columns: string[]) => {
     if (!activeList) return
@@ -641,7 +656,7 @@ const MailingListPage: React.FC = () => {
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Recipients</th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Sent / Failed</th>
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Segment</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Created</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Scheduled / Created</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100">
@@ -660,7 +675,11 @@ const MailingListPage: React.FC = () => {
                       <span className="text-red-600">{c.failedCount}</span>
                     </td>
                     <td className="px-4 py-3 text-sm text-gray-500">{c.segmentName || 'Ad-hoc'}</td>
-                    <td className="px-4 py-3 text-sm text-gray-500">{new Date(c.createdAt).toLocaleDateString()}</td>
+                    <td className="px-4 py-3 text-sm text-gray-500">
+                      {c.scheduledAt
+                        ? <span className="text-purple-600 font-medium">{new Date(c.scheduledAt).toLocaleString()}</span>
+                        : new Date(c.createdAt).toLocaleDateString()}
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/admin/src/services/api.ts
+++ b/admin/src/services/api.ts
@@ -1180,6 +1180,7 @@ export const apiService = {
     segmentId?: string;
     customListId?: string;
     extraEmails?: string[];
+    scheduledAt?: string;
   }) => apiClient.post('/admin/mailing/campaigns', data),
 
   mailingListCampaigns: (apiClient: AxiosInstance, params?: { page?: number; pageSize?: number }) =>

--- a/admin/src/types/api.ts
+++ b/admin/src/types/api.ts
@@ -621,7 +621,7 @@ export interface MailingSegmentListResponse {
   totalPages: number;
 }
 
-export type MailingCampaignStatus = 'DRAFT' | 'SENDING' | 'SENT' | 'FAILED' | 'CANCELLED';
+export type MailingCampaignStatus = 'DRAFT' | 'SCHEDULED' | 'SENDING' | 'SENT' | 'FAILED' | 'CANCELLED';
 
 export interface MailingCampaignSummary {
   id: string;
@@ -631,6 +631,7 @@ export interface MailingCampaignSummary {
   sentCount: number;
   failedCount: number;
   segmentName: string | null;
+  scheduledAt: string | null;
   createdAt: string;
   sentAt: string | null;
   completedAt: string | null;
@@ -649,6 +650,7 @@ export interface MailingCampaignDetail {
   failedCount: number;
   cursor: string | null;
   createdById: string;
+  scheduledAt: string | null;
   sentAt: string | null;
   completedAt: string | null;
   createdAt: string;

--- a/api/prisma/migrations/20260615000000_add_scheduled_campaign/migration.sql
+++ b/api/prisma/migrations/20260615000000_add_scheduled_campaign/migration.sql
@@ -1,0 +1,8 @@
+-- AddValue
+ALTER TYPE "MailingCampaignStatus" ADD VALUE IF NOT EXISTS 'SCHEDULED' BEFORE 'SENDING';
+
+-- AlterTable
+ALTER TABLE "mailing_campaigns" ADD COLUMN IF NOT EXISTS "scheduled_at" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "mailing_campaigns_scheduled_at_idx" ON "mailing_campaigns"("scheduled_at");

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -2585,6 +2585,7 @@ model SeedRecord {
 
 enum MailingCampaignStatus {
   DRAFT
+  SCHEDULED
   SENDING
   SENT
   FAILED
@@ -2631,6 +2632,7 @@ model MailingCampaign {
 
   // Admin tracking
   createdById    String                @map("created_by_id")
+  scheduledAt    DateTime?             @map("scheduled_at")
   sentAt         DateTime?             @map("sent_at")
   completedAt    DateTime?             @map("completed_at")
 
@@ -2641,6 +2643,7 @@ model MailingCampaign {
   segment MailingSegment? @relation(fields: [segmentId], references: [id], onDelete: SetNull)
 
   @@index([status])
+  @@index([scheduledAt])
   @@index([createdById])
   @@index([segmentId])
   @@map("mailing_campaigns")

--- a/api/src/mailing/dto/campaign.dto.ts
+++ b/api/src/mailing/dto/campaign.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, ValidateNested, IsInt, Min, Max, IsArray, IsEmail, ArrayMaxSize } from 'class-validator';
+import { IsString, IsOptional, ValidateNested, IsInt, Min, Max, IsArray, IsEmail, ArrayMaxSize, IsDateString } from 'class-validator';
 import { Type } from 'class-transformer';
 import { MailingFiltersDto } from './mailing-filters.dto';
 
@@ -31,6 +31,10 @@ export class CreateCampaignDto {
   @ArrayMaxSize(500)
   @IsEmail({}, { each: true })
   extraEmails?: string[];
+
+  @IsOptional()
+  @IsDateString()
+  scheduledAt?: string;
 }
 
 export class SendBatchDto {

--- a/api/src/mailing/mailing.controller.ts
+++ b/api/src/mailing/mailing.controller.ts
@@ -266,6 +266,7 @@ export class MailingController {
       filters,
       body.customListId ? undefined : body.segmentId,
       body.extraEmails,
+      body.scheduledAt ? new Date(body.scheduledAt) : undefined,
     );
   }
 

--- a/api/src/mailing/mailing.service.ts
+++ b/api/src/mailing/mailing.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, BadRequestException, NotFoundException, ConflictException } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
 import { PrismaService } from '../prisma/prisma.service';
 import { MailingTransportService } from './mailing-transport.service';
 import { MailingFiltersDto } from './dto/mailing-filters.dto';
@@ -568,6 +569,7 @@ export class MailingService {
     filters?: MailingFiltersDto,
     segmentId?: string,
     extraEmails?: string[],
+    scheduledAt?: Date,
   ) {
     let resolvedFilters = filters;
 
@@ -620,7 +622,8 @@ export class MailingService {
         extraEmailsJson: normalizedExtras.length > 0 ? normalizedExtras : null,
         totalEstimated,
         createdById,
-        status: MailingCampaignStatus.DRAFT,
+        status: scheduledAt ? MailingCampaignStatus.SCHEDULED : MailingCampaignStatus.DRAFT,
+        scheduledAt: scheduledAt || null,
       },
     });
 
@@ -632,14 +635,14 @@ export class MailingService {
           entityId: campaign.id,
           action: 'create',
           actorId: createdById,
-          metadata: { subject, segmentId, totalEstimated, extraEmailCount: normalizedExtras.length },
+          metadata: { subject, segmentId, totalEstimated, extraEmailCount: normalizedExtras.length, scheduledAt },
         },
       });
     } catch (auditErr: any) {
       this.logger.warn(`Audit log failed for campaign ${campaign.id}: ${auditErr?.message}`);
     }
 
-    return { campaignId: campaign.id, estimatedCount: totalEstimated, status: campaign.status };
+    return { campaignId: campaign.id, estimatedCount: totalEstimated, status: campaign.status, scheduledAt: campaign.scheduledAt };
   }
 
   async listCampaigns(page = 1, pageSize = 20) {
@@ -685,8 +688,12 @@ export class MailingService {
 
   async cancelCampaign(id: string, adminId: string) {
     const campaign = await this.getCampaign(id);
-    if (campaign.status !== MailingCampaignStatus.DRAFT && campaign.status !== MailingCampaignStatus.SENDING) {
-      throw new BadRequestException('Can only cancel DRAFT or SENDING campaigns');
+    if (
+      campaign.status !== MailingCampaignStatus.DRAFT &&
+      campaign.status !== MailingCampaignStatus.SCHEDULED &&
+      campaign.status !== MailingCampaignStatus.SENDING
+    ) {
+      throw new BadRequestException('Can only cancel DRAFT, SCHEDULED, or SENDING campaigns');
     }
 
     await this.prisma.auditLog.create({
@@ -706,6 +713,36 @@ export class MailingService {
   }
 
   /* ================================================================ */
+  /*  SCHEDULER                                                        */
+  /* ================================================================ */
+
+  @Cron(CronExpression.EVERY_MINUTE)
+  async processScheduledCampaigns() {
+    const due = await this.prisma.mailingCampaign.findMany({
+      where: {
+        status: MailingCampaignStatus.SCHEDULED,
+        scheduledAt: { lte: new Date() },
+      },
+      select: { id: true, subject: true },
+    });
+
+    for (const campaign of due) {
+      this.logger.log(`Auto-sending scheduled campaign ${campaign.id}: "${campaign.subject}"`);
+      this.runScheduledCampaign(campaign.id).catch((err) => {
+        this.logger.error(`Failed to auto-send campaign ${campaign.id}: ${err?.message}`);
+      });
+    }
+  }
+
+  private async runScheduledCampaign(campaignId: string) {
+    let done = false;
+    while (!done) {
+      const result = await this.sendBatch(campaignId, DEFAULT_BATCH_SIZE);
+      done = result.done;
+    }
+  }
+
+  /* ================================================================ */
   /*  BATCH SENDING                                                    */
   /* ================================================================ */
 
@@ -714,6 +751,7 @@ export class MailingService {
 
     if (
       campaign.status !== MailingCampaignStatus.DRAFT &&
+      campaign.status !== MailingCampaignStatus.SCHEDULED &&
       campaign.status !== MailingCampaignStatus.SENDING
     ) {
       throw new BadRequestException(`Cannot send: campaign status is ${campaign.status}`);
@@ -772,11 +810,11 @@ export class MailingService {
     }
 
     // SEC: optimistic concurrency — prevent duplicate batch sends from parallel requests
-    // Only one request should transition DRAFT -> SENDING; others will see SENDING and proceed safely
+    // Only one request should transition DRAFT/SCHEDULED -> SENDING; others will see SENDING and proceed safely
     // The cursor-based pagination prevents duplicate emails even if two batches run concurrently
-    if (campaign.status === MailingCampaignStatus.DRAFT) {
+    if (campaign.status === MailingCampaignStatus.DRAFT || campaign.status === MailingCampaignStatus.SCHEDULED) {
       const updated = await this.prisma.mailingCampaign.updateMany({
-        where: { id: campaignId, status: MailingCampaignStatus.DRAFT },
+        where: { id: campaignId, status: { in: [MailingCampaignStatus.DRAFT, MailingCampaignStatus.SCHEDULED] } },
         data: { status: MailingCampaignStatus.SENDING, sentAt: new Date() },
       });
       if (updated.count === 0) {

--- a/api/src/mailing/mailing.service.ts
+++ b/api/src/mailing/mailing.service.ts
@@ -571,6 +571,15 @@ export class MailingService {
     extraEmails?: string[],
     scheduledAt?: Date,
   ) {
+    if (scheduledAt) {
+      if (Number.isNaN(scheduledAt.getTime())) {
+        throw new BadRequestException('Invalid scheduledAt value');
+      }
+      if (scheduledAt.getTime() < Date.now() + 60_000) {
+        throw new BadRequestException('scheduledAt must be at least 1 minute in the future');
+      }
+    }
+
     let resolvedFilters = filters;
 
     // If segmentId is provided, load its filters
@@ -666,6 +675,7 @@ export class MailingService {
         sentCount: c.sentCount,
         failedCount: c.failedCount,
         segmentName: c.segment?.name || null,
+        scheduledAt: c.scheduledAt?.toISOString() || null,
         createdAt: c.createdAt.toISOString(),
         sentAt: c.sentAt?.toISOString() || null,
         completedAt: c.completedAt?.toISOString() || null,
@@ -999,21 +1009,22 @@ export class MailingService {
     const newSentCount = campaign.sentCount + sentThisBatch;
     const newFailedCount = campaign.failedCount + failedThisBatch;
 
-    await this.prisma.mailingCampaign.update({
-      where: { id: campaignId },
-      data: {
-        sentCount: newSentCount,
-        failedCount: newFailedCount,
-        cursor: lastUserId,
-        ...(dbDone && extraEmails.length > 0 ? { extraEmailsSent: true } : {}),
-        ...(done
-          ? {
-              status: MailingCampaignStatus.SENT,
-              completedAt: new Date(),
-            }
-          : {}),
-      },
-    });
+    const baseData: Prisma.MailingCampaignUpdateInput = {
+      sentCount: newSentCount,
+      failedCount: newFailedCount,
+      cursor: lastUserId,
+      ...(dbDone && extraEmails.length > 0 ? { extraEmailsSent: true } : {}),
+    };
+
+    if (done) {
+      // Use updateMany with a status guard so a concurrent cancel cannot be overwritten
+      await this.prisma.mailingCampaign.updateMany({
+        where: { id: campaignId, status: MailingCampaignStatus.SENDING },
+        data: { ...baseData, status: MailingCampaignStatus.SENT, completedAt: new Date() },
+      });
+    } else {
+      await this.prisma.mailingCampaign.update({ where: { id: campaignId }, data: baseData });
+    }
 
     return {
       sentCountThisBatch: sentThisBatch,

--- a/frontend/pages/educator/EducatorApplicationsPage.tsx
+++ b/frontend/pages/educator/EducatorApplicationsPage.tsx
@@ -6,8 +6,23 @@ import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../../contexts/AppContext';
 import { Application, ApplicationStatus } from '../../types';
 
+const getStatusInfo = (status: ApplicationStatus, t: (key: string, fallback?: string) => string) => {
+  switch (status) {
+    case ApplicationStatus.PENDING: return { className: 'bg-teal-100 text-teal-800', label: t('educatorApplicationsPage.status.submitted', 'Submitted') };
+    case ApplicationStatus.REVIEWED: return { className: 'bg-blue-100 text-blue-800', label: t('educatorApplicationsPage.status.reviewed') };
+    case ApplicationStatus.SHORTLISTED: return { className: 'bg-yellow-100 text-yellow-800', label: t('educatorApplicationsPage.status.shortlisted', 'Shortlisted') };
+    case ApplicationStatus.INTERVIEW: return { className: 'bg-purple-100 text-purple-800', label: t('educatorApplicationsPage.status.interview', 'Interview') };
+    case ApplicationStatus.OFFER: return { className: 'bg-orange-100 text-orange-800', label: t('educatorApplicationsPage.status.offer', 'Offer') };
+    case ApplicationStatus.HIRED: return { className: 'bg-green-100 text-green-800', label: t('educatorApplicationsPage.status.hired', 'Hired') };
+    case ApplicationStatus.ACCEPTED: return { className: 'bg-swiss-mint text-white', label: t('educatorApplicationsPage.status.accepted') };
+    case ApplicationStatus.REJECTED: return { className: 'bg-swiss-coral/20 text-swiss-coral', label: t('educatorApplicationsPage.status.rejected') };
+    default: return { className: 'bg-gray-100 text-gray-700', label: status };
+  }
+};
+
 const ApplicationDetailModal: React.FC<{ app: Application; onClose: () => void }> = ({ app, onClose }) => {
   const { t, i18n } = useTranslation(['dashboard', 'common']);
+  const statusInfo = getStatusInfo(app.status, t);
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" onClick={onClose}>
       <div
@@ -24,9 +39,11 @@ const ApplicationDetailModal: React.FC<{ app: Application; onClose: () => void }
           <p className="text-sm text-gray-500">{app.foundationName}</p>
         )}
         <div className="text-sm text-gray-600 space-y-1">
-          <p>
-            <span className="font-medium">{t('educatorApplicationsPage.table.status')}:</span>{' '}
-            {app.status}
+          <p className="flex items-center gap-2">
+            <span className="font-medium">{t('educatorApplicationsPage.table.status')}:</span>
+            <span className={`px-2 py-0.5 text-xs font-semibold rounded-full ${statusInfo.className}`}>
+              {statusInfo.label}
+            </span>
           </p>
           <p>
             <span className="font-medium">{t('educatorApplicationsPage.table.lastUpdated')}:</span>{' '}
@@ -56,20 +73,6 @@ const EducatorApplicationsPage: React.FC = () => {
   const { applications } = useAppContext();
   const [selectedApp, setSelectedApp] = useState<Application | null>(null);
 
-  const getStatusInfo = (status: ApplicationStatus) => {
-    switch (status) {
-      case ApplicationStatus.PENDING: return { className: 'bg-swiss-sand/30 text-amber-800', label: t('educatorApplicationsPage.status.pending') };
-      case ApplicationStatus.REVIEWED: return { className: 'bg-blue-100 text-blue-800', label: t('educatorApplicationsPage.status.reviewed') };
-      case ApplicationStatus.SHORTLISTED: return { className: 'bg-yellow-100 text-yellow-800', label: t('educatorApplicationsPage.status.shortlisted', 'Shortlisted') };
-      case ApplicationStatus.INTERVIEW: return { className: 'bg-purple-100 text-purple-800', label: t('educatorApplicationsPage.status.interview', 'Interview') };
-      case ApplicationStatus.OFFER: return { className: 'bg-orange-100 text-orange-800', label: t('educatorApplicationsPage.status.offer', 'Offer') };
-      case ApplicationStatus.HIRED: return { className: 'bg-green-100 text-green-800', label: t('educatorApplicationsPage.status.hired', 'Hired') };
-      case ApplicationStatus.ACCEPTED: return { className: 'bg-swiss-mint text-white', label: t('educatorApplicationsPage.status.accepted') };
-      case ApplicationStatus.REJECTED: return { className: 'bg-swiss-coral/20 text-swiss-coral', label: t('educatorApplicationsPage.status.rejected') };
-      default: return { className: 'bg-gray-100 text-gray-700', label: status };
-    }
-  };
-
   return (
     <div className="space-y-6">
       {selectedApp && (
@@ -93,7 +96,7 @@ const EducatorApplicationsPage: React.FC = () => {
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
                 {applications.map((app) => {
-                const statusInfo = getStatusInfo(app.status);
+                const statusInfo = getStatusInfo(app.status, t);
                 return (
                   <tr key={app.id} className="hover:bg-gray-50">
                     <td className="px-6 py-4 whitespace-nowrap font-medium text-swiss-charcoal">{app.jobTitle}</td>

--- a/packages/translations/locales/de/dashboard.json
+++ b/packages/translations/locales/de/dashboard.json
@@ -86,9 +86,14 @@
     "footerNote": "Bewerbungen werden in Echtzeit aktualisiert",
     "status": {
       "accepted": "Angenommen",
+      "hired": "Eingestellt",
+      "interview": "Vorstellungsgespräch",
+      "offer": "Angebot",
       "pending": "Ausstehend",
       "rejected": "Abgelehnt",
-      "reviewed": "Gesehen"
+      "reviewed": "Gesehen",
+      "shortlisted": "Vorausgewählt",
+      "submitted": "Eingereicht"
     },
     "table": {
       "actions": "Aktionen",

--- a/packages/translations/locales/en/dashboard.json
+++ b/packages/translations/locales/en/dashboard.json
@@ -326,9 +326,14 @@
     "footerNote": "Applications are updated in real-time",
     "status": {
       "accepted": "Accepted",
+      "hired": "Hired",
+      "interview": "Interview",
+      "offer": "Offer",
       "pending": "Pending",
       "rejected": "Rejected",
-      "reviewed": "Reviewed"
+      "reviewed": "Reviewed",
+      "shortlisted": "Shortlisted",
+      "submitted": "Submitted"
     },
     "table": {
       "actions": "Actions",

--- a/packages/translations/locales/fr/dashboard.json
+++ b/packages/translations/locales/fr/dashboard.json
@@ -85,9 +85,14 @@
     "footerNote": "Les candidatures sont mises à jour en temps réel",
     "status": {
       "accepted": "Acceptée",
+      "hired": "Engagée",
+      "interview": "Entretien",
+      "offer": "Offre",
       "pending": "En attente",
       "rejected": "Refusée",
-      "reviewed": "Examinée"
+      "reviewed": "Examinée",
+      "shortlisted": "Présélectionnée",
+      "submitted": "Soumise"
     },
     "table": {
       "actions": "Actions",


### PR DESCRIPTION
## Summary
Adds the ability to schedule mailing campaigns for automatic sending at a future date. Campaigns can now be created in a `SCHEDULED` status and will be automatically sent when their scheduled time arrives via a cron job that runs every minute.

## Key Changes

**Backend (API)**
- Added `SCHEDULED` status to `MailingCampaignStatus` enum
- Added `scheduledAt` field to `MailingCampaign` model with database index
- Extended `createCampaign()` to accept optional `scheduledAt` parameter; sets status to `SCHEDULED` if provided
- Implemented `@Cron(EVERY_MINUTE)` decorator on `processScheduledCampaigns()` to find and auto-send due campaigns
- Added `runScheduledCampaign()` helper to batch-send scheduled campaigns
- Updated `cancelCampaign()` to allow canceling `SCHEDULED` campaigns
- Updated `sendBatch()` to accept both `DRAFT` and `SCHEDULED` statuses for sending
- Updated concurrency control logic to handle `DRAFT` → `SCHEDULED` → `SENDING` transitions
- Added `scheduledAt` to campaign creation response and audit log metadata
- Created database migration to add `scheduled_at` column and index

**Admin UI**
- Added schedule toggle and datetime picker to `ComposeEmailModal`
- Minimum scheduled time is 1 minute in the future
- Updated campaign creation handlers to pass `scheduledAt` when scheduling is enabled
- Added `SCHEDULED` status badge styling (purple) to campaign list
- Updated campaign list table header from "Created" to "Scheduled / Created"
- Display scheduled time in purple when present, otherwise show creation date
- Updated campaign detail page to show scheduled time and refetch every 5 seconds for `SCHEDULED` status
- Added `Calendar` icon to scheduled campaign actions

**Frontend (Educator Applications)**
- Extracted `getStatusInfo()` helper function to module level for reusability
- Updated status badge rendering in application detail modal to use styled badges
- Fixed translation key for `PENDING` status

## Implementation Details

- Scheduled campaigns transition to `SENDING` status when their batch sending begins, preventing duplicate sends
- Cursor-based pagination in batch sending prevents duplicate emails even if concurrent requests occur
- Audit logs capture the scheduled time for compliance tracking
- UI prevents scheduling without a valid future datetime
- Cron job uses optimistic locking to ensure only one process sends each campaign

https://claude.ai/code/session_012h9WwirH5TgV49is4Vq929

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email scheduling: schedule emails for future delivery with a datetime picker.
  * Scheduled campaigns: campaigns can be set to start later and automatically send when due.
  * Campaign views: scheduled timestamps are shown, and the UI reflects the new scheduled state.
  * Cancellation: scheduled campaigns can be cancelled before they start.
* **Refactor**
  * Improved educator applications status rendering with localized labels.
* **Documentation**
  * Updated dashboard translations for additional educator application statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->