### PR TITLE
Persist signup wizard state to survive refresh & tab suspension

### DIFF
--- a/frontend/components/signup/EducatorProfileStep.tsx
+++ b/frontend/components/signup/EducatorProfileStep.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   UserCircleIcon,
@@ -12,6 +12,7 @@ import {
 import Button from '../ui/Button';
 import FileUploadZone from '../ui/FileUploadZone';
 import { STANDARD_INPUT_FIELD, SWISS_CANTONS, EDUCATOR_JOB_ROLES, type EducatorJobRole } from '../../constants';
+import { readEducatorDraft, writeEducatorDraft } from '../../utils/signupDraft';
 
 export interface EducatorProfileStepData {
   firstName: string;
@@ -54,21 +55,35 @@ const EducatorProfileStep: React.FC<EducatorProfileStepProps> = ({
 }) => {
   const { t } = useTranslation(['signup', 'common', 'settings']);
 
-  const [data, setData] = useState<EducatorProfileStepData>({
-    firstName: initialData.firstName || '',
-    lastName: initialData.lastName || '',
-    phone: initialData.phone || '',
-    email: initialData.email || '',
-    canton: initialData.canton || '',
-    city: initialData.city || '',
-    shortBio: initialData.shortBio || '',
-    professionalExperience: initialData.professionalExperience || '',
-    cvUrl: initialData.cvUrl || '',
-    cvAssetId: initialData.cvAssetId || '',
-    jobRole: initialData.jobRole || '',
+  const [data, setData] = useState<EducatorProfileStepData>(() => {
+    // Restore a previously saved draft (survives refresh / tab suspension / the
+    // verification link opening in another tab) and layer it over initialData so
+    // the educator never re-types their profile after signup information is lost.
+    const draft = readEducatorDraft<Partial<EducatorProfileStepData>>(initialData.email);
+    const pick = (field: keyof EducatorProfileStepData) =>
+      (draft?.[field] as string | undefined) || (initialData[field] as string | undefined) || '';
+    return {
+      firstName: pick('firstName'),
+      lastName: pick('lastName'),
+      phone: pick('phone'),
+      email: initialData.email || (draft?.email as string) || '',
+      canton: pick('canton'),
+      city: pick('city'),
+      shortBio: pick('shortBio'),
+      professionalExperience: pick('professionalExperience'),
+      cvUrl: pick('cvUrl'),
+      cvAssetId: pick('cvAssetId'),
+      jobRole: (draft?.jobRole as EducatorJobRole | '') || initialData.jobRole || '',
+    };
   });
 
   const [errors, setErrors] = useState<EducatorProfileStepErrors>({});
+
+  // Persist the draft as the user edits so nothing typed here is lost before the
+  // "Complete Setup" PATCH succeeds. The parent clears it once step 4 is reached.
+  useEffect(() => {
+    writeEducatorDraft(data.email, data);
+  }, [data]);
 
   const set = (field: keyof EducatorProfileStepData, value: string) => {
     setData(prev => ({ ...prev, [field]: value }));

--- a/frontend/pages/SignupPage.tsx
+++ b/frontend/pages/SignupPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, FormEvent, useEffect } from 'react';
+import React, { useState, FormEvent, useEffect, useRef } from 'react';
 import { useNavigate, Link, useLocation, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useSignUp, useAuth, useUser } from '@clerk/clerk-react';
@@ -230,10 +230,22 @@ const SignupPage: React.FC = () => {
     }
   }, [isSignedIn, currentUser, hasStartedSignup, isIncompleteEducator, navigate]);
 
-  // Restore any persisted wizard progress once on mount, before the redirect guard
-  // above can act. This brings back the role and the details the user already typed
-  // after a refresh or when the tab is restored from Safari's bfcache.
+  // Restore any persisted wizard progress once, before the redirect guard above can
+  // act. This brings back the role and the details the user already typed after a
+  // refresh or when the tab is restored from Safari's bfcache.
+  //
+  // Crucially, this must wait until Clerk AND the backend user have settled: Clerk
+  // loads asynchronously, so `isSignedIn` starts out false. If we restored a step-2
+  // draft during that window we would mark the signup "started" and then block the
+  // incomplete-educator resume effect once the real (signed-in) state arrives,
+  // stranding the user on the step-2 account-creation form. Gate on settled auth and
+  // only touch step-2 state for a genuinely anonymous draft.
+  const hasRestoredRef = useRef(false);
   useEffect(() => {
+    if (!isLoaded || isAuthLoading) return; // wait for auth to settle
+    if (hasRestoredRef.current) return;
+    hasRestoredRef.current = true;
+
     const saved = readWizardState();
     if (!saved) return;
 
@@ -244,16 +256,15 @@ const SignupPage: React.FC = () => {
       setFormData(prev => ({ ...prev, ...(saved.formData as Partial<SignupFormData>) }));
     }
     // Only restore an un-authenticated draft to step 2 (and mark the signup as
-    // started so the dashboard redirect guard leaves them alone). Resuming to step 3
-    // for a signed-in educator is server-driven by the resume effect below, so we
-    // never set hasStartedSignup here on a stale role alone — that would block the
-    // resume effect and strand the user on step 1.
-    if (saved.currentStep === 2 && !isSignedIn) {
+    // started so the dashboard redirect guard leaves them alone). A signed-in
+    // incomplete educator is resumed into step 3 by the effect below, so we must not
+    // set hasStartedSignup here for them — that would skip the resume.
+    if (saved.currentStep === 2 && !isSignedIn && !isIncompleteEducator) {
       setCurrentStep(2);
       setHasStartedSignup(true);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isLoaded, isAuthLoading, isSignedIn, isIncompleteEducator]);
 
   // Resume an incomplete educator straight into step 3 so they can finish saving
   // their profile instead of silently landing on the dashboard with their signup

--- a/frontend/pages/SignupPage.tsx
+++ b/frontend/pages/SignupPage.tsx
@@ -17,6 +17,11 @@ import { API_ENDPOINTS } from '../services/api-endpoints';
 import { getHomePath } from '../utils/navigation';
 import LogoLink from '../components/shared/LogoLink';
 import EducatorProfileStep, { EducatorProfileStepData } from '../components/signup/EducatorProfileStep';
+import {
+  readWizardState,
+  writeWizardState,
+  clearSignupDrafts,
+} from '../utils/signupDraft';
 
 const SIGNUP_ROLE_TO_USER_ROLE: Record<SignupRole, UserRole> = {
   [SignupRole.FOUNDATION]: UserRole.FOUNDATION,
@@ -67,6 +72,19 @@ const SignupPage: React.FC = () => {
   
   // For backwards compatibility, keep isOAuthCompletion for OAuth-specific UI
   const isOAuthCompletion = needsProfileCompletion && hasOAuthAccount;
+
+  // An educator whose backend account exists (created by the Clerk webhook at the
+  // end of step 2) but who never submitted step 3 has an empty profile — no
+  // shortBio and no CV. Detect that so we can resume them into step 3 instead of
+  // dropping them on the dashboard with their signup information discarded.
+  const isIncompleteEducator = Boolean(
+    isSignedIn &&
+      currentUser &&
+      !isAuthLoading &&
+      currentUser.role === UserRole.EDUCATOR &&
+      !((currentUser as any).shortBio && String((currentUser as any).shortBio).trim()) &&
+      !((currentUser as any).cvUrl && String((currentUser as any).cvUrl).trim()),
+  );
 
   useEffect(() => {
     if (settingsError) {
@@ -201,11 +219,85 @@ const SignupPage: React.FC = () => {
 
   // Redirect if user is already logged in AND has a backend profile (currentUser is set)
   // If currentUser is null, it means they need to complete their profile (e.g. after Google Sign Up)
+  //
+  // Exception: an educator who never completed step 3 (empty profile) must NOT be
+  // redirected to the dashboard here — that is exactly how signup information gets
+  // lost on refresh / when the verification link opens in a new tab. Such users are
+  // resumed into step 3 by the effect below instead.
   useEffect(() => {
-    if (isSignedIn && currentUser && !hasStartedSignup) {
+    if (isSignedIn && currentUser && !hasStartedSignup && !isIncompleteEducator) {
       navigate('/dashboard', { replace: true });
     }
-  }, [isSignedIn, currentUser, hasStartedSignup, navigate]);
+  }, [isSignedIn, currentUser, hasStartedSignup, isIncompleteEducator, navigate]);
+
+  // Restore any persisted wizard progress once on mount, before the redirect guard
+  // above can act. This brings back the role and the details the user already typed
+  // after a refresh or when the tab is restored from Safari's bfcache.
+  useEffect(() => {
+    const saved = readWizardState();
+    if (!saved) return;
+
+    if (saved.selectedRole) {
+      setSelectedRole(saved.selectedRole as SignupRole);
+    }
+    if (saved.formData) {
+      setFormData(prev => ({ ...prev, ...(saved.formData as Partial<SignupFormData>) }));
+    }
+    // Only restore an un-authenticated draft to step 2 (and mark the signup as
+    // started so the dashboard redirect guard leaves them alone). Resuming to step 3
+    // for a signed-in educator is server-driven by the resume effect below, so we
+    // never set hasStartedSignup here on a stale role alone — that would block the
+    // resume effect and strand the user on step 1.
+    if (saved.currentStep === 2 && !isSignedIn) {
+      setCurrentStep(2);
+      setHasStartedSignup(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Resume an incomplete educator straight into step 3 so they can finish saving
+  // their profile instead of silently landing on the dashboard with their signup
+  // information discarded.
+  useEffect(() => {
+    if (!isIncompleteEducator || hasStartedSignup) return;
+    setSelectedRole(SignupRole.EDUCATOR);
+    setHasStartedSignup(true);
+    setShowVerificationStep(false);
+    setSuccessRedirect(getSuccessRedirectForRole());
+    // Seed the wizard from the authenticated account so a resume that has no
+    // persisted draft (e.g. the verification link opened in a fresh webview) still
+    // shows the educator's email/name rather than a blank read-only email field.
+    setFormData(prev => ({
+      ...prev,
+      email: prev.email || currentUser?.email || '',
+      contactPerson:
+        prev.contactPerson ||
+        `${currentUser?.firstName || ''} ${currentUser?.lastName || ''}`.trim(),
+      phone: prev.phone || (currentUser as any)?.phoneNumber || '',
+    }));
+    setCurrentStep(3);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isIncompleteEducator, hasStartedSignup]);
+
+  // Persist wizard progress (never the password) while a signup is in flight, so it
+  // survives a refresh, tab suspension, or the verification link opening elsewhere.
+  useEffect(() => {
+    if (!hasStartedSignup || currentStep === 4) return;
+    // writeWizardState strips password/confirmPassword before persisting.
+    writeWizardState({
+      selectedRole,
+      currentStep,
+      formData: formData as unknown as Record<string, unknown>,
+    });
+  }, [hasStartedSignup, currentStep, selectedRole, formData]);
+
+  // Once the signup is fully completed (step 4) the persisted draft is no longer
+  // needed — clear it so a later visit starts fresh.
+  useEffect(() => {
+    if (currentStep === 4) {
+      clearSignupDrafts(formData.email);
+    }
+  }, [currentStep, formData.email]);
 
   // Handle successful verification - redirect if user becomes authenticated after showing success
   useEffect(() => {

--- a/frontend/utils/signupDraft.ts
+++ b/frontend/utils/signupDraft.ts
@@ -1,0 +1,114 @@
+// Persistence helpers for the sign-up wizard.
+//
+// Why this exists: for educators the backend AppUser/User record is created by
+// the Clerk `user.created` webhook at the END of step 2 (email verification),
+// while the educator profile details (bio, city, job role, experience, CV) are
+// only saved in step 3 via PATCH /settings/educator. Step 3 is pure in-memory
+// React state, so anything that discards that state after step 2 — a refresh,
+// the verification link opening in a different tab/webview, Safari suspending a
+// backgrounded tab — silently loses everything the user typed in step 3 and
+// leaves an account with no profile information.
+//
+// Persisting the wizard + step-3 draft to sessionStorage lets us restore the
+// user's input and resume them at step 3 instead of dropping them on the
+// dashboard with their data gone.
+
+const WIZARD_KEY = 'procreche.signup.wizard.v1';
+const EDU_DRAFT_PREFIX = 'procreche.signup.educatorDraft.v1';
+
+function safeSession(): Storage | null {
+  try {
+    if (typeof window === 'undefined' || !window.sessionStorage) return null;
+    return window.sessionStorage;
+  } catch {
+    // Access can throw in private-mode / sandboxed contexts.
+    return null;
+  }
+}
+
+export interface PersistedWizardState {
+  selectedRole?: string | null;
+  currentStep?: number;
+  // Never contains password/confirmPassword — those are stripped before writing.
+  formData?: Record<string, unknown>;
+}
+
+export function readWizardState(): PersistedWizardState | null {
+  const store = safeSession();
+  if (!store) return null;
+  try {
+    const raw = store.getItem(WIZARD_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as PersistedWizardState) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeWizardState(state: PersistedWizardState): void {
+  const store = safeSession();
+  if (!store) return;
+  try {
+    const formData = { ...(state.formData ?? {}) };
+    // Defensive: never persist credentials, even if a caller forgets to strip them.
+    delete (formData as Record<string, unknown>).password;
+    delete (formData as Record<string, unknown>).confirmPassword;
+    store.setItem(WIZARD_KEY, JSON.stringify({ ...state, formData }));
+  } catch {
+    // Quota / serialization errors are non-fatal — persistence is best-effort.
+  }
+}
+
+export function clearWizardState(): void {
+  const store = safeSession();
+  if (!store) return;
+  try {
+    store.removeItem(WIZARD_KEY);
+  } catch {
+    /* best-effort */
+  }
+}
+
+function eduKey(email?: string): string {
+  return `${EDU_DRAFT_PREFIX}:${(email ?? '').trim().toLowerCase()}`;
+}
+
+export function readEducatorDraft<T = Record<string, unknown>>(email?: string): T | null {
+  const store = safeSession();
+  if (!store) return null;
+  try {
+    const raw = store.getItem(eduKey(email));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeEducatorDraft(email: string | undefined, data: Record<string, unknown>): void {
+  const store = safeSession();
+  if (!store) return;
+  try {
+    store.setItem(eduKey(email), JSON.stringify(data));
+  } catch {
+    /* best-effort */
+  }
+}
+
+export function clearEducatorDraft(email?: string): void {
+  const store = safeSession();
+  if (!store) return;
+  try {
+    store.removeItem(eduKey(email));
+  } catch {
+    /* best-effort */
+  }
+}
+
+// Clear everything once the signup has actually been completed/saved.
+export function clearSignupDrafts(email?: string): void {
+  clearWizardState();
+  clearEducatorDraft(email);
+}


### PR DESCRIPTION
## Summary

Adds sessionStorage-based persistence for the signup wizard to prevent data loss when educators refresh the page, open the verification link in a new tab, or have their tab suspended (e.g., Safari's bfcache). Educators who never complete step 3 (profile details) are now resumed into that step instead of being silently redirected to the dashboard with an empty profile.

## Key Changes

- **New utility module** (`frontend/utils/signupDraft.ts`):
  - `readWizardState()` / `writeWizardState()` — persist role, current step, and form data (passwords stripped defensively)
  - `readEducatorDraft()` / `writeEducatorDraft()` — per-email educator profile draft storage
  - `clearSignupDrafts()` — cleanup once signup completes
  - Safe sessionStorage access with try/catch for private-mode and sandboxed contexts

- **SignupPage.tsx**:
  - Detect incomplete educators (signed in, role = EDUCATOR, but no `shortBio` or `cvUrl`)
  - Restore persisted wizard state on mount (role, form data, step 2 for unauthenticated users)
  - Resume incomplete educators directly into step 3 with pre-filled email/name/phone from their account
  - Persist wizard progress on every state change (except step 4)
  - Clear drafts once step 4 (success) is reached

- **EducatorProfileStep.tsx**:
  - Initialize form state from persisted draft (layered over `initialData`)
  - Auto-persist profile edits as the user types
  - Survives refresh, tab suspension, and verification link opening in a new tab/webview

## Implementation Details

- Passwords and confirmPassword are never persisted (stripped before writing)
- sessionStorage access is wrapped in try/catch to handle private-mode and sandboxed contexts gracefully
- Educator draft is keyed by normalized email (lowercase, trimmed) for consistency
- The redirect-to-dashboard guard explicitly excludes incomplete educators so they can finish step 3
- Drafts are cleared only after step 4 completes, ensuring a fresh start on the next signup attempt

https://claude.ai/code/session_016J9xgDhUHaLCa3vDRGydZs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Signup progress now resumes after refreshes or when returning to the signup flow.
  - Educator profile drafts are automatically saved and restored during signup.
  - If an educator account exists but the profile is incomplete, the flow resumes directly at the educator profile setup step.
  - Persisted wizard data is cleared once signup reaches completion.
- **Privacy**
  - Password and confirmation fields are never saved in progress storage.
- **Bug Fixes**
  - Updated the “already signed in” redirect behavior to avoid losing signup context for incomplete educator profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->