### PR TITLE
feat(assistant): redesign admin briefing card, fix workspace layout, …

### DIFF
--- a/admin/src/components/assistant-workspace/AdminBriefingCard.tsx
+++ b/admin/src/components/assistant-workspace/AdminBriefingCard.tsx
@@ -153,7 +153,7 @@ export const AdminBriefingCard: React.FC<AdminBriefingCardProps> = ({
       <div className="relative px-6 pb-5 pt-2">
         <button
           onClick={() => onAction(HANDLE_ALL_PROMPT)}
-          className="inline-flex items-center gap-1.5 rounded-full bg-[#0f2d1e] px-4 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-[#0a2018] focus:outline-none focus:ring-2 focus:ring-white/30"
+          className="inline-flex items-center gap-1.5 rounded-full bg-[#0f2d1e] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#0a2018] focus:outline-none focus:ring-2 focus:ring-white/30"
         >
           <SparklesIcon className="h-3 w-3" aria-hidden="true" />
           {t('workspace.briefing.handleAll', 'Handle everything with me')}

--- a/admin/src/components/assistant-workspace/AdminBriefingCard.tsx
+++ b/admin/src/components/assistant-workspace/AdminBriefingCard.tsx
@@ -23,8 +23,6 @@ const ICONS: Record<BriefingItemType, React.ComponentType<{ className?: string; 
   unread_notifications: BellIcon,
 };
 
-// Each briefing item CTA is just a prompt template submitted into the normal
-// chat pipeline — exactly as in the Foundation build.
 const ITEM_PROMPTS: Record<BriefingItemType, string> = {
   pending_educator_approvals: 'Review pending educator approvals with me.',
   stale_applications_platform: 'Show me applications waiting more than 5 days across the platform.',
@@ -69,11 +67,6 @@ interface AdminBriefingCardProps {
   onAction: (prompt: string) => void;
 }
 
-/**
- * Deep-teal hero card with the platform-wide review items ("N items need
- * review today"). Dumb renderer over GET /assistant/briefing — the items are
- * deterministic counts computed server-side (BriefingService admin branch).
- */
 export const AdminBriefingCard: React.FC<AdminBriefingCardProps> = ({
   briefing,
   isLoading,
@@ -83,8 +76,9 @@ export const AdminBriefingCard: React.FC<AdminBriefingCardProps> = ({
 
   if (isLoading) {
     return (
-      <div className="mb-6 animate-pulse rounded-2xl bg-emerald-800/20 p-6">
-        <div className="mb-4 h-5 w-2/3 rounded bg-emerald-800/30" />
+      <div className="mb-6 animate-pulse rounded-2xl bg-emerald-900/30 p-6">
+        <div className="mb-2 h-3 w-24 rounded bg-emerald-700/40" />
+        <div className="mb-3 h-6 w-2/3 rounded bg-emerald-800/40" />
         <div className="space-y-2">
           <div className="h-10 rounded-xl bg-emerald-800/20" />
           <div className="h-10 rounded-xl bg-emerald-800/15" />
@@ -102,17 +96,34 @@ export const AdminBriefingCard: React.FC<AdminBriefingCardProps> = ({
       : t('adminBriefing.headline_other', '{{count}} items need review today', { count });
 
   return (
-    <div className="mb-6 overflow-hidden rounded-2xl bg-emerald-800 text-white shadow-lg">
+    <div className="relative mb-6 overflow-hidden rounded-2xl bg-gradient-to-br from-[#1e5c42] to-[#163d2b] text-white shadow-xl">
+      {/* Decorative circles */}
+      <div
+        className="pointer-events-none absolute -right-10 -top-10 h-48 w-48 rounded-full border border-white/10 bg-white/[0.07]"
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none absolute right-10 top-16 h-32 w-32 rounded-full border border-white/10 bg-white/[0.09]"
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none absolute -right-4 top-2 h-24 w-24 rounded-full bg-white/[0.06]"
+        aria-hidden="true"
+      />
+
       {/* Header */}
-      <div className="flex items-start gap-3 px-5 py-4">
-        <div className="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-white/15">
-          <SparklesIcon className="h-4 w-4 text-white" aria-hidden="true" />
+      <div className="relative px-6 pt-5 pb-3">
+        <div className="mb-3 flex items-center gap-1.5">
+          <SparklesIcon className="h-3.5 w-3.5 text-emerald-400" aria-hidden="true" />
+          <span className="text-[11px] font-bold uppercase tracking-widest text-emerald-400">
+            {t('adminBriefing.label', 'Platform Briefing')}
+          </span>
         </div>
-        <h2 className="text-base font-semibold leading-snug">{headline}</h2>
+        <h2 className="text-xl font-bold leading-tight">{headline}</h2>
       </div>
 
       {/* Items */}
-      <div className="space-y-2 px-5 pb-3">
+      <div className="relative space-y-1.5 px-6 pb-3">
         {briefing.items.map((item) => {
           const Icon = ICONS[item.type] ?? BellIcon;
           const singularKey = `adminBriefing.${item.type}`;
@@ -139,12 +150,12 @@ export const AdminBriefingCard: React.FC<AdminBriefingCardProps> = ({
       </div>
 
       {/* CTA */}
-      <div className="border-t border-white/15 px-5 py-3">
+      <div className="relative px-6 pb-5 pt-2">
         <button
           onClick={() => onAction(HANDLE_ALL_PROMPT)}
-          className="flex w-full items-center justify-center gap-2 rounded-xl bg-white px-4 py-2.5 text-sm font-semibold text-emerald-800 transition-colors hover:bg-white/90 focus:outline-none focus:ring-2 focus:ring-white/40"
+          className="inline-flex items-center gap-1.5 rounded-full bg-[#0f2d1e] px-4 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-[#0a2018] focus:outline-none focus:ring-2 focus:ring-white/30"
         >
-          <SparklesIcon className="h-4 w-4" aria-hidden="true" />
+          <SparklesIcon className="h-3 w-3" aria-hidden="true" />
           {t('workspace.briefing.handleAll', 'Handle everything with me')}
         </button>
       </div>

--- a/admin/src/components/assistant-workspace/Composer.tsx
+++ b/admin/src/components/assistant-workspace/Composer.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { ArrowRightIcon } from '@heroicons/react/24/outline';
+import { ArrowRightIcon } from '@heroicons/react/24/solid';
 import { useTranslation } from 'react-i18next';
 
 interface ComposerProps {
@@ -30,7 +30,7 @@ export const Composer: React.FC<ComposerProps> = ({ onSend, disabled }) => {
   );
 
   return (
-    <div className="flex items-end gap-2 rounded-3xl border border-gray-200 bg-white py-2 pl-5 pr-2 shadow-soft focus-within:border-emerald-300 focus-within:ring-2 focus-within:ring-emerald-100">
+    <div className="flex items-end gap-3 rounded-2xl border border-gray-200 bg-white px-6 py-4 shadow-sm transition-shadow focus-within:border-emerald-300 focus-within:shadow-md focus-within:ring-1 focus-within:ring-emerald-200">
       <textarea
         value={inputText}
         onChange={(e) => setInputText(e.target.value)}
@@ -40,16 +40,16 @@ export const Composer: React.FC<ComposerProps> = ({ onSend, disabled }) => {
         placeholder={t('workspace.composerPlaceholder', "Ask me anything — I'll handle the rest…")}
         disabled={disabled}
         aria-label={t('workspace.composerPlaceholder', "Ask me anything — I'll handle the rest…")}
-        className="flex-1 resize-none self-center bg-transparent py-1.5 text-sm text-swiss-charcoal placeholder-gray-400 focus:outline-none disabled:opacity-50"
+        className="flex-1 resize-none self-center bg-transparent py-0.5 text-sm text-swiss-charcoal placeholder-gray-400 focus:outline-none disabled:opacity-50"
         style={{ maxHeight: '120px', overflowY: 'auto' }}
       />
       <button
         onClick={handleSend}
         disabled={!inputText.trim() || disabled}
         aria-label={t('workspace.send', 'Send')}
-        className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-emerald-600 text-white transition-colors hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-1 disabled:opacity-40"
+        className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-emerald-600 text-white shadow-sm transition-all hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-1 disabled:opacity-40"
       >
-        <ArrowRightIcon className="h-5 w-5" aria-hidden="true" />
+        <ArrowRightIcon className="h-4 w-4" aria-hidden="true" />
       </button>
     </div>
   );

--- a/admin/src/pages/AssistantWorkspacePage.tsx
+++ b/admin/src/pages/AssistantWorkspacePage.tsx
@@ -72,18 +72,20 @@ const AssistantWorkspacePage: React.FC = () => {
     messages.length === 0 && !isLoadingHistory && (briefing?.items.length ?? 0) > 0;
 
   return (
-    <div className="flex h-full min-h-[calc(100dvh-8rem)] flex-col">
+    <div className="flex h-full flex-col bg-gray-50/60">
       <AssistantModalHandler pendingModal={pendingModal} onHandled={clearPendingModal} />
 
       {initError && (
-        <div className="mb-3 rounded-card border border-red-100 bg-red-50 px-4 py-2 text-sm text-red-600">
-          {initError}
+        <div className="mx-auto mt-3 w-full max-w-3xl px-4">
+          <div className="rounded-xl border border-red-100 bg-red-50 px-4 py-2 text-sm text-red-600">
+            {initError}
+          </div>
         </div>
       )}
 
       {/* Thread */}
       <div className="flex-1 overflow-y-auto">
-        <div className="mx-auto flex min-h-full w-full max-w-3xl flex-col justify-end py-2">
+        <div className="mx-auto flex min-h-full w-full max-w-3xl flex-col justify-end px-4 py-4 sm:px-6">
           {isLoadingHistory && (
             <div className="flex flex-1 items-center justify-center py-16">
               <ArrowPathIcon className="h-6 w-6 animate-spin text-emerald-600" aria-hidden="true" />
@@ -114,10 +116,12 @@ const AssistantWorkspacePage: React.FC = () => {
       </div>
 
       {/* Quick actions + composer + trust line */}
-      <div className="mx-auto w-full max-w-3xl pt-3">
-        <QuickActionChips onAction={sendMessage} disabled={composerDisabled} />
-        <Composer onSend={sendMessage} disabled={composerDisabled} />
-        <TrustFooter />
+      <div className="border-t border-gray-200/60 bg-white px-4 pb-4 pt-3 sm:px-6">
+        <div className="mx-auto w-full max-w-3xl">
+          <QuickActionChips onAction={sendMessage} disabled={composerDisabled} />
+          <Composer onSend={sendMessage} disabled={composerDisabled} />
+          <TrustFooter />
+        </div>
       </div>
     </div>
   );

--- a/admin/src/pages/AssistantWorkspacePage.tsx
+++ b/admin/src/pages/AssistantWorkspacePage.tsx
@@ -72,7 +72,7 @@ const AssistantWorkspacePage: React.FC = () => {
     messages.length === 0 && !isLoadingHistory && (briefing?.items.length ?? 0) > 0;
 
   return (
-    <div className="flex h-full flex-col bg-gray-50/60">
+    <div className="flex h-full min-h-[calc(100dvh-8rem)] flex-col bg-gray-50/60">
       <AssistantModalHandler pendingModal={pendingModal} onHandled={clearPendingModal} />
 
       {initError && (

--- a/api/src/assistant/assistant.service.ts
+++ b/api/src/assistant/assistant.service.ts
@@ -209,11 +209,13 @@ export class AssistantService {
       if (envOverride === 'true' || envOverride === '1') return;
       throw new ForbiddenException('AI Assistant is not enabled.');
     }
+    // No env var: kill-switch pattern — enabled by default unless a DB row
+    // explicitly marks it inactive. This mirrors the feature-flags controller.
     const flag = await this.prisma.featureFlag.findFirst({
-      where: { key: 'ai_assistant_enabled', isActive: true },
+      where: { key: 'ai_assistant_enabled' },
     });
-    if (!flag) {
-      throw new ForbiddenException('AI Assistant is not yet enabled.');
+    if (flag != null && !flag.isActive) {
+      throw new ForbiddenException('AI Assistant is not enabled.');
     }
   }
 }

--- a/api/src/subscription-management/feature-flags.controller.ts
+++ b/api/src/subscription-management/feature-flags.controller.ts
@@ -54,7 +54,7 @@ export class FeatureFlagsController {
     const envOverride = process.env.AI_ASSISTANT_ENABLED;
     if (envOverride !== undefined) {
       flags['ai_assistant_enabled'] = envOverride === 'true' || envOverride === '1';
-    } else if (flags['ai_assistant_enabled'] === undefined) {
+    } else if (flags['ai_assistant_enabled'] == null) {
       flags['ai_assistant_enabled'] = true;
     }
 

--- a/api/src/subscription-management/feature-flags.controller.ts
+++ b/api/src/subscription-management/feature-flags.controller.ts
@@ -49,10 +49,13 @@ export class FeatureFlagsController {
     }
 
     // AI_ASSISTANT_ENABLED env var overrides the DB for the master kill switch.
-    // Set to 'true' or 'false' in Render → Environment. If unset, DB value wins.
+    // Set to 'false' in Render → Environment to disable globally. If unset and
+    // the DB has no explicit value, the assistant defaults to ON (kill-switch pattern).
     const envOverride = process.env.AI_ASSISTANT_ENABLED;
     if (envOverride !== undefined) {
       flags['ai_assistant_enabled'] = envOverride === 'true' || envOverride === '1';
+    } else if (flags['ai_assistant_enabled'] === undefined) {
+      flags['ai_assistant_enabled'] = true;
     }
 
     return wrapResponse({ flags });

--- a/frontend/components/assistant-workspace/Composer.tsx
+++ b/frontend/components/assistant-workspace/Composer.tsx
@@ -30,7 +30,7 @@ export const Composer: React.FC<ComposerProps> = ({ onSend, disabled }) => {
   );
 
   return (
-    <div className="flex items-end gap-3 rounded-2xl border border-gray-200 bg-white px-6 py-4 shadow-sm transition-shadow focus-within:border-emerald-300 focus-within:shadow-md focus-within:ring-1 focus-within:ring-emerald-200">
+    <div className="flex items-end gap-3 rounded-2xl border border-gray-200 bg-white px-6 py-4 shadow-sm transition-shadow focus-within:border-emerald-300 focus-within:shadow-md focus-within:ring-2 focus-within:ring-emerald-200">
       <textarea
         value={inputText}
         onChange={(e) => setInputText(e.target.value)}


### PR DESCRIPTION
…default ai_assistant_enabled to ON

- AdminBriefingCard: gradient from-[#1e5c42] to-[#163d2b], decorative circles, PLATFORM BRIEFING label, dark CTA button — matches foundation card style
- Admin AssistantWorkspacePage: add bg-gray-50/60 background, px-4 sm:px-6 thread padding, white border-top bottom section — matches frontend layout
- Admin Composer: match frontend — rounded-2xl, px-6 py-4, solid ArrowRightIcon, emerald focus ring
- feature-flags controller: default ai_assistant_enabled to true when neither env var nor DB is set (kill-switch pattern — set AI_ASSISTANT_ENABLED=false to disable)

https://claude.ai/code/session_01SpJbn4rq6mbTgxDjVzEcez