### PR TITLE
Fix educator signup: persist all fields, handle slow provisioning

### DIFF
--- a/admin/src/pages/AdminUserProfileEdit.tsx
+++ b/admin/src/pages/AdminUserProfileEdit.tsx
@@ -84,7 +84,7 @@ interface UserProfile {
   avatarAssetId: string | null;
   coverImageUrl: string | null;
   coverAssetId: string | null;
-  approvalStatus?: 'PENDING_REVIEW' | 'APPROVED' | 'REJECTED' | null;
+  approvalStatus?: 'INCOMPLETE' | 'PENDING_REVIEW' | 'APPROVED' | 'REJECTED' | null;
   approvalNotes?: string | null;
   approvedAt?: string | null;
   organization?: {
@@ -1226,6 +1226,16 @@ const AdminUserProfileEdit: React.FC = () => {
         {/* ── Tab content ─────────────────────────────────────────── */}
         <div className="p-6">
           {/* Educator approval banner */}
+          {isEducator && profile.approvalStatus === 'INCOMPLETE' && (
+            <div className="mb-4 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm">
+              <p className="font-medium text-gray-800">Application not submitted</p>
+              <p className="mt-1 text-gray-600">
+                This account was created at email verification but the educator never completed
+                their profile, so there is nothing to review yet. They are prompted to finish it
+                on their next sign-in.
+              </p>
+            </div>
+          )}
           {isEducator && profile.approvalStatus === 'PENDING_REVIEW' && (
             <div className="mb-4 flex items-center justify-between gap-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3">
               <div className="flex items-center gap-3 text-sm text-amber-800">

--- a/admin/src/pages/EducatorApprovals.tsx
+++ b/admin/src/pages/EducatorApprovals.tsx
@@ -15,7 +15,7 @@ import { useApiClient, apiService } from '../services/api'
 import LoadingSpinner from '../components/ui/LoadingSpinner'
 import { toast } from 'sonner'
 
-type ApprovalStatus = 'PENDING_REVIEW' | 'APPROVED' | 'REJECTED'
+type ApprovalStatus = 'INCOMPLETE' | 'PENDING_REVIEW' | 'APPROVED' | 'REJECTED'
 
 interface Educator {
   id: string
@@ -39,12 +39,14 @@ interface Educator {
 }
 
 const STATUS_LABELS: Record<ApprovalStatus, string> = {
+  INCOMPLETE: 'Incomplete',
   PENDING_REVIEW: 'Pending Review',
   APPROVED: 'Approved',
   REJECTED: 'Rejected',
 }
 
 const STATUS_STYLES: Record<ApprovalStatus, string> = {
+  INCOMPLETE: 'bg-gray-100 text-gray-700',
   PENDING_REVIEW: 'bg-amber-100 text-amber-800',
   APPROVED: 'bg-green-100 text-green-800',
   REJECTED: 'bg-red-100 text-red-800',
@@ -128,6 +130,10 @@ const EducatorApprovals: React.FC = () => {
 
   const tabs: { key: ApprovalStatus; label: string }[] = [
     { key: 'PENDING_REVIEW', label: 'Pending' },
+    // Accounts created at email verification whose owner never submitted an
+    // application. Kept out of the Pending queue so it only holds real
+    // submissions, but still visible so they can be chased.
+    { key: 'INCOMPLETE', label: 'Incomplete' },
     { key: 'APPROVED', label: 'Approved' },
     { key: 'REJECTED', label: 'Rejected' },
   ]
@@ -197,7 +203,11 @@ const EducatorApprovals: React.FC = () => {
             <User className="w-10 h-10 mx-auto mb-3 text-gray-300" />
             <p className="font-medium">No educators found</p>
             <p className="text-sm mt-1">
-              {activeTab === 'PENDING_REVIEW' ? 'All educator applications have been reviewed.' : `No ${STATUS_LABELS[activeTab].toLowerCase()} educators.`}
+              {activeTab === 'PENDING_REVIEW'
+                ? 'All educator applications have been reviewed.'
+                : activeTab === 'INCOMPLETE'
+                  ? 'Every educator who signed up has submitted their application.'
+                  : `No ${STATUS_LABELS[activeTab].toLowerCase()} educators.`}
             </p>
           </div>
         ) : (

--- a/admin/src/pages/EducatorApprovals.tsx
+++ b/admin/src/pages/EducatorApprovals.tsx
@@ -203,11 +203,13 @@ const EducatorApprovals: React.FC = () => {
             <User className="w-10 h-10 mx-auto mb-3 text-gray-300" />
             <p className="font-medium">No educators found</p>
             <p className="text-sm mt-1">
-              {activeTab === 'PENDING_REVIEW'
-                ? 'All educator applications have been reviewed.'
-                : activeTab === 'INCOMPLETE'
-                  ? 'Every educator who signed up has submitted their application.'
-                  : `No ${STATUS_LABELS[activeTab].toLowerCase()} educators.`}
+              {search
+                ? 'No educators match your search.'
+                : activeTab === 'PENDING_REVIEW'
+                  ? 'All educator applications have been reviewed.'
+                  : activeTab === 'INCOMPLETE'
+                    ? 'Every educator who signed up has submitted their application.'
+                    : `No ${STATUS_LABELS[activeTab].toLowerCase()} educators.`}
             </p>
           </div>
         ) : (

--- a/api/package.json
+++ b/api/package.json
@@ -56,7 +56,8 @@
     "prebuild:db": "node scripts/prebuild-complete-db-setup.mjs",
     "db:seed:cantons": "ts-node scripts/seed-cantons.ts",
     "import:translations": "ts-node scripts/import-static-translations.ts",
-    "create:test-users": "ts-node scripts/create-test-users.ts"
+    "create:test-users": "ts-node scripts/create-test-users.ts",
+    "backfill:incomplete-educators": "ts-node scripts/backfill-incomplete-educators.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.888.0",

--- a/api/prisma/migrations/20260701000000_add_signup_capture_columns/migration.sql
+++ b/api/prisma/migrations/20260701000000_add_signup_capture_columns/migration.sql
@@ -1,0 +1,8 @@
+-- Signup fields that were collected on the signup form but never persisted.
+-- `childAge`/`childStartDate` are collected from PARENT signups; `termsAcceptedAt`
+-- records the consent given at signup. All three are now written by the shared
+-- applier in api/src/users/signup-profile.service.ts, from both the Clerk
+-- webhook path and the /users/complete-profile path.
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "childAge" INTEGER;
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "childStartDate" TIMESTAMP(3);
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "termsAcceptedAt" TIMESTAMP(3);

--- a/api/prisma/migrations/20260701010000_add_educator_status_incomplete/migration.sql
+++ b/api/prisma/migrations/20260701010000_add_educator_status_incomplete/migration.sql
@@ -1,0 +1,13 @@
+-- Add the INCOMPLETE educator approval status.
+--
+-- Educator accounts are created by the Clerk `user.created` webhook at email
+-- verification, which is BEFORE the profile (bio, experience, CV) is collected
+-- in step 3 of the signup wizard. Stamping those accounts PENDING_REVIEW filled
+-- the admin approval queue with blank records that could never be reviewed.
+-- INCOMPLETE marks "account exists, application never submitted"; the status is
+-- promoted to PENDING_REVIEW when the educator actually saves their profile.
+--
+-- This runs in its own migration on purpose: PostgreSQL cannot use a new enum
+-- value in the same transaction that adds it, so the data backfill that assigns
+-- INCOMPLETE lives in the migration that follows this one.
+ALTER TYPE "EducatorApprovalStatus" ADD VALUE IF NOT EXISTS 'INCOMPLETE' BEFORE 'PENDING_REVIEW';

--- a/api/prisma/migrations/20260701020000_backfill_incomplete_educators/migration.sql
+++ b/api/prisma/migrations/20260701020000_backfill_incomplete_educators/migration.sql
@@ -1,0 +1,15 @@
+-- Reclassify existing educator accounts that were never actually submitted.
+--
+-- These are accounts created by the signup webhook whose owner never completed
+-- step 3: no biography and no CV. They have been sitting in the admin approval
+-- queue as blank rows. Moving them to INCOMPLETE makes the queue truthful and
+-- routes the owners to the "Finish your application" prompt on next login.
+--
+-- Deliberately scoped to PENDING_REVIEW only: an APPROVED or REJECTED educator
+-- has already been decided on by an admin and must not be reopened.
+UPDATE "users"
+SET "approvalStatus" = 'INCOMPLETE'
+WHERE "role" = 'EDUCATOR'
+  AND "approvalStatus" = 'PENDING_REVIEW'
+  AND COALESCE(TRIM("shortBio"), '') = ''
+  AND COALESCE(TRIM("cvUrl"), '') = '';

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -196,7 +196,8 @@ enum SubscriptionCancellationRequestStatus {
 }
 
 enum EducatorApprovalStatus {
-  PENDING_REVIEW // Educator signed up, awaiting admin approval
+  INCOMPLETE     // Account created at email verification, profile never submitted — nothing to review
+  PENDING_REVIEW // Educator submitted their profile, awaiting admin approval
   APPROVED       // Admin approved - educator can access the platform
   REJECTED       // Admin rejected - educator cannot access the platform
 }
@@ -255,6 +256,12 @@ model User {
   approvalStatus  EducatorApprovalStatus? // Only set for EDUCATOR role
   approvalNotes   String?                 @db.Text // Admin rejection reason
   approvedAt      DateTime?
+
+  // Captured at signup (see users/signup-profile.service.ts). Written by both
+  // account-creation paths so email/password and OAuth signups keep the same data.
+  childAge        Int?      // PARENT role - age of the child at signup
+  childStartDate  DateTime? // PARENT role - desired childcare start date
+  termsAcceptedAt DateTime? // When the user accepted the terms during signup
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/api/scripts/backfill-incomplete-educators.ts
+++ b/api/scripts/backfill-incomplete-educators.ts
@@ -73,14 +73,10 @@ async function main() {
 
     // Belt and braces: match on the status the migration sets AND on the
     // underlying condition, so a row the migration missed is still caught.
-    const candidates = await prisma.user.findMany({
+    const rows = await prisma.user.findMany({
       where: {
         role: UserRole.EDUCATOR,
         approvalStatus: { in: [EducatorApprovalStatus.INCOMPLETE, EducatorApprovalStatus.PENDING_REVIEW] },
-        AND: [
-          { OR: [{ shortBio: null }, { shortBio: '' }] },
-          { OR: [{ cvUrl: null }, { cvUrl: '' }] },
-        ],
         email: { not: null },
       },
       select: {
@@ -90,10 +86,21 @@ async function main() {
         lastName: true,
         approvalStatus: true,
         createdAt: true,
+        shortBio: true,
+        cvUrl: true,
       },
       orderBy: { createdAt: 'asc' },
-      ...(options.limit ? { take: options.limit } : {}),
     });
+
+    // The blank test must match migration 20260701020000, which uses
+    // COALESCE(TRIM(...), '') = ''. A Prisma filter on NULL and '' alone would
+    // miss an account reclassified to INCOMPLETE for a whitespace-only value,
+    // leaving it permanently un-reminded. `trim()` here is exactly TRIM there.
+    // Filtering in JS (rather than in the query) also means --limit applies to
+    // the accounts that actually qualify, not to the rows read.
+    const isBlank = (value: string | null) => !value || value.trim() === '';
+    const matching = rows.filter((row) => isBlank(row.shortBio) && isBlank(row.cvUrl));
+    const candidates = options.limit ? matching.slice(0, options.limit) : matching;
 
     if (candidates.length === 0) {
       console.log('\nNo incomplete educator accounts found. Nothing to do.\n');

--- a/api/scripts/backfill-incomplete-educators.ts
+++ b/api/scripts/backfill-incomplete-educators.ts
@@ -1,0 +1,193 @@
+/**
+ * Report — and optionally chase — educator accounts that were never completed.
+ *
+ * Background: an educator's account is created by the Clerk `user.created`
+ * webhook at email verification, which happens BEFORE step 3 of the signup
+ * wizard collects the actual profile (bio, experience, CV). Anyone who dropped
+ * out between those two points ended up with a real, admin-visible account and
+ * a completely empty profile. Migration 20260701020000 reclassifies them to
+ * INCOMPLETE; this script finds them and, with --execute, emails them a link to
+ * finish.
+ *
+ * Usage:
+ *   ts-node scripts/backfill-incomplete-educators.ts              # dry run (default)
+ *   ts-node scripts/backfill-incomplete-educators.ts --execute    # send reminders
+ *   ts-node scripts/backfill-incomplete-educators.ts --execute --limit 5
+ *   ts-node scripts/backfill-incomplete-educators.ts --resend     # ignore "already emailed"
+ *
+ * Dry run is the default on purpose: this touches real users' inboxes.
+ */
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { NestFactory } from '@nestjs/core';
+import { EducatorApprovalStatus, PrismaClient, UserRole } from '@prisma/client';
+import { EmailNotificationModule } from '../src/email-notification/email-notification.module';
+import { EmailNotificationService } from '../src/email-notification/email-notification.service';
+
+const REMINDER_EVENT = 'educator_profile_incomplete';
+
+// Deliberately does NOT import AppModule: that registers ScheduleModule, which
+// would start every cron in the API for the lifetime of this script.
+@Module({
+  imports: [ConfigModule.forRoot({ isGlobal: true }), EmailNotificationModule],
+})
+class BackfillModule {}
+
+interface Options {
+  execute: boolean;
+  resend: boolean;
+  limit?: number;
+}
+
+function parseArgs(argv: string[]): Options {
+  const limitFlagIndex = argv.indexOf('--limit');
+  const rawLimit = limitFlagIndex >= 0 ? Number.parseInt(argv[limitFlagIndex + 1] ?? '', 10) : NaN;
+
+  if (limitFlagIndex >= 0 && (!Number.isInteger(rawLimit) || rawLimit <= 0)) {
+    throw new Error('--limit requires a positive integer');
+  }
+
+  return {
+    execute: argv.includes('--execute'),
+    resend: argv.includes('--resend'),
+    limit: Number.isInteger(rawLimit) ? rawLimit : undefined,
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const prisma = new PrismaClient();
+
+  try {
+    // Status distribution, so the operator can see what the migration did.
+    const byStatus = await prisma.user.groupBy({
+      by: ['approvalStatus'],
+      where: { role: UserRole.EDUCATOR },
+      _count: { _all: true },
+    });
+
+    console.log('\nEducator accounts by approval status:');
+    for (const row of byStatus) {
+      console.log(`  ${String(row.approvalStatus ?? 'NULL').padEnd(15)} ${row._count._all}`);
+    }
+
+    // Belt and braces: match on the status the migration sets AND on the
+    // underlying condition, so a row the migration missed is still caught.
+    const candidates = await prisma.user.findMany({
+      where: {
+        role: UserRole.EDUCATOR,
+        approvalStatus: { in: [EducatorApprovalStatus.INCOMPLETE, EducatorApprovalStatus.PENDING_REVIEW] },
+        AND: [
+          { OR: [{ shortBio: null }, { shortBio: '' }] },
+          { OR: [{ cvUrl: null }, { cvUrl: '' }] },
+        ],
+        email: { not: null },
+      },
+      select: {
+        id: true,
+        email: true,
+        firstName: true,
+        lastName: true,
+        approvalStatus: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: 'asc' },
+      ...(options.limit ? { take: options.limit } : {}),
+    });
+
+    if (candidates.length === 0) {
+      console.log('\nNo incomplete educator accounts found. Nothing to do.\n');
+      return;
+    }
+
+    // Who has already had this reminder?
+    const alreadyEmailed = new Set<string>();
+    if (!options.resend) {
+      const logs = await prisma.emailLog.findMany({
+        where: {
+          event: REMINDER_EVENT,
+          status: 'sent',
+          recipient: { in: candidates.map((c) => c.email as string) },
+        },
+        select: { recipient: true },
+      });
+      for (const log of logs) alreadyEmailed.add(log.recipient.toLowerCase());
+    }
+
+    const targets = candidates.filter((c) => !alreadyEmailed.has((c.email as string).toLowerCase()));
+
+    console.log(`\nIncomplete educator accounts: ${candidates.length}`);
+    console.log(`  already reminded: ${candidates.length - targets.length}`);
+    console.log(`  to contact:       ${targets.length}\n`);
+
+    for (const educator of targets) {
+      const name = `${educator.firstName || ''} ${educator.lastName || ''}`.trim() || '(no name)';
+      console.log(
+        `  ${educator.createdAt.toISOString().slice(0, 10)}  ${String(educator.approvalStatus).padEnd(14)}  ${String(educator.email).padEnd(40)}  ${name}`,
+      );
+    }
+
+    if (!options.execute) {
+      console.log('\nDRY RUN — no emails sent. Re-run with --execute to send reminders.\n');
+      return;
+    }
+
+    const app = await NestFactory.createApplicationContext(BackfillModule, {
+      logger: ['error', 'warn'],
+    });
+
+    try {
+      const emailService = app.get(EmailNotificationService);
+      const config = app.get(ConfigService);
+      const appUrl = config.get<string>('APP_URL') || config.get<string>('FRONTEND_URL') || '';
+
+      if (!appUrl) {
+        throw new Error('APP_URL (or FRONTEND_URL) must be set so the email can link back to the app.');
+      }
+
+      let sent = 0;
+      let failed = 0;
+
+      for (const educator of targets) {
+        const ok = await emailService
+          .sendNotification({
+            event: REMINDER_EVENT,
+            recipient: educator.email as string,
+            recipientName: educator.firstName || undefined,
+            payload: {
+              firstName: educator.firstName || 'Educator',
+              // LoginPage has no redirect parameter, but the role-based redirect
+              // lands an incomplete educator on /educator/pending-approval,
+              // which offers the "Finish your application" call to action.
+              loginUrl: `${appUrl}/login`,
+              supportUrl: `${appUrl}/support`,
+            },
+            bypassPreferences: true,
+            allowUnknownRecipient: false,
+          })
+          .catch((err: any) => {
+            console.error(`  FAILED ${educator.email}: ${err?.message || err}`);
+            return false;
+          });
+
+        if (ok) {
+          sent += 1;
+        } else {
+          failed += 1;
+          console.warn(`  not sent: ${educator.email}`);
+        }
+      }
+
+      console.log(`\nDone. sent=${sent} failed=${failed}\n`);
+    } finally {
+      await app.close();
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/api/src/admin/educator-approvals.controller.ts
+++ b/api/src/admin/educator-approvals.controller.ts
@@ -56,6 +56,13 @@ export class EducatorApprovalsController {
     return { count };
   }
 
+  // Must stay above the `:id` route below, or 'incomplete-count' is parsed as an id.
+  @Get('incomplete-count')
+  async getIncompleteCount() {
+    const count = await this.educatorApprovalsService.getIncompleteCount();
+    return { count };
+  }
+
   @Get(':id')
   async getEducator(@Param('id', ParseUUIDPipe) id: string) {
     return this.educatorApprovalsService.getEducatorById(id);

--- a/api/src/admin/educator-approvals.service.ts
+++ b/api/src/admin/educator-approvals.service.ts
@@ -165,6 +165,17 @@ export class EducatorApprovalsService {
   async rejectEducator(id: string, notes: string) {
     const educator = await this.getEducatorById(id);
 
+    // Same guard as approveEducator: an INCOMPLETE account never submitted an
+    // application, so there is nothing to reject. Without this, an admin could
+    // formally reject a blank account and send its owner a rejection email for
+    // something they never applied for — and the REJECTED status would then
+    // lock them out of finishing their signup.
+    if (educator.approvalStatus === EducatorApprovalStatus.INCOMPLETE) {
+      throw new BadRequestException(
+        'This educator has not submitted an application yet. Their profile is incomplete.',
+      );
+    }
+
     if (!notes?.trim()) {
       throw new BadRequestException('Rejection notes are required');
     }

--- a/api/src/admin/educator-approvals.service.ts
+++ b/api/src/admin/educator-approvals.service.ts
@@ -67,6 +67,16 @@ export class EducatorApprovalsService {
     });
   }
 
+  /**
+   * Educators whose account exists but who never submitted an application.
+   * Tracked separately so the review queue only contains real submissions.
+   */
+  async getIncompleteCount() {
+    return this.prisma.user.count({
+      where: { role: UserRole.EDUCATOR, approvalStatus: EducatorApprovalStatus.INCOMPLETE },
+    });
+  }
+
   async getEducatorById(id: string) {
     const educator = await this.prisma.user.findFirst({
       where: { id, role: UserRole.EDUCATOR },
@@ -109,6 +119,15 @@ export class EducatorApprovalsService {
 
     if (educator.approvalStatus === EducatorApprovalStatus.APPROVED) {
       throw new BadRequestException('Educator is already approved');
+    }
+
+    // Nothing was ever submitted for this account — there is no application to
+    // approve. Approving it would publish an empty profile into the candidate
+    // pool. The educator must finish signup first.
+    if (educator.approvalStatus === EducatorApprovalStatus.INCOMPLETE) {
+      throw new BadRequestException(
+        'This educator has not submitted an application yet. Their profile is incomplete.',
+      );
     }
 
     const updated = await this.prisma.user.update({

--- a/api/src/auth/guards/roles.guard.ts
+++ b/api/src/auth/guards/roles.guard.ts
@@ -76,6 +76,15 @@ export class RolesGuard implements CanActivate {
 
     // 7. Handle educators pending admin approval
     if (userContext.role === UserRole.EDUCATOR) {
+      // INCOMPLETE means the account exists but the application was never
+      // submitted. It is gated exactly like PENDING_REVIEW — @AllowPendingEducator
+      // routes (profile, settings) stay reachable so the educator can finish.
+      if (userContext.approvalStatus === EducatorApprovalStatus.INCOMPLETE && !allowPendingEducator) {
+        throw new ForbiddenException({
+          message: 'Please complete your educator profile before accessing the platform.',
+          code: 'EDUCATOR_PROFILE_INCOMPLETE',
+        });
+      }
       if (userContext.approvalStatus === EducatorApprovalStatus.PENDING_REVIEW && !allowPendingEducator) {
         throw new ForbiddenException({
           message: 'Your educator profile is awaiting admin approval. You will be notified once reviewed.',

--- a/api/src/email-notification/email-template.service.ts
+++ b/api/src/email-notification/email-template.service.ts
@@ -452,6 +452,47 @@ export class EmailTemplateService {
       },
       // ── Approbation des éducateur·trices ──────────────────────────────────
       {
+        name: 'Candidature éducateur·trice incomplète',
+        event: 'educator_profile_incomplete',
+        subject: 'Votre inscription est presque terminée',
+        category: 'userManagement',
+        variables: ['firstName', 'loginUrl', 'supportUrl'],
+        htmlContent: `
+          <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+            <h2>Il ne reste qu'une étape</h2>
+            <p>Bonjour {{firstName}},</p>
+            <p>Votre compte Pro Crèche Solutions a bien été créé, mais votre candidature d'éducateur·trice n'a jamais été soumise : il nous manque encore votre biographie, votre expérience et votre CV.</p>
+            <p>Tant que ces informations sont manquantes, notre équipe ne peut pas examiner votre dossier et votre profil n'est visible par aucune crèche.</p>
+            <div style="background-color: #FFFBEB; border-left: 4px solid #F59E0B; padding: 12px 16px; margin: 20px 0; border-radius: 4px;">
+              <p style="margin: 0;">Comptez environ 5 minutes. Connectez-vous et vous serez guidé·e directement vers l'étape restante.</p>
+            </div>
+            <div style="text-align: center; margin: 30px 0;">
+              <a href="{{loginUrl}}" style="background-color: #10B981; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px;">Terminer ma candidature</a>
+            </div>
+            <p>Un problème ou une question ? <a href="{{supportUrl}}">Contactez notre assistance</a>.</p>
+            <p>Cordialement,<br>L'équipe Pro Crèche Solutions</p>
+          </div>
+        `.trim(),
+        textContent: `
+          Il ne reste qu'une étape
+
+          Bonjour {{firstName}},
+
+          Votre compte Pro Crèche Solutions a bien été créé, mais votre candidature d'éducateur·trice n'a jamais été soumise : il nous manque encore votre biographie, votre expérience et votre CV.
+
+          Tant que ces informations sont manquantes, notre équipe ne peut pas examiner votre dossier et votre profil n'est visible par aucune crèche.
+
+          Comptez environ 5 minutes. Connectez-vous et vous serez guidé·e directement vers l'étape restante :
+          {{loginUrl}}
+
+          Un problème ou une question ? Contactez notre assistance : {{supportUrl}}
+
+          Cordialement,
+          L'équipe Pro Crèche Solutions
+        `.trim(),
+        isActive: true,
+      },
+      {
         name: 'Candidature éducateur·trice reçue',
         event: 'educator_pending',
         subject: 'Candidature reçue — en attente de vérification',
@@ -1325,6 +1366,32 @@ export class EmailTemplateService {
           {{description}}
 
           Nous nous excusons pour tout inconvénient et vous remercions de votre patience.
+
+          Cordialement,
+          L'équipe Pro Crèche Solutions
+        `,
+      },
+      educator_profile_incomplete: {
+        subject: 'Votre inscription est presque terminée',
+        htmlContent: `
+          <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+            <h2>Il ne reste qu'une étape</h2>
+            <p>Bonjour {{firstName}},</p>
+            <p>Votre compte a bien été créé, mais votre candidature d'éducateur·trice n'a jamais été soumise : il nous manque votre biographie, votre expérience et votre CV.</p>
+            <div style="text-align: center; margin: 30px 0;">
+              <a href="{{loginUrl}}" style="background-color: #10B981; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px;">Terminer ma candidature</a>
+            </div>
+            <p>Cordialement,<br>L'équipe Pro Crèche Solutions</p>
+          </div>
+        `,
+        textContent: `
+          Il ne reste qu'une étape
+
+          Bonjour {{firstName}},
+
+          Votre compte a bien été créé, mais votre candidature d'éducateur·trice n'a jamais été soumise : il nous manque votre biographie, votre expérience et votre CV.
+
+          Terminer ma candidature : {{loginUrl}}
 
           Cordialement,
           L'équipe Pro Crèche Solutions

--- a/api/src/principal/principal.service.spec.ts
+++ b/api/src/principal/principal.service.spec.ts
@@ -2,13 +2,13 @@ import { Test } from '@nestjs/testing';
 import { NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { PrincipalService } from './principal.service';
-import { UserRole } from '@prisma/client';
+import { EducatorApprovalStatus, UserRole } from '@prisma/client';
 
 describe('PrincipalService', () => {
   let service: PrincipalService;
   let prisma: {
     appUser: { findUnique: jest.Mock; upsert: jest.Mock };
-    user: { findUnique: jest.Mock; upsert: jest.Mock };
+    user: { findUnique: jest.Mock; upsert: jest.Mock; update: jest.Mock };
     userNotificationPreferences: { upsert: jest.Mock; findUnique: jest.Mock };
   };
 
@@ -26,6 +26,7 @@ describe('PrincipalService', () => {
             user: {
               findUnique: jest.fn(),
               upsert: jest.fn(),
+              update: jest.fn(),
             },
             userNotificationPreferences: {
               upsert: jest.fn(),
@@ -216,6 +217,99 @@ describe('PrincipalService', () => {
     });
   });
 
+  describe('educator approval status on bootstrap', () => {
+    const educatorAppUser = {
+      id: 'app-1',
+      clerkId: 'clerk_edu',
+      email: 'edu@example.com',
+      role: UserRole.EDUCATOR,
+    };
+
+    it('bootstraps a new educator as INCOMPLETE, not PENDING_REVIEW', async () => {
+      // The profile row is created before the educator has submitted anything,
+      // so it must not land in the admin review queue.
+      prisma.appUser.findUnique.mockResolvedValue(educatorAppUser as any);
+      prisma.user.upsert.mockResolvedValue({
+        id: 'user-1',
+        approvalStatus: EducatorApprovalStatus.INCOMPLETE,
+      } as any);
+
+      await service.getOrBootstrapAccountAndProfile('clerk_edu');
+
+      expect(prisma.user.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            approvalStatus: EducatorApprovalStatus.INCOMPLETE,
+          }),
+        }),
+      );
+    });
+
+    it('backfills a legacy educator with no application as INCOMPLETE', async () => {
+      prisma.appUser.findUnique.mockResolvedValue(educatorAppUser as any);
+      // Predates the approval workflow: approvalStatus is still null.
+      prisma.user.upsert.mockResolvedValue({
+        id: 'user-1',
+        approvalStatus: null,
+        shortBio: null,
+        cvUrl: null,
+      } as any);
+      prisma.user.update.mockResolvedValue({ id: 'user-1' } as any);
+
+      await service.getOrBootstrapAccountAndProfile('clerk_edu');
+
+      expect(prisma.user.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { approvalStatus: EducatorApprovalStatus.INCOMPLETE },
+        }),
+      );
+    });
+
+    it('backfills a legacy educator who did submit as PENDING_REVIEW', async () => {
+      prisma.appUser.findUnique.mockResolvedValue(educatorAppUser as any);
+      prisma.user.upsert.mockResolvedValue({
+        id: 'user-1',
+        approvalStatus: null,
+        shortBio: 'I have taught for ten years',
+        cvUrl: null,
+      } as any);
+      prisma.user.update.mockResolvedValue({ id: 'user-1' } as any);
+
+      await service.getOrBootstrapAccountAndProfile('clerk_edu');
+
+      expect(prisma.user.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { approvalStatus: EducatorApprovalStatus.PENDING_REVIEW },
+        }),
+      );
+    });
+
+    it('leaves an already-decided educator alone', async () => {
+      prisma.appUser.findUnique.mockResolvedValue(educatorAppUser as any);
+      prisma.user.upsert.mockResolvedValue({
+        id: 'user-1',
+        approvalStatus: EducatorApprovalStatus.APPROVED,
+      } as any);
+
+      await service.getOrBootstrapAccountAndProfile('clerk_edu');
+
+      expect(prisma.user.update).not.toHaveBeenCalled();
+    });
+
+    it('does not set an approval status for non-educator roles', async () => {
+      prisma.appUser.findUnique.mockResolvedValue({
+        ...educatorAppUser,
+        role: UserRole.FOUNDATION,
+      } as any);
+      prisma.user.upsert.mockResolvedValue({ id: 'user-1' } as any);
+
+      await service.getOrBootstrapAccountAndProfile('clerk_foundation');
+
+      const createArg = prisma.user.upsert.mock.calls[0][0].create;
+      expect(createArg).not.toHaveProperty('approvalStatus');
+    });
+  });
+
   describe('getOrDefaultNotificationPrefs', () => {
     it('creates notification preferences with sensible defaults', async () => {
       const mockPrefs = {
@@ -231,7 +325,11 @@ describe('PrincipalService', () => {
         subscription: true,
         contentModeration: false,
         systemAdmin: false,
-        marketing: false,
+        // Marketing defaults to opted-in (see PrincipalService: "Default to
+        // opted-in; users can opt out explicitly"), with mailingListOptOut as
+        // the explicit opt-out. This assertion previously expected false and
+        // had drifted from the implementation.
+        marketing: true,
         frequency: 'immediate',
         quietHoursEnabled: false,
       };
@@ -247,7 +345,7 @@ describe('PrincipalService', () => {
         create: expect.objectContaining({
           userId: 'user-1',
           emailNotifications: true,
-          marketing: false,
+          marketing: true,
         }),
       });
     });

--- a/api/src/principal/principal.service.ts
+++ b/api/src/principal/principal.service.ts
@@ -74,16 +74,27 @@ export class PrincipalService {
         email: emailForCreate,
         role: appUser.role,
         isActive: true,
-        ...(appUser.role === UserRole.EDUCATOR ? { approvalStatus: EducatorApprovalStatus.PENDING_REVIEW } : {}),
+        // INCOMPLETE: a profile bootstrapped here has no educator application on
+        // it yet. PATCH /settings/educator promotes it to PENDING_REVIEW.
+        ...(appUser.role === UserRole.EDUCATOR ? { approvalStatus: EducatorApprovalStatus.INCOMPLETE } : {}),
       },
       ...(include ? { include } : {}),
     } as Prisma.UserUpsertArgs);
 
-    // Backfill: educators created before this fix may have null approvalStatus
+    // Backfill: educators created before the approval workflow may have a null
+    // approvalStatus. Derive the right one from whether an application was ever
+    // submitted, rather than assuming there is something to review.
     if (appUser.role === UserRole.EDUCATOR && !(user as any).approvalStatus) {
+      const hasSubmittedApplication = Boolean(
+        (user as any).shortBio?.trim() || (user as any).cvUrl?.trim(),
+      );
       user = await this.prisma.user.update({
         where: { clerkId },
-        data: { approvalStatus: EducatorApprovalStatus.PENDING_REVIEW },
+        data: {
+          approvalStatus: hasSubmittedApplication
+            ? EducatorApprovalStatus.PENDING_REVIEW
+            : EducatorApprovalStatus.INCOMPLETE,
+        },
         ...(include ? { include } : {}),
       } as Prisma.UserUpdateArgs);
     }

--- a/api/src/settings/educator-submission-notification.unit.spec.ts
+++ b/api/src/settings/educator-submission-notification.unit.spec.ts
@@ -2,7 +2,8 @@ import { EducatorApprovalStatus } from '@prisma/client';
 
 /**
  * Guards the single-trigger rule for educator "application received"
- * notifications, reported by automated review on PR #680.
+ * notifications, and the status transitions around it. Both were raised by
+ * automated review on PR #680.
  *
  * The account is created before the profile is collected — by the Clerk webhook
  * for email/password signups, by completeProfile for OAuth — so it starts
@@ -11,69 +12,109 @@ import { EducatorApprovalStatus } from '@prisma/client';
  * a blank application and then fired a second time when the profile was really
  * submitted. Those sends were removed, leaving the INCOMPLETE -> PENDING_REVIEW
  * promotion in SettingsController.updateEducatorSettings as the only trigger.
- *
- * This mirrors that decision so the promotion and the notifications can never
- * drift apart again: one flag drives both.
  */
-const decideFirstSubmission = (
-  existing: { approvalStatus: EducatorApprovalStatus | null },
+
+/**
+ * Mirrors the conditional promotion inside the settings transaction. The real
+ * code issues `updateMany({ where: { id, approvalStatus: INCOMPLETE } })` and
+ * reads the affected-row count, so two concurrent submissions cannot both claim
+ * the transition — only the first sees count === 1.
+ */
+const promote = (
+  current: EducatorApprovalStatus | null,
   incoming: { shortBio?: string; cvUrl?: string },
-): boolean => {
+): { promoted: boolean; status: EducatorApprovalStatus | null } => {
   const isSubmittingApplication = Boolean(incoming.shortBio?.trim() || incoming.cvUrl?.trim());
-  return isSubmittingApplication && existing.approvalStatus === EducatorApprovalStatus.INCOMPLETE;
+  if (isSubmittingApplication && current === EducatorApprovalStatus.INCOMPLETE) {
+    return { promoted: true, status: EducatorApprovalStatus.PENDING_REVIEW };
+  }
+  return { promoted: false, status: current };
+};
+
+/** Mirrors DELETE /settings/educator/cv. */
+const deleteCv = (profile: {
+  shortBio: string | null;
+  approvalStatus: EducatorApprovalStatus | null;
+}): EducatorApprovalStatus | null => {
+  const wouldBeEmpty = !profile.shortBio?.trim();
+  return wouldBeEmpty && profile.approvalStatus === EducatorApprovalStatus.PENDING_REVIEW
+    ? EducatorApprovalStatus.INCOMPLETE
+    : profile.approvalStatus;
 };
 
 describe('educator first-submission trigger', () => {
   it('fires when an INCOMPLETE educator submits their profile', () => {
     expect(
-      decideFirstSubmission(
-        { approvalStatus: EducatorApprovalStatus.INCOMPLETE },
-        { shortBio: 'I have taught for ten years', cvUrl: 'https://x/cv.pdf' },
-      ),
+      promote(EducatorApprovalStatus.INCOMPLETE, {
+        shortBio: 'I have taught for ten years',
+        cvUrl: 'https://x/cv.pdf',
+      }).promoted,
     ).toBe(true);
   });
 
   it('fires on a CV-only submission, so the status and the emails agree', () => {
-    // The promotion and the notification read the same flag; if this returned
-    // false the profile would sit in the review queue with nobody told.
-    expect(
-      decideFirstSubmission(
-        { approvalStatus: EducatorApprovalStatus.INCOMPLETE },
-        { cvUrl: 'https://x/cv.pdf' },
-      ),
-    ).toBe(true);
+    const result = promote(EducatorApprovalStatus.INCOMPLETE, { cvUrl: 'https://x/cv.pdf' });
+    expect(result.promoted).toBe(true);
+    expect(result.status).toBe(EducatorApprovalStatus.PENDING_REVIEW);
   });
 
   it('does not fire when an INCOMPLETE educator saves nothing substantive', () => {
-    expect(
-      decideFirstSubmission(
-        { approvalStatus: EducatorApprovalStatus.INCOMPLETE },
-        { shortBio: '   ', cvUrl: '' },
-      ),
-    ).toBe(false);
+    expect(promote(EducatorApprovalStatus.INCOMPLETE, { shortBio: '   ', cvUrl: '' }).promoted).toBe(
+      false,
+    );
   });
 
   it('does not re-fire when an already-submitted educator edits their profile', () => {
     expect(
-      decideFirstSubmission(
-        { approvalStatus: EducatorApprovalStatus.PENDING_REVIEW },
-        { shortBio: 'An edited biography' },
-      ),
+      promote(EducatorApprovalStatus.PENDING_REVIEW, { shortBio: 'An edited biography' }).promoted,
     ).toBe(false);
   });
 
   it('does not fire for an educator already approved or rejected', () => {
+    expect(promote(EducatorApprovalStatus.APPROVED, { shortBio: 'edited' }).promoted).toBe(false);
+    expect(promote(EducatorApprovalStatus.REJECTED, { shortBio: 'edited' }).promoted).toBe(false);
+  });
+
+  it('lets only one of two concurrent submissions claim the transition', () => {
+    // Both requests read INCOMPLETE, but the conditional update means the
+    // second finds no matching row once the first has committed.
+    let stored: EducatorApprovalStatus | null = EducatorApprovalStatus.INCOMPLETE;
+
+    const first = promote(stored, { shortBio: 'first' });
+    stored = first.status;
+    const second = promote(stored, { shortBio: 'second' });
+
+    expect(first.promoted).toBe(true);
+    expect(second.promoted).toBe(false);
+    expect(stored).toBe(EducatorApprovalStatus.PENDING_REVIEW);
+  });
+});
+
+describe('educator CV deletion', () => {
+  it('sends a CV-only application back to INCOMPLETE when the CV is removed', () => {
+    // Otherwise the profile keeps PENDING_REVIEW with nothing in it, and
+    // approveEducator (which only refuses INCOMPLETE) would let an admin
+    // approve a blank profile into the candidate pool.
+    expect(deleteCv({ shortBio: null, approvalStatus: EducatorApprovalStatus.PENDING_REVIEW })).toBe(
+      EducatorApprovalStatus.INCOMPLETE,
+    );
+    expect(deleteCv({ shortBio: '   ', approvalStatus: EducatorApprovalStatus.PENDING_REVIEW })).toBe(
+      EducatorApprovalStatus.INCOMPLETE,
+    );
+  });
+
+  it('leaves the status alone when a biography still remains', () => {
     expect(
-      decideFirstSubmission(
-        { approvalStatus: EducatorApprovalStatus.APPROVED },
-        { shortBio: 'An edited biography' },
-      ),
-    ).toBe(false);
-    expect(
-      decideFirstSubmission(
-        { approvalStatus: EducatorApprovalStatus.REJECTED },
-        { shortBio: 'An edited biography' },
-      ),
-    ).toBe(false);
+      deleteCv({ shortBio: 'I have taught for ten years', approvalStatus: EducatorApprovalStatus.PENDING_REVIEW }),
+    ).toBe(EducatorApprovalStatus.PENDING_REVIEW);
+  });
+
+  it('never reopens an educator an admin has already decided on', () => {
+    expect(deleteCv({ shortBio: null, approvalStatus: EducatorApprovalStatus.APPROVED })).toBe(
+      EducatorApprovalStatus.APPROVED,
+    );
+    expect(deleteCv({ shortBio: null, approvalStatus: EducatorApprovalStatus.REJECTED })).toBe(
+      EducatorApprovalStatus.REJECTED,
+    );
   });
 });

--- a/api/src/settings/educator-submission-notification.unit.spec.ts
+++ b/api/src/settings/educator-submission-notification.unit.spec.ts
@@ -1,0 +1,79 @@
+import { EducatorApprovalStatus } from '@prisma/client';
+
+/**
+ * Guards the single-trigger rule for educator "application received"
+ * notifications, reported by automated review on PR #680.
+ *
+ * The account is created before the profile is collected — by the Clerk webhook
+ * for email/password signups, by completeProfile for OAuth — so it starts
+ * INCOMPLETE. completeProfile used to also send the applicant email and the
+ * "New Educator Application" admin notification at that moment, which announced
+ * a blank application and then fired a second time when the profile was really
+ * submitted. Those sends were removed, leaving the INCOMPLETE -> PENDING_REVIEW
+ * promotion in SettingsController.updateEducatorSettings as the only trigger.
+ *
+ * This mirrors that decision so the promotion and the notifications can never
+ * drift apart again: one flag drives both.
+ */
+const decideFirstSubmission = (
+  existing: { approvalStatus: EducatorApprovalStatus | null },
+  incoming: { shortBio?: string; cvUrl?: string },
+): boolean => {
+  const isSubmittingApplication = Boolean(incoming.shortBio?.trim() || incoming.cvUrl?.trim());
+  return isSubmittingApplication && existing.approvalStatus === EducatorApprovalStatus.INCOMPLETE;
+};
+
+describe('educator first-submission trigger', () => {
+  it('fires when an INCOMPLETE educator submits their profile', () => {
+    expect(
+      decideFirstSubmission(
+        { approvalStatus: EducatorApprovalStatus.INCOMPLETE },
+        { shortBio: 'I have taught for ten years', cvUrl: 'https://x/cv.pdf' },
+      ),
+    ).toBe(true);
+  });
+
+  it('fires on a CV-only submission, so the status and the emails agree', () => {
+    // The promotion and the notification read the same flag; if this returned
+    // false the profile would sit in the review queue with nobody told.
+    expect(
+      decideFirstSubmission(
+        { approvalStatus: EducatorApprovalStatus.INCOMPLETE },
+        { cvUrl: 'https://x/cv.pdf' },
+      ),
+    ).toBe(true);
+  });
+
+  it('does not fire when an INCOMPLETE educator saves nothing substantive', () => {
+    expect(
+      decideFirstSubmission(
+        { approvalStatus: EducatorApprovalStatus.INCOMPLETE },
+        { shortBio: '   ', cvUrl: '' },
+      ),
+    ).toBe(false);
+  });
+
+  it('does not re-fire when an already-submitted educator edits their profile', () => {
+    expect(
+      decideFirstSubmission(
+        { approvalStatus: EducatorApprovalStatus.PENDING_REVIEW },
+        { shortBio: 'An edited biography' },
+      ),
+    ).toBe(false);
+  });
+
+  it('does not fire for an educator already approved or rejected', () => {
+    expect(
+      decideFirstSubmission(
+        { approvalStatus: EducatorApprovalStatus.APPROVED },
+        { shortBio: 'An edited biography' },
+      ),
+    ).toBe(false);
+    expect(
+      decideFirstSubmission(
+        { approvalStatus: EducatorApprovalStatus.REJECTED },
+        { shortBio: 'An edited biography' },
+      ),
+    ).toBe(false);
+  });
+});

--- a/api/src/settings/educator-submission-notification.unit.spec.ts
+++ b/api/src/settings/educator-submission-notification.unit.spec.ts
@@ -90,6 +90,63 @@ describe('educator first-submission trigger', () => {
   });
 });
 
+/**
+ * Mirrors the emptying check inside the settings transaction: a PATCH can clear
+ * the CV via `cvUrl: ''` just as DELETE /settings/educator/cv can, so both doors
+ * into "PENDING_REVIEW with an empty profile" are closed.
+ */
+const applyPatch = (
+  existing: { shortBio: string | null; cvUrl: string | null; approvalStatus: EducatorApprovalStatus | null },
+  incoming: { shortBio?: string; cvUrl?: string },
+): EducatorApprovalStatus | null => {
+  const resultingShortBio = incoming.shortBio !== undefined ? incoming.shortBio : existing.shortBio;
+  const resultingCvUrl = incoming.cvUrl !== undefined ? incoming.cvUrl : existing.cvUrl;
+  const wouldBeEmpty = !resultingShortBio?.trim() && !resultingCvUrl?.trim();
+
+  if (wouldBeEmpty && existing.approvalStatus === EducatorApprovalStatus.PENDING_REVIEW) {
+    return EducatorApprovalStatus.INCOMPLETE;
+  }
+  return promote(existing.approvalStatus, incoming).status;
+};
+
+describe('educator profile emptied via PATCH', () => {
+  it('reverts to INCOMPLETE when a PATCH clears the last substantive field', () => {
+    expect(
+      applyPatch(
+        { shortBio: null, cvUrl: 'https://x/cv.pdf', approvalStatus: EducatorApprovalStatus.PENDING_REVIEW },
+        { cvUrl: '' },
+      ),
+    ).toBe(EducatorApprovalStatus.INCOMPLETE);
+  });
+
+  it('keeps PENDING_REVIEW when a biography survives the patch', () => {
+    expect(
+      applyPatch(
+        { shortBio: 'I have taught for ten years', cvUrl: 'https://x/cv.pdf', approvalStatus: EducatorApprovalStatus.PENDING_REVIEW },
+        { cvUrl: '' },
+      ),
+    ).toBe(EducatorApprovalStatus.PENDING_REVIEW);
+  });
+
+  it('never reopens an educator an admin has already decided on', () => {
+    expect(
+      applyPatch(
+        { shortBio: null, cvUrl: 'https://x/cv.pdf', approvalStatus: EducatorApprovalStatus.APPROVED },
+        { cvUrl: '' },
+      ),
+    ).toBe(EducatorApprovalStatus.APPROVED);
+  });
+
+  it('still promotes an INCOMPLETE educator submitting through the same patch', () => {
+    expect(
+      applyPatch(
+        { shortBio: null, cvUrl: null, approvalStatus: EducatorApprovalStatus.INCOMPLETE },
+        { shortBio: 'I have taught for ten years' },
+      ),
+    ).toBe(EducatorApprovalStatus.PENDING_REVIEW);
+  });
+});
+
 describe('educator CV deletion', () => {
   it('sends a CV-only application back to INCOMPLETE when the CV is removed', () => {
     // Otherwise the profile keeps PENDING_REVIEW with nothing in it, and

--- a/api/src/settings/settings.controller.ts
+++ b/api/src/settings/settings.controller.ts
@@ -448,9 +448,13 @@ export class SettingsController {
     const isSubmittingApplication = Boolean(
       settings.shortBio?.trim() || settings.cvUrl?.trim(),
     );
-    const isFirstSubmission =
-      isSubmittingApplication &&
-      existingCv?.approvalStatus === EducatorApprovalStatus.INCOMPLETE;
+
+    // Set inside the transaction below by a conditional update, NOT from the
+    // snapshot above: two concurrent submissions would both read INCOMPLETE and
+    // both send the applicant email and admin notification. The update targets
+    // `approvalStatus: INCOMPLETE` explicitly, so exactly one of them can report
+    // an affected row and the notifications fire once.
+    let isFirstSubmission = false;
 
     const previousCvUrl = existingCv?.cvUrl || '';
     const normalizedIncomingCvUrl =
@@ -513,13 +517,19 @@ export class SettingsController {
 
       // Promote inside the same transaction as the data, so the admin queue can
       // never show an application whose content failed to save (or miss one
-      // that did).
+      // that did). Conditional on the current status, so concurrent submissions
+      // cannot both claim the transition.
+      if (isSubmittingApplication) {
+        const promotion = await tx.user.updateMany({
+          where: { id: profileId, approvalStatus: EducatorApprovalStatus.INCOMPLETE },
+          data: { approvalStatus: EducatorApprovalStatus.PENDING_REVIEW },
+        });
+        isFirstSubmission = promotion.count === 1;
+      }
+
       await tx.user.update({
         where: { id: profileId },
         data: {
-          ...(isFirstSubmission
-            ? { approvalStatus: EducatorApprovalStatus.PENDING_REVIEW }
-            : {}),
           firstName: settings.firstName,
           lastName: settings.lastName,
           email: settings.email,
@@ -712,7 +722,7 @@ export class SettingsController {
 
     const user = await this.prisma.user.findUnique({
       where: { id: profileId },
-      select: { cvUrl: true },
+      select: { cvUrl: true, shortBio: true, approvalStatus: true },
     });
 
     const cvUrl = user?.cvUrl || '';
@@ -720,10 +730,25 @@ export class SettingsController {
       return { success: true, message: 'No CV to delete' };
     }
 
+    // Removing the CV can empty out an application that was only ever submitted
+    // as a CV. Without this, the profile would keep its PENDING_REVIEW status
+    // with nothing in it — and approveEducator only refuses INCOMPLETE, so an
+    // admin could approve a blank profile straight into the candidate pool.
+    // Send it back to INCOMPLETE in the same write, which also re-triggers the
+    // "finish your application" prompt for the educator.
+    const wouldBeEmpty = !user?.shortBio?.trim();
+    const shouldRevertToIncomplete =
+      wouldBeEmpty && user?.approvalStatus === EducatorApprovalStatus.PENDING_REVIEW;
+
     // Clear cvUrl first, then delete the underlying asset best-effort.
     await this.prisma.user.update({
       where: { id: profileId },
-      data: { cvUrl: null },
+      data: {
+        cvUrl: null,
+        ...(shouldRevertToIncomplete
+          ? { approvalStatus: EducatorApprovalStatus.INCOMPLETE }
+          : {}),
+      },
     });
 
     try {

--- a/api/src/settings/settings.controller.ts
+++ b/api/src/settings/settings.controller.ts
@@ -499,9 +499,23 @@ export class SettingsController {
         'CV',
       );
 
+      // An educator whose account was created at email verification sits at
+      // INCOMPLETE until they actually submit their profile. Promote inside the
+      // same transaction as the data, so the admin queue can never show an
+      // application whose content failed to save (or miss one that did).
+      const isSubmittingApplication = Boolean(
+        settings.shortBio?.trim() || settings.cvUrl?.trim(),
+      );
+      const shouldPromoteToPendingReview =
+        isSubmittingApplication &&
+        existingCv?.approvalStatus === EducatorApprovalStatus.INCOMPLETE;
+
       await tx.user.update({
         where: { id: profileId },
         data: {
+          ...(shouldPromoteToPendingReview
+            ? { approvalStatus: EducatorApprovalStatus.PENDING_REVIEW }
+            : {}),
           firstName: settings.firstName,
           lastName: settings.lastName,
           email: settings.email,

--- a/api/src/settings/settings.controller.ts
+++ b/api/src/settings/settings.controller.ts
@@ -527,6 +527,28 @@ export class SettingsController {
         isFirstSubmission = promotion.count === 1;
       }
 
+      // The mirror of the promotion above. A PATCH can also EMPTY an
+      // application — `cvUrl: ''` clears the CV, and a CV-only submission then
+      // has nothing left. Without this, the profile would keep PENDING_REVIEW
+      // with no content, and approveEducator (which only refuses INCOMPLETE)
+      // would let an admin approve a blank profile into the candidate pool.
+      // DELETE /settings/educator/cv is guarded the same way; this covers the
+      // other door into the same state.
+      const resultingShortBio =
+        settings.shortBio !== undefined ? settings.shortBio : existingCv?.shortBio;
+      const resultingCvUrl =
+        settings.cvUrl !== undefined ? normalizedIncomingCvUrl : existingCv?.cvUrl;
+      const wouldBeEmpty = !resultingShortBio?.trim() && !resultingCvUrl?.trim();
+
+      if (wouldBeEmpty) {
+        // Scoped to PENDING_REVIEW: an APPROVED or REJECTED educator has been
+        // decided on by an admin and is never reopened by clearing a field.
+        await tx.user.updateMany({
+          where: { id: profileId, approvalStatus: EducatorApprovalStatus.PENDING_REVIEW },
+          data: { approvalStatus: EducatorApprovalStatus.INCOMPLETE },
+        });
+      }
+
       await tx.user.update({
         where: { id: profileId },
         data: {

--- a/api/src/settings/settings.controller.ts
+++ b/api/src/settings/settings.controller.ts
@@ -440,6 +440,18 @@ export class SettingsController {
       where: { id: profileId },
       select: { cvUrl: true, shortBio: true, approvalStatus: true, email: true, firstName: true },
     });
+    // An educator whose account was created at email verification sits at
+    // INCOMPLETE until they actually submit their profile. This single flag
+    // drives both the status promotion (inside the transaction below) and the
+    // "application received" notifications (after it), so the admin queue and
+    // the emails can never disagree about whether an application exists.
+    const isSubmittingApplication = Boolean(
+      settings.shortBio?.trim() || settings.cvUrl?.trim(),
+    );
+    const isFirstSubmission =
+      isSubmittingApplication &&
+      existingCv?.approvalStatus === EducatorApprovalStatus.INCOMPLETE;
+
     const previousCvUrl = existingCv?.cvUrl || '';
     const normalizedIncomingCvUrl =
       settings.cvUrl !== undefined && typeof settings.cvUrl === 'string' && settings.cvUrl.trim().length === 0
@@ -499,21 +511,13 @@ export class SettingsController {
         'CV',
       );
 
-      // An educator whose account was created at email verification sits at
-      // INCOMPLETE until they actually submit their profile. Promote inside the
-      // same transaction as the data, so the admin queue can never show an
-      // application whose content failed to save (or miss one that did).
-      const isSubmittingApplication = Boolean(
-        settings.shortBio?.trim() || settings.cvUrl?.trim(),
-      );
-      const shouldPromoteToPendingReview =
-        isSubmittingApplication &&
-        existingCv?.approvalStatus === EducatorApprovalStatus.INCOMPLETE;
-
+      // Promote inside the same transaction as the data, so the admin queue can
+      // never show an application whose content failed to save (or miss one
+      // that did).
       await tx.user.update({
         where: { id: profileId },
         data: {
-          ...(shouldPromoteToPendingReview
+          ...(isFirstSubmission
             ? { approvalStatus: EducatorApprovalStatus.PENDING_REVIEW }
             : {}),
           firstName: settings.firstName,
@@ -630,16 +634,16 @@ export class SettingsController {
       }
     }
 
-    // Send "application received" email the first time an educator submits their profile.
-    // Fires when: profile was blank (no shortBio) and is now being filled in,
-    // AND the educator has not yet been approved or rejected.
-    // This covers the email/password signup path; OAuth educators get it via completeProfile.
-    const isFirstSubmission =
-      !existingCv?.shortBio?.trim() &&
-      settings.shortBio?.trim() &&
-      existingCv?.approvalStatus !== EducatorApprovalStatus.APPROVED &&
-      existingCv?.approvalStatus !== EducatorApprovalStatus.REJECTED;
-
+    // Send "application received" email and notify admins — exactly once, on the
+    // same condition that promoted the profile to PENDING_REVIEW above.
+    //
+    // This is the single trigger for BOTH signup paths. completeProfile used to
+    // send these too, for OAuth educators, but it only creates the account: the
+    // user is then routed into step 3 to submit the actual profile, so those
+    // notifications announced a blank application and then fired again here.
+    //
+    // Gating on the INCOMPLETE -> PENDING_REVIEW transition also means an
+    // educator editing an already-submitted profile never re-triggers them.
     // Use settings values (post-update) for name/email, falling back to pre-update snapshot.
     const recipientEmail = settings.email ?? existingCv?.email;
     const recipientName = settings.firstName ?? existingCv?.firstName;

--- a/api/src/users/dto/complete-profile.dto.ts
+++ b/api/src/users/dto/complete-profile.dto.ts
@@ -50,4 +50,9 @@ export class CompleteProfileDto {
   @IsString()
   @IsOptional()
   childStartDate?: string;
+
+  // Consent timestamp captured when the user ticked the terms box at signup.
+  @IsString()
+  @IsOptional()
+  termsAcceptedAt?: string;
 }

--- a/api/src/users/signup-profile.module.ts
+++ b/api/src/users/signup-profile.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { SignupProfileService } from './signup-profile.service';
+
+/**
+ * Standalone module so both account-creation paths can share the applier:
+ * the Clerk webhook (WebhooksModule) and POST /users/complete-profile
+ * (UsersModule). The service is stateless and receives its transaction client
+ * per call, so it has no module dependencies of its own.
+ */
+@Module({
+  providers: [SignupProfileService],
+  exports: [SignupProfileService],
+})
+export class SignupProfileModule {}

--- a/api/src/users/signup-profile.service.ts
+++ b/api/src/users/signup-profile.service.ts
@@ -35,8 +35,15 @@ export interface SignupIntent {
   childAge?: number;
   /** PARENT - desired start date. */
   childStartDate?: Date;
-  /** When the user ticked the terms checkbox during signup. */
-  termsAcceptedAt?: Date;
+  /**
+   * Whether the user ticked the terms checkbox during signup.
+   *
+   * Deliberately a boolean, not the client's timestamp: this value is consent
+   * evidence, and both transports are client-controlled (Clerk unsafe_metadata,
+   * or the complete-profile request body). A caller could otherwise record a
+   * consent time that never happened. The server stamps the actual time.
+   */
+  termsAccepted?: boolean;
 }
 
 export const ORGANIZATION_ROLES: UserRole[] = [
@@ -93,7 +100,8 @@ export function parseSignupIntent(raw: unknown): SignupIntent {
     serviceType: toTrimmedString(source.serviceType),
     childAge: toPositiveInt(source.childAge),
     childStartDate: toDate(source.childStartDate),
-    termsAcceptedAt: toDate(source.termsAcceptedAt),
+    // Presence of either signal marks acceptance; the timestamp itself is not trusted.
+    termsAccepted: source.termsAccepted === true || toDate(source.termsAcceptedAt) !== undefined,
   };
 }
 
@@ -128,7 +136,8 @@ export class SignupProfileService {
 
     const profileData: Prisma.UserUpdateInput = {};
     if (resolvedPhone) profileData.phoneNumber = resolvedPhone;
-    if (intent.termsAcceptedAt) profileData.termsAcceptedAt = intent.termsAcceptedAt;
+    // Server time, not the client's: see SignupIntent.termsAccepted.
+    if (intent.termsAccepted) profileData.termsAcceptedAt = new Date();
     if (role === UserRole.PARENT) {
       if (intent.childAge !== undefined) profileData.childAge = intent.childAge;
       if (intent.childStartDate) profileData.childStartDate = intent.childStartDate;

--- a/api/src/users/signup-profile.service.ts
+++ b/api/src/users/signup-profile.service.ts
@@ -1,0 +1,182 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Prisma, UserRole } from '@prisma/client';
+
+/**
+ * Everything the signup wizard collects on step 2, in one shape.
+ *
+ * Why this exists: there are two paths that create an account, and they used to
+ * persist DIFFERENT subsets of the signup form.
+ *
+ *   - email/password  -> Clerk `user.created` webhook (clerk-webhook.controller)
+ *   - OAuth / recovery -> POST /users/complete-profile (users.service)
+ *
+ * The webhook path only ever read `organisationName` and `canton`, so a
+ * Foundation that signed up with Google kept its capacity while the same
+ * Foundation signing up with email/password silently lost it. Phone, supplier
+ * category, service type and the parent's child details were dropped the same
+ * way, and `childAge`/`childStartDate`/`termsAccepted` were never persisted by
+ * either path.
+ *
+ * Both paths now build a `SignupIntent` and hand it to `applySignupIntent`, so
+ * the two can no longer drift apart.
+ */
+export interface SignupIntent {
+  organisationName?: string;
+  contactPerson?: string;
+  phone?: string;
+  canton?: string;
+  /** FOUNDATION - number of childcare places. */
+  capacity?: number;
+  /** PRODUCT_SUPPLIER - product category. */
+  category?: string;
+  /** SERVICE_PROVIDER - type of service offered. */
+  serviceType?: string;
+  /** PARENT - age of the child. */
+  childAge?: number;
+  /** PARENT - desired start date. */
+  childStartDate?: Date;
+  /** When the user ticked the terms checkbox during signup. */
+  termsAcceptedAt?: Date;
+}
+
+export const ORGANIZATION_ROLES: UserRole[] = [
+  UserRole.FOUNDATION,
+  UserRole.PRODUCT_SUPPLIER,
+  UserRole.SERVICE_PROVIDER,
+];
+
+const ORGANIZATION_TYPE_BY_ROLE: Record<string, 'FOUNDATION' | 'PRODUCT_SUPPLIER' | 'SERVICE_PROVIDER'> = {
+  [UserRole.FOUNDATION]: 'FOUNDATION',
+  [UserRole.PRODUCT_SUPPLIER]: 'PRODUCT_SUPPLIER',
+  [UserRole.SERVICE_PROVIDER]: 'SERVICE_PROVIDER',
+};
+
+function toTrimmedString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function toPositiveInt(value: unknown): number | undefined {
+  const parsed = typeof value === 'number' ? value : Number.parseInt(String(value ?? ''), 10);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) return undefined;
+  return parsed;
+}
+
+function toDate(value: unknown): Date | undefined {
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? undefined : value;
+  if (typeof value !== 'string' && typeof value !== 'number') return undefined;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+/**
+ * Build a `SignupIntent` from untrusted input.
+ *
+ * The email/password path carries this through Clerk `unsafe_metadata`, which is
+ * writable from the browser. Every value is therefore whitelisted and coerced
+ * before it can reach Prisma, and unknown keys are dropped. These are all
+ * self-asserted profile fields the user could equally edit in settings later, so
+ * there is no privilege concern — but `role` is deliberately NOT read here:
+ * the role stays resolved and scrubbed server-side, exactly as before.
+ */
+export function parseSignupIntent(raw: unknown): SignupIntent {
+  const source = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+
+  return {
+    organisationName: toTrimmedString(source.organisationName),
+    contactPerson: toTrimmedString(source.contactPerson),
+    phone: toTrimmedString(source.phone),
+    canton: toTrimmedString(source.canton),
+    capacity: toPositiveInt(source.capacity),
+    category: toTrimmedString(source.category),
+    serviceType: toTrimmedString(source.serviceType),
+    childAge: toPositiveInt(source.childAge),
+    childStartDate: toDate(source.childStartDate),
+    termsAcceptedAt: toDate(source.termsAcceptedAt),
+  };
+}
+
+export interface ApplySignupIntentArgs {
+  /** `User.id` (profile id) of the freshly created/updated user. */
+  userId: string;
+  role: UserRole;
+  firstName?: string | null;
+  lastName?: string | null;
+  /** Phone already known from the identity provider, if any; takes precedence. */
+  phoneNumber?: string | null;
+  intent: SignupIntent;
+}
+
+@Injectable()
+export class SignupProfileService {
+  private readonly logger = new Logger(SignupProfileService.name);
+
+  /**
+   * Persist the signup form onto the profile, and create + link the
+   * organization for organization-based roles.
+   *
+   * Must be called inside the same transaction that creates the user so a
+   * failure here cannot leave a half-provisioned account behind.
+   */
+  async applySignupIntent(
+    tx: Prisma.TransactionClient,
+    { userId, role, firstName, lastName, phoneNumber, intent }: ApplySignupIntentArgs,
+  ): Promise<void> {
+    const fullName = `${firstName || ''} ${lastName || ''}`.trim();
+    const resolvedPhone = phoneNumber || intent.phone || null;
+
+    const profileData: Prisma.UserUpdateInput = {};
+    if (resolvedPhone) profileData.phoneNumber = resolvedPhone;
+    if (intent.termsAcceptedAt) profileData.termsAcceptedAt = intent.termsAcceptedAt;
+    if (role === UserRole.PARENT) {
+      if (intent.childAge !== undefined) profileData.childAge = intent.childAge;
+      if (intent.childStartDate) profileData.childStartDate = intent.childStartDate;
+    }
+
+    if (Object.keys(profileData).length > 0) {
+      await tx.user.update({ where: { id: userId }, data: profileData });
+    }
+
+    if (!ORGANIZATION_ROLES.includes(role)) {
+      return;
+    }
+
+    // Avoid duplicating the organization when this runs again for an existing
+    // user (webhook redelivery, or completeProfile after a partial signup).
+    const existingLink = await tx.userOrganization.findFirst({ where: { userId } });
+    if (existingLink) {
+      this.logger.log(`User ${userId} already linked to an organization, skipping creation`);
+      return;
+    }
+
+    const organization = await tx.organization.create({
+      data: {
+        name: intent.organisationName || fullName || 'New Organization',
+        type: ORGANIZATION_TYPE_BY_ROLE[role as string],
+        contactPerson: intent.contactPerson || fullName || null,
+        phoneNumber: resolvedPhone,
+        canton: intent.canton || null,
+        region: intent.canton || null,
+        ...(role === UserRole.FOUNDATION && intent.capacity !== undefined
+          ? { capacity: intent.capacity }
+          : {}),
+        ...(role === UserRole.PRODUCT_SUPPLIER && intent.category
+          ? { productCategory: intent.category }
+          : {}),
+        ...(role === UserRole.SERVICE_PROVIDER && intent.serviceType
+          ? { serviceType: intent.serviceType }
+          : {}),
+        isActive: true,
+      },
+    });
+
+    await tx.userOrganization.create({
+      data: { userId, organizationId: organization.id, role },
+    });
+
+    this.logger.log(
+      `Created organization "${organization.name}" (${organization.type}) and linked it to user ${userId}`,
+    );
+  }
+}

--- a/api/src/users/signup-profile.service.unit.spec.ts
+++ b/api/src/users/signup-profile.service.unit.spec.ts
@@ -48,7 +48,18 @@ describe('SignupProfileService', () => {
       expect(intent.capacity).toBe(42);
       expect(intent.childAge).toBe(3);
       expect(intent.childStartDate).toEqual(new Date('2026-09-01'));
-      expect(intent.termsAcceptedAt).toEqual(new Date('2026-08-30T10:00:00.000Z'));
+    });
+
+    it('treats consent as a flag, never trusting the client timestamp', () => {
+      // Both transports are client-controlled, so a caller could otherwise
+      // record a consent time that never happened. The server stamps the time.
+      const backdated = parseSignupIntent({ termsAcceptedAt: '1999-01-01T00:00:00.000Z' });
+      expect(backdated.termsAccepted).toBe(true);
+      expect(backdated as Record<string, unknown>).not.toHaveProperty('termsAcceptedAt');
+
+      expect(parseSignupIntent({ termsAccepted: true }).termsAccepted).toBe(true);
+      expect(parseSignupIntent({}).termsAccepted).toBe(false);
+      expect(parseSignupIntent({ termsAcceptedAt: 'not-a-date' }).termsAccepted).toBe(false);
     });
 
     it('drops blank, malformed and unknown values', () => {
@@ -214,11 +225,20 @@ describe('SignupProfileService', () => {
         }),
       });
 
+      // Assert the writes actually happened before comparing them: `?.[0]` is
+      // undefined on both sides when neither path wrote, and
+      // expect(undefined).toEqual(undefined) would pass — silently turning this
+      // drift guard into a no-op.
+      expect(webhookTx.organization.create).toHaveBeenCalledTimes(1);
+      expect(completeProfileTx.organization.create).toHaveBeenCalledTimes(1);
+      expect(webhookTx.user.update).toHaveBeenCalledTimes(1);
+      expect(completeProfileTx.user.update).toHaveBeenCalledTimes(1);
+
       expect(webhookTx.organization.create.mock.calls[0][0]).toEqual(
         completeProfileTx.organization.create.mock.calls[0][0],
       );
-      expect(webhookTx.user.update.mock.calls[0]?.[0]).toEqual(
-        completeProfileTx.user.update.mock.calls[0]?.[0],
+      expect(webhookTx.user.update.mock.calls[0][0]).toEqual(
+        completeProfileTx.user.update.mock.calls[0][0],
       );
     });
   });

--- a/api/src/users/signup-profile.service.unit.spec.ts
+++ b/api/src/users/signup-profile.service.unit.spec.ts
@@ -1,0 +1,225 @@
+import { UserRole } from '@prisma/client';
+import {
+  SignupProfileService,
+  parseSignupIntent,
+} from './signup-profile.service';
+
+/**
+ * These tests exist because of a real production defect: the two paths that
+ * create an account — the Clerk `user.created` webhook (email/password) and
+ * POST /users/complete-profile (OAuth) — each built the organization inline and
+ * persisted DIFFERENT field sets. A Foundation signing up with Google kept its
+ * capacity; the same Foundation signing up with email/password silently lost
+ * it, along with phone, supplier category and service type.
+ *
+ * Both paths now go through `applySignupIntent`, and the parity test below is
+ * the guard that stops them drifting apart again.
+ */
+describe('SignupProfileService', () => {
+  let service: SignupProfileService;
+
+  const makeTx = () => {
+    const organization = { id: 'org-1', name: 'Crèche du Lac', type: 'FOUNDATION' };
+    return {
+      user: { update: jest.fn().mockResolvedValue({}) },
+      userOrganization: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({}),
+      },
+      organization: { create: jest.fn().mockResolvedValue(organization) },
+    };
+  };
+
+  beforeEach(() => {
+    service = new SignupProfileService();
+  });
+
+  describe('parseSignupIntent', () => {
+    it('coerces the values that arrive as strings through Clerk metadata', () => {
+      const intent = parseSignupIntent({
+        organisationName: '  Crèche du Lac  ',
+        capacity: '42',
+        childAge: '3',
+        childStartDate: '2026-09-01',
+        termsAcceptedAt: '2026-08-30T10:00:00.000Z',
+      });
+
+      expect(intent.organisationName).toBe('Crèche du Lac');
+      expect(intent.capacity).toBe(42);
+      expect(intent.childAge).toBe(3);
+      expect(intent.childStartDate).toEqual(new Date('2026-09-01'));
+      expect(intent.termsAcceptedAt).toEqual(new Date('2026-08-30T10:00:00.000Z'));
+    });
+
+    it('drops blank, malformed and unknown values', () => {
+      const intent = parseSignupIntent({
+        organisationName: '   ',
+        capacity: 'not-a-number',
+        childAge: -1,
+        childStartDate: 'never',
+        role: 'ADMIN',
+        somethingElse: 'ignored',
+      });
+
+      expect(intent.organisationName).toBeUndefined();
+      expect(intent.capacity).toBeUndefined();
+      expect(intent.childAge).toBeUndefined();
+      expect(intent.childStartDate).toBeUndefined();
+      // Role must never be taken from client-writable metadata.
+      expect(intent as Record<string, unknown>).not.toHaveProperty('role');
+      expect(intent as Record<string, unknown>).not.toHaveProperty('somethingElse');
+    });
+
+    it('tolerates null and non-object input', () => {
+      expect(parseSignupIntent(null).phone).toBeUndefined();
+      expect(parseSignupIntent('nope').phone).toBeUndefined();
+    });
+  });
+
+  describe('applySignupIntent', () => {
+    it('persists the foundation capacity and phone onto a new organization', async () => {
+      const tx = makeTx();
+
+      await service.applySignupIntent(tx as any, {
+        userId: 'user-1',
+        role: UserRole.FOUNDATION,
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+        phoneNumber: null,
+        intent: parseSignupIntent({
+          organisationName: 'Crèche du Lac',
+          phone: '+41 79 000 00 00',
+          canton: 'Vaud',
+          capacity: 42,
+        }),
+      });
+
+      expect(tx.organization.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          name: 'Crèche du Lac',
+          type: 'FOUNDATION',
+          phoneNumber: '+41 79 000 00 00',
+          canton: 'Vaud',
+          region: 'Vaud',
+          capacity: 42,
+        }),
+      });
+      expect(tx.userOrganization.create).toHaveBeenCalled();
+    });
+
+    it('maps the supplier and service-provider specific fields', async () => {
+      const supplierTx = makeTx();
+      await service.applySignupIntent(supplierTx as any, {
+        userId: 'user-2',
+        role: UserRole.PRODUCT_SUPPLIER,
+        intent: parseSignupIntent({ category: 'Furniture' }),
+      });
+      expect(supplierTx.organization.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ productCategory: 'Furniture' }),
+      });
+
+      const providerTx = makeTx();
+      await service.applySignupIntent(providerTx as any, {
+        userId: 'user-3',
+        role: UserRole.SERVICE_PROVIDER,
+        intent: parseSignupIntent({ serviceType: 'Cleaning' }),
+      });
+      expect(providerTx.organization.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ serviceType: 'Cleaning' }),
+      });
+    });
+
+    it('stores the parent child details that were previously discarded', async () => {
+      const tx = makeTx();
+
+      await service.applySignupIntent(tx as any, {
+        userId: 'user-4',
+        role: UserRole.PARENT,
+        intent: parseSignupIntent({ childAge: 3, childStartDate: '2026-09-01' }),
+      });
+
+      expect(tx.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-4' },
+        data: expect.objectContaining({
+          childAge: 3,
+          childStartDate: new Date('2026-09-01'),
+        }),
+      });
+      // Parents are not organization-based.
+      expect(tx.organization.create).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the signup phone when the provider supplied none', async () => {
+      const tx = makeTx();
+
+      await service.applySignupIntent(tx as any, {
+        userId: 'user-5',
+        role: UserRole.EDUCATOR,
+        phoneNumber: null, // Clerk `phone_numbers` is empty for email/password signups
+        intent: parseSignupIntent({ phone: '+41 79 111 11 11' }),
+      });
+
+      expect(tx.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-5' },
+        data: expect.objectContaining({ phoneNumber: '+41 79 111 11 11' }),
+      });
+    });
+
+    it('does not create a second organization when one is already linked', async () => {
+      const tx = makeTx();
+      tx.userOrganization.findFirst.mockResolvedValue({ id: 'existing' });
+
+      await service.applySignupIntent(tx as any, {
+        userId: 'user-6',
+        role: UserRole.FOUNDATION,
+        intent: parseSignupIntent({ organisationName: 'Crèche du Lac' }),
+      });
+
+      expect(tx.organization.create).not.toHaveBeenCalled();
+      expect(tx.userOrganization.create).not.toHaveBeenCalled();
+    });
+
+    it('produces identical writes for the webhook and complete-profile paths', async () => {
+      // The webhook receives everything as strings through Clerk unsafe_metadata;
+      // complete-profile receives a typed DTO. Same signup, same resulting rows.
+      const webhookTx = makeTx();
+      await service.applySignupIntent(webhookTx as any, {
+        userId: 'user-7',
+        role: UserRole.FOUNDATION,
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+        phoneNumber: null,
+        intent: parseSignupIntent({
+          organisationName: 'Crèche du Lac',
+          contactPerson: 'Ada Lovelace',
+          phone: '+41 79 000 00 00',
+          canton: 'Vaud',
+          capacity: '42',
+        }),
+      });
+
+      const completeProfileTx = makeTx();
+      await service.applySignupIntent(completeProfileTx as any, {
+        userId: 'user-7',
+        role: UserRole.FOUNDATION,
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+        phoneNumber: '+41 79 000 00 00',
+        intent: parseSignupIntent({
+          organisationName: 'Crèche du Lac',
+          contactPerson: 'Ada Lovelace',
+          phone: '+41 79 000 00 00',
+          canton: 'Vaud',
+          capacity: 42,
+        }),
+      });
+
+      expect(webhookTx.organization.create.mock.calls[0][0]).toEqual(
+        completeProfileTx.organization.create.mock.calls[0][0],
+      );
+      expect(webhookTx.user.update.mock.calls[0]?.[0]).toEqual(
+        completeProfileTx.user.update.mock.calls[0]?.[0],
+      );
+    });
+  });
+});

--- a/api/src/users/users.module.ts
+++ b/api/src/users/users.module.ts
@@ -6,9 +6,10 @@ import { PrismaModule } from '../prisma/prisma.module';
 import { PrincipalModule } from '../principal/principal.module';
 import { SyncModule } from '../sync/sync.module';
 import { EmailNotificationModule } from '../email-notification/email-notification.module';
+import { SignupProfileModule } from './signup-profile.module';
 
 @Module({
-  imports: [AuthModule, PrismaModule, PrincipalModule, SyncModule, EmailNotificationModule],
+  imports: [AuthModule, PrismaModule, PrincipalModule, SyncModule, EmailNotificationModule, SignupProfileModule],
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -679,56 +679,22 @@ export class UsersService {
         });
       });
 
-      // Fire educator pending email after the transaction commits so the new
-      // user row is visible to EmailNotificationService.findUnique({ email }).
-      if (dto.role === UserRole.EDUCATOR) {
-        const appUrl = this.configService.get<string>('APP_URL') || this.configService.get<string>('FRONTEND_URL') || '';
-
-        // educator_pending email — gated by v2_staffing_emails (defaults enabled when flag absent)
-        this.prisma.featureFlag.findUnique({ where: { key: 'v2_staffing_emails' } }).then(async (flag) => {
-          if (flag && !flag.isActive) return;
-          await this.emailNotificationService.sendNotification({
-            event: 'educator_pending',
-            recipient: email,
-            recipientName: firstName || undefined,
-            payload: {
-              firstName: firstName || 'Educator',
-              supportUrl: appUrl ? `${appUrl}/support` : '',
-            },
-            bypassPreferences: true,
-            allowUnknownRecipient: false,
-          });
-        }).catch((err: any) => {
-          this.logger.warn(`Educator pending email failed: ${err?.message || err}`);
-        });
-
-        // Admin in-app notifications — gated by v2_in_app_notifications
-        const adminLink = appUrl ? `${appUrl}/admin/content-dashboard` : '/admin/content-dashboard';
-        this.prisma.featureFlag.findUnique({ where: { key: 'v2_in_app_notifications' } }).then(async (flag) => {
-          if (flag && !flag.isActive) return;
-          const admins = await this.prisma.user.findMany({
-            where: {
-              role: { in: [UserRole.ADMIN, UserRole.SUPER_ADMIN] },
-              isActive: { not: false },
-            },
-            select: { id: true },
-          });
-          const educatorName = firstName || email || 'An educator';
-          for (const admin of admins) {
-            await this.prisma.notification.create({
-              data: {
-                userId: admin.id,
-                type: 'GENERAL' as any,
-                title: 'New Educator Application',
-                body: `${educatorName} has submitted their profile and is awaiting approval.`,
-                link: adminLink,
-              },
-            }).catch(() => {});
-          }
-        }).catch((err: any) => {
-          this.logger.warn(`Admin notification for educator signup failed: ${err?.message || err}`);
-        });
-      }
+      // No educator notifications here on purpose.
+      //
+      // completeProfile creates the account only — the educator has not
+      // submitted anything yet, which is exactly why the profile is created
+      // INCOMPLETE above. The frontend then routes them into step 3 of the
+      // wizard to fill in the actual application.
+      //
+      // Announcing a "New Educator Application" at this point told admins a
+      // blank account was awaiting review, and sent the applicant a
+      // confirmation for something they had not submitted. Worse, the first
+      // successful PATCH /settings/educator fires the same email and admin
+      // notification again, so every OAuth educator got both twice.
+      //
+      // The single trigger is the promotion to PENDING_REVIEW in
+      // SettingsController.updateEducatorSettings, which runs when the profile
+      // is genuinely submitted.
     }
 
     if (dto.role === UserRole.PARENT) {

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -587,6 +587,25 @@ export class UsersService {
         select: { id: true },
       });
       profileUserIdToLink = existingProfile?.id || null;
+
+      // Apply the signup intent here too. This branch runs when the AppUser
+      // already exists — for example the Clerk webhook provisioned the account
+      // (possibly under the fallback role) and the user is now completing their
+      // profile with the real role. Skipping it left those accounts without the
+      // organization, phone and parent fields the form had already collected.
+      if (existingProfile?.id) {
+        const [firstNamePart, ...lastNameParts] = (dto.contactPerson || '').trim().split(' ');
+        await this.prisma.$transaction(async (tx) => {
+          await this.signupProfileService.applySignupIntent(tx, {
+            userId: existingProfile.id,
+            role: dto.role,
+            firstName: firstNamePart || null,
+            lastName: lastNameParts.join(' ') || null,
+            phoneNumber: dto.phone,
+            intent: parseSignupIntent(dto),
+          });
+        });
+      }
     } else {
       // Check if an account with this email already exists (for a DIFFERENT clerkId)
       // This can happen when:

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -12,6 +12,7 @@ import { RoleSyncService } from '../sync/role-sync.service';
 import { ConfigService } from '@nestjs/config';
 import { createClerkClient } from '@clerk/clerk-sdk-node';
 import { EmailNotificationService } from '../email-notification/email-notification.service';
+import { SignupProfileService, parseSignupIntent } from './signup-profile.service';
 
 /**
  * Roles considered "admin-level" roles in the system.
@@ -64,6 +65,7 @@ export class UsersService {
     private readonly roleSyncService: RoleSyncService,
     private readonly configService: ConfigService,
     private readonly emailNotificationService: EmailNotificationService,
+    private readonly signupProfileService: SignupProfileService,
   ) {
     const clerkSecretKey = this.configService.get<string>('CLERK_SECRET_KEY');
     if (clerkSecretKey) {
@@ -653,52 +655,28 @@ export class UsersService {
             lastName: lastName || null,
             phoneNumber: dto.phone,
             isActive: true,
+            // INCOMPLETE until the educator actually submits their profile
+            // (see PATCH /settings/educator), so the admin approval queue only
+            // ever contains real applications.
             ...(dto.role === UserRole.EDUCATOR && {
-              approvalStatus: EducatorApprovalStatus.PENDING_REVIEW,
+              approvalStatus: EducatorApprovalStatus.INCOMPLETE,
             }),
           },
         });
         profileUserIdToLink = user.id;
 
-        // Create organization and link user for organization-based roles
-        const orgBasedRoles: UserRole[] = [UserRole.FOUNDATION, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER];
-        if (orgBasedRoles.includes(dto.role)) {
-          // Determine organization type from user role
-          const orgTypeMap: Record<string, 'FOUNDATION' | 'PRODUCT_SUPPLIER' | 'SERVICE_PROVIDER'> = {
-            [UserRole.FOUNDATION]: 'FOUNDATION',
-            [UserRole.PRODUCT_SUPPLIER]: 'PRODUCT_SUPPLIER',
-            [UserRole.SERVICE_PROVIDER]: 'SERVICE_PROVIDER',
-          };
-          const orgType = orgTypeMap[dto.role];
-          
-          // Create the organization with signup data
-          const organization = await tx.organization.create({
-            data: {
-              name: dto.organisationName || `${firstName} ${lastName}`.trim() || 'New Organization',
-              type: orgType,
-              contactPerson: dto.contactPerson || `${firstName} ${lastName}`.trim() || null,
-              phoneNumber: dto.phone || null,
-              canton: dto.canton || null,
-              region: dto.canton || null,
-              // Role-specific fields
-              ...(dto.role === UserRole.FOUNDATION && dto.capacity ? { capacity: dto.capacity } : {}),
-              ...(dto.role === UserRole.PRODUCT_SUPPLIER && dto.category ? { productCategory: dto.category } : {}),
-              ...(dto.role === UserRole.SERVICE_PROVIDER && dto.serviceType ? { serviceType: dto.serviceType } : {}),
-              isActive: true,
-            },
-          });
-
-          // Link user to organization
-          await tx.userOrganization.create({
-            data: {
-              userId: user.id,
-              organizationId: organization.id,
-              role: dto.role,
-            },
-          });
-
-          this.logger.log(`🏢 [COMPLETE PROFILE] Created organization "${organization.name}" (${orgType}) and linked to user ${user.id}`);
-        }
+        // Persist the rest of the signup form and create/link the organization.
+        // Shared with the Clerk `user.created` webhook path so both keep the
+        // same fields — they used to diverge, which is how email/password
+        // signups silently lost capacity, category, service type and phone.
+        await this.signupProfileService.applySignupIntent(tx, {
+          userId: user.id,
+          role: dto.role,
+          firstName,
+          lastName,
+          phoneNumber: dto.phone,
+          intent: parseSignupIntent(dto),
+        });
       });
 
       // Fire educator pending email after the transaction commits so the new

--- a/api/src/users/users.service.unit.spec.ts
+++ b/api/src/users/users.service.unit.spec.ts
@@ -66,6 +66,8 @@ describe('UsersService.remove (soft delete)', () => {
       {} as any, // principal
       {} as any, // roleSyncService
       { get: jest.fn().mockReturnValue(undefined) } as any, // configService
+      {} as any, // emailNotificationService
+      {} as any, // signupProfileService
     );
 
     const result = await service.remove(appUser.id);
@@ -167,6 +169,8 @@ describe('UsersService.hardRemove (hard delete)', () => {
       {} as any,
       {} as any,
       { get: jest.fn().mockReturnValue(undefined) } as any,
+      {} as any, // emailNotificationService
+      {} as any, // signupProfileService
     );
 
     await expect(service.hardRemove(appUser.id)).rejects.toMatchObject({
@@ -189,6 +193,8 @@ describe('UsersService.hardRemove (hard delete)', () => {
     const profile = { id: 'profile-id', clerkId: appUser.clerkId } as any;
 
     const tx = {
+      // hardRemove issues raw SQL to break FK cycles before deleting.
+      $executeRawUnsafe: jest.fn().mockResolvedValue(0),
       // dependency deletes
       message: { findMany: jest.fn().mockResolvedValue([]), deleteMany: jest.fn() },
       conversationParticipant: { findMany: jest.fn().mockResolvedValue([]), deleteMany: jest.fn() },
@@ -197,7 +203,7 @@ describe('UsersService.hardRemove (hard delete)', () => {
       ticketResponse: { deleteMany: jest.fn() },
       supportTicket: { deleteMany: jest.fn() },
       userSubscription: { deleteMany: jest.fn() },
-      subscription: { deleteMany: jest.fn() },
+      subscription: { deleteMany: jest.fn(), findMany: jest.fn().mockResolvedValue([]) },
       certificate: { deleteMany: jest.fn() },
       discussionReply: { deleteMany: jest.fn() },
       courseDiscussion: { deleteMany: jest.fn() },
@@ -236,6 +242,8 @@ describe('UsersService.hardRemove (hard delete)', () => {
       {} as any,
       {} as any,
       { get: jest.fn().mockReturnValue(undefined) } as any,
+      {} as any, // emailNotificationService
+      {} as any, // signupProfileService
     );
     (service as any).clerk = { users: { deleteUser: jest.fn().mockResolvedValue(undefined) } };
 
@@ -264,6 +272,8 @@ describe('UsersService.hardRemove (hard delete)', () => {
     const profile = { id: 'profile-id', clerkId: appUser.clerkId } as any;
 
     const tx = {
+      // hardRemove issues raw SQL to break FK cycles before deleting.
+      $executeRawUnsafe: jest.fn().mockResolvedValue(0),
       userOrganization: { deleteMany: jest.fn() },
       userContactInfo: { deleteMany: jest.fn() },
       user: { delete: jest.fn(), deleteMany: jest.fn() },
@@ -291,6 +301,8 @@ describe('UsersService.hardRemove (hard delete)', () => {
       {} as any,
       {} as any,
       { get: jest.fn().mockReturnValue(undefined) } as any,
+      {} as any, // emailNotificationService
+      {} as any, // signupProfileService
     );
     (service as any).clerk = { users: { deleteUser: jest.fn().mockResolvedValue(undefined) } };
 

--- a/api/src/users/users.service.unit.spec.ts
+++ b/api/src/users/users.service.unit.spec.ts
@@ -1,6 +1,54 @@
 import { UsersService } from './users.service';
 import { UserRole } from '@prisma/client';
 
+/**
+ * Build a Prisma transaction-client mock that auto-creates its models.
+ *
+ * `hardRemove({ force: true })` deliberately reaches across ~30 relations to
+ * clear FK constraints before a user row can be dropped, and it grows a new one
+ * every time a relation with a Restrict/SetNull FK is added to the schema. A
+ * hand-listed mock silently rots the moment that happens: this spec had already
+ * drifted far enough that it no longer compiled at all.
+ *
+ * So instead of enumerating models, unknown ones are vivified on access with
+ * neutral defaults. Adding a relation to hardRemove can no longer break this
+ * spec, while `overrides` still pins the specific calls the assertions check.
+ */
+function createTxMock(overrides: Record<string, Record<string, jest.Mock>> = {}): any {
+  const models = new Map<string, Record<string, jest.Mock>>();
+
+  const target: Record<string, any> = {
+    // safeDeleteMany / safeUpdateMany wrap each statement in a SAVEPOINT so a
+    // missing table cannot abort the surrounding transaction.
+    $executeRawUnsafe: jest.fn().mockResolvedValue(0),
+  };
+
+  return new Proxy(target, {
+    get(t, prop) {
+      if (typeof prop !== 'string' || prop === 'then') return (t as any)[prop];
+      if (prop in t) return t[prop];
+
+      if (!models.has(prop)) {
+        models.set(prop, {
+          findMany: jest.fn().mockResolvedValue([]),
+          findFirst: jest.fn().mockResolvedValue(null),
+          findUnique: jest.fn().mockResolvedValue(null),
+          count: jest.fn().mockResolvedValue(0),
+          create: jest.fn().mockResolvedValue({ id: `${prop}-id` }),
+          createMany: jest.fn().mockResolvedValue({ count: 0 }),
+          update: jest.fn().mockResolvedValue({ id: `${prop}-id` }),
+          updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+          upsert: jest.fn().mockResolvedValue({ id: `${prop}-id` }),
+          delete: jest.fn().mockResolvedValue({ id: `${prop}-id` }),
+          deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+          ...(overrides[prop] ?? {}),
+        });
+      }
+      return models.get(prop);
+    },
+  });
+}
+
 describe('UsersService.remove (soft delete)', () => {
   it('suspends the user profile (isActive=false) without changing role', async () => {
     const appUser = {
@@ -192,33 +240,11 @@ describe('UsersService.hardRemove (hard delete)', () => {
     };
     const profile = { id: 'profile-id', clerkId: appUser.clerkId } as any;
 
-    const tx = {
-      // hardRemove issues raw SQL to break FK cycles before deleting.
-      $executeRawUnsafe: jest.fn().mockResolvedValue(0),
-      // dependency deletes
-      message: { findMany: jest.fn().mockResolvedValue([]), deleteMany: jest.fn() },
-      conversationParticipant: { findMany: jest.fn().mockResolvedValue([]), deleteMany: jest.fn() },
-      conversation: { deleteMany: jest.fn() },
-      jobApplication: { deleteMany: jest.fn() },
-      ticketResponse: { deleteMany: jest.fn() },
-      supportTicket: { deleteMany: jest.fn() },
-      userSubscription: { deleteMany: jest.fn() },
-      subscription: { deleteMany: jest.fn(), findMany: jest.fn().mockResolvedValue([]) },
-      certificate: { deleteMany: jest.fn() },
-      discussionReply: { deleteMany: jest.fn() },
-      courseDiscussion: { deleteMany: jest.fn() },
-      courseEnrollment: { deleteMany: jest.fn() },
-
-      // uploader reassignment
-      asset: { updateMany: jest.fn() },
-      course: { updateMany: jest.fn() },
-
-      // final deletes
-      userOrganization: { deleteMany: jest.fn() },
-      userContactInfo: { deleteMany: jest.fn() },
-      user: { delete: jest.fn(), deleteMany: jest.fn() },
-      appUser: { upsert: jest.fn().mockResolvedValue({ id: 'system-app-user' }), delete: jest.fn() },
-    } as any;
+    // Only the models the assertions below actually inspect need pinning; the
+    // rest are vivified with neutral defaults.
+    const tx = createTxMock({
+      appUser: { upsert: jest.fn().mockResolvedValue({ id: 'system-app-user' }) },
+    });
 
     const prisma = {
       appUser: { findUnique: jest.fn().mockResolvedValue(appUser) },
@@ -271,14 +297,7 @@ describe('UsersService.hardRemove (hard delete)', () => {
     };
     const profile = { id: 'profile-id', clerkId: appUser.clerkId } as any;
 
-    const tx = {
-      // hardRemove issues raw SQL to break FK cycles before deleting.
-      $executeRawUnsafe: jest.fn().mockResolvedValue(0),
-      userOrganization: { deleteMany: jest.fn() },
-      userContactInfo: { deleteMany: jest.fn() },
-      user: { delete: jest.fn(), deleteMany: jest.fn() },
-      appUser: { delete: jest.fn() },
-    };
+    const tx = createTxMock();
 
     const prisma = {
       appUser: { findUnique: jest.fn().mockResolvedValue(appUser) },

--- a/api/src/webhooks/clerk-webhook.controller.ts
+++ b/api/src/webhooks/clerk-webhook.controller.ts
@@ -11,6 +11,7 @@ import { Public } from '../auth/decorators/public.decorator';
 import { Webhook } from 'svix';
 import { Request, Response } from 'express';
 import { PrismaService } from '../prisma/prisma.service';
+import { SignupProfileService, parseSignupIntent } from '../users/signup-profile.service';
 import { createClerkClient } from '@clerk/clerk-sdk-node';
 import { ConfigService } from '@nestjs/config';
 import { UserRole, EducatorApprovalStatus } from '@prisma/client';
@@ -34,6 +35,7 @@ export class ClerkWebhookController {
     private prisma: PrismaService,
     private configService: ConfigService,
     private emailNotificationService: EmailNotificationService,
+    private signupProfileService: SignupProfileService,
   ) {
     const clerkSecretKey = this.configService.get<string>('CLERK_SECRET_KEY');
     const webhookSecret = this.configService.get<string>('CLERK_WEBHOOK_SECRET');
@@ -578,7 +580,12 @@ ${'='.repeat(100)}`);
     
     const firstName = data.first_name || 'Unknown';
     const lastName = data.last_name || 'User';
-    const phoneNumber = data.phone_numbers?.[0]?.phone_number || null;
+    // Clerk only populates `phone_numbers` when the identity provider supplied
+    // one — it is empty for every email/password signup, so the phone typed on
+    // the signup form arrives in unsafe_metadata instead. Reading only the
+    // former silently dropped the phone number for all such accounts.
+    const signupIntent = parseSignupIntent(data.unsafe_metadata);
+    const phoneNumber = data.phone_numbers?.[0]?.phone_number || signupIntent.phone || null;
     const lastActiveAt = this.resolveLastActiveAt(data);
 
     console.log(`👤 [E2E DEBUG] USER DETAILS EXTRACTED:`, {
@@ -613,14 +620,9 @@ ${'='.repeat(100)}`);
       }
     });
 
-    // Extract organization data from unsafe_metadata (set during signup)
-    const organisationName = data.unsafe_metadata?.organisationName;
-    const signupCanton = data.unsafe_metadata?.canton;
-
-    console.log(`🏢 [E2E DEBUG] ORGANIZATION DATA FROM SIGNUP:`, {
-      organisationName,
-      signupCanton,
-      phone: phoneNumber,
+    console.log(`🏢 [E2E DEBUG] SIGNUP INTENT PARSED FROM METADATA:`, {
+      ...signupIntent,
+      resolvedPhone: phoneNumber,
       unsafeMetadataKeys: data.unsafe_metadata ? Object.keys(data.unsafe_metadata) : [],
     });
 
@@ -664,8 +666,11 @@ ${'='.repeat(100)}`);
           role: validRole as UserRole,
           phoneNumber,
           isActive: true,
+          // INCOMPLETE, not PENDING_REVIEW: this account is created at email
+          // verification, before the educator has submitted anything. It is
+          // promoted to PENDING_REVIEW by PATCH /settings/educator.
           ...(validRole === UserRole.EDUCATOR && {
-            approvalStatus: EducatorApprovalStatus.PENDING_REVIEW,
+            approvalStatus: EducatorApprovalStatus.INCOMPLETE,
           }),
         };
 
@@ -681,50 +686,17 @@ ${'='.repeat(100)}`);
         });
         profileUserId = user.id;
 
-        // Create organization and link user for organization-based roles
-        const orgBasedRoles: UserRole[] = [UserRole.FOUNDATION, UserRole.PRODUCT_SUPPLIER, UserRole.SERVICE_PROVIDER];
-        if (orgBasedRoles.includes(validRole as UserRole)) {
-          // Check if user already has an organization link (to avoid duplicates on updates)
-          const existingOrgLink = await tx.userOrganization.findFirst({
-            where: { userId: user.id },
-          });
-
-          if (!existingOrgLink) {
-            // Determine organization type from user role
-            const orgTypeMap: Record<string, 'FOUNDATION' | 'PRODUCT_SUPPLIER' | 'SERVICE_PROVIDER'> = {
-              [UserRole.FOUNDATION]: 'FOUNDATION',
-              [UserRole.PRODUCT_SUPPLIER]: 'PRODUCT_SUPPLIER',
-              [UserRole.SERVICE_PROVIDER]: 'SERVICE_PROVIDER',
-            };
-            const orgType = orgTypeMap[validRole as string];
-
-            // Create the organization with signup data
-            const organization = await tx.organization.create({
-              data: {
-                name: organisationName || `${firstName} ${lastName}`.trim() || 'New Organization',
-                type: orgType,
-                contactPerson: `${firstName} ${lastName}`.trim() || null,
-                phoneNumber: phoneNumber || null,
-                canton: signupCanton || null,
-                region: signupCanton || null,
-                isActive: true,
-              },
-            });
-
-            // Link user to organization
-            await tx.userOrganization.create({
-              data: {
-                userId: user.id,
-                organizationId: organization.id,
-                role: validRole as UserRole,
-              },
-            });
-
-            console.log(`🏢 [E2E DEBUG] Created organization "${organization.name}" (${orgType}) and linked to user ${user.id}`);
-          } else {
-            console.log(`⏭️ [E2E DEBUG] User already has an organization link, skipping org creation`);
-          }
-        }
+        // Persist the rest of the signup form (phone, terms, parent child data)
+        // and create/link the organization. Shared with the
+        // POST /users/complete-profile path so both keep the same fields.
+        await this.signupProfileService.applySignupIntent(tx, {
+          userId: user.id,
+          role: validRole as UserRole,
+          firstName,
+          lastName,
+          phoneNumber,
+          intent: signupIntent,
+        });
       });
 
       console.log(`✅ [E2E DEBUG] APPUSER & USER UPSERTED SUCCESSFULLY:`, {

--- a/api/src/webhooks/webhooks.module.ts
+++ b/api/src/webhooks/webhooks.module.ts
@@ -4,9 +4,10 @@ import { WebhookDiagnosticsController } from './diagnostics.controller';
 import { PrismaModule } from '../prisma/prisma.module';
 import { ConfigModule } from '@nestjs/config';
 import { EmailNotificationModule } from '../email-notification/email-notification.module';
+import { SignupProfileModule } from '../users/signup-profile.module';
 
 @Module({
-  imports: [PrismaModule, ConfigModule, EmailNotificationModule],
+  imports: [PrismaModule, ConfigModule, EmailNotificationModule, SignupProfileModule],
   controllers: [ClerkWebhookController, WebhookDiagnosticsController],
 })
 export class WebhooksModule {}

--- a/frontend/components/signup/EducatorProfileStep.tsx
+++ b/frontend/components/signup/EducatorProfileStep.tsx
@@ -8,6 +8,7 @@ import {
   DocumentTextIcon,
   XMarkIcon,
   ArrowLeftIcon,
+  ArrowRightOnRectangleIcon,
 } from '@heroicons/react/24/outline';
 import Button from '../ui/Button';
 import FileUploadZone from '../ui/FileUploadZone';
@@ -49,6 +50,12 @@ interface EducatorProfileStepProps {
   submitError?: string | null;
   /** Set when the account is still being provisioned in the background. */
   provisioningDelayed?: boolean;
+  /**
+   * True once a Clerk account exists. There is then no earlier wizard step to
+   * return to — step 2 is the account-creation form and would reject the
+   * already-registered email — so "Go Back" becomes "Sign out".
+   */
+  accountExists?: boolean;
 }
 
 // Drop blank values so already-typed input wins over a stale draft field, but
@@ -67,6 +74,7 @@ const EducatorProfileStep: React.FC<EducatorProfileStepProps> = ({
   isLoading,
   submitError = null,
   provisioningDelayed = false,
+  accountExists = false,
 }) => {
   const { t } = useTranslation(['signup', 'common', 'settings']);
 
@@ -431,10 +439,12 @@ const EducatorProfileStep: React.FC<EducatorProfileStepProps> = ({
           type="button"
           variant="light"
           onClick={onBack}
-          leftIcon={ArrowLeftIcon}
+          leftIcon={accountExists ? ArrowRightOnRectangleIcon : ArrowLeftIcon}
           className="w-full sm:w-auto text-sm"
         >
-          {t('common:buttons.goBack', 'Go Back')}
+          {accountExists
+            ? t('common:loginPage.signOutButton', 'Sign Out')
+            : t('common:buttons.goBack', 'Go Back')}
         </Button>
         <Button
           type="submit"

--- a/frontend/components/signup/EducatorProfileStep.tsx
+++ b/frontend/components/signup/EducatorProfileStep.tsx
@@ -116,8 +116,16 @@ const EducatorProfileStep: React.FC<EducatorProfileStepProps> = ({
     if (!email || hasRestoredRef.current) return;
     hasRestoredRef.current = true;
 
+    // Precedence matters: anything the user has ALREADY TYPED must win over the
+    // stored draft. `buildFrom` gives its first argument priority, so the typed
+    // values are layered on top of the draft there — not passed as `base`, which
+    // would let a stale draft silently overwrite live input. That window is real:
+    // the form is editable before `initialData.email` resolves, and the persist
+    // effect is skipped while the email is unknown.
     const draft = readEducatorDraft<Partial<EducatorProfileStepData>>(email);
-    setData(prev => buildFrom(draft, { ...initialData, ...stripEmpty(prev), email }));
+    setData(prev =>
+      buildFrom({ ...(draft ?? {}), ...stripEmpty(prev) }, { ...initialData, email }),
+    );
   }, [initialData.email]);
 
   // Persist the draft as the user edits so nothing typed here is lost before the

--- a/frontend/components/signup/EducatorProfileStep.tsx
+++ b/frontend/components/signup/EducatorProfileStep.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   UserCircleIcon,
@@ -45,43 +45,79 @@ interface EducatorProfileStepProps {
   onSubmit: (data: EducatorProfileStepData) => Promise<void>;
   onBack: () => void;
   isLoading: boolean;
+  /** Set when the last save attempt failed, so the user can retry without retyping. */
+  submitError?: string | null;
+  /** Set when the account is still being provisioned in the background. */
+  provisioningDelayed?: boolean;
 }
+
+// Drop blank values so already-typed input wins over a stale draft field, but
+// an untouched field still falls back to the draft.
+const stripEmpty = (
+  value: Partial<EducatorProfileStepData>,
+): Partial<EducatorProfileStepData> =>
+  Object.fromEntries(
+    Object.entries(value).filter(([, v]) => typeof v === 'string' && v.trim() !== ''),
+  ) as Partial<EducatorProfileStepData>;
 
 const EducatorProfileStep: React.FC<EducatorProfileStepProps> = ({
   initialData,
   onSubmit,
   onBack,
   isLoading,
+  submitError = null,
+  provisioningDelayed = false,
 }) => {
   const { t } = useTranslation(['signup', 'common', 'settings']);
 
-  const [data, setData] = useState<EducatorProfileStepData>(() => {
-    // Restore a previously saved draft (survives refresh / tab suspension / the
-    // verification link opening in another tab) and layer it over initialData so
-    // the educator never re-types their profile after signup information is lost.
-    const draft = readEducatorDraft<Partial<EducatorProfileStepData>>(initialData.email);
+  const buildFrom = (
+    draft: Partial<EducatorProfileStepData> | null,
+    base: Partial<EducatorProfileStepData>,
+  ): EducatorProfileStepData => {
     const pick = (field: keyof EducatorProfileStepData) =>
-      (draft?.[field] as string | undefined) || (initialData[field] as string | undefined) || '';
+      (draft?.[field] as string | undefined) || (base[field] as string | undefined) || '';
     return {
       firstName: pick('firstName'),
       lastName: pick('lastName'),
       phone: pick('phone'),
-      email: initialData.email || (draft?.email as string) || '',
+      email: base.email || (draft?.email as string) || '',
       canton: pick('canton'),
       city: pick('city'),
       shortBio: pick('shortBio'),
       professionalExperience: pick('professionalExperience'),
       cvUrl: pick('cvUrl'),
       cvAssetId: pick('cvAssetId'),
-      jobRole: (draft?.jobRole as EducatorJobRole | '') || initialData.jobRole || '',
+      jobRole: (draft?.jobRole as EducatorJobRole | '') || base.jobRole || '',
     };
-  });
+  };
+
+  const [data, setData] = useState<EducatorProfileStepData>(() =>
+    buildFrom(readEducatorDraft<Partial<EducatorProfileStepData>>(initialData.email), initialData),
+  );
 
   const [errors, setErrors] = useState<EducatorProfileStepErrors>({});
 
+  // The authenticated account often resolves *after* this form first mounts, so
+  // `initialData.email` starts empty and no draft can be looked up yet. Restore
+  // once, as soon as the email is known, layering the saved draft over whatever
+  // the user has already typed. Without this the draft written during an earlier
+  // visit is never found and the educator silently re-types everything.
+  const hasRestoredRef = useRef(false);
+  useEffect(() => {
+    const email = initialData.email;
+    if (!email || hasRestoredRef.current) return;
+    hasRestoredRef.current = true;
+
+    const draft = readEducatorDraft<Partial<EducatorProfileStepData>>(email);
+    setData(prev => buildFrom(draft, { ...initialData, ...stripEmpty(prev), email }));
+  }, [initialData.email]);
+
   // Persist the draft as the user edits so nothing typed here is lost before the
   // "Complete Setup" PATCH succeeds. The parent clears it once step 4 is reached.
+  // Skipped while the email is unknown — an anonymous draft could never be
+  // safely matched back to its owner.
   useEffect(() => {
+    if (!data.email) return;
     writeEducatorDraft(data.email, data);
   }, [data]);
 
@@ -134,6 +170,37 @@ const EducatorProfileStep: React.FC<EducatorProfileStepProps> = ({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-5">
+
+      {/* Account still provisioning — non-blocking. The educator can fill the
+          form now; the save retries until the backend account is ready. */}
+      {provisioningDelayed && !submitError && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-3">
+          <p className="text-sm text-amber-800">
+            {t(
+              'signup:educatorProfile.provisioningDelayed',
+              'Your account is still being set up. You can fill in your details now — we will save them as soon as it is ready.',
+            )}
+          </p>
+        </div>
+      )}
+
+      {/* Save failure — surfaced inline (never as an alert() that can be
+          dismissed while the typed data is discarded). The draft is kept, so
+          "Complete Setup" can simply be pressed again. */}
+      {submitError && (
+        <div className="rounded-lg border border-swiss-coral bg-red-50 p-3" role="alert">
+          <p className="text-sm font-medium text-swiss-coral">
+            {t('signup:educatorProfile.saveFailedTitle', 'We could not save your profile')}
+          </p>
+          <p className="text-sm text-gray-700 mt-1">{submitError}</p>
+          <p className="text-xs text-gray-600 mt-2">
+            {t(
+              'signup:educatorProfile.saveFailedHint',
+              'Your answers have been kept on this device. Press "Complete Setup" again to retry.',
+            )}
+          </p>
+        </div>
+      )}
 
       {/* Basic Information */}
       <div className="bg-gray-50 rounded-lg p-4 space-y-4">

--- a/frontend/pages/SignupPage.tsx
+++ b/frontend/pages/SignupPage.tsx
@@ -114,7 +114,25 @@ const SignupPage: React.FC = () => {
   // Webhook status hook - no clerkId param needed, uses authenticated session
   const { error: webhookErrorFromHook, startPolling, checkWebhookStatus } = useWebhookStatus();
 
-  // Wait for webhook processing to complete
+  // Wait for webhook processing to complete.
+  //
+  // Two hard-won rules here, both of which previously caused educators to end up
+  // with completely empty profiles:
+  //
+  // 1. A single failed poll must NOT abort the signup. `checkWebhookStatus`
+  //    reports 'error' for any transient fetch failure — a dropped connection, a
+  //    cold-started backend returning 502, a mobile network hiccup. Treating the
+  //    first one as fatal ended the signup at step 2 for an account that was
+  //    provisioned moments later, and the educator never saw step 3 at all.
+  //
+  // 2. Slow provisioning must NOT dead-end an educator. Step 3 is where every
+  //    piece of educator profile data is collected; if we never show it, the
+  //    account exists with nothing in it. When the wait is exhausted we send
+  //    educators into step 3 anyway with a non-blocking notice — filling the form
+  //    takes minutes, by which time the webhook has long since landed, and the
+  //    save itself retries.
+  const TRANSIENT_POLL_FAILURE_LIMIT = 5;
+
   const waitForWebhookProcessing = async (_userId: string, _sessionId: string | null) => {
     let stopPollingCleanup: (() => void) | undefined;
 
@@ -122,9 +140,10 @@ const SignupPage: React.FC = () => {
       console.log('[Signup Debug] waitForWebhookProcessing: starting provisioning wait');
       stopPollingCleanup = startPolling();
 
-      const maxWaitTime = 30000;
-      const pollInterval = 1000;
+      const maxWaitTime = 60000;
+      const pollInterval = 1500;
       const startTime = Date.now();
+      let consecutiveFailures = 0;
 
       setWebhookError(null);
 
@@ -132,25 +151,52 @@ const SignupPage: React.FC = () => {
         await new Promise(resolve => setTimeout(resolve, pollInterval));
 
         const currentStatus = await checkWebhookStatus();
-        setWebhookStatus(currentStatus);
         console.log('[Signup Debug] waitForWebhookProcessing: poll result', {
           currentStatus,
+          consecutiveFailures,
           elapsedMs: Date.now() - startTime,
         });
 
         if (currentStatus === 'ready') {
+          setWebhookStatus('ready');
           setSuccessRedirect(getSuccessRedirectForRole());
           setCurrentStep(getPostSignupStep());
           return;
         }
 
         if (currentStatus === 'error') {
-          console.error('[Signup Debug] waitForWebhookProcessing: webhook status error', webhookErrorFromHook);
-          throw new Error(webhookErrorFromHook || 'Webhook processing failed');
+          consecutiveFailures += 1;
+          console.warn('[Signup Debug] waitForWebhookProcessing: transient poll failure', {
+            consecutiveFailures,
+            error: webhookErrorFromHook,
+          });
+          // Keep the user on the "setting up your account" state and try again;
+          // only a sustained run of failures is treated as real.
+          setWebhookStatus('processing');
+          if (consecutiveFailures >= TRANSIENT_POLL_FAILURE_LIMIT) {
+            break;
+          }
+          continue;
         }
+
+        consecutiveFailures = 0;
+        setWebhookStatus(currentStatus);
       }
 
-      console.error('[Signup Debug] waitForWebhookProcessing: timed out waiting for provisioning');
+      // Provisioning was not confirmed within the budget.
+      console.warn('[Signup Debug] waitForWebhookProcessing: provisioning not confirmed in time');
+
+      if (isEducatorRole()) {
+        // Never strand an educator here — everything they are about to type is
+        // the profile itself, and there is nowhere else it gets captured.
+        setWebhookStatus('processing');
+        setProvisioningDelayed(true);
+        setVerificationError('');
+        setSuccessRedirect(getSuccessRedirectForRole());
+        setCurrentStep(3);
+        return;
+      }
+
       throw new Error('Account setup timeout - please contact support');
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Account setup failed';
@@ -201,6 +247,12 @@ const SignupPage: React.FC = () => {
   const [webhookError, setWebhookError] = useState<string | null>(null);
   const [isHelpModalOpen, setIsHelpModalOpen] = useState(false);
   const [isEducatorProfileLoading, setIsEducatorProfileLoading] = useState(false);
+  // Set when the backend account was not confirmed before we let the educator
+  // into step 3 anyway (see waitForWebhookProcessing).
+  const [provisioningDelayed, setProvisioningDelayed] = useState(false);
+  // Last step-3 save failure, shown inline on the form so the typed profile is
+  // never discarded behind a dismissible alert().
+  const [educatorSaveError, setEducatorSaveError] = useState<string | null>(null);
 
   const getSuccessRedirectForRole = () => ({ path: '/dashboard' });
 
@@ -847,48 +899,116 @@ const SignupPage: React.FC = () => {
     }
   };
   
+  // This PATCH is the *only* place educator profile data is ever persisted, so a
+  // failure here means the account keeps an empty profile. Retry hard: the
+  // realistic failures are all transient and all recoverable.
+  //
+  //  - 401  stale/not-yet-valid Clerk token (cold-started backend, clock skew)
+  //  - 403  request arrived before the role/context was readable
+  //  - 404  the user.created webhook has not landed yet
+  //  - 5xx / network  backend restart, dropped mobile connection
+  //
+  // A 400 is a genuine validation problem and is surfaced immediately.
+  const EDUCATOR_SAVE_MAX_ATTEMPTS = 5;
+  const isRetryableSaveStatus = (status: number) =>
+    status === 401 || status === 403 || status === 404 || status === 408 || status === 429 || status >= 500;
+
   const handleEducatorProfileSubmit = async (profileData: EducatorProfileStepData) => {
     setIsEducatorProfileLoading(true);
+    setEducatorSaveError(null);
+
+    const payload = {
+      firstName: profileData.firstName,
+      lastName: profileData.lastName,
+      phoneNumber: profileData.phone,
+      region: profileData.canton,
+      cities: profileData.city ? [profileData.city] : [],
+      shortBio: profileData.shortBio,
+      workExperience: profileData.professionalExperience,
+      jobRole: profileData.jobRole || undefined,
+      cvUrl: profileData.cvUrl || undefined,
+      cvAssetId: profileData.cvAssetId || undefined,
+    };
+
+    let lastError = '';
+    let saved = false;
+
     try {
-      const token = await getToken();
-      if (!token) throw new Error('Authentication token not available');
+      for (let attempt = 0; attempt < EDUCATOR_SAVE_MAX_ATTEMPTS; attempt++) {
+        if (attempt > 0) {
+          // 1s, 2s, 4s, 8s — long enough to outlast a webhook that is merely slow.
+          await new Promise(resolve => setTimeout(resolve, 1000 * 2 ** (attempt - 1)));
+        }
 
-      const payload = {
-        firstName: profileData.firstName,
-        lastName: profileData.lastName,
-        phoneNumber: profileData.phone,
-        region: profileData.canton,
-        cities: profileData.city ? [profileData.city] : [],
-        shortBio: profileData.shortBio,
-        workExperience: profileData.professionalExperience,
-        jobRole: profileData.jobRole || undefined,
-        cvUrl: profileData.cvUrl || undefined,
-        cvAssetId: profileData.cvAssetId || undefined,
-      };
+        try {
+          // Always fetch a fresh token; a retry after a 401 with the same token
+          // would simply fail the same way.
+          const token = await getToken();
+          if (!token) {
+            lastError = 'Authentication token not available';
+            continue;
+          }
 
-      const response = await fetch(
-        `${apiService.apiBaseUrl}${API_ENDPOINTS.settings.educator}`,
-        {
-          method: 'PATCH',
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(payload),
-        },
-      );
+          const response = await fetch(
+            `${apiService.apiBaseUrl}${API_ENDPOINTS.settings.educator}`,
+            {
+              method: 'PATCH',
+              headers: {
+                Authorization: `Bearer ${token}`,
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify(payload),
+            },
+          );
 
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({}));
-        throw new Error(err.message || 'Failed to save profile');
+          if (response.ok) {
+            saved = true;
+            break;
+          }
+
+          const err = await response.json().catch(() => ({}));
+          const rawMsg = err?.message;
+          lastError =
+            (typeof rawMsg === 'string' ? rawMsg : rawMsg?.message) ||
+            `Failed to save profile (HTTP ${response.status})`;
+
+          if (!isRetryableSaveStatus(response.status)) {
+            break;
+          }
+
+          console.warn('[Signup Debug] educator profile save: retryable failure', {
+            attempt: attempt + 1,
+            status: response.status,
+          });
+        } catch (networkErr: any) {
+          // fetch() rejected — always worth another try.
+          lastError = networkErr?.message || 'Network error while saving your profile';
+          console.warn('[Signup Debug] educator profile save: network failure', {
+            attempt: attempt + 1,
+            error: lastError,
+          });
+        }
       }
 
-      await refreshCurrentUser();
-      setCurrentStep(4);
-    } catch (err: any) {
-      console.error('Educator profile save error:', err);
-      // Surface the error – the component stays on step 3 so the user can retry
-      alert(err.message || 'An error occurred while saving your profile. Please try again.');
+      if (saved) {
+        setProvisioningDelayed(false);
+        // Clear the draft only once the server has actually accepted the data.
+        clearSignupDrafts(profileData.email || formData.email);
+        // A failure to refresh the local user must not look like a failed save —
+        // the profile is already persisted at this point.
+        await refreshCurrentUser().catch((refreshErr: any) => {
+          console.warn('[Signup Debug] refreshCurrentUser after profile save failed', refreshErr);
+        });
+        setCurrentStep(4);
+        return;
+      }
+
+      console.error('Educator profile save failed after retries:', lastError);
+      // Stay on step 3 with the draft intact so the educator can simply press
+      // "Complete Setup" again — nothing they typed is thrown away.
+      setEducatorSaveError(
+        lastError || 'An error occurred while saving your profile. Please try again.',
+      );
     } finally {
       setIsEducatorProfileLoading(false);
     }
@@ -1366,6 +1486,8 @@ const SignupPage: React.FC = () => {
                 onSubmit={handleEducatorProfileSubmit}
                 onBack={() => { setCurrentStep(2); setShowVerificationStep(false); }}
                 isLoading={isEducatorProfileLoading}
+                submitError={educatorSaveError}
+                provisioningDelayed={provisioningDelayed}
               />
             )}
 

--- a/frontend/pages/SignupPage.tsx
+++ b/frontend/pages/SignupPage.tsx
@@ -223,7 +223,6 @@ const SignupPage: React.FC = () => {
     confirmPassword: '',
     phone: '',
     canton: '',
-    languagesSpoken: [],
     capacity: undefined,
     category: '',
     serviceType: '',
@@ -253,6 +252,27 @@ const SignupPage: React.FC = () => {
   // Last step-3 save failure, shown inline on the form so the typed profile is
   // never discarded behind a dismissible alert().
   const [educatorSaveError, setEducatorSaveError] = useState<string | null>(null);
+
+  // The signup form is collected once but consumed by two different backend
+  // paths: `signUp.create` -> Clerk `user.created` webhook (email/password), and
+  // POST /users/complete-profile (OAuth / webhook recovery). They used to be
+  // built separately and drifted, so email/password signups silently lost
+  // capacity, category, service type and phone. One builder, both callers.
+  const buildSignupIntent = () => ({
+    organisationName: requiresOrganizationDetails ? formData.organisationName || undefined : undefined,
+    contactPerson: formData.contactPerson || undefined,
+    phone: formData.phone || undefined,
+    canton: formData.canton || undefined,
+    capacity: selectedRole === SignupRole.FOUNDATION ? formData.capacity : undefined,
+    category: selectedRole === SignupRole.SUPPLIER ? formData.category || undefined : undefined,
+    serviceType:
+      selectedRole === SignupRole.SERVICE_PROVIDER ? formData.serviceType || undefined : undefined,
+    childAge: selectedRole === SignupRole.PARENT ? formData.childAge : undefined,
+    childStartDate:
+      selectedRole === SignupRole.PARENT ? formData.childStartDate || undefined : undefined,
+    // Consent timestamp: the moment the form was submitted with the box ticked.
+    termsAcceptedAt: formData.termsAccepted ? new Date().toISOString() : undefined,
+  });
 
   const getSuccessRedirectForRole = () => ({ path: '/dashboard' });
 
@@ -317,6 +337,31 @@ const SignupPage: React.FC = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoaded, isAuthLoading, isSignedIn, isIncompleteEducator]);
+
+  // Once a Clerk account exists, step 2 IS the account-creation form and can
+  // never be completed again (`form_identifier_exists`). Reaching it is a dead
+  // end, so send the user forward instead: an educator with an unsubmitted
+  // profile back to step 3, anyone else to their dashboard. The one exception is
+  // `needsProfileCompletion`, where step 2 renders as a role/profile form for a
+  // Clerk account that has no backend user yet — that IS the way out for them.
+  useEffect(() => {
+    if (!isSignedIn || isAuthLoading || currentStep !== 2 || needsProfileCompletion) return;
+    if (isIncompleteEducator) {
+      setCurrentStep(3);
+      return;
+    }
+    if (currentUser) {
+      navigate('/dashboard', { replace: true });
+    }
+  }, [
+    isSignedIn,
+    isAuthLoading,
+    currentStep,
+    needsProfileCompletion,
+    isIncompleteEducator,
+    currentUser,
+    navigate,
+  ]);
 
   // Resume an incomplete educator straight into step 3 so they can finish saving
   // their profile instead of silently landing on the dashboard with their signup
@@ -595,15 +640,7 @@ const SignupPage: React.FC = () => {
        const payload = {
            role: SIGNUP_ROLE_TO_USER_ROLE[selectedRole!],
            email: formData.email || (clerkUser && clerkUser.primaryEmailAddress && clerkUser.primaryEmailAddress.emailAddress),  // Include email for pending users
-           organisationName: formData.organisationName || undefined,
-           contactPerson: formData.contactPerson || undefined,
-           phone: formData.phone || undefined,
-           canton: formData.canton || undefined,
-           capacity: formData.capacity,
-           category: formData.category || undefined,
-           serviceType: formData.serviceType || undefined,
-           childAge: formData.childAge,
-           childStartDate: formData.childStartDate || undefined,
+           ...buildSignupIntent(),
        };
 
        const makeCompleteProfileRequest = async (authToken: string) =>
@@ -715,13 +752,13 @@ const SignupPage: React.FC = () => {
         firstName: firstName,
         lastName: lastName,
         unsafeMetadata: {
-          // Store signup intent for backend webhook to process
-          // Backend will assign actual role via publicMetadata (secure)
-            signupType: selectedRole,
-            pendingRole: pendingUserRole,
-            organisationName: requiresOrganizationDetails ? formData.organisationName : undefined,
-            phone: formData.phone || undefined,
-            canton: formData.canton || undefined,
+          // Signup intent for the backend webhook to persist. The backend still
+          // assigns the real role via publicMetadata (secure) and scrubs any
+          // role written here; every other key is whitelisted and coerced
+          // server-side by parseSignupIntent().
+          signupType: selectedRole,
+          pendingRole: pendingUserRole,
+          ...buildSignupIntent(),
         },
       });
 
@@ -1484,7 +1521,18 @@ const SignupPage: React.FC = () => {
                   canton: formData.canton || '',
                 }}
                 onSubmit={handleEducatorProfileSubmit}
-                onBack={() => { setCurrentStep(2); setShowVerificationStep(false); }}
+                onBack={async () => {
+                  if (isSignedIn) {
+                    // The account already exists — there is no earlier step to
+                    // return to. Signing out is the only honest way back.
+                    await logout();
+                    navigate('/login', { replace: true });
+                    return;
+                  }
+                  setCurrentStep(2);
+                  setShowVerificationStep(false);
+                }}
+                accountExists={isSignedIn}
                 isLoading={isEducatorProfileLoading}
                 submitError={educatorSaveError}
                 provisioningDelayed={provisioningDelayed}

--- a/frontend/pages/educator/EducatorPendingApprovalPage.tsx
+++ b/frontend/pages/educator/EducatorPendingApprovalPage.tsx
@@ -1,13 +1,73 @@
 import React from 'react';
-import { ClockIcon, EnvelopeIcon, UserCircleIcon } from '@heroicons/react/24/outline';
+import { ClockIcon, EnvelopeIcon, UserCircleIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import { useClerk } from '@clerk/clerk-react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { useAppContext } from '../../contexts/AppContext';
 
 const EducatorPendingApprovalPage: React.FC = () => {
   const { signOut } = useClerk();
   const navigate = useNavigate();
   const { t } = useTranslation('dashboard');
+  const { currentUser } = useAppContext();
+
+  // An educator who never completed step 3 of signup lands here too, because the
+  // account is created (and marked PENDING_REVIEW) at email verification, before
+  // any profile data is collected. Telling them their profile is "under review"
+  // is wrong and is why these accounts stayed empty forever: nothing ever asked
+  // them to finish. Detect the empty profile and route them back into the
+  // signup wizard, which resumes at step 3 with their saved draft.
+  const hasSubmittedApplication = Boolean(
+    (currentUser as any)?.shortBio?.trim() || (currentUser as any)?.cvUrl?.trim(),
+  );
+
+  if (currentUser && !hasSubmittedApplication) {
+    return (
+      <div className="min-h-screen bg-page-bg flex items-center justify-center p-4">
+        <div className="max-w-lg w-full bg-white rounded-2xl shadow-lg p-8 text-center">
+          <div className="flex justify-center mb-6">
+            <div className="w-20 h-20 rounded-full bg-amber-100 flex items-center justify-center">
+              <ExclamationTriangleIcon className="w-10 h-10 text-amber-500" />
+            </div>
+          </div>
+
+          <h1 className="text-2xl font-bold text-gray-900 mb-3">
+            {t('educatorPendingApprovalPage.incompleteTitle')}
+          </h1>
+          <p className="text-gray-600 mb-6">
+            {t('educatorPendingApprovalPage.incompleteDescription')}
+          </p>
+
+          <button
+            onClick={() => navigate('/signup')}
+            className="w-full inline-flex items-center justify-center gap-2 px-5 py-3 rounded-lg bg-swiss-mint text-white text-sm font-semibold hover:bg-opacity-90 transition-colors"
+          >
+            <UserCircleIcon className="w-4 h-4" />
+            {t('educatorPendingApprovalPage.incompleteCta')}
+          </button>
+          <p className="text-xs text-gray-500 mt-3">
+            {t('educatorPendingApprovalPage.incompleteNote')}
+          </p>
+
+          <div className="border-t border-gray-100 mt-6 pt-6 flex flex-col sm:flex-row gap-3 justify-center">
+            <a
+              href="mailto:support@procreche.ch"
+              className="inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors"
+            >
+              <EnvelopeIcon className="w-4 h-4" />
+              {t('educatorPendingApprovalPage.contactSupport')}
+            </a>
+            <button
+              onClick={() => signOut().catch((err) => console.error('Sign out failed:', err))}
+              className="px-5 py-2.5 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors"
+            >
+              {t('educatorPendingApprovalPage.signOut')}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-page-bg flex items-center justify-center p-4">

--- a/frontend/tests/unit/signupDraft.test.ts
+++ b/frontend/tests/unit/signupDraft.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  readWizardState,
+  writeWizardState,
+  clearWizardState,
+  readEducatorDraft,
+  writeEducatorDraft,
+  clearSignupDrafts,
+} from '../../utils/signupDraft';
+
+const EDU_KEY = 'procreche.signup.educatorDraft.v2';
+const WIZARD_KEY = 'procreche.signup.wizard.v2';
+
+describe('signupDraft', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('wizard state', () => {
+    it('round-trips the wizard state', () => {
+      writeWizardState({
+        selectedRole: 'EDUCATOR',
+        currentStep: 2,
+        formData: { email: 'a@example.com', contactPerson: 'Ada Lovelace' },
+      });
+
+      expect(readWizardState()).toMatchObject({
+        selectedRole: 'EDUCATOR',
+        currentStep: 2,
+        formData: { email: 'a@example.com', contactPerson: 'Ada Lovelace' },
+      });
+    });
+
+    it('never persists credentials', () => {
+      writeWizardState({
+        selectedRole: 'EDUCATOR',
+        currentStep: 2,
+        formData: { email: 'a@example.com', password: 'hunter2', confirmPassword: 'hunter2' },
+      });
+
+      const raw = window.localStorage.getItem(WIZARD_KEY) ?? '';
+      expect(raw).not.toContain('hunter2');
+      expect(readWizardState()?.formData).not.toHaveProperty('password');
+      expect(readWizardState()?.formData).not.toHaveProperty('confirmPassword');
+    });
+
+    it('clears the wizard state', () => {
+      writeWizardState({ selectedRole: 'EDUCATOR', currentStep: 2 });
+      clearWizardState();
+      expect(readWizardState()).toBeNull();
+    });
+  });
+
+  describe('educator draft', () => {
+    it('survives a closed tab (written to localStorage, not sessionStorage only)', () => {
+      writeEducatorDraft('edu@example.com', { shortBio: 'I love teaching' });
+
+      // Simulate a new tab: sessionStorage is gone, localStorage remains.
+      window.sessionStorage.clear();
+
+      expect(readEducatorDraft('edu@example.com')).toEqual({ shortBio: 'I love teaching' });
+      expect(window.localStorage.getItem(EDU_KEY)).toBeTruthy();
+    });
+
+    it('is returned regardless of email casing or surrounding whitespace', () => {
+      writeEducatorDraft('Edu@Example.com', { city: 'Zurich' });
+      expect(readEducatorDraft('  edu@example.com ')).toEqual({ city: 'Zurich' });
+    });
+
+    it('is not returned before the owning email is known', () => {
+      writeEducatorDraft('edu@example.com', { city: 'Zurich' });
+      expect(readEducatorDraft(undefined)).toBeNull();
+      expect(readEducatorDraft('')).toBeNull();
+    });
+
+    it('is not handed to a different account on a shared device', () => {
+      writeEducatorDraft('first@example.com', { shortBio: 'first user' });
+      expect(readEducatorDraft('second@example.com')).toBeNull();
+    });
+
+    it('is never written without an email, since it could not be matched back', () => {
+      writeEducatorDraft(undefined, { shortBio: 'orphan' });
+      expect(window.localStorage.getItem(EDU_KEY)).toBeNull();
+    });
+
+    it('expires after the TTL', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+      writeEducatorDraft('edu@example.com', { shortBio: 'stale' });
+
+      vi.setSystemTime(new Date('2026-01-06T00:00:00Z')); // 5 days — still valid
+      expect(readEducatorDraft('edu@example.com')).toEqual({ shortBio: 'stale' });
+
+      vi.setSystemTime(new Date('2026-01-09T00:00:00Z')); // 8 days — expired
+      expect(readEducatorDraft('edu@example.com')).toBeNull();
+    });
+
+    it('clearSignupDrafts removes both the wizard state and the educator draft', () => {
+      writeWizardState({ selectedRole: 'EDUCATOR', currentStep: 3 });
+      writeEducatorDraft('edu@example.com', { shortBio: 'done' });
+
+      clearSignupDrafts('edu@example.com');
+
+      expect(readWizardState()).toBeNull();
+      expect(readEducatorDraft('edu@example.com')).toBeNull();
+    });
+
+    it('ignores corrupted storage instead of throwing', () => {
+      window.localStorage.setItem(EDU_KEY, '{not json');
+      expect(() => readEducatorDraft('edu@example.com')).not.toThrow();
+      expect(readEducatorDraft('edu@example.com')).toBeNull();
+    });
+  });
+});

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -12,6 +12,8 @@ export enum UserRole {
 }
 
 export enum EducatorApprovalStatus {
+  /** Account created at email verification; the application was never submitted. */
+  INCOMPLETE = 'INCOMPLETE',
   PENDING_REVIEW = 'PENDING_REVIEW',
   APPROVED = 'APPROVED',
   REJECTED = 'REJECTED',
@@ -626,7 +628,6 @@ export interface SignupFormData {
     confirmPassword: string;
     phone: string;
     canton: SwissCanton | '';
-    languagesSpoken: SupportedLanguage[];
     capacity?: number;
     category: string; // For supplier
     serviceType: string; // For service provider

--- a/frontend/utils/signupDraft.ts
+++ b/frontend/utils/signupDraft.ts
@@ -5,24 +5,114 @@
 // while the educator profile details (bio, city, job role, experience, CV) are
 // only saved in step 3 via PATCH /settings/educator. Step 3 is pure in-memory
 // React state, so anything that discards that state after step 2 — a refresh,
-// the verification link opening in a different tab/webview, Safari suspending a
-// backgrounded tab — silently loses everything the user typed in step 3 and
-// leaves an account with no profile information.
+// a closed tab, Safari suspending a backgrounded tab, a transient error while
+// provisioning — silently loses everything the user typed in step 3 and leaves
+// an account with no profile information.
 //
-// Persisting the wizard + step-3 draft to sessionStorage lets us restore the
-// user's input and resume them at step 3 instead of dropping them on the
-// dashboard with their data gone.
+// Persisting the wizard + step-3 draft lets us restore the user's input and
+// resume them at step 3 instead of dropping them on the dashboard with their
+// data gone.
+//
+// Storage choice: `localStorage`, not `sessionStorage`. sessionStorage is
+// scoped to a single tab and is destroyed the moment that tab is closed, which
+// is precisely the most common way this data was being lost ("I'll finish this
+// later"). localStorage survives tab close and browser restart. Entries carry
+// an explicit TTL so an abandoned draft does not linger forever, and the
+// wizard draft never contains credentials.
 
-const WIZARD_KEY = 'procreche.signup.wizard.v1';
-const EDU_DRAFT_PREFIX = 'procreche.signup.educatorDraft.v1';
+const WIZARD_KEY = 'procreche.signup.wizard.v2';
+const EDU_DRAFT_KEY = 'procreche.signup.educatorDraft.v2';
+
+// Legacy v1 keys (sessionStorage, email-suffixed) — cleared on completion so
+// upgrading users do not keep stale drafts around.
+const LEGACY_WIZARD_KEY = 'procreche.signup.wizard.v1';
+const LEGACY_EDU_DRAFT_PREFIX = 'procreche.signup.educatorDraft.v1';
+
+// Drafts older than this are ignored (and dropped on next read).
+const DRAFT_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+type Envelope<T> = {
+  savedAt?: number;
+  email?: string;
+  data: T;
+};
+
+function safeLocal(): Storage | null {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) return null;
+    return window.localStorage;
+  } catch {
+    // Access can throw in private-mode / sandboxed contexts.
+    return null;
+  }
+}
 
 function safeSession(): Storage | null {
   try {
     if (typeof window === 'undefined' || !window.sessionStorage) return null;
     return window.sessionStorage;
   } catch {
-    // Access can throw in private-mode / sandboxed contexts.
     return null;
+  }
+}
+
+// localStorage first; fall back to sessionStorage where localStorage is
+// unavailable (some in-app webviews, strict privacy modes) so we still get
+// refresh-survival rather than nothing at all.
+function stores(): Storage[] {
+  return [safeLocal(), safeSession()].filter(Boolean) as Storage[];
+}
+
+function readEnvelope<T>(key: string): Envelope<T> | null {
+  for (const store of stores()) {
+    let raw: string | null = null;
+    try {
+      raw = store.getItem(key);
+    } catch {
+      continue;
+    }
+    if (!raw) continue;
+
+    let parsed: any;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== 'object' || !parsed.data) continue;
+
+    if (typeof parsed.savedAt === 'number' && Date.now() - parsed.savedAt > DRAFT_TTL_MS) {
+      try {
+        store.removeItem(key);
+      } catch {
+        /* best-effort */
+      }
+      continue;
+    }
+
+    return parsed as Envelope<T>;
+  }
+  return null;
+}
+
+function writeEnvelope<T>(key: string, envelope: Envelope<T>): void {
+  const payload = JSON.stringify({ ...envelope, savedAt: Date.now() });
+  for (const store of stores()) {
+    try {
+      store.setItem(key, payload);
+    } catch {
+      // Quota / serialization errors are non-fatal — persistence is best-effort.
+    }
+  }
+}
+
+function removeKey(key: string): void {
+  for (const store of stores()) {
+    try {
+      store.removeItem(key);
+    } catch {
+      /* best-effort */
+    }
   }
 }
 
@@ -34,77 +124,59 @@ export interface PersistedWizardState {
 }
 
 export function readWizardState(): PersistedWizardState | null {
-  const store = safeSession();
-  if (!store) return null;
-  try {
-    const raw = store.getItem(WIZARD_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === 'object' ? (parsed as PersistedWizardState) : null;
-  } catch {
-    return null;
-  }
+  const envelope = readEnvelope<PersistedWizardState>(WIZARD_KEY);
+  const state = envelope?.data;
+  return state && typeof state === 'object' ? state : null;
 }
 
 export function writeWizardState(state: PersistedWizardState): void {
-  const store = safeSession();
-  if (!store) return;
-  try {
-    const formData = { ...(state.formData ?? {}) };
-    // Defensive: never persist credentials, even if a caller forgets to strip them.
-    delete (formData as Record<string, unknown>).password;
-    delete (formData as Record<string, unknown>).confirmPassword;
-    store.setItem(WIZARD_KEY, JSON.stringify({ ...state, formData }));
-  } catch {
-    // Quota / serialization errors are non-fatal — persistence is best-effort.
-  }
+  const formData = { ...(state.formData ?? {}) };
+  // Defensive: never persist credentials, even if a caller forgets to strip them.
+  delete (formData as Record<string, unknown>).password;
+  delete (formData as Record<string, unknown>).confirmPassword;
+  writeEnvelope(WIZARD_KEY, { data: { ...state, formData } });
 }
 
 export function clearWizardState(): void {
-  const store = safeSession();
-  if (!store) return;
-  try {
-    store.removeItem(WIZARD_KEY);
-  } catch {
-    /* best-effort */
-  }
+  removeKey(WIZARD_KEY);
+  removeKey(LEGACY_WIZARD_KEY);
 }
 
-function eduKey(email?: string): string {
-  return `${EDU_DRAFT_PREFIX}:${(email ?? '').trim().toLowerCase()}`;
-}
-
+/**
+ * Read the educator step-3 draft.
+ *
+ * The draft is stored under a single key (not one key per email) because the
+ * email is frequently not known yet at the moment the step-3 form mounts — the
+ * authenticated user is still loading — and an email-suffixed key written
+ * before the email arrived could never be found again afterwards.
+ *
+ * To keep a shared device safe, the owning email is stored inside the draft and
+ * the caller must pass the email it expects. A draft is only returned when the
+ * emails match (or the draft predates knowing one).
+ */
 export function readEducatorDraft<T = Record<string, unknown>>(email?: string): T | null {
-  const store = safeSession();
-  if (!store) return null;
-  try {
-    const raw = store.getItem(eduKey(email));
-    if (!raw) return null;
-    const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === 'object' ? (parsed as T) : null;
-  } catch {
-    return null;
-  }
+  const normalized = (email ?? '').trim().toLowerCase();
+  if (!normalized) return null; // Never hand a draft back before we know whose it is.
+
+  const envelope = readEnvelope<T>(EDU_DRAFT_KEY);
+  if (!envelope) return null;
+
+  const owner = (envelope.email ?? '').trim().toLowerCase();
+  if (owner && owner !== normalized) return null;
+
+  return envelope.data && typeof envelope.data === 'object' ? envelope.data : null;
 }
 
-export function writeEducatorDraft(email: string | undefined, data: Record<string, unknown>): void {
-  const store = safeSession();
-  if (!store) return;
-  try {
-    store.setItem(eduKey(email), JSON.stringify(data));
-  } catch {
-    /* best-effort */
-  }
+export function writeEducatorDraft<T extends object>(email: string | undefined, data: T): void {
+  const normalized = (email ?? '').trim().toLowerCase();
+  if (!normalized) return; // Anonymous drafts can never be safely restored.
+  writeEnvelope(EDU_DRAFT_KEY, { email: normalized, data });
 }
 
 export function clearEducatorDraft(email?: string): void {
-  const store = safeSession();
-  if (!store) return;
-  try {
-    store.removeItem(eduKey(email));
-  } catch {
-    /* best-effort */
-  }
+  removeKey(EDU_DRAFT_KEY);
+  const legacy = `${LEGACY_EDU_DRAFT_PREFIX}:${(email ?? '').trim().toLowerCase()}`;
+  removeKey(legacy);
 }
 
 // Clear everything once the signup has actually been completed/saved.

--- a/packages/translations/locales/de/dashboard.json
+++ b/packages/translations/locales/de/dashboard.json
@@ -157,7 +157,11 @@
     "completeProfile": "Vervollständigen Sie Ihr Profil",
     "completeProfileDesc": "Stellen Sie während der Wartezeit auf die Genehmigung sicher, dass Ihr Profil vollständig und aktuell ist. Ein vollständiges Profil erhöht Ihre Chancen, mit den richtigen Möglichkeiten zusammengeführt zu werden.",
     "contactSupport": "Support kontaktieren",
-    "signOut": "Abmelden"
+    "signOut": "Abmelden",
+    "incompleteTitle": "Bewerbung abschliessen",
+    "incompleteDescription": "Ihr Konto wurde erstellt, aber Ihre Bewerbung als Erzieher/in wurde nie eingereicht — es liegen noch keine Biografie, Erfahrung oder Lebenslauf vor. Unser Team kann sie erst prüfen, wenn Sie diesen letzten Schritt abgeschlossen haben.",
+    "incompleteCta": "Bewerbung abschliessen",
+    "incompleteNote": "Es dauert etwa 5 Minuten. Was Sie auf diesem Gerät bereits eingegeben haben, wurde gespeichert und wird für Sie ausgefüllt."
   },
   "educatorProfilePage": {
     "availability": {

--- a/packages/translations/locales/de/dashboard.json
+++ b/packages/translations/locales/de/dashboard.json
@@ -161,7 +161,7 @@
     "incompleteTitle": "Bewerbung abschliessen",
     "incompleteDescription": "Ihr Konto wurde erstellt, aber Ihre Bewerbung als Erzieher/in wurde nie eingereicht — es liegen noch keine Biografie, Erfahrung oder Lebenslauf vor. Unser Team kann sie erst prüfen, wenn Sie diesen letzten Schritt abgeschlossen haben.",
     "incompleteCta": "Bewerbung abschliessen",
-    "incompleteNote": "Es dauert etwa 5 Minuten. Was Sie auf diesem Gerät bereits eingegeben haben, wurde gespeichert und wird für Sie ausgefüllt."
+    "incompleteNote": "Es dauert etwa 5 Minuten. Wenn Sie kürzlich auf diesem Gerät begonnen haben, sind Ihre Angaben möglicherweise noch vorausgefüllt — Entwürfe werden 7 Tage aufbewahrt."
   },
   "educatorProfilePage": {
     "availability": {

--- a/packages/translations/locales/en/dashboard.json
+++ b/packages/translations/locales/en/dashboard.json
@@ -397,7 +397,11 @@
     "completeProfile": "Complete your profile",
     "completeProfileDesc": "While you wait for approval, make sure your profile is complete and up to date. A complete profile increases your chances of being matched with the right opportunities.",
     "contactSupport": "Contact Support",
-    "signOut": "Sign Out"
+    "signOut": "Sign Out",
+    "incompleteTitle": "Finish your application",
+    "incompleteDescription": "Your account was created, but your educator application was never submitted — we have no biography, experience or CV on file yet. Our team cannot review it until you complete this last step.",
+    "incompleteCta": "Complete my application",
+    "incompleteNote": "It takes about 5 minutes. Anything you already typed on this device has been saved and will be filled in for you."
   },
   "educatorProfilePage": {
     "availability": {

--- a/packages/translations/locales/en/dashboard.json
+++ b/packages/translations/locales/en/dashboard.json
@@ -401,7 +401,7 @@
     "incompleteTitle": "Finish your application",
     "incompleteDescription": "Your account was created, but your educator application was never submitted — we have no biography, experience or CV on file yet. Our team cannot review it until you complete this last step.",
     "incompleteCta": "Complete my application",
-    "incompleteNote": "It takes about 5 minutes. Anything you already typed on this device has been saved and will be filled in for you."
+    "incompleteNote": "It takes about 5 minutes. If you started recently on this device, your answers may still be filled in for you — drafts are kept for 7 days."
   },
   "educatorProfilePage": {
     "availability": {

--- a/packages/translations/locales/fr/dashboard.json
+++ b/packages/translations/locales/fr/dashboard.json
@@ -160,7 +160,7 @@
     "incompleteTitle": "Terminez votre candidature",
     "incompleteDescription": "Votre compte a été créé, mais votre candidature d'éducateur/éducatrice n'a jamais été soumise — nous n'avons encore ni biographie, ni expérience, ni CV. Notre équipe ne peut pas l'examiner tant que vous n'avez pas terminé cette dernière étape.",
     "incompleteCta": "Compléter ma candidature",
-    "incompleteNote": "Cela prend environ 5 minutes. Ce que vous avez déjà saisi sur cet appareil a été conservé et sera pré-rempli."
+    "incompleteNote": "Cela prend environ 5 minutes. Si vous avez commencé récemment sur cet appareil, vos réponses peuvent être pré-remplies — les brouillons sont conservés 7 jours."
   },
   "educatorProfilePage": {
     "availability": {

--- a/packages/translations/locales/fr/dashboard.json
+++ b/packages/translations/locales/fr/dashboard.json
@@ -156,7 +156,11 @@
     "completeProfile": "Complétez votre profil",
     "completeProfileDesc": "En attendant l'approbation, assurez-vous que votre profil est complet et à jour. Un profil complet augmente vos chances d'être mis(e) en relation avec les bonnes opportunités.",
     "contactSupport": "Contacter le support",
-    "signOut": "Se déconnecter"
+    "signOut": "Se déconnecter",
+    "incompleteTitle": "Terminez votre candidature",
+    "incompleteDescription": "Votre compte a été créé, mais votre candidature d'éducateur/éducatrice n'a jamais été soumise — nous n'avons encore ni biographie, ni expérience, ni CV. Notre équipe ne peut pas l'examiner tant que vous n'avez pas terminé cette dernière étape.",
+    "incompleteCta": "Compléter ma candidature",
+    "incompleteNote": "Cela prend environ 5 minutes. Ce que vous avez déjà saisi sur cet appareil a été conservé et sera pré-rempli."
   },
   "educatorProfilePage": {
     "availability": {


### PR DESCRIPTION
## Summary

Fixes a critical defect where educators signing up with email/password lost profile data (capacity, phone, category, service type, child details) that was retained for OAuth signups. Also improves resilience when account provisioning is slow by allowing educators to proceed to step 3 with a non-blocking notice instead of timing out.

## Key Changes

**Signup Data Persistence**
- Introduced `SignupProfileService` with `parseSignupIntent()` and `applySignupIntent()` to unify how both account-creation paths (Clerk webhook + OAuth recovery) persist signup form data
- Both paths now build a single `SignupIntent` object and apply it consistently, eliminating field drift
- Added unit tests (`signup-profile.service.unit.spec.ts`) to guard against future divergence
- Extracted signup form building into `buildSignupIntent()` helper in `SignupPage` to ensure credentials are never persisted

**Webhook Provisioning Resilience**
- Changed `waitForWebhookProcessing()` to tolerate transient poll failures (up to 5 consecutive) instead of aborting on the first error
- Increased max wait time from 30s → 60s and poll interval from 1s → 1.5s
- When provisioning is not confirmed within the budget, educators are sent to step 3 anyway with a non-blocking notice (`provisioningDelayed` flag) instead of a fatal error
- This prevents empty profiles: step 3 is where all educator data is collected, and the form submission itself retries

**Educator Approval Status**
- Added `INCOMPLETE` status to `EducatorApprovalStatus` enum to distinguish accounts created at email verification (before any profile submission) from real applications awaiting review
- New educators bootstrap as `INCOMPLETE`, not `PENDING_REVIEW`, so the admin queue only contains actual submissions
- Migration `20260701020000` reclassifies legacy educators with empty profiles as `INCOMPLETE`
- Added `backfill-incomplete-educators.ts` script to email reminders to educators who never completed step 3

**Draft Persistence Improvements**
- Migrated signup drafts from `sessionStorage` (lost on tab close) to `localStorage` with explicit 7-day TTL
- Drafts now survive tab close and browser restart, addressing the most common data loss scenario
- Added envelope structure with `savedAt` timestamp for TTL enforcement
- Falls back to `sessionStorage` where `localStorage` is unavailable (private mode, sandboxed webviews)

**UI & UX**
- `EducatorProfileStep` now shows inline save errors instead of dismissible alerts, preventing typed data from being discarded
- Added "Sign out" button when account already exists (step 2 would reject the email)
- `EducatorPendingApprovalPage` detects incomplete applications and routes back into signup wizard at step 3 with draft restoration
- Added email template for incomplete educator reminders

**Database**
- Added `childAge`, `childStartDate`, `termsAcceptedAt` columns to `User` table (previously collected but never persisted)
- Updated Prisma schema and migrations

## Implementation Details

- `parseSignupIntent()` safely coerces untrusted Clerk metadata: trims strings, validates numbers/dates, drops unknown keys, never reads `role`
- Transient failure tracking uses a counter that resets on any successful poll, so a single success clears the failure budget
- Educator draft restoration uses email as the key (normalized, case-insensitive) to prevent cross-account leakage on shared devices
- The `buildSignupIntent()` helper explicitly excludes credentials (`password`, `confirmPassword`) and `languagesSpoken` (removed from form)
- Admin approval count endpoint now distinguishes `INCOMPLETE` from `PENDING_REVIEW` for accurate queue metrics

https://claude.ai/code/session_01ABQRGFEvWZK1nEG8MMh76Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clear incomplete-application status for educator accounts that have not submitted a profile.
  * Educators can resume saved signup information, complete their application, and receive guidance when account setup is delayed.
  * Signup details such as child information, consent, phone, and organization-related fields are now retained more consistently.
* **Bug Fixes**
  * Improved signup retry handling and error messages.
  * Prevented incomplete educator accounts from appearing in the review queue until an application is submitted.
* **Translations**
  * Added incomplete-application messaging in English, German, and French.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->